### PR TITLE
any GetMessage error handling

### DIFF
--- a/pkg/utils/proto/any.go
+++ b/pkg/utils/proto/any.go
@@ -7,12 +7,14 @@ import (
 	"github.com/gogo/protobuf/types"
 )
 
+var NotFoundError = fmt.Errorf("message not found")
+
 func GetMessage(protos map[string]*types.Any, name string) (proto.Message, error) {
 	if any, ok := protos[name]; ok {
 		return getProto(any)
 	}
 
-	return nil, fmt.Errorf("message not found")
+	return nil, NotFoundError
 }
 
 func getProto(p *types.Any) (proto.Message, error) {

--- a/pkg/utils/proto/any.go
+++ b/pkg/utils/proto/any.go
@@ -9,19 +9,17 @@ import (
 
 var NotFoundError = fmt.Errorf("message not found")
 
-func GetMessage(protos map[string]*types.Any, name string) (proto.Message, error) {
+func UnmarshalAnyFromMap(protos map[string]*types.Any, name string, outproto proto.Message) error {
 	if any, ok := protos[name]; ok {
-		return getProto(any)
+		return getProto(any, outproto)
 	}
-
-	return nil, NotFoundError
+	return NotFoundError
 }
 
-func getProto(p *types.Any) (proto.Message, error) {
-	var x types.DynamicAny
-	err := types.UnmarshalAny(p, &x)
+func getProto(p *types.Any, outproto proto.Message) error {
+	err := types.UnmarshalAny(p, outproto)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	return x.Message, nil
+	return nil
 }

--- a/pkg/utils/proto/any_test.go
+++ b/pkg/utils/proto/any_test.go
@@ -24,17 +24,18 @@ var _ = Describe("Any", func() {
 			"duration": anyduration,
 		}
 
-		m, err := GetMessage(protos, "duration")
+		var outm types.Duration
+		err = UnmarshalAnyFromMap(protos, "duration", &outm)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(m).NotTo(BeNil())
-		Expect(*m.(*types.Duration)).To(Equal(duration))
+		Expect(outm).To(Equal(duration))
 	})
 
 	It("should error if no name found with expected error", func() {
 
 		protos := map[string]*types.Any{}
-		_, err := GetMessage(protos, "duration")
+		var outm types.Duration
+		err := UnmarshalAnyFromMap(protos, "duration", &outm)
 		Expect(err).To(HaveOccurred())
 		Expect(err).To(Equal(NotFoundError))
 	})
@@ -47,7 +48,8 @@ var _ = Describe("Any", func() {
 		protos := map[string]*types.Any{
 			"duration": anyduration,
 		}
-		_, err = GetMessage(protos, "duration")
+		var outm types.Duration
+		err = UnmarshalAnyFromMap(protos, "duration", &outm)
 		Expect(err).To(HaveOccurred())
 		Expect(err).NotTo(Equal(NotFoundError))
 	})

--- a/pkg/utils/proto/any_test.go
+++ b/pkg/utils/proto/any_test.go
@@ -31,11 +31,25 @@ var _ = Describe("Any", func() {
 		Expect(*m.(*types.Duration)).To(Equal(duration))
 	})
 
-	It("should error if no name found", func() {
+	It("should error if no name found with expected error", func() {
 
 		protos := map[string]*types.Any{}
 		_, err := GetMessage(protos, "duration")
 		Expect(err).To(HaveOccurred())
-
+		Expect(err).To(Equal(NotFoundError))
 	})
+
+	It("should error if proto is bad with other error", func() {
+
+		anyduration, err := types.MarshalAny(&types.Duration{})
+		Expect(err).NotTo(HaveOccurred())
+		anyduration.Value = []byte("bad proto")
+		protos := map[string]*types.Any{
+			"duration": anyduration,
+		}
+		_, err = GetMessage(protos, "duration")
+		Expect(err).To(HaveOccurred())
+		Expect(err).NotTo(Equal(NotFoundError))
+	})
+
 })


### PR DESCRIPTION
allow the user to know if GetMessage didn't find a value, or had a different error
change the name of GetMessage to UnmarshalAnyFromMap
make it use an output param to make usage less verbose.