### PR TITLE
Support the use of the env-var KUBECONFIG

### DIFF
--- a/cmd/kube-ingress-controller/main.go
+++ b/cmd/kube-ingress-controller/main.go
@@ -8,14 +8,14 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 
-	"github.com/solo-io/gloo/pkg/kube-ingress-controller/ingress"
 	"github.com/solo-io/gloo/pkg/bootstrap"
 	"github.com/solo-io/gloo/pkg/bootstrap/configstorage"
 	"github.com/solo-io/gloo/pkg/bootstrap/flags"
+	"github.com/solo-io/gloo/pkg/kube-ingress-controller/ingress"
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/signals"
 	"github.com/solo-io/gloo/pkg/storage"
-	"github.com/solo-io/gloo/pkg/storage/crd"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 )
 
 func main() {
@@ -38,7 +38,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "failed to create config store client")
 		}
-		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := kubeutils.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to create kube restclient config")
 		}

--- a/cmd/kube-ingress-controller/main.go
+++ b/cmd/kube-ingress-controller/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/solo-io/gloo/pkg/kube-ingress-controller/ingress"
 	"github.com/solo-io/gloo/pkg/bootstrap"
@@ -16,6 +15,7 @@ import (
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/signals"
 	"github.com/solo-io/gloo/pkg/storage"
+	"github.com/solo-io/gloo/pkg/storage/crd"
 )
 
 func main() {
@@ -38,7 +38,7 @@ var rootCmd = &cobra.Command{
 		if err != nil {
 			return errors.Wrap(err, "failed to create config store client")
 		}
-		cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to create kube restclient config")
 		}

--- a/pkg/bootstrap/artifactstorage/bootstrap.go
+++ b/pkg/bootstrap/artifactstorage/bootstrap.go
@@ -6,11 +6,11 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/solo-io/gloo/pkg/bootstrap"
+	"github.com/solo-io/gloo/pkg/storage/crd"
 	"github.com/solo-io/gloo/pkg/storage/dependencies"
 	consulfiles "github.com/solo-io/gloo/pkg/storage/dependencies/consul"
 	filestorage "github.com/solo-io/gloo/pkg/storage/dependencies/file"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/kube"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func Bootstrap(opts bootstrap.Options) (dependencies.FileStorage, error) {
@@ -30,7 +30,7 @@ func Bootstrap(opts bootstrap.Options) (dependencies.FileStorage, error) {
 		}
 		return store, nil
 	case bootstrap.WatcherTypeKube:
-		cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "building kube restclient")
 		}

--- a/pkg/bootstrap/artifactstorage/bootstrap.go
+++ b/pkg/bootstrap/artifactstorage/bootstrap.go
@@ -6,11 +6,11 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/solo-io/gloo/pkg/bootstrap"
-	"github.com/solo-io/gloo/pkg/storage/crd"
 	"github.com/solo-io/gloo/pkg/storage/dependencies"
 	consulfiles "github.com/solo-io/gloo/pkg/storage/dependencies/consul"
 	filestorage "github.com/solo-io/gloo/pkg/storage/dependencies/file"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/kube"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 )
 
 func Bootstrap(opts bootstrap.Options) (dependencies.FileStorage, error) {
@@ -30,7 +30,7 @@ func Bootstrap(opts bootstrap.Options) (dependencies.FileStorage, error) {
 		}
 		return store, nil
 	case bootstrap.WatcherTypeKube:
-		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := kubeutils.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "building kube restclient")
 		}

--- a/pkg/bootstrap/configstorage/bootstrap.go
+++ b/pkg/bootstrap/configstorage/bootstrap.go
@@ -7,6 +7,7 @@ import (
 	"github.com/solo-io/gloo/pkg/storage/consul"
 	"github.com/solo-io/gloo/pkg/storage/crd"
 	"github.com/solo-io/gloo/pkg/storage/file"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 )
 
 func Bootstrap(opts bootstrap.Options) (storage.Interface, error) {
@@ -22,7 +23,7 @@ func Bootstrap(opts bootstrap.Options) (storage.Interface, error) {
 		}
 		return client, nil
 	case bootstrap.WatcherTypeKube:
-		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := kubeutils.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "building kube restclient")
 		}

