### PR TITLE
eventloop: gloo snapshots

### DIFF
--- a/.circleci/Dockerfile
+++ b/.circleci/Dockerfile
@@ -52,4 +52,7 @@ RUN go get -v github.com/golang/protobuf/...
 RUN mkdir -p ${GOPATH}/src/k8s.io && \
     git clone https://github.com/kubernetes/code-generator ${GOPATH}/src/k8s.io/code-generator
 
+RUN git clone https://github.com/kubernetes/apimachinery ${GOPATH}/src/k8s.io/apimachinery
+
+
 CMD ["/bin/bash"]

--- a/Makefile
+++ b/Makefile
@@ -145,13 +145,12 @@ hackrun: $(BINARY)
 	./hack/run-local.sh
 
 unit:
-	ginkgo -r -v pkg/ internal/
+	ginkgo -r pkg/ internal/
 
 e2e:
-	ginkgo -r -v test/
+	ginkgo -r test/
 
-test: e2e unit
-
+test: unit e2e
 
 
 

--- a/cmd/control-plane/main.go
+++ b/cmd/control-plane/main.go
@@ -38,9 +38,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "setting up event loop")
 		}
-		if err := eventLoop.Run(stop); err != nil {
-			return errors.Wrap(err, "failed running event loop")
-		}
+		eventLoop.Run(stop)
 		return nil
 	},
 }

