### PR TITLE
Fix introduction outline links

### DIFF
--- a/docs/introduction/introduction.md
+++ b/docs/introduction/introduction.md
@@ -1,8 +1,8 @@
 # Introduction
 
-- [What is Gloo?](#What is Gloo?)
-- [Using Gloo](#Using Gloo)
-- [Basic Workflow](#Basic Workflow)
+- [What is Gloo?](#what-is-gloo)
+- [Using Gloo](#using-gloo)
+- [Basic Workflow](#basic-workflow)
 
 
 


### PR DESCRIPTION
The existing internal links were broken, at least in GitHub preview :link: 