### PR TITLE
docs: fix broken link in introduction.md

### DIFF
--- a/docs/introduction/introduction.md
+++ b/docs/introduction/introduction.md
@@ -50,8 +50,8 @@ It is entirely possible to run Gloo as a traditional API gateway, without levera
 can be configured as a fully-featured<!--(TODO)--> API gateway, simply by using upstreams that don't support functions.
 
 
-However, we at [solo.io](solo.io) believe that function level routing will open the door to many new use cases and improve
-existing ones. <!--(TODO)-->
+However, we at [solo.io](https://solo.io) believe that function-level routing will open the door to
+many new use cases and improve existing ones. <!--(TODO)-->
 
 
 


### PR DESCRIPTION
Fix a broken link and a minor grammar mistake in `introduction.md`.