--- a/pkg/bootstrap/configstorage/bootstrap.go
+++ b/pkg/bootstrap/configstorage/bootstrap.go
@@ -7,7 +7,6 @@ import (
 	"github.com/solo-io/gloo/pkg/storage/consul"
 	"github.com/solo-io/gloo/pkg/storage/crd"
 	"github.com/solo-io/gloo/pkg/storage/file"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func Bootstrap(opts bootstrap.Options) (storage.Interface, error) {
@@ -23,7 +22,7 @@ func Bootstrap(opts bootstrap.Options) (storage.Interface, error) {
 		}
 		return client, nil
 	case bootstrap.WatcherTypeKube:
-		cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "building kube restclient")
 		}

--- a/pkg/bootstrap/secretstorage/bootstrap.go
+++ b/pkg/bootstrap/secretstorage/bootstrap.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
 	"github.com/solo-io/gloo/pkg/bootstrap"
-	"github.com/solo-io/gloo/pkg/storage/crd"
 	"github.com/solo-io/gloo/pkg/storage/dependencies"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/file"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/kube"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/vault"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 )
 
 func Bootstrap(opts bootstrap.Options) (dependencies.SecretStorage, error) {
@@ -24,7 +24,7 @@ func Bootstrap(opts bootstrap.Options) (dependencies.SecretStorage, error) {
 		}
 		return file.NewSecretStorage(opts.FileOptions.SecretDir, opts.SecretStorageOptions.SyncFrequency)
 	case bootstrap.WatcherTypeKube:
-		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := kubeutils.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "building kube restclient")
 		}

