### PR TITLE
Update "Refactoring monolith" tutorial

### DIFF
--- a/docs/tutorials/refactor_monolith.md
+++ b/docs/tutorials/refactor_monolith.md
@@ -23,7 +23,7 @@ this readme (usually this is `cd $GOPATH/src/github.com/solo-io/gloo/example/dem
 ## Install Kubernetes
 
 ```shell
-minikube start --extra-config=apiserver.Authorization.Mode=RBAC --cpus 4 --memory 4096
+minikube start --extra-config=apiserver.authorization-mode=RBAC --cpus 4 --memory 4096
 kubectl create clusterrolebinding permissive-binding \
          --clusterrole=cluster-admin \
          --user=admin \


### PR DESCRIPTION
Fix instructions to start minikube with RBAC. The currently used option name causes `minikube start` to time out. See [here](https://github.com/kubernetes/website/commit/cb8aae1b0dbeb6a75e7f735dceb4e762232ffa45/) for more info.