### PR TITLE
enable envoy configs to be grouped

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -286,7 +286,6 @@
   revision = "02826c3e79038b59d737d3b1c0a1d937f71a4433"
 
 [[projects]]
-  branch = "master"
   name = "github.com/golang/protobuf"
   packages = [
     "jsonpb",
@@ -300,7 +299,8 @@
     "ptypes/struct",
     "ptypes/timestamp"
   ]
-  revision = "e09c5db296004fbe3f74490e84dcd62c3c5ddb1b"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
@@ -1237,6 +1237,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ba93629066671f994c151429828254244759be22247eb167007f4aab053c9c2a"
+  inputs-digest = "ecad3bbd90f18e7aea041c4b5def520eefabc0ed6242a065c64a10fc6faf0815"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -168,13 +168,9 @@
     "envoy/api/v2/endpoint",
     "envoy/api/v2/listener",
     "envoy/api/v2/route",
-    "envoy/config/bootstrap/v2",
     "envoy/config/filter/accesslog/v2",
     "envoy/config/filter/http/transcoder/v2",
     "envoy/config/filter/network/http_connection_manager/v2",
-    "envoy/config/metrics/v2",
-    "envoy/config/ratelimit/v2",
-    "envoy/config/trace/v2",
     "envoy/service/discovery/v2",
     "envoy/type",
     "pkg/cache",
@@ -1241,6 +1237,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "c562f3c600110bc422057e99f9f32e3f006a02106e68dd8f7a9bdb1eff8027c0"
+  inputs-digest = "ba93629066671f994c151429828254244759be22247eb167007f4aab053c9c2a"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -82,7 +82,7 @@
   name = "github.com/golang/glog"
 
 [[constraint]]
-  branch = "master"
+  version = "v1.1.0"
   name = "github.com/golang/protobuf"
 
 [[constraint]]

--- a/api/v1/virtualmesh.proto
+++ b/api/v1/virtualmesh.proto
@@ -14,7 +14,7 @@ import "metadata.proto";
  * A Virtual Mesh is a container for a set of Virtual Services that will be used to generate a single proxy config
  * to be applied to one or more Envoy nodes. The Virtual Mesh is best understood as an in-mesh application's localized view
  * of the rest of the mesh.
