### PR TITLE
Cli improvements

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1110,6 +1110,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:c08e59153cb7590afc7453ffc5f1bce9b3913b71a4b29cc3aeeadec8aaf4f67a"
+  name = "github.com/solo-io/go-utils"
+  packages = ["kubeutils"]
+  pruneopts = "UT"
+  revision = "20850e4923eaa754a69ec42eba7a1c5ed095e1e6"
+
+[[projects]]
+  branch = "master"
   digest = "1:898faa8b0ea3e2a812fb293db0d9d3359c15669559f7128f15d11e597012fdee"
   name = "github.com/solo-io/kubecontroller"
   packages = ["."]
@@ -1805,6 +1813,7 @@
     "github.com/prometheus/prometheus/discovery/targetgroup",
     "github.com/solo-io/envoy-operator/pkg/downward",
     "github.com/solo-io/go-checkpoint",
+    "github.com/solo-io/go-utils/kubeutils",
     "github.com/solo-io/kubecontroller",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/factory",

--- a/projects/gloo/cli/pkg/cmd/gateway/cmd.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/cmd.go
@@ -11,6 +11,8 @@ func Cmd(opts *options.Options) *cobra.Command {
 		Aliases: []string{"gw"},
 		Short:   "interact with the Gloo Gateway/Ingress",
 	}
+	cmd.PersistentFlags().StringVarP(&opts.Gateway.Proxy, "proxy", "p", "gateway-proxy", "the proxy to target with this command")
+
 	cmd.AddCommand(urlCmd(opts))
 	cmd.AddCommand(dumpCmd(opts))
 	cmd.AddCommand(logsCmd(opts))

--- a/projects/gloo/cli/pkg/cmd/gateway/dump.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/dump.go
@@ -37,7 +37,7 @@ func dumpCmd(opts *options.Options) *cobra.Command {
 func getEnvoyCfgDump(opts *options.Options) (string, error) {
 	adminPort := strconv.Itoa(int(defaults.EnvoyAdminPort))
 	portFwd := exec.Command("kubectl", "port-forward", "-n", opts.Metadata.Namespace,
-		"deployment/gateway-proxy", adminPort)
+		"deployment/"+opts.Gateway.Proxy, adminPort)
 	portFwd.Stdout = os.Stderr
 	portFwd.Stderr = os.Stderr
 	if err := portFwd.Start(); err != nil {
@@ -115,7 +115,7 @@ func statsCmd(opts *options.Options) *cobra.Command {
 func getEnvoyStatsDump(opts *options.Options) (string, error) {
 	adminPort := strconv.Itoa(int(defaults.EnvoyAdminPort))
 	portFwd := exec.Command("kubectl", "port-forward", "-n", opts.Metadata.Namespace,
-		"deployment/gateway-proxy", adminPort)
+		"deployment/"+opts.Gateway.Proxy, adminPort)
 	portFwd.Stdout = os.Stderr
 	portFwd.Stderr = os.Stderr
 	if err := portFwd.Start(); err != nil {

--- a/projects/gloo/cli/pkg/cmd/gateway/logs.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/logs.go
@@ -42,7 +42,7 @@ func getEnvoyLogs(opts *options.Options) error {
 
 		adminPort := strconv.Itoa(int(defaults.EnvoyAdminPort))
 		portFwd := exec.Command("kubectl", "port-forward", "-n", opts.Metadata.Namespace,
-			"deployment/gateway-proxy", adminPort)
+			"deployment/"+opts.Gateway.Proxy, adminPort)
 		portFwd.Stdout = os.Stderr
 		portFwd.Stderr = os.Stderr
 		if err := portFwd.Start(); err != nil {
@@ -93,7 +93,7 @@ func getEnvoyLogs(opts *options.Options) error {
 	}
 
 	logsCmd := exec.Command("kubectl", "logs", "-n", opts.Metadata.Namespace,
-		"deployment/gateway-proxy", "-c", "gateway-proxy")
+		"deployment/"+opts.Gateway.Proxy, "-c", opts.Gateway.Proxy)
 	if opts.Gateway.FollowLogs {
 		logsCmd.Args = append(logsCmd.Args, "-f")
 	}

--- a/projects/gloo/cli/pkg/cmd/gateway/url.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/url.go
@@ -46,13 +46,13 @@ func getIngressHost(opts *options.Options) (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "starting kube client")
 	}
-	svc, err := kube.CoreV1().Services(opts.Metadata.Namespace).Get("gateway-proxy", metav1.GetOptions{})
+	svc, err := kube.CoreV1().Services(opts.Metadata.Namespace).Get(opts.Gateway.Proxy, metav1.GetOptions{})
 	if err != nil {
-		return "", errors.Wrapf(err, "could not detect 'gateway-proxy' service in %v namespace. "+
-			"Check that Gloo has been installed properly and is running with 'kubectl get pod -n gloo-system'")
+		return "", errors.Wrapf(err, "could not detect '%v' service in %v namespace. "+
+			"Check that Gloo has been installed properly and is running with 'kubectl get pod -n gloo-system'", opts.Gateway.Proxy)
 	}
 	if len(svc.Spec.Ports) != 1 {
-		return "", errors.Errorf("service gateway-proxy is missing expected number of ports (1)")
+		return "", errors.Errorf("service %v is missing expected number of ports (1)", opts.Gateway.Proxy)
 	}
 	svcPort := svc.Spec.Ports[0]
 

--- a/projects/gloo/cli/pkg/cmd/options/options.go
+++ b/projects/gloo/cli/pkg/cmd/options/options.go
@@ -43,6 +43,7 @@ const (
 
 type Gateway struct {
 	ClusterProvider string
+	Proxy           string
 	FollowLogs      bool
 	DebugLogs       bool
 }

--- a/projects/gloo/cli/pkg/flagutils/metadata.go
+++ b/projects/gloo/cli/pkg/flagutils/metadata.go
@@ -1,8 +1,11 @@
 package flagutils
 
 import (
+	"github.com/pkg/errors"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
+	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"github.com/spf13/pflag"
 )
 
@@ -16,5 +19,27 @@ func addNameFlag(set *pflag.FlagSet, strptr *string) {
 }
 
 func AddNamespaceFlag(set *pflag.FlagSet, strptr *string) {
-	set.StringVarP(strptr, "namespace", "n", defaults.GlooSystem, "namespace for reading or writing resources")
+	// attempt to get current config context and use that as the default
+	defaultNs, err := getNamespaceFromCurrentContext()
+	if err != nil {
+		log.Warnf("failed to retrieve kubeconfig namespace, falling back to %v", defaultNs)
+		defaultNs = defaults.GlooSystem
+	}
+
+	set.StringVarP(strptr, "namespace", "n", defaultNs, "namespace for reading or writing resources")
+}
+
+func getNamespaceFromCurrentContext() (string, error) {
+	kubeCfg, err := kubeutils.GetKubeConfig("", "")
+	if err != nil {
+		return "", err
+	}
+	if kubeCfg.CurrentContext == "" {
+		return "", errors.Errorf("no current context set in kubeconfig")
+	}
+	kCtx, ok := kubeCfg.Contexts[kubeCfg.CurrentContext]
+	if !ok {
+		return "", errors.Errorf("ctx %v not found in kubeconfig, even though it's the current context", kubeCfg.CurrentContext)
+	}
+	return kCtx.Namespace, nil
 }


### PR DESCRIPTION
2 small improvements to the CLI:
- `glooctl gateway X` commands now allow passing in the name of a proxy to get config dumps, logs from, etc.
- `--namespace` flag defaults to that found in the user's kubeconfig/current-context