### PR TITLE
init-for-plugins

### DIFF
--- a/pkg/control-plane/endpointswatcher/endpoints_watcher.go
+++ b/pkg/control-plane/endpointswatcher/endpoints_watcher.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/solo-io/gloo/pkg/api/types/v1"
-	"github.com/solo-io/gloo/pkg/bootstrap"
 	"github.com/solo-io/gloo/pkg/endpointdiscovery"
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/plugins"
@@ -19,10 +18,10 @@ type endpointsAggregator struct {
 	errors               chan error
 }
 
-func NewEndpointsWatcher(opts bootstrap.Options, endpointDiscoveryPlugins ...plugins.EndpointDiscoveryPlugin) endpointdiscovery.Interface {
+func NewEndpointsWatcher(endpointDiscoveryPlugins ...plugins.EndpointDiscoveryPlugin) endpointdiscovery.Interface {
 	var endpointDiscoveries []endpointdiscovery.Interface
 	for _, edPlugin := range endpointDiscoveryPlugins {
-		discovery, err := edPlugin.SetupEndpointDiscovery(opts)
+		discovery, err := edPlugin.SetupEndpointDiscovery()
 		if err != nil {
 			log.Warnf("Starting endpoint discovery failed: %v, endpoints will not be discovered for this "+
 				"upstream type", err)

--- a/pkg/control-plane/endpointswatcher/endpoints_watcher_test.go
+++ b/pkg/control-plane/endpointswatcher/endpoints_watcher_test.go
@@ -22,7 +22,7 @@ import (
 var upstreams []*v1.Upstream
 
 var _ = Describe("EndpointsWatcher", func() {
-	eds := NewEndpointsWatcher(opts, &kubernetes.Plugin{}, &consul.Plugin{})
+	eds := NewEndpointsWatcher(&kubernetes.Plugin{}, &consul.Plugin{})
 	Context("running both consul eds and kubernetes eds", func() {
 		BeforeEach(func() {
 			createKubeResources()

--- a/pkg/control-plane/eventloop/eventloop.go
+++ b/pkg/control-plane/eventloop/eventloop.go
@@ -146,9 +146,11 @@ func getDependenciesFor(translatorPlugins []plugins.TranslatorPlugin) func(cfg *
 		var dependencies []*plugins.Dependencies
 		// secrets plugins need
 		for _, plug := range translatorPlugins {
-			dep := plug.GetDependencies(cfg)
-			if dep != nil {
-				dependencies = append(dependencies, dep)
+			if dependentPlugin, ok := plug.(plugins.PluginWithDependencies); ok {
+				dep := dependentPlugin.GetDependencies(cfg)
+				if dep != nil {
+					dependencies = append(dependencies, dep)
+				}
 			}
 		}
 		return dependencies

--- a/pkg/control-plane/eventloop/eventloop.go
+++ b/pkg/control-plane/eventloop/eventloop.go
@@ -103,7 +103,7 @@ func SetupWithConfig(cfg Config) (EventLoop, error) {
 		}
 	}
 
-	endpointsWatcher := endpointswatcher.NewEndpointsWatcher(cfg.Options.Options, edPlugins...)
+	endpointsWatcher := endpointswatcher.NewEndpointsWatcher(edPlugins...)
 
 	snapshotEmitter := snapshot.NewEmitter(
 		cfgWatcher,

--- a/pkg/control-plane/snapshot/emitter_test.go
+++ b/pkg/control-plane/snapshot/emitter_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Emitter", func() {
 				Expect(err).NotTo(HaveOccurred())
 				fileWatcher, err := filewatcher.NewFileWatcher(filestore)
 				Expect(err).NotTo(HaveOccurred())
-				endpointsWatcher := endpointswatcher.NewEndpointsWatcher(opts, &kubernetes.Plugin{})
+				endpointsWatcher := endpointswatcher.NewEndpointsWatcher(&kubernetes.Plugin{})
 				getDependencies := func(cfg *v1.Config) []*plugins.Dependencies {
 					return []*plugins.Dependencies{
 						{

--- a/pkg/control-plane/translator/function_processor_plugin.go
+++ b/pkg/control-plane/translator/function_processor_plugin.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/solo-io/gloo/pkg/api/types/v1"
 	"github.com/solo-io/gloo/pkg/plugins"
@@ -24,7 +25,7 @@ func newFunctionalPluginProcessor(functionPlugins []plugins.FunctionPlugin) *fun
 	return &functionalPluginProcessor{functionPlugins: functionPlugins}
 }
 
-func (p *functionalPluginProcessor) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *functionalPluginProcessor) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/control-plane/translator/route_init_plugin.go
+++ b/pkg/control-plane/translator/route_init_plugin.go
@@ -4,6 +4,7 @@ import (
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/solo-io/gloo/pkg/api/types/v1"
 	"github.com/solo-io/gloo/pkg/plugins"
@@ -23,7 +24,7 @@ func newRouteInitializerPlugin() *routeInitializerPlugin {
 	return &routeInitializerPlugin{}
 }
 
-func (p *routeInitializerPlugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *routeInitializerPlugin) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/control-plane/translator/translator.go
+++ b/pkg/control-plane/translator/translator.go
@@ -216,7 +216,11 @@ func generateXDSSnapshot(clusters []*envoyapi.Cluster,
 // utility functions
 
 func dependenciesForPlugin(inputs *snapshot.Cache, plug plugins.TranslatorPlugin) (secretwatcher.SecretMap, filewatcher.Files) {
-	dependencyRefs := plug.GetDependencies(inputs.Cfg)
+	dependentPlugin, ok := plug.(plugins.PluginWithDependencies)
+	if !ok {
+		return nil, nil
+	}
+	dependencyRefs := dependentPlugin.GetDependencies(inputs.Cfg)
 	if dependencyRefs == nil {
 		return nil, nil
 	}

--- a/pkg/coreplugins/matcher/plugin.go
+++ b/pkg/coreplugins/matcher/plugin.go
@@ -2,6 +2,7 @@ package matcher
 
 import (
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"strings"
 
@@ -18,7 +19,7 @@ const (
 
 type Plugin struct{}
 
-func (p *Plugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/coreplugins/routing/plugin.go
+++ b/pkg/coreplugins/routing/plugin.go
@@ -6,6 +6,7 @@ import (
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/solo-io/gloo/pkg/api/types/v1"
@@ -28,7 +29,7 @@ type Plugin struct {
 	corsFilterNeeded bool
 }
 
-func (p *Plugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/coreplugins/static/plugin.go
+++ b/pkg/coreplugins/static/plugin.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/solo-io/gloo/pkg/api/types/v1"
 	"github.com/solo-io/gloo/pkg/plugins"
@@ -33,7 +34,7 @@ const (
 	UpstreamTypeStatic = "static"
 )
 
-func (p *Plugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/plugins/aws/plugin.go
+++ b/pkg/plugins/aws/plugin.go
@@ -8,6 +8,7 @@ import (
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/hashicorp/go-multierror"
@@ -49,6 +50,10 @@ const (
 )
 
 //go:generate protoc -I=./ -I=${GOPATH}/src/github.com/gogo/protobuf/ -I=${GOPATH}/src/github.com/gogo/protobuf/protobuf/ --gogo_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types:${GOPATH}/src spec.proto
+
+func (p *Plugin) Init(options bootstrap.Options) error{
+	return nil
+}
 
 func (p *Plugin) GetDependencies(cfg *v1.Config) *plugins.Dependencies {
 	deps := new(plugins.Dependencies)

--- a/pkg/plugins/azure/plugin.go
+++ b/pkg/plugins/azure/plugin.go
@@ -8,6 +8,7 @@ import (
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -44,6 +45,10 @@ const (
 	// function-specific metadata
 	azureFunctionPath = "path"
 )
+
+func (p *Plugin) Init(options bootstrap.Options) error{
+	return nil
+}
 
 func (p *Plugin) GetDependencies(cfg *v1.Config) *plugins.Dependencies {
 	deps := new(plugins.Dependencies)

--- a/pkg/plugins/cloudfoundry/plugin.go
+++ b/pkg/plugins/cloudfoundry/plugin.go
@@ -21,14 +21,16 @@ func init() {
 
 var _ plugins.UpstreamPlugin = &Plugin{}
 
-type Plugin struct{}
+type Plugin struct{
+	opts bootstrap.Options
+}
 
-func (p *Plugin) SetupEndpointDiscovery(opts bootstrap.Options) (endpointdiscovery.Interface, error) {
-	istioclient, err := GetClientFromOptions(opts.CoPilotOptions)
+func (p *Plugin) SetupEndpointDiscovery() (endpointdiscovery.Interface, error) {
+	istioclient, err := GetClientFromOptions(p.opts.CoPilotOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create copilot client")
 	}
-	resyncDuration := opts.ConfigStorageOptions.SyncFrequency
+	resyncDuration := p.opts.ConfigStorageOptions.SyncFrequency
 	disc := NewEndpointDiscovery(context.Background(), istioclient, resyncDuration)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start copilot endpoint discovery")
@@ -36,7 +38,8 @@ func (p *Plugin) SetupEndpointDiscovery(opts bootstrap.Options) (endpointdiscove
 	return disc, nil
 }
 
-func (p *Plugin) GetDependencies(cfg *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
+	p.opts = options
 	return nil
 }
 

--- a/pkg/plugins/connect/plugin.go
+++ b/pkg/plugins/connect/plugin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
 	"github.com/solo-io/gloo/pkg/api/types/v1"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 	"github.com/solo-io/gloo/pkg/log"
 	"github.com/solo-io/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/pkg/plugins/consul"
@@ -44,7 +45,7 @@ type Plugin struct {
 	clustersToGenerate []*envoyapi.Cluster
 }
 
-func (p *Plugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/plugins/consul/plugin.go
+++ b/pkg/plugins/consul/plugin.go
@@ -38,6 +38,10 @@ const (
 	UpstreamTypeConsul = "consul"
 )
 
+func (p *Plugin) Init(options bootstrap.Options) error{
+	return nil
+}
+
 func (p *Plugin) GetDependencies(cfg *v1.Config) *plugins.Dependencies {
 	deps := new(plugins.Dependencies)
 	for _, us := range cfg.Upstreams {

--- a/pkg/plugins/consul/plugin.go
+++ b/pkg/plugins/consul/plugin.go
@@ -22,8 +22,8 @@ func init() {
 
 //go:generate protoc -I=./ -I=${GOPATH}/src/github.com/gogo/protobuf/ -I=${GOPATH}/src/github.com/gogo/protobuf/protobuf/ --gogo_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types:${GOPATH}/src spec.proto
 
-func (p *Plugin) SetupEndpointDiscovery(opts bootstrap.Options) (endpointdiscovery.Interface, error) {
-	cfg := opts.ConsulOptions.ToConsulConfig()
+func (p *Plugin) SetupEndpointDiscovery() (endpointdiscovery.Interface, error) {
+	cfg := p.opts.ConsulOptions.ToConsulConfig()
 	disc, err := NewEndpointController(cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start consul endpoint discovery")
@@ -31,7 +31,9 @@ func (p *Plugin) SetupEndpointDiscovery(opts bootstrap.Options) (endpointdiscove
 	return disc, err
 }
 
-type Plugin struct{}
+type Plugin struct{
+	opts bootstrap.Options
+}
 
 const (
 	// define Upstream type name
@@ -39,6 +41,7 @@ const (
 )
 
 func (p *Plugin) Init(options bootstrap.Options) error{
+	p.opts = options
 	return nil
 }
 

--- a/pkg/plugins/fake/plugin.go
+++ b/pkg/plugins/fake/plugin.go
@@ -14,7 +14,7 @@ func init() {
 	plugins.Register(&Plugin{})
 }
 
-func (p *Plugin) SetupEndpointDiscovery(opts bootstrap.Options) (endpointdiscovery.Interface, error) {
+func (p *Plugin) SetupEndpointDiscovery() (endpointdiscovery.Interface, error) {
 	return &FakeEndpointDiscovery, nil
 }
 

--- a/pkg/plugins/fake/plugin.go
+++ b/pkg/plugins/fake/plugin.go
@@ -25,6 +25,10 @@ const (
 	UpstreamTypeFake = "fake"
 )
 
+func (p *Plugin) Init(options bootstrap.Options) error{
+	return nil
+}
+
 func (p *Plugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
 	return nil
 }

--- a/pkg/plugins/google/plugin.go
+++ b/pkg/plugins/google/plugin.go
@@ -8,6 +8,7 @@ import (
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/pkg/errors"
@@ -42,8 +43,7 @@ const (
 	functionPath = "path"
 )
 
-func (p *Plugin) GetDependencies(cfg *v1.Config) *plugins.Dependencies {
-
+func (p *Plugin) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/plugins/grpc/plugin.go
+++ b/pkg/plugins/grpc/plugin.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gogo/googleapis/google/api"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/protoc-gen-gogo/descriptor"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/gogo/protobuf/types"
@@ -54,6 +55,10 @@ const (
 
 	ServiceTypeGRPC = "gRPC"
 )
+
+func (p *Plugin) Init(options bootstrap.Options) error{
+	return nil
+}
 
 func (p *Plugin) GetDependencies(cfg *v1.Config) *plugins.Dependencies {
 	deps := &plugins.Dependencies{}

--- a/pkg/plugins/interface.go
+++ b/pkg/plugins/interface.go
@@ -33,6 +33,11 @@ type Dependencies struct {
 }
 
 type TranslatorPlugin interface {
+	Init(options bootstrap.Options) error
+}
+
+type PluginWithDependencies interface {
+	TranslatorPlugin
 	GetDependencies(cfg *v1.Config) *Dependencies
 }
 
@@ -50,7 +55,7 @@ type UpstreamPlugin interface {
 
 type EndpointDiscoveryPlugin interface {
 	UpstreamPlugin
-	SetupEndpointDiscovery(options bootstrap.Options) (endpointdiscovery.Interface, error)
+	SetupEndpointDiscovery() (endpointdiscovery.Interface, error)
 }
 
 // Params for ParseFunctionSpec()

--- a/pkg/plugins/kubernetes/plugin.go
+++ b/pkg/plugins/kubernetes/plugin.go
@@ -28,14 +28,17 @@ func (p *Plugin) SetupEndpointDiscovery(opts bootstrap.Options) (endpointdiscove
 	return disc, err
 }
 
-type Plugin struct{}
+type Plugin struct{
+	opts bootstrap.Options
+}
 
 const (
 	// define Upstream type name
 	UpstreamTypeKube = "kubernetes"
 )
 
-func (p *Plugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
+	p.opts = options
 	return nil
 }
 

--- a/pkg/plugins/kubernetes/plugin.go
+++ b/pkg/plugins/kubernetes/plugin.go
@@ -17,10 +17,10 @@ func init() {
 
 //go:generate protoc -I=./ -I=${GOPATH}/src/github.com/gogo/protobuf/ -I=${GOPATH}/src/github.com/gogo/protobuf/protobuf/ --gogo_out=Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types:${GOPATH}/src spec.proto
 
-func (p *Plugin) SetupEndpointDiscovery(opts bootstrap.Options) (endpointdiscovery.Interface, error) {
-	kubeConfig := opts.KubeOptions.KubeConfig
-	masterUrl := opts.KubeOptions.MasterURL
-	resyncDuration := opts.ConfigStorageOptions.SyncFrequency
+func (p *Plugin) SetupEndpointDiscovery() (endpointdiscovery.Interface, error) {
+	kubeConfig := p.opts.KubeOptions.KubeConfig
+	masterUrl := p.opts.KubeOptions.MasterURL
+	resyncDuration := p.opts.ConfigStorageOptions.SyncFrequency
 	disc, err := NewEndpointDiscovery(masterUrl, kubeConfig, resyncDuration)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to start Kubernetes endpoint discovery")

--- a/pkg/plugins/nats/plugin.go
+++ b/pkg/plugins/nats/plugin.go
@@ -4,6 +4,7 @@ import (
 	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/solo-io/gloo/pkg/protoutil"
@@ -55,7 +56,7 @@ func EncodeServiceProperties(props ServiceProperties) *types.Struct {
 	return s
 }
 
-func (p *Plugin) GetDependencies(cfg *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
 	return nil
 }
 

--- a/pkg/plugins/rest/plugin.go
+++ b/pkg/plugins/rest/plugin.go
@@ -3,6 +3,7 @@ package rest
 import (
 	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/solo-io/gloo/pkg/bootstrap"
 
 	"github.com/pkg/errors"
 
@@ -30,7 +31,7 @@ type Plugin struct {
 	transformation transformation.Plugin
 }
 
-func (p *Plugin) GetDependencies(_ *v1.Config) *plugins.Dependencies {
+func (p *Plugin) Init(options bootstrap.Options) error{
 	return nil
 }
 


### PR DESCRIPTION
change the plugin interface to use Init() instead of GetDependencies
this allows us to not pass Opts to the endpoitndiscovery method