--- a/pkg/bootstrap/secretstorage/bootstrap.go
+++ b/pkg/bootstrap/secretstorage/bootstrap.go
@@ -8,11 +8,11 @@ import (
 	"github.com/hashicorp/vault/api"
 	"github.com/pkg/errors"
 	"github.com/solo-io/gloo/pkg/bootstrap"
+	"github.com/solo-io/gloo/pkg/storage/crd"
 	"github.com/solo-io/gloo/pkg/storage/dependencies"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/file"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/kube"
 	"github.com/solo-io/gloo/pkg/storage/dependencies/vault"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func Bootstrap(opts bootstrap.Options) (dependencies.SecretStorage, error) {
@@ -24,7 +24,7 @@ func Bootstrap(opts bootstrap.Options) (dependencies.SecretStorage, error) {
 		}
 		return file.NewSecretStorage(opts.FileOptions.SecretDir, opts.SecretStorageOptions.SyncFrequency)
 	case bootstrap.WatcherTypeKube:
-		cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, errors.Wrap(err, "building kube restclient")
 		}

--- a/pkg/function-discovery/eventloop/event_loop.go
+++ b/pkg/function-discovery/eventloop/event_loop.go
@@ -7,6 +7,12 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/hashicorp/consul/api"
+	"github.com/solo-io/gloo/pkg/api/types/v1"
+	"github.com/solo-io/gloo/pkg/bootstrap"
+	"github.com/solo-io/gloo/pkg/bootstrap/artifactstorage"
+	"github.com/solo-io/gloo/pkg/bootstrap/configstorage"
+	"github.com/solo-io/gloo/pkg/bootstrap/secretstorage"
+	secretwatchersetup "github.com/solo-io/gloo/pkg/bootstrap/secretwatcher"
 	"github.com/solo-io/gloo/pkg/function-discovery/detector"
 	"github.com/solo-io/gloo/pkg/function-discovery/fission"
 	"github.com/solo-io/gloo/pkg/function-discovery/grpc"
@@ -18,15 +24,9 @@ import (
 	"github.com/solo-io/gloo/pkg/function-discovery/swagger"
 	"github.com/solo-io/gloo/pkg/function-discovery/updater"
 	"github.com/solo-io/gloo/pkg/function-discovery/upstreamwatcher"
-	"github.com/solo-io/gloo/pkg/api/types/v1"
-	"github.com/solo-io/gloo/pkg/bootstrap"
-	"github.com/solo-io/gloo/pkg/bootstrap/artifactstorage"
-	"github.com/solo-io/gloo/pkg/bootstrap/configstorage"
-	"github.com/solo-io/gloo/pkg/bootstrap/secretstorage"
-	secretwatchersetup "github.com/solo-io/gloo/pkg/bootstrap/secretwatcher"
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/secretwatcher"
-	"github.com/solo-io/gloo/pkg/storage/crd"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 )
 
 const (
@@ -183,7 +183,7 @@ func Run(opts bootstrap.Options, discoveryOpts options.DiscoveryOptions, stop <-
 
 func createResolver(opts bootstrap.Options) resolver.Resolver {
 	kube, err := func() (kubernetes.Interface, error) {
-		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := kubeutils.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/function-discovery/eventloop/event_loop.go
+++ b/pkg/function-discovery/eventloop/event_loop.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/hashicorp/consul/api"
 	"github.com/solo-io/gloo/pkg/function-discovery/detector"
@@ -27,6 +26,7 @@ import (
 	secretwatchersetup "github.com/solo-io/gloo/pkg/bootstrap/secretwatcher"
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/secretwatcher"
+	"github.com/solo-io/gloo/pkg/storage/crd"
 )
 
 const (
@@ -183,7 +183,7 @@ func Run(opts bootstrap.Options, discoveryOpts options.DiscoveryOptions, stop <-
 
 func createResolver(opts bootstrap.Options) resolver.Resolver {
 	kube, err := func() (kubernetes.Interface, error) {
-		cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/function-discovery/updater/fission/imported/client.go
+++ b/pkg/function-discovery/updater/fission/imported/client.go
@@ -24,7 +24,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/solo-io/gloo/pkg/storage/crd"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -59,7 +59,7 @@ func GetKubernetesClient() (*rest.Config, *kubernetes.Clientset, *apiextensionsc
 	// in-cluster service account
 	kubeConfig := os.Getenv("KUBECONFIG")
 	if len(kubeConfig) != 0 {
-		config, err = crd.GetConfig("", kubeConfig)
+		config, err = kubeutils.GetConfig("", kubeConfig)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/function-discovery/updater/fission/imported/client.go
+++ b/pkg/function-discovery/updater/fission/imported/client.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/solo-io/gloo/pkg/storage/crd"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -32,7 +33,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 type (
@@ -59,7 +59,7 @@ func GetKubernetesClient() (*rest.Config, *kubernetes.Clientset, *apiextensionsc
 	// in-cluster service account
 	kubeConfig := os.Getenv("KUBECONFIG")
 	if len(kubeConfig) != 0 {
-		config, err = clientcmd.BuildConfigFromFlags("", kubeConfig)
+		config, err = crd.GetConfig("", kubeConfig)
 		if err != nil {
 			return nil, nil, nil, err
 		}

--- a/pkg/plugins/kubernetes/kube_discovery.go
+++ b/pkg/plugins/kubernetes/kube_discovery.go
@@ -5,11 +5,11 @@ import (
 	"time"
 
 	"github.com/solo-io/gloo/pkg/endpointdiscovery"
-	"github.com/solo-io/gloo/pkg/storage/crd"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 )
 
 func NewEndpointDiscovery(masterUrl, kubeconfigPath string, resyncDuration time.Duration) (endpointdiscovery.Interface, error) {
-	cfg, err := crd.GetConfig(masterUrl, kubeconfigPath)
+	cfg, err := kubeutils.GetConfig(masterUrl, kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build rest config: %v", err)
 	}

--- a/pkg/plugins/kubernetes/kube_discovery.go
+++ b/pkg/plugins/kubernetes/kube_discovery.go
@@ -4,13 +4,12 @@ import (
 	"fmt"
 	"time"
 
-	"k8s.io/client-go/tools/clientcmd"
-
 	"github.com/solo-io/gloo/pkg/endpointdiscovery"
+	"github.com/solo-io/gloo/pkg/storage/crd"
 )
 
 func NewEndpointDiscovery(masterUrl, kubeconfigPath string, resyncDuration time.Duration) (endpointdiscovery.Interface, error) {
-	cfg, err := clientcmd.BuildConfigFromFlags(masterUrl, kubeconfigPath)
+	cfg, err := crd.GetConfig(masterUrl, kubeconfigPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build rest config: %v", err)
 	}

--- a/pkg/storage/crd/crd_storage_client.go
+++ b/pkg/storage/crd/crd_storage_client.go
@@ -2,7 +2,6 @@ package crd
 
 import (
 	"fmt"
-	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -12,8 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
-	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/storage"
@@ -24,34 +21,6 @@ import (
 //go:generate go run ${GOPATH}/src/github.com/solo-io/gloo/pkg/storage/generate/generate_clients.go -f ${GOPATH}/src/github.com/solo-io/gloo/pkg/storage/crd/client_template.go.tmpl -o ${GOPATH}/src/github.com/solo-io/gloo/pkg/storage/crd/
 type Client struct {
 	v1 *v1client
-}
-
-// GetConfig gets the kubernetes client config
-func GetConfig(masterURL, kubeconfigPath string) (*rest.Config, error) {
-
-	envVarName := clientcmd.RecommendedConfigPathEnvVar
-	if kubeconfigPath == "" && masterURL == "" && os.Getenv(envVarName) == "" {
-		// Neither kubeconfig nor master URL nor envVarName(KUBECONFIG) was specified. Using the inClusterConfig.
-		kubeconfig, err := rest.InClusterConfig()
-		if err == nil {
-			return kubeconfig, nil
-		}
-		// error creating inClusterConfig, falling back to default config
-	}
-
-	if kubeconfigPath != "" {
-		if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
-			// the specified kubeconfig does not exist so fallback to default
-			kubeconfigPath = ""
-		}
-	}
-
-	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
-	loadingRules.ExplicitPath = kubeconfigPath
-	configOverrides := &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}}
-
-	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
-
 }
 
 func NewStorage(cfg *rest.Config, namespace string, syncFrequency time.Duration) (storage.Interface, error) {

--- a/pkg/storage/crd/crd_storage_client.go
+++ b/pkg/storage/crd/crd_storage_client.go
@@ -2,6 +2,7 @@ package crd
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -11,6 +12,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/storage"
@@ -21,6 +24,34 @@ import (
 //go:generate go run ${GOPATH}/src/github.com/solo-io/gloo/pkg/storage/generate/generate_clients.go -f ${GOPATH}/src/github.com/solo-io/gloo/pkg/storage/crd/client_template.go.tmpl -o ${GOPATH}/src/github.com/solo-io/gloo/pkg/storage/crd/
 type Client struct {
 	v1 *v1client
+}
+
+// GetConfig gets the kubernetes client config
+func GetConfig(masterURL, kubeconfigPath string) (*rest.Config, error) {
+
+	envVarName := clientcmd.RecommendedConfigPathEnvVar
+	if kubeconfigPath == "" && masterURL == "" && os.Getenv(envVarName) == "" {
+		// Neither kubeconfig nor master URL nor envVarName(KUBECONFIG) was specified. Using the inClusterConfig.
+		kubeconfig, err := rest.InClusterConfig()
+		if err == nil {
+			return kubeconfig, nil
+		}
+		// error creating inClusterConfig, falling back to default config
+	}
+
+	if kubeconfigPath != "" {
+		if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+			// the specified kubeconfig does not exist so fallback to default
+			kubeconfigPath = ""
+		}
+	}
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfigPath
+	configOverrides := &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+
 }
 
 func NewStorage(cfg *rest.Config, namespace string, syncFrequency time.Duration) (storage.Interface, error) {

--- a/pkg/upstream-discovery/start.go
+++ b/pkg/upstream-discovery/start.go
@@ -6,18 +6,18 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/solo-io/gloo/pkg/plugins/cloudfoundry"
+	"github.com/solo-io/gloo/pkg/storage"
 	"github.com/solo-io/gloo/pkg/upstream-discovery/bootstrap"
 	"github.com/solo-io/gloo/pkg/upstream-discovery/consul"
 	"github.com/solo-io/gloo/pkg/upstream-discovery/copilot"
 	"github.com/solo-io/gloo/pkg/upstream-discovery/kube"
-	"github.com/solo-io/gloo/pkg/plugins/cloudfoundry"
-	"github.com/solo-io/gloo/pkg/storage"
-	"github.com/solo-io/gloo/pkg/storage/crd"
+	kubeutils "github.com/solo-io/gloo/pkg/utils/kube"
 )
 
 func Start(opts bootstrap.Options, store storage.Interface, stop <-chan struct{}) error {
 	if opts.UpstreamDiscoveryOptions.EnableDiscoveryForKubernetes {
-		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := kubeutils.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to create kube restclient config")
 		}

--- a/pkg/upstream-discovery/start.go
+++ b/pkg/upstream-discovery/start.go
@@ -12,12 +12,12 @@ import (
 	"github.com/solo-io/gloo/pkg/upstream-discovery/kube"
 	"github.com/solo-io/gloo/pkg/plugins/cloudfoundry"
 	"github.com/solo-io/gloo/pkg/storage"
-	"k8s.io/client-go/tools/clientcmd"
+	"github.com/solo-io/gloo/pkg/storage/crd"
 )
 
 func Start(opts bootstrap.Options, store storage.Interface, stop <-chan struct{}) error {
 	if opts.UpstreamDiscoveryOptions.EnableDiscoveryForKubernetes {
-		cfg, err := clientcmd.BuildConfigFromFlags(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
+		cfg, err := crd.GetConfig(opts.KubeOptions.MasterURL, opts.KubeOptions.KubeConfig)
 		if err != nil {
 			return errors.Wrap(err, "failed to create kube restclient config")
 		}

--- a/pkg/utils/kube/config.go
+++ b/pkg/utils/kube/config.go
@@ -1,0 +1,36 @@
+package kube
+
+import (
+	"os"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+// GetConfig gets the kubernetes client config
+func GetConfig(masterURL, kubeconfigPath string) (*rest.Config, error) {
+
+	envVarName := clientcmd.RecommendedConfigPathEnvVar
+	if kubeconfigPath == "" && masterURL == "" && os.Getenv(envVarName) == "" {
+		// Neither kubeconfig nor master URL nor envVarName(KUBECONFIG) was specified. Using the inClusterConfig.
+		kubeconfig, err := rest.InClusterConfig()
+		if err == nil {
+			return kubeconfig, nil
+		}
+		// error creating inClusterConfig, falling back to default config
+	}
+
+	if kubeconfigPath != "" {
+		if _, err := os.Stat(kubeconfigPath); os.IsNotExist(err) {
+			// the specified kubeconfig does not exist so fallback to default
+			kubeconfigPath = ""
+		}
+	}
+
+	loadingRules := clientcmd.NewDefaultClientConfigLoadingRules()
+	loadingRules.ExplicitPath = kubeconfigPath
+	configOverrides := &clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}}
+
+	return clientcmd.NewNonInteractiveDeferredLoadingClientConfig(loadingRules, configOverrides).ClientConfig()
+}

--- a/pkg/utils/kube/config_test.go
+++ b/pkg/utils/kube/config_test.go
@@ -1,0 +1,139 @@
+package kube
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/solo-io/gloo/test/helpers"
+)
+
+var _ = Describe("KubeConfigUtils", func() {
+	Describe("load kubeconfig", func() {
+		defaultHost := "https://1.2.3.4"
+		var (
+			configWithAll         string
+			configWithOnlyContext string
+		)
+		BeforeEach(func() {
+			configStr1 := `apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: ` + defaultHost + `
+  name: development
+contexts:
+- context:
+    cluster: development
+    namespace: frontend
+    user: developer
+  name: dev-frontend
+current-context: dev-frontend
+kind: Config
+preferences: {}
+users:
+- name: developer
+  user:
+    password: some-password
+    username: exp`
+			var err error
+			configWithAll, err = generateKubeConfig(configStr1)
+			Must(err)
+
+			configStr2 := `apiVersion: v1
+kind: Config
+preferences: {}
+contexts:
+- context:
+    cluster: development
+    namespace: ramp
+    user: developer
+  name: dev-ramp-up`
+			configWithOnlyContext, err = generateKubeConfig(configStr2)
+			Must(err)
+		})
+		AfterEach(func() {
+			os.RemoveAll(filepath.Dir(configWithAll))
+		})
+		Context("when a minimum kube config is set", func() {
+			It("should load the kube config", func() {
+				config, err := GetConfig("", configWithAll)
+				Must(err)
+				Expect(config.Host).To(Equal(defaultHost))
+			})
+		})
+		Context("when master url is set and the kube config does not contain a host url", func() {
+			It("should set the master url as the host", func() {
+				host := "https://9.9.9.9"
+				config, err := GetConfig(host, configWithOnlyContext)
+				Must(err)
+				Expect(config.Host).To(Equal(host))
+			})
+		})
+		Describe("from env var KUBECONFIG", func() {
+			var currentEnv string
+			BeforeEach(func() {
+				currentEnv = os.Getenv("KUBECONFIG")
+			})
+			AfterEach(func() {
+				os.Setenv("KUBECONFIG", currentEnv)
+			})
+			Context("when KUBECONFIG is set with a single path", func() {
+				It("should load the specified kube config", func() {
+					os.Setenv("KUBECONFIG", configWithAll)
+					config, err := GetConfig("", "")
+					Must(err)
+					Expect(config.Host).To(Equal(defaultHost))
+				})
+			})
+			Context("when KUBECONFIG is set with multiple paths (first one containing the host url)", func() {
+				It("should load the merged kube config without errors", func() {
+					os.Setenv("KUBECONFIG", configWithAll+":"+configWithOnlyContext)
+					config, err := GetConfig("", "")
+					Must(err)
+					Expect(config.Host).To(Equal(defaultHost))
+				})
+			})
+			Context("when KUBECONFIG is set with multiple paths (second one containing the host url)", func() {
+				It("should load the merged kube config without errors", func() {
+					os.Setenv("KUBECONFIG", configWithOnlyContext+":"+configWithAll)
+					config, err := GetConfig("", "")
+					Must(err)
+					Expect(config.Host).To(Equal(defaultHost))
+				})
+			})
+			Context("when KUBECONFIG is set with multiple paths (first one with invalid path)", func() {
+				It("should load the kube config without errors", func() {
+					os.Setenv("KUBECONFIG", "invalid:"+configWithAll)
+					config, err := GetConfig("", "")
+					Must(err)
+					Expect(config.Host).To(Equal(defaultHost))
+				})
+			})
+			Context("when KUBECONFIG is set with multiple paths (second one with invalid path)", func() {
+				It("should load the kube config without errors", func() {
+					os.Setenv("KUBECONFIG", configWithAll+":invalid")
+					config, err := GetConfig("", "")
+					Must(err)
+					Expect(config.Host).To(Equal(defaultHost))
+				})
+			})
+		})
+	})
+})
+
+func generateKubeConfig(configString string) (string, error) {
+	tempDir, err := ioutil.TempDir("/tmp/", ".kube")
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(tempDir, "config")
+
+	err = ioutil.WriteFile(path, []byte(configString), 0644)
+	if err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/pkg/utils/kube/kube_suite_test.go
+++ b/pkg/utils/kube/kube_suite_test.go
@@ -1,0 +1,13 @@
+package kube_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestKube(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kube Suite")
+}


### PR DESCRIPTION
This change respects the usage of the environment variable KUBECONFIG
when loading the kubeconfig. It also supports the default behavior of
setting multiple kubeconfig paths inside the KUBECONFIG variable.

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>

Related issue: https://github.com/solo-io/glooctl/issues/53

---

**This change hasn't been tested.**

I wanted to test what I have changed and also test this with `glooctl` but had no luck so far in building on my Mac. I wonder if this can be tested on a Mac in the first place (as documented, maybe this only works on Linux?).

I've tried following https://gloo.solo.io/dev/README/ but this didn't work either.

I'm more than happy to be able to contribute, but am stuck for now.