--- a/internal/control-plane/configwatcher/config_watcher.go
+++ b/internal/control-plane/configwatcher/config_watcher.go
@@ -11,6 +11,7 @@ import (
 	"github.com/solo-io/gloo/pkg/api/types/v1"
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/storage"
+	"github.com/gogo/protobuf/proto"
 )
 
 type configWatcher struct {
@@ -63,7 +64,7 @@ func NewConfigWatcher(storageClient storage.Interface) (*configWatcher, error) {
 		log.GreyPrintf("change detected in upstream: %v", diff)
 
 		cache.Upstreams = updatedList
-		configs <- cache
+		configs <- proto.Clone(cache).(*v1.Config)
 	}
 	upstreamWatcher, err := storageClient.V1().Upstreams().Watch(&storage.UpstreamEventHandlerFuncs{
 		AddFunc:    syncUpstreams,
@@ -86,7 +87,7 @@ func NewConfigWatcher(storageClient storage.Interface) (*configWatcher, error) {
 		log.GreyPrintf("change detected in virtualservices: %v", diff)
 
 		cache.VirtualServices = updatedList
-		configs <- cache
+		configs <- proto.Clone(cache).(*v1.Config)
 	}
 	vServiceWatcher, err := storageClient.V1().VirtualServices().Watch(&storage.VirtualServiceEventHandlerFuncs{
 		AddFunc:    syncvServices,
@@ -110,7 +111,7 @@ func NewConfigWatcher(storageClient storage.Interface) (*configWatcher, error) {
 		log.GreyPrintf("change detected in virtualservices: %v", diff)
 
 		cache.Roles = updatedList
-		configs <- cache
+		configs <- proto.Clone(cache).(*v1.Config)
 	}
 	roleWatcher, err := storageClient.V1().Roles().Watch(&storage.RoleEventHandlerFuncs{
 		AddFunc:    syncroles,

--- a/internal/control-plane/endpointswatcher/endpoints_watcher_test.go
+++ b/internal/control-plane/endpointswatcher/endpoints_watcher_test.go
@@ -182,6 +182,7 @@ func createKubeResources() {
 	}
 	upstreams = append(upstreams, kubeUpstreams...)
 }
+
 func createConsulResources() {
 	cfg := api.DefaultConfig()
 

--- a/internal/control-plane/endpointswatcher/endpointswatcher_suite_test.go
+++ b/internal/control-plane/endpointswatcher/endpointswatcher_suite_test.go
@@ -31,11 +31,7 @@ func TestEndpointswatcher(t *testing.T) {
 
 }
 
-var opts = bootstrap.Options {
-	KubeOptions: bootstrap.KubeOptions{
-		KubeConfig: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
-	},
-}
+var opts bootstrap.Options
 
 // consul vars
 var (
@@ -61,6 +57,13 @@ var _ = BeforeSuite(func() {
 	namespace = helpers.RandString(8)
 	err = helpers.SetupKubeForTest(namespace)
 	helpers.Must(err)
+
+	opts = bootstrap.Options{
+		KubeOptions: bootstrap.KubeOptions{
+			Namespace:  namespace,
+			KubeConfig: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
+		},
+	}
 
 	cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 	Expect(err).NotTo(HaveOccurred())

--- a/internal/control-plane/snapshot/cache.go
+++ b/internal/control-plane/snapshot/cache.go
@@ -1,0 +1,64 @@
+package snapshot
+
+import (
+	"github.com/solo-io/gloo/pkg/secretwatcher"
+	"github.com/solo-io/gloo/internal/control-plane/filewatcher"
+	"github.com/solo-io/gloo/pkg/endpointdiscovery"
+	"github.com/mitchellh/hashstructure"
+	"github.com/solo-io/gloo/pkg/api/types/v1"
+	"github.com/gogo/protobuf/proto"
+)
+
+// Cache contains the latest Gloo snapshot
+type Cache struct {
+	Cfg       *v1.Config
+	Secrets   secretwatcher.SecretMap
+	Files     filewatcher.Files
+	Endpoints endpointdiscovery.EndpointGroups
+}
+
+func newCache() *Cache {
+	return &Cache{}
+}
+
+// ready doesn't necessarily tell us whetehr endpoints have been discovered yet
+// but that's okay. envoy won't mind
+func (c *Cache) Ready() bool {
+	return c.Cfg != nil
+}
+
+func (c *Cache) Hash() uint64 {
+	cfgForHashing := proto.Clone(c.Cfg).(*v1.Config)
+	for _, us := range cfgForHashing.Upstreams {
+		us.Status = nil
+		if us.Metadata != nil {
+			us.Metadata.ResourceVersion = ""
+		}
+		us.Metadata = nil
+	}
+	for _, vs := range cfgForHashing.VirtualServices {
+		vs.Status = nil
+		if vs.Metadata != nil {
+			vs.Metadata.ResourceVersion = ""
+		}
+		vs.Metadata = nil
+	}
+	h0, err := hashstructure.Hash(*cfgForHashing, nil)
+	if err != nil {
+		panic(err)
+	}
+	h1, err := hashstructure.Hash(c.Secrets, nil)
+	if err != nil {
+		panic(err)
+	}
+	h2, err := hashstructure.Hash(c.Endpoints, nil)
+	if err != nil {
+		panic(err)
+	}
+	h3, err := hashstructure.Hash(c.Files, nil)
+	if err != nil {
+		panic(err)
+	}
+	h := h0 + h1 + h2 + h3
+	return h
+}

--- a/internal/control-plane/snapshot/cache.go
+++ b/internal/control-plane/snapshot/cache.go
@@ -28,6 +28,9 @@ func (c *Cache) Ready() bool {
 }
 
 func (c *Cache) Hash() uint64 {
+	if !c.Ready() {
+		return 0
+	}
 	cfgForHashing := proto.Clone(c.Cfg).(*v1.Config)
 	for _, us := range cfgForHashing.Upstreams {
 		us.Status = nil

--- a/internal/control-plane/snapshot/cache_test.go
+++ b/internal/control-plane/snapshot/cache_test.go
@@ -1,0 +1,71 @@
+package snapshot
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/solo-io/gloo/test/helpers"
+	"github.com/solo-io/gloo/pkg/api/types/v1"
+)
+
+var _ = Describe("Cache", func() {
+	Describe("hash function", func() {
+		It("computes equal hashes for the same cache", func() {
+			c := newCache()
+			c.Cfg = helpers.NewTestConfig()
+			Expect(c.Hash()).To(Equal(c.Hash()))
+		})
+		It("computes equal hashes for the same cache", func() {
+			c := newCache()
+			c.Cfg = helpers.NewTestConfig()
+			h1 := c.Hash()
+			c.Cfg = helpers.NewTestConfig()
+			Expect(h1).To(Equal(c.Hash()))
+			c.Secrets = helpers.NewTestSecrets()
+			h1 = c.Hash()
+			c.Secrets = helpers.NewTestSecrets()
+			Expect(h1).To(Equal(c.Hash()))
+		})
+		It("computes equal hashes for the same cache", func() {
+			c := newCache()
+			c.Cfg = helpers.NewTestConfig()
+			h1 := c.Hash()
+			c.Cfg = helpers.NewTestConfig()
+			Expect(h1).To(Equal(c.Hash()))
+			c.Secrets = helpers.NewTestSecrets()
+			h1 = c.Hash()
+			c.Secrets = helpers.NewTestSecrets()
+			Expect(h1).To(Equal(c.Hash()))
+		})
+		It("ignores status on config objects", func() {
+			c := newCache()
+			c.Cfg = helpers.NewTestConfig()
+			h1 := c.Hash()
+			c.Cfg.Upstreams[0].Status = &v1.Status{
+				Reason: "idk",
+			}
+			c.Cfg.VirtualServices[0].Status = &v1.Status{
+				Reason: "idk",
+			}
+			Expect(h1).To(Equal(c.Hash()))
+		})
+		It("ignores resource version on config objects", func() {
+			c := newCache()
+			c.Cfg = helpers.NewTestConfig()
+			c.Cfg.Upstreams[0].Metadata = &v1.Metadata{
+				ResourceVersion: "1",
+			}
+			c.Cfg.VirtualServices[0].Metadata = &v1.Metadata{
+				ResourceVersion: "1",
+			}
+			h1 := c.Hash()
+			c.Cfg.Upstreams[0].Metadata = &v1.Metadata{
+				ResourceVersion: "2",
+			}
+			c.Cfg.VirtualServices[0].Metadata = &v1.Metadata{
+				ResourceVersion: "2",
+			}
+			Expect(h1).To(Equal(c.Hash()))
+		})
+	})
+})

--- a/internal/control-plane/snapshot/emitter.go
+++ b/internal/control-plane/snapshot/emitter.go
@@ -1,0 +1,118 @@
+package snapshot
+
+import (
+	"github.com/solo-io/gloo/internal/control-plane/configwatcher"
+	"github.com/solo-io/gloo/pkg/secretwatcher"
+	"github.com/solo-io/gloo/internal/control-plane/filewatcher"
+	"github.com/solo-io/gloo/pkg/endpointdiscovery"
+	"github.com/solo-io/gloo/pkg/log"
+	"github.com/solo-io/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/pkg/api/types/v1"
+	"github.com/pkg/errors"
+)
+
+// the snapshot emitter wraps various config sources
+// and emits a new snapshot when any element in the config updates
+type Emitter struct {
+	configWatcher    configwatcher.Interface
+	secretWatcher    secretwatcher.Interface
+	fileWatcher      filewatcher.Interface
+	endpointsWatcher endpointdiscovery.Interface
+
+	getDependencies func(cfg *v1.Config) []*plugins.Dependencies
+	snapshots       chan *Cache
+}
+
+func NewEmitter(configWatcher configwatcher.Interface,
+	secretWatcher secretwatcher.Interface,
+	fileWatcher filewatcher.Interface,
+	endpointsWatcher endpointdiscovery.Interface,
+	getDependencies func(cfg *v1.Config) []*plugins.Dependencies) *Emitter {
+
+	return &Emitter{
+		configWatcher:    configWatcher,
+		secretWatcher:    secretWatcher,
+		fileWatcher:      fileWatcher,
+		endpointsWatcher: endpointsWatcher,
+
+		getDependencies: getDependencies,
+		snapshots:       make(chan *Cache),
+	}
+}
+
+func (e *Emitter) Snapshot() <-chan *Cache {
+	return e.snapshots
+}
+
+func (e *Emitter) Run(stop <-chan struct{}) {
+	go e.configWatcher.Run(stop)
+	go e.fileWatcher.Run(stop)
+	go e.secretWatcher.Run(stop)
+	go e.endpointsWatcher.Run(stop)
+
+	latest := newCache()
+	for {
+		select {
+		case <-stop:
+			return
+		case cfg := <-e.configWatcher.Config():
+			log.Debugf("change triggered by config")
+			latest.Cfg = cfg
+			dependencies := e.getDependencies(cfg)
+			var secretRefs, fileRefs []string
+			for _, dep := range dependencies {
+				secretRefs = append(secretRefs, dep.SecretRefs...)
+				fileRefs = append(fileRefs, dep.FileRefs...)
+			}
+			// secrets for virtual services
+			for _, vService := range cfg.VirtualServices {
+				if vService.SslConfig != nil && vService.SslConfig.SecretRef != "" {
+					secretRefs = append(secretRefs, vService.SslConfig.SecretRef)
+				}
+			}
+			go e.secretWatcher.TrackSecrets(secretRefs)
+			go e.fileWatcher.TrackFiles(fileRefs)
+			go e.endpointsWatcher.TrackUpstreams(cfg.Upstreams)
+
+			e.snapshots <- latest
+		case secrets := <-e.secretWatcher.Secrets():
+			log.Debugf("change triggered by secrets")
+			latest.Secrets = secrets
+			e.snapshots <- latest
+		case files := <-e.fileWatcher.Files():
+			log.Debugf("change triggered by files")
+			latest.Files = files
+			e.snapshots <- latest
+		case endpoints := <-e.endpointsWatcher.Endpoints():
+			log.Debugf("change triggered by endpoints")
+			latest.Endpoints = endpoints
+			e.snapshots <- latest
+		}
+	}
+}
+
+// fan out to cover all channels that return errors
+func (e *Emitter) Error() <-chan error {
+	aggregatedErrorsChan := make(chan error)
+	go func() {
+		for err := range e.configWatcher.Error() {
+			aggregatedErrorsChan <- errors.Wrap(err, "config watcher encountered an error")
+		}
+	}()
+	go func() {
+		for err := range e.secretWatcher.Error() {
+			aggregatedErrorsChan <- errors.Wrap(err, "secret watcher encountered an error")
+		}
+	}()
+	go func() {
+		for err := range e.fileWatcher.Error() {
+			aggregatedErrorsChan <- errors.Wrap(err, "file watcher encountered an error")
+		}
+	}()
+	go func() {
+		for err := range e.endpointsWatcher.Error() {
+			aggregatedErrorsChan <- errors.Wrap(err, "endpoints watcher encountered an error")
+		}
+	}()
+	return aggregatedErrorsChan
+}

--- a/internal/control-plane/snapshot/emitter.go
+++ b/internal/control-plane/snapshot/emitter.go
@@ -58,12 +58,10 @@ func (e *Emitter) Run(stop <-chan struct{}) {
 		case <-stop:
 			return
 		case cfg := <-e.configWatcher.Config():
-			log.GreyPrintf("change triggered by config")
-
-			log.Printf("old hash %v", latest.Hash())
+			log.Printf("change triggered by config")
 			latest.Cfg = cfg
-			log.Printf("new hash %v", latest.Hash())
 
+			// update everything we're tracking
 			dependencies := e.getDependencies(cfg)
 			var secretRefs, fileRefs []string
 			for _, dep := range dependencies {

--- a/internal/control-plane/snapshot/emitter_test.go
+++ b/internal/control-plane/snapshot/emitter_test.go
@@ -4,6 +4,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	kubev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	. "github.com/solo-io/gloo/internal/control-plane/snapshot"
 	"github.com/solo-io/gloo/pkg/bootstrap/configstorage"
 	secretwatchersetup "github.com/solo-io/gloo/pkg/bootstrap/secretwatcher"
@@ -15,29 +17,426 @@ import (
 	"github.com/solo-io/gloo/pkg/plugins/kubernetes"
 	"github.com/solo-io/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/pkg/api/types/v1"
+	"path/filepath"
+	"os"
+	"github.com/solo-io/gloo/test/helpers"
+	"k8s.io/client-go/tools/clientcmd"
+	kube "k8s.io/client-go/kubernetes"
+	"github.com/gogo/protobuf/types"
+	"k8s.io/apimachinery/pkg/labels"
+	"time"
+	"log"
+	kubeupstreamdiscovery "github.com/solo-io/gloo/internal/upstream-discovery/kube"
+	"github.com/solo-io/gloo/pkg/secretwatcher"
+	"github.com/solo-io/gloo/pkg/storage"
+	"github.com/solo-io/gloo/pkg/endpointdiscovery"
 )
 
-var opts bootstrap.Options
+var (
+	store storage.Interface
+
+	namespace  string
+	kubeClient kube.Interface
+
+	storageOpts = bootstrap.StorageOptions{
+		Type: bootstrap.WatcherTypeKube,
+	}
+
+	opts bootstrap.Options
+)
 
 var _ = Describe("Emitter", func() {
 	Describe("Snapshot()", func() {
 		Context("using kubernetes for config, endpoints, secrets, and files", func() {
-			It("sends snapshots down the channel", func() {
-				store, err := configstorage.Bootstrap(opts)
-				Expect(err).NotTo(BeNil())
+			if os.Getenv("RUN_KUBE_TESTS") != "1" {
+				log.Printf("This test creates kubernetes resources and is disabled by default. To enable, set RUN_KUBE_TESTS=1 in your env.")
+				return
+			}
+			BeforeEach(func() {
+				namespace = helpers.RandString(8)
+				err := helpers.SetupKubeForTest(namespace)
+				helpers.Must(err)
+
+				opts = bootstrap.Options{
+					ConfigStorageOptions: storageOpts,
+					SecretStorageOptions: storageOpts,
+					FileStorageOptions:   storageOpts,
+					KubeOptions: bootstrap.KubeOptions{
+						Namespace:  namespace,
+						KubeConfig: filepath.Join(os.Getenv("HOME"), ".kube", "config"),
+					},
+				}
+
+				cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+				Expect(err).NotTo(HaveOccurred())
+
+				// add a pod and service pointing to it
+				kubeClient, err = kube.NewForConfig(cfg)
+				Expect(err).NotTo(HaveOccurred())
+
+				store, err = configstorage.Bootstrap(opts)
+				Expect(err).NotTo(HaveOccurred())
+
+				store.V1().VirtualServices().Create(&v1.VirtualService{
+					Name: "foo",
+				})
+
+				discovery, err := kubeupstreamdiscovery.NewUpstreamController(cfg, store, time.Minute)
+				Expect(err).NotTo(HaveOccurred())
+				go discovery.Run(make(chan struct{}))
+
+				createKubeResources()
+			})
+			AfterEach(func() {
+				helpers.TeardownKube(namespace)
+			})
+			FIt("sends snapshots down the channel", func() {
 				cfgWatcher, err := configwatcher.NewConfigWatcher(store)
-				Expect(err).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				secretWatcher, err := secretwatchersetup.Bootstrap(opts)
 				filestore, err := artifactstorage.Bootstrap(opts)
-				Expect(err).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				fileWatcher, err := filewatcher.NewFileWatcher(filestore)
-				Expect(err).NotTo(BeNil())
+				Expect(err).NotTo(HaveOccurred())
 				endpointsWatcher := endpointswatcher.NewEndpointsWatcher(opts, &kubernetes.Plugin{})
 				getDependencies := func(cfg *v1.Config) []*plugins.Dependencies {
-					return nil
+					return []*plugins.Dependencies{
+						{
+							SecretRefs: []string{"secret-name"},
+							FileRefs:   []string{"myfile:username"},
+						},
+					}
 				}
 				emitter := NewEmitter(cfgWatcher, secretWatcher, fileWatcher, endpointsWatcher, getDependencies)
+				go emitter.Run(make(chan struct{}))
+				var snap *Cache
+				Eventually(func() (*Cache, error) {
+					select {
+					case err := <-emitter.Error():
+						return nil, err
+					case snap = <-emitter.Snapshot():
+					case <-time.After(time.Second):
+					}
+					return snap, nil
+				}, time.Second*5, time.Millisecond*250).ShouldNot(BeNil())
+				files := snap.Files
+				Eventually(func() (filewatcher.Files, error) {
+					select {
+					case err := <-emitter.Error():
+						return nil, err
+					case snap = <-emitter.Snapshot():
+						files = snap.Files
+					case <-time.After(time.Second):
+					}
+					for _, f := range files {
+						f.ResourceVersion = ""
+					}
+					return files, nil
+				}, time.Second*5, time.Millisecond*250).Should(Equal(filewatcher.Files{
+					"myfile:username": {
+						Ref:      "myfile:username",
+						Contents: []byte("me@example.com"),
+					},
+				}))
+				secrets := snap.Secrets
+				Eventually(func() (secretwatcher.SecretMap, error) {
+					select {
+					case err := <-emitter.Error():
+						return nil, err
+					case snap = <-emitter.Snapshot():
+						secrets = snap.Secrets
+					case <-time.After(time.Second):
+					}
+					for _, s := range secrets {
+						s.ResourceVersion = ""
+					}
+					return secrets, nil
+				}, time.Second*5, time.Millisecond*250).Should(Equal(secretwatcher.SecretMap{
+					"secret-name": {
+						Ref: "secret-name",
+						Data: map[string]string{
+							"username": "me@example.com",
+							"password": "foobar",
+						},
+					},
+				}))
+				endpoints := snap.Endpoints
+				Eventually(func() (endpointdiscovery.EndpointGroups, error) {
+					select {
+					case err := <-emitter.Error():
+						return nil, err
+					case snap = <-emitter.Snapshot():
+						endpoints = snap.Endpoints
+					case <-time.After(time.Second):
+					}
+					for _, s := range secrets {
+						s.ResourceVersion = ""
+					}
+					return endpoints, nil
+				}, time.Second*5, time.Millisecond*250).Should(HaveLen(3))
+				Expect(endpoints[namespace+"-test-service-8080"]).To(HaveLen(2))
+				Expect(endpoints[namespace+"-test-service-with-labels-8080"]).To(HaveLen(2))
+				Expect(endpoints[namespace+"-test-service-8080"]).To(HaveLen(2))
+				cfg := snap.Cfg
+				Eventually(func() (*v1.Config, error) {
+					select {
+					case err := <-emitter.Error():
+						return nil, err
+					case snap = <-emitter.Snapshot():
+						cfg = snap.Cfg
+					case <-time.After(time.Second):
+					}
+					if cfg != nil {
+						for _, u := range cfg.Upstreams {
+							u.Metadata.ResourceVersion = ""
+						}
+						for _, v := range cfg.VirtualServices {
+							v.Metadata.ResourceVersion = ""
+						}
+					}
+					return cfg, nil
+				}, time.Second*5, time.Millisecond*250).Should(Equal(&v1.Config{
+					Upstreams: []*v1.Upstream{
+						{
+							Name:              namespace + "-test-service-8080",
+							Type:              "kubernetes",
+							ConnectionTimeout: 0,
+							Spec: &types.Struct{
+								Fields: map[string]*types.Value{
+									"service_name": {
+										Kind: &types.Value_StringValue{
+											StringValue: "test-service",
+										},
+									},
+									"service_namespace": {
+										Kind: &types.Value_StringValue{
+											StringValue: namespace,
+										},
+									},
+									"service_port": {
+										Kind: &types.Value_NumberValue{NumberValue: 8080},
+									},
+								},
+							},
+							Functions:   nil,
+							ServiceInfo: nil,
+							Status:      nil,
+							Metadata: &v1.Metadata{
+								Namespace: namespace,
+								Annotations: map[string]string{
+									"generated_by": "kubernetes-upstream-discovery",
+								},
+							},
+						},
+						{
+							Name:              namespace + "-test-service-with-labels-8080",
+							Type:              "kubernetes",
+							ConnectionTimeout: 0,
+							Spec: &types.Struct{
+								Fields: map[string]*types.Value{
+									"service_name": {
+										Kind: &types.Value_StringValue{
+											StringValue: "test-service-with-labels",
+										},
+									},
+									"service_namespace": {
+										Kind: &types.Value_StringValue{
+											StringValue: namespace,
+										},
+									},
+									"service_port": {
+										Kind: &types.Value_NumberValue{NumberValue: 8080},
+									},
+								},
+							},
+							Functions:   nil,
+							ServiceInfo: nil,
+							Status:      nil,
+							Metadata: &v1.Metadata{
+								Namespace: namespace,
+								Annotations: map[string]string{
+									"generated_by": "kubernetes-upstream-discovery",
+								},
+							},
+						},
+						{
+							Name:              namespace + "-test-service-with-port-8080",
+							Type:              "kubernetes",
+							ConnectionTimeout: 0,
+							Spec: &types.Struct{
+								Fields: map[string]*types.Value{
+									"service_name": {
+										Kind: &types.Value_StringValue{
+											StringValue: "test-service-with-port",
+										},
+									},
+									"service_namespace": {
+										Kind: &types.Value_StringValue{
+											StringValue: namespace,
+										},
+									},
+									"service_port": {
+										Kind: &types.Value_NumberValue{NumberValue: 8080},
+									},
+								},
+							},
+							Functions:   nil,
+							ServiceInfo: nil,
+							Status:      nil,
+							Metadata: &v1.Metadata{
+								Namespace: namespace,
+								Annotations: map[string]string{
+									"generated_by": "kubernetes-upstream-discovery",
+								},
+							},
+						},
+					},
+					VirtualServices: []*v1.VirtualService{
+						{
+							Name:      "foo",
+							Metadata: &v1.Metadata{
+								Namespace: namespace,
+							},
+						},
+					},
+				}))
 			})
 		})
 	})
 })
+
+func createKubeResources() {
+	specLabels := map[string]string{"version": "v1"}
+	singlePortServiceSpec := kubernetes.EncodeUpstreamSpec(kubernetes.UpstreamSpec{
+		ServiceName:      "test-service",
+		ServiceNamespace: namespace,
+	})
+	serviceWithSpecificPortSpec := kubernetes.EncodeUpstreamSpec(kubernetes.UpstreamSpec{
+		ServiceName:      "test-service-with-port",
+		ServiceNamespace: namespace,
+		ServicePort:      80,
+	})
+	serviceWithSpecificLabels := kubernetes.EncodeUpstreamSpec(kubernetes.UpstreamSpec{
+		ServiceName:      "test-service-with-labels",
+		ServiceNamespace: namespace,
+		ServicePort:      80,
+		Labels:           specLabels,
+	})
+	kubeUpstreams := []*v1.Upstream{
+		{
+			Name: "my_upstream_with_specific_port",
+			Type: kubernetes.UpstreamTypeKube,
+			Spec: serviceWithSpecificPortSpec,
+		},
+		{
+			Name: "my_upstream_with_one_port",
+			Type: kubernetes.UpstreamTypeKube,
+			Spec: singlePortServiceSpec,
+		},
+		{
+			Name: "my_upstream_with_specific_port_v1",
+			Type: kubernetes.UpstreamTypeKube,
+			Spec: serviceWithSpecificLabels,
+		},
+	}
+	for _, us := range kubeUpstreams {
+		serviceName := us.Spec.Fields["service_name"].Kind.(*types.Value_StringValue).StringValue
+		podLabels := map[string]string{"app": serviceName}
+		withoutLabels := &kubev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-for-" + serviceName,
+				Namespace: namespace,
+				Labels:    podLabels,
+			},
+			Spec: kubev1.PodSpec{
+				Containers: []kubev1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx:latest",
+					},
+				},
+			},
+		}
+		_, err := kubeClient.CoreV1().Pods(namespace).Create(withoutLabels)
+		Expect(err).NotTo(HaveOccurred())
+		withLabels := &kubev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-withlabels-for-" + serviceName,
+				Namespace: namespace,
+				Labels:    labels.Merge(podLabels, specLabels),
+			},
+			Spec: kubev1.PodSpec{
+				Containers: []kubev1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx:latest",
+					},
+				},
+			},
+		}
+		p, err := kubeClient.CoreV1().Pods(namespace).Create(withLabels)
+		Expect(err).NotTo(HaveOccurred())
+
+		// wait for pod to be running
+		podReady := make(chan struct{})
+		go func() {
+			for {
+				pod, err := kubeClient.CoreV1().Pods(namespace).Get(p.Name, metav1.GetOptions{})
+				if err != nil {
+					panic(err)
+				}
+				if pod.Status.Phase == kubev1.PodRunning {
+					close(podReady)
+					return
+				}
+				time.Sleep(time.Second)
+			}
+		}()
+
+		select {
+		case <-time.After(time.Minute):
+			Fail("timed out waiting for pod " + p.Name + " to start")
+		case <-podReady:
+		}
+
+		service := &kubev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+			},
+			Spec: kubev1.ServiceSpec{
+				Selector: podLabels,
+				Ports: []kubev1.ServicePort{
+					{
+						Name: "foo",
+						Port: 8080,
+					},
+				},
+			},
+		}
+		_, err = kubeClient.CoreV1().Services(namespace).Create(service)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	secret := &kubev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "secret-name",
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{"username": []byte("me@example.com"), "password": []byte("foobar")},
+	}
+
+	_, err := kubeClient.CoreV1().Secrets(namespace).Create(secret)
+	Expect(err).NotTo(HaveOccurred())
+
+	file := &kubev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "myfile",
+			Namespace: namespace,
+		},
+		Data: map[string]string{"username": "me@example.com"},
+	}
+
+	_, err = kubeClient.CoreV1().ConfigMaps(namespace).Create(file)
+	Expect(err).NotTo(HaveOccurred())
+}

--- a/internal/control-plane/snapshot/emitter_test.go
+++ b/internal/control-plane/snapshot/emitter_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Emitter", func() {
 			AfterEach(func() {
 				helpers.TeardownKube(namespace)
 			})
-			FIt("sends snapshots down the channel", func() {
+			It("sends snapshots down the channel", func() {
 				cfgWatcher, err := configwatcher.NewConfigWatcher(store)
 				Expect(err).NotTo(HaveOccurred())
 				secretWatcher, err := secretwatchersetup.Bootstrap(opts)

--- a/internal/control-plane/snapshot/emitter_test.go
+++ b/internal/control-plane/snapshot/emitter_test.go
@@ -1,0 +1,43 @@
+package snapshot_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/solo-io/gloo/internal/control-plane/snapshot"
+	"github.com/solo-io/gloo/pkg/bootstrap/configstorage"
+	secretwatchersetup "github.com/solo-io/gloo/pkg/bootstrap/secretwatcher"
+	"github.com/solo-io/gloo/pkg/bootstrap"
+	"github.com/solo-io/gloo/internal/control-plane/configwatcher"
+	"github.com/solo-io/gloo/pkg/bootstrap/artifactstorage"
+	"github.com/solo-io/gloo/internal/control-plane/filewatcher"
+	"github.com/solo-io/gloo/internal/control-plane/endpointswatcher"
+	"github.com/solo-io/gloo/pkg/plugins/kubernetes"
+	"github.com/solo-io/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/pkg/api/types/v1"
+)
+
+var opts bootstrap.Options
+
+var _ = Describe("Emitter", func() {
+	Describe("Snapshot()", func() {
+		Context("using kubernetes for config, endpoints, secrets, and files", func() {
+			It("sends snapshots down the channel", func() {
+				store, err := configstorage.Bootstrap(opts)
+				Expect(err).NotTo(BeNil())
+				cfgWatcher, err := configwatcher.NewConfigWatcher(store)
+				Expect(err).NotTo(BeNil())
+				secretWatcher, err := secretwatchersetup.Bootstrap(opts)
+				filestore, err := artifactstorage.Bootstrap(opts)
+				Expect(err).NotTo(BeNil())
+				fileWatcher, err := filewatcher.NewFileWatcher(filestore)
+				Expect(err).NotTo(BeNil())
+				endpointsWatcher := endpointswatcher.NewEndpointsWatcher(opts, &kubernetes.Plugin{})
+				getDependencies := func(cfg *v1.Config) []*plugins.Dependencies {
+					return nil
+				}
+				emitter := NewEmitter(cfgWatcher, secretWatcher, fileWatcher, endpointsWatcher, getDependencies)
+			})
+		})
+	})
+})

--- a/internal/control-plane/snapshot/snapshot_suite_test.go
+++ b/internal/control-plane/snapshot/snapshot_suite_test.go
@@ -1,0 +1,13 @@
+package snapshot_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSnapshot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Snapshot Suite")
+}

--- a/internal/control-plane/translator/translator.go
+++ b/internal/control-plane/translator/translator.go
@@ -30,6 +30,7 @@ import (
 	"github.com/solo-io/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/pkg/secretwatcher"
 	"github.com/solo-io/gloo/internal/control-plane/bootstrap"
+	"github.com/solo-io/gloo/internal/control-plane/snapshot"
 )
 
 const (
@@ -85,19 +86,12 @@ func NewTranslator(opts bootstrap.IngressOptions, translatorPlugins []plugins.Tr
 	}
 }
 
-type Inputs struct {
-	Cfg       *v1.Config
-	Secrets   secretwatcher.SecretMap
-	Files     filewatcher.Files
-	Endpoints endpointdiscovery.EndpointGroups
-}
-
 type pluginDependencies struct {
 	Secrets secretwatcher.SecretMap
 	Files   filewatcher.Files
 }
 
-func (t *Translator) Translate(inputs Inputs) (*envoycache.Snapshot, []reporter.ConfigObjectReport, error) {
+func (t *Translator) Translate(inputs *snapshot.Cache) (*envoycache.Snapshot, []reporter.ConfigObjectReport, error) {
 	cfg := inputs.Cfg
 	dependencies := &pluginDependencies{Secrets: inputs.Secrets, Files: inputs.Files}
 	secrets := inputs.Secrets

--- a/internal/control-plane/translator/translator_test.go
+++ b/internal/control-plane/translator/translator_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/solo-io/gloo/pkg/coreplugins/service"
 	"github.com/solo-io/gloo/pkg/storage/dependencies"
 	"github.com/solo-io/gloo/internal/control-plane/bootstrap"
+	"github.com/solo-io/gloo/internal/control-plane/snapshot"
 )
 
 func newTranslator() *Translator {
@@ -27,7 +28,7 @@ var _ = Describe("Translator", func() {
 		Context("domains are not unique amongst virtual services", func() {
 			cfg := InvalidConfigSharedDomains()
 			t := newTranslator()
-			snap, reports, err := t.Translate(Inputs{Cfg: cfg})
+			snap, reports, err := t.Translate(&snapshot.Cache{Cfg: cfg})
 			It("returns four reports, one for each upstream, one for each virtualservice", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(reports).To(HaveLen(3))
@@ -55,7 +56,7 @@ var _ = Describe("Translator", func() {
 		Context("one valid route, one invalid route", func() {
 			cfg := PartiallyValidConfig()
 			t := newTranslator()
-			snap, reports, err := t.Translate(Inputs{Cfg: cfg})
+			snap, reports, err := t.Translate(&snapshot.Cache{Cfg: cfg})
 			It("returns four reports, one for each upstream, one for each virtualservice", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(reports).To(HaveLen(4))
@@ -87,7 +88,7 @@ var _ = Describe("Translator", func() {
 			cfg := InvalidConfigNoUpstream()
 			t := newTranslator()
 			It("returns report for the error and no virtual services", func() {
-				snap, reports, err := t.Translate(Inputs{Cfg: cfg})
+				snap, reports, err := t.Translate(&snapshot.Cache{Cfg: cfg})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(reports).To(HaveLen(2))
 				Expect(reports[0].CfgObject).To(Equal(cfg.Upstreams[0]))
@@ -109,7 +110,7 @@ var _ = Describe("Translator", func() {
 			cfg := ValidConfigNoSsl()
 			t := newTranslator()
 			It("returns an empty ssl routeconfig and a len 1 nossl routeconfig", func() {
-				snap, reports, err := t.Translate(Inputs{Cfg: cfg})
+				snap, reports, err := t.Translate(&snapshot.Cache{Cfg: cfg})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(reports).To(HaveLen(2))
 				Expect(reports[0].CfgObject).To(Equal(cfg.Upstreams[0]))
@@ -131,7 +132,7 @@ var _ = Describe("Translator", func() {
 			t := newTranslator()
 			Context("the desired ssl secret not present in the secret map", func() {
 				It("returns an error for the not found secretref", func() {
-					_, reports, err := t.Translate(Inputs{Cfg: cfg})
+					_, reports, err := t.Translate(&snapshot.Cache{Cfg: cfg})
 					Expect(err).NotTo(HaveOccurred())
 					Expect(reports).To(HaveLen(2))
 					Expect(reports[0].CfgObject).To(Equal(cfg.Upstreams[0]))
@@ -143,7 +144,7 @@ var _ = Describe("Translator", func() {
 			})
 			Context("the desired ssl secret not present in the secret map", func() {
 				It("returns an empty ssl routeconfig and a len 1 nossl routeconfig", func() {
-					snap, reports, err := t.Translate(Inputs{
+					snap, reports, err := t.Translate(&snapshot.Cache{
 						Cfg: cfg,
 						Secrets: secretwatcher.SecretMap{
 							"ssl-secret-ref": &dependencies.Secret{Ref: "ssl-secret-ref", Data: map[string]string{

--- a/internal/upstream-discovery/kube/kube_upstream_controller.go
+++ b/internal/upstream-discovery/kube/kube_upstream_controller.go
@@ -125,6 +125,9 @@ func (c *UpstreamController) generateDesiredUpstreams() ([]*v1.Upstream, error) 
 			// annotate
 			annotations := map[string]string{}
 			for k, v := range svc.Annotations {
+				if k == "kubectl.kubernetes.io/last-applied-configuration" {
+					continue
+				}
 				annotations[k] = v
 			}
 			// copy annotations from the service = happy users

--- a/test/kube_e2e/containers/event-emitter/main.go
+++ b/test/kube_e2e/containers/event-emitter/main.go
@@ -40,7 +40,7 @@ func main() {
 			Time:    t,
 			Message: eventData,
 		}); err != nil {
-			log.Print("error emitting: %v", err)
+			log.Printf("error emitting: %v", err)
 		} else {
 			log.Printf("successful emit")
 		}

--- a/test/kube_e2e/containers/upstream-for-events/main.go
+++ b/test/kube_e2e/containers/upstream-for-events/main.go
@@ -19,17 +19,15 @@ func (h handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func logRequest(r *http.Request) {
-	log.Printf("Got request with headers: ")
-	for k, v := range r.Header {
-		log.Printf("%v: %v", k, v)
-	}
 	data, err := ioutil.ReadAll(r.Body)
 	if err != nil {
 		log.Printf("error reading body: %v", err)
 		return
 	}
 	defer r.Body.Close()
-	log.Printf("received event: %s", data)
+	if len(data) > 0 {
+		log.Printf("received event: %s", data)
+	}
 }
 
 func serve(port uint) {


### PR DESCRIPTION
isolate the logic that handles "gloo snapshots" (all of the inputs from the different watchers, hashing, caching, etc) from the core event loop.

change `translator.Inputs` -> `snapshot.Cache`

based on #79 