- * Each domains for each Virtual Services contained in a Virtual Mesh cannot appear more than once, or the Virtual Mesh
+ * Each domain for each Virtual Service contained in a Virtual Mesh cannot appear more than once, or the Virtual Mesh
  * will be invalid.
  */
 message VirtualMesh {
@@ -28,7 +28,7 @@ message VirtualMesh {
     // One or more lowercase rfc1035/rfc1123 labels separated by '.' with a maximum length of 253 characters.
     string name = 1;
 
-    // the list of names of the virtual services this vmesh includes.
+    // the list of names of the virtual services this vmesh encapsulates.
     repeated string virtual_services = 2;
 
     // Status indicates the validation status of the virtual mesh resource.

--- a/docs/api.json
+++ b/docs/api.json
@@ -370,7 +370,7 @@
           "name": "VirtualMesh",
           "longName": "VirtualMesh",
           "fullName": "v1.VirtualMesh",
-          "description": "A Virtual Mesh is a container for a set of Virtual Services that will be used to generate a single proxy config\nto be applied to one or more Envoy nodes. The Virtual Mesh is best understood as an in-mesh application's localized view\nof the rest of the mesh.\nEach domains for each Virtual Services contained in a Virtual Mesh cannot appear more than once, or the Virtual Mesh\nwill be invalid.",
+          "description": "A Virtual Mesh is a container for a set of Virtual Services that will be used to generate a single proxy config\nto be applied to one or more Envoy nodes. The Virtual Mesh is best understood as an in-mesh application's localized view\nof the rest of the mesh.\nEach domain for each Virtual Service contained in a Virtual Mesh cannot appear more than once, or the Virtual Mesh\nwill be invalid.",
           "hasExtensions": false,
           "hasFields": true,
           "extensions": [],
@@ -386,7 +386,7 @@
             },
             {
               "name": "virtual_services",
-              "description": "the list of names of the virtual services this vmesh includes.",
+              "description": "the list of names of the virtual services this vmesh encapsulates.",
               "label": "repeated",
               "type": "string",
               "longType": "string",

--- a/example/nats/envoy.yaml
+++ b/example/nats/envoy.yaml
@@ -1,7 +1,7 @@
 
 node:
   cluster: ingress
-  id: ingress-1
+  id: ingress~1
 static_resources:
   clusters:
   - name: xds_cluster

--- a/hack/run-local-binaries.sh
+++ b/hack/run-local-binaries.sh
@@ -38,7 +38,7 @@ GLOO_IP=localhost
 cat > ${CONFIG_DIR}/envoy.yaml <<EOF
 node:
   cluster: ingress
-  id: ingress
+  id: ingress~1
 
 static_resources:
   clusters:

--- a/hack/run-local-docker.sh
+++ b/hack/run-local-docker.sh
@@ -50,7 +50,7 @@ CONTROL_PLANE_IP=localhost
 cat > ${CONFIG_DIR}/envoy.yaml <<EOF
 node:
   cluster: ingress
-  id: ingress
+  id: ingress~1
 
 static_resources:
   clusters:

--- a/hack/run-local.sh
+++ b/hack/run-local.sh
@@ -38,7 +38,7 @@ GLOO_IP=127.0.0.1
 cat > ${CONFIG_DIR}/envoy.yaml <<EOF
 node:
   cluster: ingress
-  id: ingress
+  id: ingress~1
 
 static_resources:
   clusters:

--- a/install/helm/gloo/templates/ingress-configmap.yaml
+++ b/install/helm/gloo/templates/ingress-configmap.yaml
@@ -7,7 +7,7 @@ data:
   envoy.yaml: |
     node:
       cluster: ingress
-      id: NODE_ID_PLACE_HOLDER
+      id: ingress~NODE_ID_PLACE_HOLDER
     static_resources:
       clusters:
       - name: xds_cluster

--- a/install/kube/install.yaml
+++ b/install/kube/install.yaml
@@ -46,7 +46,7 @@ data:
   envoy.yaml: |
     node:
       cluster: ingress
-      id: NODE_ID_PLACE_HOLDER
+      id: ingress~NODE_ID_PLACE_HOLDER
     static_resources:
       clusters:
       - name: xds_cluster

--- a/install/nomad/install.nomad
+++ b/install/nomad/install.nomad
@@ -105,7 +105,7 @@ job "gloo" {
         data = <<EOF
 node:
   cluster: ingress
-  id: {{ env "NOMAD_ALLOC_ID" }}
+  id: ingress~{{ env "NOMAD_ALLOC_ID" }}
 
 static_resources:
   clusters:

--- a/install/openshift/install.yml
+++ b/install/openshift/install.yml
@@ -43,7 +43,7 @@ data:
   envoy.yaml: |
     node:
       cluster: ingress
-      id: NODE_ID_PLACE_HOLDER
+      id: ingress~NODE_ID_PLACE_HOLDER
     static_resources:
       clusters:
       - name: xds_cluster

--- a/internal/control-plane/bootstrap/flags/ingress_flags.go
+++ b/internal/control-plane/bootstrap/flags/ingress_flags.go
@@ -7,7 +7,7 @@ import (
 
 func AddIngressFlags(cmd *cobra.Command, opts *bootstrap.Options) {
 	// TODO ingress.bind-adress
-	cmd.PersistentFlags().StringVar(&opts.IngressOptions.BindAddress, "envoy.bind-adress", "", "The address that the ingress envoy should bind to.")
-	cmd.PersistentFlags().IntVar(&opts.IngressOptions.Port, "envoy.port", 8080, "The HTTP port envoy uses.")
-	cmd.PersistentFlags().IntVar(&opts.IngressOptions.SecurePort, "envoy.secure-port", 8443, "The HTTPS port envoy uses.")
+	cmd.PersistentFlags().StringVar(&opts.IngressOptions.BindAddress, "envoy.bind-adress", "::", "The address that the ingress envoy should bind to.")
+	cmd.PersistentFlags().Uint32Var(&opts.IngressOptions.Port, "envoy.port", 8080, "The HTTP port envoy uses.")
+	cmd.PersistentFlags().Uint32Var(&opts.IngressOptions.SecurePort, "envoy.secure-port", 8443, "The HTTPS port envoy uses.")
 }

--- a/internal/control-plane/bootstrap/options.go
+++ b/internal/control-plane/bootstrap/options.go
@@ -11,6 +11,6 @@ type Options struct {
 
 type IngressOptions struct {
 	BindAddress string
-	Port        int
-	SecurePort  int
+	Port        uint32
+	SecurePort  uint32
 }

--- a/internal/control-plane/eventloop/eventloop.go
+++ b/internal/control-plane/eventloop/eventloop.go
@@ -227,8 +227,8 @@ func (e *eventLoop) updateXds(cache *cache) {
 		}
 	}
 
-	log.Debugf("FINAL: XDS Snapshot: %v", snapshot)
-	e.xdsConfig.SetSnapshot(xds.NodeKey, *snapshot)
+	log.Debugf("Setting xDS Snapshot for Virtual Mesh %v: %v", "ingress", snapshot)
+	e.xdsConfig.SetSnapshot("ingress", *snapshot)
 }
 
 // fan out to cover all endpoint discovery services

--- a/internal/control-plane/eventloop/eventloop.go
+++ b/internal/control-plane/eventloop/eventloop.go
@@ -273,7 +273,7 @@ func (e *eventLoop) errors() <-chan error {
 	for _, ed := range e.endpointDiscoveries {
 		go func() {
 			for err := range ed.Error() {
-				aggregatedErrorsChan <- err
+				aggregatedErrorsChan <-  errors.Wrap(err, "endpoint discovery encountered an error")
 			}
 		}()
 	}

--- a/internal/control-plane/reporter/crd_reporter_test.go
+++ b/internal/control-plane/reporter/crd_reporter_test.go
@@ -44,6 +44,7 @@ var _ = Describe("CrdReporter", func() {
 			reports         []ConfigObjectReport
 			upstreams       []*v1.Upstream
 			virtualServices []*v1.VirtualService
+			virtualMeshes []*v1.VirtualMesh
 		)
 		Context("writes status reports for cfg crds with 0 errors", func() {
 			BeforeEach(func() {
@@ -67,6 +68,13 @@ var _ = Describe("CrdReporter", func() {
 					Expect(err).NotTo(HaveOccurred())
 					storables = append(storables, vService)
 				}
+				virtualMeshes = testCfg.VirtualMeshes
+				for _, vMesh := range virtualMeshes {
+					_, err := glooClient.V1().VirtualMeshes().Create(vMesh)
+					Expect(err).NotTo(HaveOccurred())
+
+					storables = append(storables, vMesh)
+				}
 				for _, storable := range storables {
 					reports = append(reports, ConfigObjectReport{
 						CfgObject: storable,
@@ -89,6 +97,12 @@ var _ = Describe("CrdReporter", func() {
 				Expect(updatedvServices).To(HaveLen(len(upstreams)))
 				for _, updatedvService := range updatedvServices {
 					Expect(updatedvService.Status.State).To(Equal(v1.Status_Accepted))
+				}
+				updatedvMeshes, err := glooClient.V1().VirtualMeshes().List()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedvMeshes).To(HaveLen(len(upstreams)))
+				for _, updatedvMesh := range updatedvMeshes {
+					Expect(updatedvMesh.Status.State).To(Equal(v1.Status_Accepted))
 				}
 			})
 		})
@@ -114,6 +128,12 @@ var _ = Describe("CrdReporter", func() {
 					Expect(err).NotTo(HaveOccurred())
 					storables = append(storables, vService)
 				}
+				virtualMeshes = testCfg.VirtualMeshes
+				for _, vMesh := range virtualMeshes {
+					_, err := glooClient.V1().VirtualMeshes().Create(vMesh)
+					Expect(err).NotTo(HaveOccurred())
+					storables = append(storables, vMesh)
+				}
 				for _, storable := range storables {
 					reports = append(reports, ConfigObjectReport{
 						CfgObject: storable,
@@ -136,6 +156,12 @@ var _ = Describe("CrdReporter", func() {
 				Expect(updatedvServices).To(HaveLen(len(upstreams)))
 				for _, updatedvService := range updatedvServices {
 					Expect(updatedvService.Status.State).To(Equal(v1.Status_Rejected))
+				}
+				updatedvMeshes, err := glooClient.V1().VirtualMeshes().List()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedvMeshes).To(HaveLen(len(upstreams)))
+				for _, updatedvMesh := range updatedvMeshes {
+					Expect(updatedvMesh.Status.State).To(Equal(v1.Status_Rejected))
 				}
 			})
 		})

--- a/internal/control-plane/reporter/reporter.go
+++ b/internal/control-plane/reporter/reporter.go
@@ -62,6 +62,19 @@ func (r *reporter) writeReport(report ConfigObjectReport) error {
 		if _, err := r.store.V1().VirtualServices().Update(virtualService); err != nil {
 			return errors.Wrapf(err, "failed to update virtualservice store with status report")
 		}
+	case *v1.VirtualMesh:
+		virtualMesh, err := r.store.V1().VirtualMeshes().Get(name)
+		if err != nil {
+			return errors.Wrapf(err, "failed to find virtual mesh %v", name)
+		}
+		// only update if status doesn't match
+		if virtualMesh.Status.Equal(status) {
+			return nil
+		}
+		virtualMesh.Status = status
+		if _, err := r.store.V1().VirtualMeshes().Update(virtualMesh); err != nil {
+			return errors.Wrapf(err, "failed to update virtual mesh store with status report")
+		}
 	}
 	return nil
 }

--- a/internal/control-plane/translator/translator_test.go
+++ b/internal/control-plane/translator/translator_test.go
@@ -15,10 +15,11 @@ import (
 	"github.com/solo-io/gloo/pkg/coreplugins/route-extensions"
 	"github.com/solo-io/gloo/pkg/coreplugins/service"
 	"github.com/solo-io/gloo/pkg/storage/dependencies"
+	"github.com/solo-io/gloo/internal/control-plane/bootstrap"
 )
 
 func newTranslator() *Translator {
-	return NewTranslator(TranslatorConfig{"::", 8080, 8443}, []plugins.TranslatorPlugin{&service.Plugin{}})
+	return NewTranslator(bootstrap.IngressOptions{"::", 8080, 8443}, []plugins.TranslatorPlugin{&service.Plugin{}})
 }
 
 var _ = Describe("Translator", func() {

--- a/internal/control-plane/xds/snapshot_for_bad_nodes.go
+++ b/internal/control-plane/xds/snapshot_for_bad_nodes.go
@@ -1,0 +1,109 @@
+package xds
+
+import (
+	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	envoylistener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
+	envoyhttpconnectionmanager "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/envoyproxy/go-control-plane/pkg/cache"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+)
+
+const invalidConfigStatusCode = 500
+
+// errorResponseVirtualHost is used to set a 500 route with a useful error message
+// on envoy instances that have been improperly configured
+var errorResponseVirtualHost = envoyroute.VirtualHost{
+	Name:    "invalid-envoy-config-vhost",
+	Domains: []string{"*"},
+	Routes: []envoyroute.Route{
+		{
+			Match: envoyroute.RouteMatch{
+				PathSpecifier: &envoyroute.RouteMatch_Prefix{
+					Prefix: "/",
+				},
+			},
+			Action: &envoyroute.Route_DirectResponse{
+				DirectResponse: &envoyroute.DirectResponseAction{
+					Status: invalidConfigStatusCode,
+					Body: &envoycore.DataSource{
+						Specifier: &envoycore.DataSource_InlineString{
+							InlineString: "Invalid Envoy Bootstrap Configuration. " +
+								"Please refer to Gloo documentation https://gloo.solo.io/",
+						},
+					},
+				},
+			},
+		},
+	},
+}
+
+func BadNodeSnapshot(bindAddress string, port uint32) cache.Snapshot {
+	routeConfigName := "routes-for-invalid-envoy"
+	listenerName := "listener-for-invalid-envoy"
+	var (
+		endpoints []cache.Resource
+		clusters  []cache.Resource
+	)
+	routes := []cache.Resource{
+		&envoyapi.RouteConfiguration{
+			Name: routeConfigName,
+			VirtualHosts: []envoyroute.VirtualHost{
+				errorResponseVirtualHost,
+			},
+		},
+	}
+	adsSource := envoycore.ConfigSource{
+		ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
+			Ads: &envoycore.AggregatedConfigSource{},
+		},
+	}
+	manager := &envoyhttpconnectionmanager.HttpConnectionManager{
+		CodecType:  envoyhttpconnectionmanager.AUTO,
+		StatPrefix: "http",
+		RouteSpecifier: &envoyhttpconnectionmanager.HttpConnectionManager_Rds{
+			Rds: &envoyhttpconnectionmanager.Rds{
+				ConfigSource:    adsSource,
+				RouteConfigName: routeConfigName,
+			},
+		},
+		HttpFilters: []*envoyhttpconnectionmanager.HttpFilter{
+			{
+				Name: "envoy.router",
+			},
+		},
+	}
+	pbst, err := util.MessageToStruct(manager)
+	if err != nil {
+		panic(err)
+	}
+
+	listener := &envoyapi.Listener{
+		Name: listenerName,
+		Address: envoycore.Address{
+			Address: &envoycore.Address_SocketAddress{
+				SocketAddress: &envoycore.SocketAddress{
+					Protocol: envoycore.TCP,
+					Address:  bindAddress,
+					PortSpecifier: &envoycore.SocketAddress_PortValue{
+						PortValue: port,
+					},
+				},
+			},
+		},
+		FilterChains: []envoylistener.FilterChain{{
+			Filters: []envoylistener.Filter{
+				{
+					Name:   "envoy.http_connection_manager",
+					Config: pbst,
+				},
+			},
+		}},
+	}
+
+	listeners := []cache.Resource{
+		listener,
+	}
+	return cache.NewSnapshot("unversioned", endpoints, clusters, routes, listeners)
+}

--- a/internal/control-plane/xds/snapshot_for_bad_nodes.go
+++ b/internal/control-plane/xds/snapshot_for_bad_nodes.go
@@ -89,6 +89,7 @@ func BadNodeSnapshot(bindAddress string, port uint32) cache.Snapshot {
 					PortSpecifier: &envoycore.SocketAddress_PortValue{
 						PortValue: port,
 					},
+					Ipv4Compat: true,
 				},
 			},
 		},

--- a/internal/control-plane/xds/xds.go
+++ b/internal/control-plane/xds/xds.go
@@ -15,15 +15,24 @@ import (
 	"github.com/solo-io/gloo/pkg/log"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"strings"
 )
 
-// For now we're only running one envoy instance
-const NodeKey = string("gloo-envoy")
+// used to let nodes know they have a bad config
+// we assign a "fix me" virtualhost for bad nodes
+const badNodeKey = "misconfigured-node"
 
 type hasher struct{}
 
 func (h hasher) ID(node *core.Node) string {
-	return NodeKey
+	parts := strings.Split(node.Id, "~")
+	if len(parts) != 2 {
+		log.Warnf("node has registered with invalid config: %v\n " +
+			"assigning error response virtual host", node)
+		return badNodeKey
+	}
+	log.Printf("node %v registered from virtual mesh %v", parts[1], parts[0])
+	return parts[0]
 }
 
 type logger struct{}
@@ -35,7 +44,7 @@ func (*logger) Errorf(format string, args ...interface{}) {
 	log.Warnf(format, args...)
 }
 
-func RunXDS(port int) (envoycache.SnapshotCache, *grpc.Server, error) {
+func RunXDS(port int, badNodeSnapshot envoycache.Snapshot) (envoycache.SnapshotCache, *grpc.Server, error) {
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to listen: %v", err)
@@ -57,6 +66,9 @@ func RunXDS(port int) (envoycache.SnapshotCache, *grpc.Server, error) {
 	v2.RegisterClusterDiscoveryServiceServer(grpcServer, xdsServer)
 	v2.RegisterRouteDiscoveryServiceServer(grpcServer, xdsServer)
 	v2.RegisterListenerDiscoveryServiceServer(grpcServer, xdsServer)
+
+	// set bad node virtualhost
+	envoyCache.SetSnapshot(badNodeKey, badNodeSnapshot)
 
 	go func() {
 		log.Debugf("xDS server listening on %s", port)

--- a/internal/control-plane/xds/xds.go
+++ b/internal/control-plane/xds/xds.go
@@ -25,7 +25,7 @@ const badNodeKey = "misconfigured-node"
 type hasher struct{}
 
 func (h hasher) ID(node *core.Node) string {
-	parts := strings.Split(node.Id, "~")
+	parts := strings.SplitN(node.Id, "~", 2)
 	if len(parts) != 2 {
 		log.Warnf("node has registered with invalid config: %v\n " +
 			"assigning error response virtual host", node)

--- a/internal/control-plane/xds/xds_suite_test.go
+++ b/internal/control-plane/xds/xds_suite_test.go
@@ -29,17 +29,3 @@ var _ = BeforeSuite(func() {
 var _ = AfterSuite(func() {
 	envoyFactory.Clean()
 })
-
-var _ = BeforeEach(func() {
-	var err error
-	envoyInstance, err = envoyFactory.NewEnvoyInstance()
-	Expect(err).NotTo(HaveOccurred())
-	err = envoyInstance.Run()
-	Expect(err).NotTo(HaveOccurred())
-})
-
-var _ = AfterEach(func() {
-	if envoyInstance != nil {
-		envoyInstance.Clean()
-	}
-})

--- a/internal/control-plane/xds/xds_test.go
+++ b/internal/control-plane/xds/xds_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Xds", func() {
 	Describe("RunXDS Server", func() {
 		Context("with invalid node name", func() {
 			BeforeEach(func() {
-				err := envoyInstance.Run()
+				err := envoyInstance.RunWithId("badid")
 				Expect(err).NotTo(HaveOccurred())
 				_, grpcSrv, err := RunXDS(8081, badNodeSnapshot)
 				Expect(err).NotTo(HaveOccurred())
@@ -52,7 +52,7 @@ var _ = Describe("Xds", func() {
 				srv.Stop()
 			})
 			It("successfully bootstraps the envoy proxy", func() {
-				Eventually(envoyInstance.Logs, time.Second*30).Should(ContainSubstring("lds: add/update listener 'listener-for-invalid-envoy'"))
+				Eventually(envoyInstance.Logs, time.Second*10).Should(ContainSubstring("lds: add/update listener 'listener-for-invalid-envoy'"))
 			})
 			It("has a 500 route with body 'Invalid Envoy Bootstrap Configuration. Please refer to Gloo documentation https://gloo.solo.io/'", func() {
 				Eventually(func() error {

--- a/internal/control-plane/xds/xds_test.go
+++ b/internal/control-plane/xds/xds_test.go
@@ -1,22 +1,21 @@
 package xds_test
 
 import (
-	"time"
-
-	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoylistener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	envoyhttpconnectionmanager "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/envoyproxy/go-control-plane/pkg/cache"
 	"github.com/envoyproxy/go-control-plane/pkg/util"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v2"
-	. "github.com/solo-io/gloo/internal/control-plane/xds"
-	"github.com/solo-io/gloo/pkg/log"
-	. "github.com/solo-io/gloo/test/helpers"
 	"google.golang.org/grpc"
+	"time"
+	. "github.com/solo-io/gloo/internal/control-plane/xds"
+	"net/http"
+	"io/ioutil"
 )
 
 var _ = Describe("Xds", func() {
@@ -25,21 +24,76 @@ var _ = Describe("Xds", func() {
 
 		routeConfigName = "xds-test-route-config"
 		listenerName    = "xds-test-listener"
+		nodeGroup       = "valid-group"
+		badNodeSnapshot = BadNodeSnapshot("0.0.0.0", 1234)
 	)
-	BeforeEach(func() {
-		cache, grpcSrv, err := RunXDS(8081)
-		Must(err)
-		srv = grpcSrv
-
-		snapshot, err := createSnapshot(routeConfigName, listenerName)
-		if err != nil {
-			log.Fatalf(err.Error())
-		}
-		cache.SetSnapshot(NodeKey, snapshot)
+	var _ = BeforeEach(func() {
+		var err error
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		Expect(err).NotTo(HaveOccurred())
 	})
+
+	AfterEach(func() {
+		if envoyInstance != nil {
+			envoyInstance.Clean()
+		}
+	})
+
 	Describe("RunXDS Server", func() {
-		It("successfully bootstraps the envoy proxy", func() {
-			Eventually(envoyInstance.Logs, time.Second*30).Should(ContainSubstring("lds: add/update listener '" + listenerName))
+		Context("with invalid node name", func() {
+			BeforeEach(func() {
+				err := envoyInstance.Run()
+				Expect(err).NotTo(HaveOccurred())
+				_, grpcSrv, err := RunXDS(8081, badNodeSnapshot)
+				Expect(err).NotTo(HaveOccurred())
+				srv = grpcSrv
+			})
+			AfterEach(func() {
+				srv.Stop()
+			})
+			It("successfully bootstraps the envoy proxy", func() {
+				Eventually(envoyInstance.Logs, time.Second*30).Should(ContainSubstring("lds: add/update listener 'listener-for-invalid-envoy'"))
+			})
+			FIt("has a 500 route with body 'Invalid Envoy Bootstrap Configuration. Please refer to Gloo documentation https://gloo.solo.io/'", func() {
+				Eventually(func() error {
+					_, err := http.Get("http://"+envoyInstance.LocalAddr() + ":1234/")
+					return err
+				}).Should(Not(HaveOccurred()))
+				res, err := http.Get("http://"+envoyInstance.LocalAddr() + ":1234/")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(500))
+				Expect(res.Body).NotTo(BeNil())
+				b, err := ioutil.ReadAll(res.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(b)).To(Equal("Invalid Envoy Bootstrap Configuration. Please refer to Gloo documentation https://gloo.solo.io/"))
+			})
+		})
+		Context("with valid node name", func() {
+			BeforeEach(func() {
+				err := envoyInstance.RunWithId(nodeGroup + "~12345")
+				Expect(err).NotTo(HaveOccurred())
+				cache, grpcSrv, err := RunXDS(8081, badNodeSnapshot)
+				Expect(err).NotTo(HaveOccurred())
+				srv = grpcSrv
+				snapshot, err := createSnapshot(routeConfigName, listenerName)
+				Expect(err).NotTo(HaveOccurred())
+				cache.SetSnapshot(nodeGroup, snapshot)
+			})
+			AfterEach(func() {
+				srv.Stop()
+			})
+			It("successfully bootstraps the envoy proxy", func() {
+				Eventually(envoyInstance.Logs, time.Second*30).Should(ContainSubstring("lds: add/update listener '" + listenerName))
+			})
+			It("works with the test route", func() {
+				res, err := http.Get("http://"+envoyInstance.LocalAddr() + ":1234/")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(res.StatusCode).To(Equal(200))
+				Expect(res.Body).NotTo(BeNil())
+				b, err := ioutil.ReadAll(res.Body)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(string(b)).To(Equal("the route worked. yay."))
+			})
 		})
 	})
 })
@@ -48,8 +102,37 @@ func createSnapshot(routeConfigName, listenerName string) (cache.Snapshot, error
 	var (
 		endpoints []cache.Resource
 		clusters  []cache.Resource
-		routes    []cache.Resource
 	)
+	routes := []cache.Resource{
+		&envoyapi.RouteConfiguration{
+			Name: routeConfigName,
+			VirtualHosts: []envoyroute.VirtualHost{
+				{
+					Name:    "test-vhost",
+					Domains: []string{"*"},
+					Routes: []envoyroute.Route{
+						{
+							Match: envoyroute.RouteMatch{
+								PathSpecifier: &envoyroute.RouteMatch_Prefix{
+									Prefix: "/",
+								},
+							},
+							Action: &envoyroute.Route_DirectResponse{
+								DirectResponse: &envoyroute.DirectResponseAction{
+									Status: 200,
+									Body: &envoycore.DataSource{
+										Specifier: &envoycore.DataSource_InlineString{
+											InlineString: "the route worked. yay.",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 	adsSource := envoycore.ConfigSource{
 		ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
 			Ads: &envoycore.AggregatedConfigSource{},
@@ -70,7 +153,7 @@ func createSnapshot(routeConfigName, listenerName string) (cache.Snapshot, error
 		panic(err)
 	}
 
-	listener := &v2.Listener{
+	listener := &envoyapi.Listener{
 		Name: listenerName,
 		Address: envoycore.Address{
 			Address: &envoycore.Address_SocketAddress{
@@ -84,85 +167,20 @@ func createSnapshot(routeConfigName, listenerName string) (cache.Snapshot, error
 			},
 		},
 		FilterChains: []envoylistener.FilterChain{{
-			Filters: []envoylistener.Filter{{
-				Name:   "envoy.http_connection_manager",
-				Config: pbst,
-			}},
+			Filters: []envoylistener.Filter{
+				{
+					Name:   "envoy.http_connection_manager",
+					Config: pbst,
+				},
+				{
+					Name: "envoy.router",
+				},
+			},
 		}},
 	}
 
 	listeners := []cache.Resource{
 		listener,
 	}
-	return cache.NewSnapshot("foo", endpoints, clusters, routes, listeners), nil
-}
-
-// MakeBootstrap creates a bootstrap envoy configuration
-func makeBootstrap(ads bool, controlPort, adminPort uint32) *bootstrap.Bootstrap {
-	source := &envoycore.ApiConfigSource{
-		ApiType:      envoycore.ApiConfigSource_GRPC,
-		ClusterNames: []string{"xds_cluster"},
-	}
-
-	var dynamic *bootstrap.Bootstrap_DynamicResources
-	if ads {
-		dynamic = &bootstrap.Bootstrap_DynamicResources{
-			LdsConfig: &envoycore.ConfigSource{
-				ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{Ads: &envoycore.AggregatedConfigSource{}},
-			},
-			CdsConfig: &envoycore.ConfigSource{
-				ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{Ads: &envoycore.AggregatedConfigSource{}},
-			},
-			AdsConfig: source,
-		}
-	} else {
-		dynamic = &bootstrap.Bootstrap_DynamicResources{
-			LdsConfig: &envoycore.ConfigSource{
-				ConfigSourceSpecifier: &envoycore.ConfigSource_ApiConfigSource{ApiConfigSource: source},
-			},
-			CdsConfig: &envoycore.ConfigSource{
-				ConfigSourceSpecifier: &envoycore.ConfigSource_ApiConfigSource{ApiConfigSource: source},
-			},
-		}
-	}
-
-	return &bootstrap.Bootstrap{
-		Node: &envoycore.Node{
-			Id:      "test-id",
-			Cluster: "test-cluster",
-		},
-		Admin: bootstrap.Admin{
-			AccessLogPath: "/dev/null",
-			Address: envoycore.Address{
-				Address: &envoycore.Address_SocketAddress{
-					SocketAddress: &envoycore.SocketAddress{
-						Address: "127.0.0.1",
-						PortSpecifier: &envoycore.SocketAddress_PortValue{
-							PortValue: adminPort,
-						},
-					},
-				},
-			},
-		},
-		StaticResources: &bootstrap.Bootstrap_StaticResources{
-			Clusters: []v2.Cluster{{
-				Name:           "xds_cluster",
-				ConnectTimeout: 5 * time.Second,
-				Type:           v2.Cluster_STATIC,
-				Hosts: []*envoycore.Address{{
-					Address: &envoycore.Address_SocketAddress{
-						SocketAddress: &envoycore.SocketAddress{
-							Address: "127.0.0.1",
-							PortSpecifier: &envoycore.SocketAddress_PortValue{
-								PortValue: controlPort,
-							},
-						},
-					},
-				}},
-				LbPolicy:             v2.Cluster_ROUND_ROBIN,
-				Http2ProtocolOptions: &envoycore.Http2ProtocolOptions{},
-			}},
-		},
-		DynamicResources: dynamic,
-	}
+	return cache.NewSnapshot("1", endpoints, clusters, routes, listeners), nil
 }

--- a/pkg/api/types/v1/virtualmesh.pb.go
+++ b/pkg/api/types/v1/virtualmesh.pb.go
@@ -19,7 +19,7 @@ var _ = math.Inf
 // A Virtual Mesh is a container for a set of Virtual Services that will be used to generate a single proxy config
 // to be applied to one or more Envoy nodes. The Virtual Mesh is best understood as an in-mesh application's localized view
 // of the rest of the mesh.
-// Each domains for each Virtual Services contained in a Virtual Mesh cannot appear more than once, or the Virtual Mesh
+// Each domain for each Virtual Service contained in a Virtual Mesh cannot appear more than once, or the Virtual Mesh
 // will be invalid.
 type VirtualMesh struct {
 	// Name of the virtual mesh. Envoy nodes will be assigned a config corresponding with virtual mesh they are assigned.
@@ -31,7 +31,7 @@ type VirtualMesh struct {
 	// Names must be unique and follow the following syntax rules:
 	// One or more lowercase rfc1035/rfc1123 labels separated by '.' with a maximum length of 253 characters.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
-	// the list of names of the virtual services this vmesh includes.
+	// the list of names of the virtual services this vmesh encapsulates.
 	VirtualServices []string `protobuf:"bytes,2,rep,name=virtual_services,json=virtualServices" json:"virtual_services,omitempty"`
 	// Status indicates the validation status of the virtual mesh resource.
 	// Status is read-only by clients, and set by gloo during validation

--- a/test/helpers/config.go
+++ b/test/helpers/config.go
@@ -14,9 +14,14 @@ func NewTestConfig() *v1.Config {
 		NewTestVirtualService("my-vservice", NewTestRoute1(), NewTestRoute2()),
 		NewTestVirtualService("my-vservice-2", NewTestRoute1(), NewTestRoute2()),
 	}
+	virtualMeshes := []*v1.VirtualMesh{
+		NewTestVirtualMesh("my-mesh", "my-vservice"),
+		NewTestVirtualMesh("my-mesh-2", "my-vservice-2"),
+	}
 	return &v1.Config{
 		Upstreams:       upstreams,
 		VirtualServices: virtualServices,
+		VirtualMeshes:   virtualMeshes,
 	}
 }
 

--- a/test/helpers/local/envoy.go
+++ b/test/helpers/local/envoy.go
@@ -21,14 +21,14 @@ const (
 	containerName = "e2e_envoy"
 )
 
-func buildBootstrap(glooAddr string, xdsPort uint32) []byte {
-	return []byte(fmt.Sprintf(envoyConfigTemplate, glooAddr, xdsPort))
+func buildBootstrap(nodeId, glooAddr string, xdsPort uint32) []byte {
+	return []byte(fmt.Sprintf(envoyConfigTemplate, nodeId, glooAddr, xdsPort))
 }
 
 const envoyConfigTemplate = `
 node:
  cluster: ingress
- id: testnode
+ id: %s
 
 static_resources:
   clusters:
@@ -195,13 +195,16 @@ func (ei *EnvoyInstance) Run() error {
 }
 
 func (ei *EnvoyInstance) runWithPort(id string, port uint32) error {
-	err := ioutil.WriteFile(ei.envoycfgpath, buildBootstrap(ei.localAddr, port), 0644)
+	if id == "" {
+		id = "testingress"
+	}
+	err := ioutil.WriteFile(ei.envoycfgpath, buildBootstrap(id, ei.localAddr, port), 0644)
 	if err != nil {
 		return err
 	}
 
 	if ei.useDocker {
-		err := runContainer(ei.envoycfgpath, id)
+		err := runContainer(ei.envoycfgpath)
 		if err != nil {
 			return err
 		}
@@ -209,9 +212,6 @@ func (ei *EnvoyInstance) runWithPort(id string, port uint32) error {
 	}
 
 	args := []string{"-c", ei.envoycfgpath, "--v2-config-only"}
-	if id != "" {
-		args = append(args, "--service-node", id)
-	}
 
 	// run directly
 	cmd := exec.Command(ei.envoypath, args...)
@@ -255,7 +255,7 @@ func (ei *EnvoyInstance) Clean() error {
 	return nil
 }
 
-func runContainer(cfgpath, id string) error {
+func runContainer(cfgpath string) error {
 	envoyImageTag := os.Getenv("ENVOY_IMAGE_TAG")
 	if envoyImageTag == "" {
 		envoyImageTag = "latest"
@@ -270,9 +270,6 @@ func runContainer(cfgpath, id string) error {
 		image,
 		"/usr/local/bin/envoy", "--v2-config-only",
 		"-c", "/etc/config/" + filepath.Base(cfgpath),
-	}
-	if id != "" {
-		args = append(args, "--service-node", id)
 	}
 
 	fmt.Fprintln(ginkgo.GinkgoWriter, args)

--- a/test/helpers/local/envoy.go
+++ b/test/helpers/local/envoy.go
@@ -196,7 +196,7 @@ func (ei *EnvoyInstance) Run() error {
 
 func (ei *EnvoyInstance) runWithPort(id string, port uint32) error {
 	if id == "" {
-		id = "testingress"
+		id = "ingress~for-testing"
 	}
 	err := ioutil.WriteFile(ei.envoycfgpath, buildBootstrap(id, ei.localAddr, port), 0644)
 	if err != nil {

--- a/test/helpers/local/envoy.go
+++ b/test/helpers/local/envoy.go
@@ -186,26 +186,35 @@ func (ef *EnvoyFactory) NewEnvoyInstance() (*EnvoyInstance, error) {
 
 }
 
-func (ei *EnvoyInstance) Run() error {
-	return ei.RunWithPort(8081)
+func (ei *EnvoyInstance) RunWithId(id string) error {
+	return ei.runWithPort(id, 8081)
 }
 
-func (ei *EnvoyInstance) RunWithPort(port uint32) error {
+func (ei *EnvoyInstance) Run() error {
+	return ei.runWithPort("", 8081)
+}
+
+func (ei *EnvoyInstance) runWithPort(id string, port uint32) error {
 	err := ioutil.WriteFile(ei.envoycfgpath, buildBootstrap(ei.localAddr, port), 0644)
 	if err != nil {
 		return err
 	}
 
 	if ei.useDocker {
-		err := runContainer(ei.envoycfgpath, port)
+		err := runContainer(ei.envoycfgpath, id)
 		if err != nil {
 			return err
 		}
 		return nil
 	}
 
+	args := []string{"-c", ei.envoycfgpath, "--v2-config-only"}
+	if id != "" {
+		args = append(args, "--service-node", id)
+	}
+
 	// run directly
-	cmd := exec.Command(ei.envoypath, "-c", ei.envoycfgpath, "--v2-config-only")
+	cmd := exec.Command(ei.envoypath, args...)
 	cmd.Dir = ei.tmpdir
 	buf := &bytes.Buffer{}
 	ei.logs = buf
@@ -246,7 +255,7 @@ func (ei *EnvoyInstance) Clean() error {
 	return nil
 }
 
-func runContainer(cfgpath string, port uint32) error {
+func runContainer(cfgpath, id string) error {
 	envoyImageTag := os.Getenv("ENVOY_IMAGE_TAG")
 	if envoyImageTag == "" {
 		envoyImageTag = "latest"
@@ -262,6 +271,10 @@ func runContainer(cfgpath string, port uint32) error {
 		"/usr/local/bin/envoy", "--v2-config-only",
 		"-c", "/etc/config/" + filepath.Base(cfgpath),
 	}
+	if id != "" {
+		args = append(args, "--service-node", id)
+	}
+
 	fmt.Fprintln(ginkgo.GinkgoWriter, args)
 	cmd := exec.Command("docker", args...)
 	cmd.Dir = cfgDir

--- a/test/kube_e2e/kubernetes_e2e_test.go
+++ b/test/kube_e2e/kubernetes_e2e_test.go
@@ -152,6 +152,9 @@ func curl(opts curlOpts) (string, error) {
 }
 
 func setupMinikubeEnvVars() bool {
+	if os.Getenv("FORCE_PUSH") == "1" {
+		return false
+	}
 	// are we in minikube?
 	out, _ := exec.Command("kubectl", "config", "current-context").CombinedOutput()
 	if strings.Contains(string(out), "minikube") {

--- a/test/nomad_e2e/nomad_resources/install.nomad.tmpl
+++ b/test/nomad_e2e/nomad_resources/install.nomad.tmpl
@@ -91,7 +91,7 @@ job "gloo" {
         data = <<EOF
 node:
   cluster: ingress
-  id: {{"{{"}} env "NOMAD_ALLOC_ID" {{"}}"}}
+  id: ingress~{{"{{"}} env "NOMAD_ALLOC_ID" {{"}}"}}
 
 static_resources:
   clusters:

--- a/test/utilities/xdsclient/main.go
+++ b/test/utilities/xdsclient/main.go
@@ -17,7 +17,7 @@ var dr v2.DiscoveryRequest
 
 func init() {
 	dr.Node = new(envoy_api_v2_core1.Node)
-	dr.Node.Id = "oneid"
+	dr.Node.Id = "ingress~xdsclient"
 	dr.Node.Cluster = "ingress"
 }
 

--- a/test/utilities/xdsclient/main.go
+++ b/test/utilities/xdsclient/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"log"
 
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2"
@@ -17,14 +18,17 @@ var dr v2.DiscoveryRequest
 
 func init() {
 	dr.Node = new(envoy_api_v2_core1.Node)
-	dr.Node.Id = "ingress~xdsclient"
-	dr.Node.Cluster = "ingress"
 }
 
 func main() {
+	role := flag.String("r", "ingress~xdsclient", "role to register with")
+	flag.Parse()
+	dr.Node.Id = *role
+	dr.Node.Cluster = "my_cluster"
+
 	conn, err := grpc.Dial("localhost:8081", grpc.WithInsecure())
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("dial err: %v",err)
 	}
 	ctx := context.Background()
 	listClusters(ctx, conn)
@@ -59,7 +63,7 @@ func listClusters(ctx context.Context, conn *grpc.ClientConn) []v2.Cluster {
 	cdsc := v2.NewClusterDiscoveryServiceClient(conn)
 	dresp, err := cdsc.FetchClusters(ctx, &dr)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("clusters err: %v", err)
 	}
 	var clusters []v2.Cluster
 	for _, anyCluster := range dresp.Resources {
@@ -76,7 +80,7 @@ func listendpoints(ctx context.Context, conn *grpc.ClientConn) []v2.ClusterLoadA
 	eds := v2.NewEndpointDiscoveryServiceClient(conn)
 	dresp, err := eds.FetchEndpoints(ctx, &dr)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("endpoints err: %v",err)
 	}
 	var clas []v2.ClusterLoadAssignment
 
@@ -95,7 +99,7 @@ func listListeners(ctx context.Context, conn *grpc.ClientConn) []v2.Listener {
 	ldsc := v2.NewListenerDiscoveryServiceClient(conn)
 	dresp, err := ldsc.FetchListeners(ctx, &dr)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("listeners err: %v",err)
 	}
 	var listeners []v2.Listener
 
@@ -119,7 +123,7 @@ func listRoutes(ctx context.Context, conn *grpc.ClientConn, routenames []string)
 
 	dresp, err := ldsc.FetchRoutes(ctx, &drr)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatalf("routes err: %v",err)
 	}
 	var routes []v2.RouteConfiguration
 


### PR DESCRIPTION
snapshots are now set on a per-group basis. we only have one group currently which is `ingress`

groups are determined from the service node's prefix `<group>~<id>` where `~` is a required separator and currently `id` is ignored.

envoy nodes that register to gloo without providing this format will be given a "bad config snapshot" that will configure them to reply 500 to all requests