### PR TITLE
Fix issue of not being able to login to gcp

### DIFF
--- a/projects/gloo/cli/pkg/cmd/install/kube.go
+++ b/projects/gloo/cli/pkg/cmd/install/kube.go
@@ -12,6 +12,7 @@ import (
 	kubeerrs "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/spf13/cobra"


### PR DESCRIPTION
Fixes:

Error: creating image pull seret: creating installation namespace: No Auth Provider found for name "gcp"

When using gcp