### PR TITLE
Const commands

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1109,7 +1109,7 @@
   version = "0.0.4"
 
 [[projects]]
-  digest = "1:5689ccff238a7dcdaec7c5ed18632b1f58345320895b1d28d1c555b1f53dbe7b"
+  digest = "1:1fbae7b7218b4d4e8d417c12e0fa88936cca20a9f77a09b97ca6ecf14a5840b5"
   name = "github.com/solo-io/go-utils"
   packages = [
     "cliutils",
@@ -1118,7 +1118,7 @@
     "protoutils",
   ]
   pruneopts = "UT"
-  revision = "aed107e26498b88eb641f3e9a794dd1ddeda6a10"
+  revision = "67428b92743fd710ab708665d5fff86e06ff1612"
 
 [[projects]]
   branch = "master"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -67,5 +67,5 @@
 
 [[constraint]]
   name = "github.com/solo-io/go-utils"
-  revision = "aed107e26498b88eb641f3e9a794dd1ddeda6a10"
+  revision = "67428b92743fd710ab708665d5fff86e06ff1612"
 

--- a/projects/gloo/cli/pkg/cmd/create/root.go
+++ b/projects/gloo/cli/pkg/cmd/create/root.go
@@ -1,10 +1,11 @@
 package create
 
 import (
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"io"
 	"io/ioutil"
 	"os"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/create/secret"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"

--- a/projects/gloo/cli/pkg/cmd/create/root.go
+++ b/projects/gloo/cli/pkg/cmd/create/root.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"io"
 	"io/ioutil"
 	"os"
@@ -16,10 +17,10 @@ import (
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "create",
-		Aliases: []string{"c"},
-		Short:   "Create a Gloo resource",
-		Long:    "Gloo resources be created from files (including stdin)",
+		Use:     constants.CREATE_COMMAND.Use,
+		Aliases: constants.CREATE_COMMAND.Aliases,
+		Short:   constants.CREATE_COMMAND.Short,
+		Long:    constants.CREATE_COMMAND.Long,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var reader io.ReadCloser
 			if opts.Top.File == "" {

--- a/projects/gloo/cli/pkg/cmd/create/secret/root.go
+++ b/projects/gloo/cli/pkg/cmd/create/secret/root.go
@@ -2,14 +2,15 @@ package secret
 
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/go-utils/cliutils"
 	"github.com/spf13/cobra"
 )
 
 func CreateCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "secret",
-		Aliases: []string{"s", "secret"},
+		Use:     constants.SECRET_COMMAND.Use,
+		Aliases: constants.SECRET_COMMAND.Aliases,
 		Short:   "Create a secret",
 		Long:    "Create a secret",
 		Args:    cobra.ExactArgs(2),

--- a/projects/gloo/cli/pkg/cmd/create/upstream.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"strconv"
 	"strings"
 
@@ -27,8 +28,8 @@ import (
 
 func Upstream(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "upstream",
-		Aliases: []string{"us", "upstream", "upstreams"},
+		Use:     constants.UPSTREAM_COMMAND.Use,
+		Aliases: constants.UPSTREAM_COMMAND.Aliases,
 		Short:   "Create an Upstream Interactively",
 		Long: "Upstreams represent destination for routing HTTP requests. Upstreams can be compared to \n" +
 			"[clusters](https://www.envoyproxy.io/docs/envoy/latest/api-v1/cluster_manager/cluster.html?highlight=cluster) in Envoy terminology. \n" +

--- a/projects/gloo/cli/pkg/cmd/create/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/create/virtualservice.go
@@ -17,8 +17,8 @@ import (
 
 func VirtualService(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "virtualservice",
-		Aliases: []string{"vs", "virtualservice", "virtualservices"},
+		Use:     constants.VIRTUAL_SERVICE_COMMAND.Use,
+		Aliases: constants.VIRTUAL_SERVICE_COMMAND.Aliases,
 		Short:   "Create a Virtual Service",
 		Long: "A virtual service describes the set of routes to match for a set of domains. \n" +
 			"Virtual services are containers for routes assigned to a domain or set of domains. \n" +

--- a/projects/gloo/cli/pkg/cmd/del/proxy.go
+++ b/projects/gloo/cli/pkg/cmd/del/proxy.go
@@ -2,6 +2,7 @@ package del
 
 import (
 	"fmt"
+
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"

--- a/projects/gloo/cli/pkg/cmd/del/proxy.go
+++ b/projects/gloo/cli/pkg/cmd/del/proxy.go
@@ -2,6 +2,7 @@ package del
 
 import (
 	"fmt"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
 	"github.com/solo-io/go-utils/cliutils"
@@ -14,8 +15,8 @@ import (
 
 func Proxy(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "proxy",
-		Aliases: []string{"p", "px", "proxies"},
+		Use:     constants.PROXY_COMMAND.Use,
+		Aliases: constants.PROXY_COMMAND.Aliases,
 		Short:   "delete a proxy",
 		Long:    "usage: glooctl delete proxy [NAME] [--namespace=namespace]",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/projects/gloo/cli/pkg/cmd/del/root.go
+++ b/projects/gloo/cli/pkg/cmd/del/root.go
@@ -2,6 +2,7 @@ package del
 
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/flagutils"
 	"github.com/solo-io/go-utils/cliutils"
 	"github.com/spf13/cobra"
@@ -9,9 +10,9 @@ import (
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "delete",
-		Aliases: []string{"d"},
-		Short:   "Delete a Gloo resource",
+		Use:     constants.DELETE_COMMAND.Use,
+		Aliases: constants.DELETE_COMMAND.Aliases,
+		Short:   constants.DELETE_COMMAND.Short,
 	}
 	pflags := cmd.PersistentFlags()
 	flagutils.AddMetadataFlags(pflags, &opts.Metadata)

--- a/projects/gloo/cli/pkg/cmd/del/upstream.go
+++ b/projects/gloo/cli/pkg/cmd/del/upstream.go
@@ -2,6 +2,7 @@ package del
 
 import (
 	"fmt"
+
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"

--- a/projects/gloo/cli/pkg/cmd/del/upstream.go
+++ b/projects/gloo/cli/pkg/cmd/del/upstream.go
@@ -2,6 +2,7 @@ package del
 
 import (
 	"fmt"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
 	"github.com/solo-io/go-utils/cliutils"
@@ -14,8 +15,8 @@ import (
 
 func Upstream(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "upstream",
-		Aliases: []string{"u", "us", "upstreams"},
+		Use:     constants.UPSTREAM_COMMAND.Use,
+		Aliases: constants.UPSTREAM_COMMAND.Aliases,
 		Short:   "delete an upstream",
 		Long:    "usage: glooctl get upstream [NAME] [--namespace=namespace]",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/projects/gloo/cli/pkg/cmd/del/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/del/virtualservice.go
@@ -2,6 +2,7 @@ package del
 
 import (
 	"fmt"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
 	"github.com/solo-io/go-utils/cliutils"
@@ -14,8 +15,8 @@ import (
 
 func VirtualService(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "virtualservice",
-		Aliases: []string{"v", "vs", "virtualservices"},
+		Use:     constants.VIRTUAL_SERVICE_COMMAND.Use,
+		Aliases: constants.VIRTUAL_SERVICE_COMMAND.Aliases,
 		Short:   "delete a virtualservice",
 		Long:    "usage: glooctl delete virtualservice [NAME] [--namespace=namespace]",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/projects/gloo/cli/pkg/cmd/del/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/del/virtualservice.go
@@ -2,6 +2,7 @@ package del
 
 import (
 	"fmt"
+
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"

--- a/projects/gloo/cli/pkg/cmd/gateway/root.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/root.go
@@ -2,15 +2,16 @@ package gateway
 
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/go-utils/cliutils"
 	"github.com/spf13/cobra"
 )
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "gateway",
-		Aliases: []string{"gw"},
-		Short:   "interact with the Gloo Gateway/Ingress",
+		Use:     constants.GATEWAY_COMMAND.Use,
+		Aliases: constants.GATEWAY_COMMAND.Aliases,
+		Short:   constants.GATEWAY_COMMAND.Short,
 	}
 	cmd.PersistentFlags().StringVarP(&opts.Gateway.Proxy, "proxy", "p", "gateway-proxy", "the proxy to target with this command")
 

--- a/projects/gloo/cli/pkg/cmd/get/proxy.go
+++ b/projects/gloo/cli/pkg/cmd/get/proxy.go
@@ -3,14 +3,15 @@ package get
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/spf13/cobra"
 )
 
 func Proxy(opts *options.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "proxy",
-		Aliases: []string{"p", "proxies"},
+		Use:     constants.PROXY_COMMAND.Use,
+		Aliases: constants.PROXY_COMMAND.Aliases,
 		Short:   "read a proxy or list proxies in a namespace",
 		Long:    "usage: glooctl get proxy",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/projects/gloo/cli/pkg/cmd/get/root.go
+++ b/projects/gloo/cli/pkg/cmd/get/root.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/flagutils"
 	"github.com/solo-io/go-utils/cliutils"
 	"github.com/spf13/cobra"
@@ -9,9 +10,9 @@ import (
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "get",
-		Aliases: []string{"g"},
-		Short:   "Display one or a list of Gloo resources",
+		Use:     constants.GET_COMMAND.Use,
+		Aliases: constants.GET_COMMAND.Aliases,
+		Short:   constants.GET_COMMAND.Short,
 	}
 	pflags := cmd.PersistentFlags()
 	flagutils.AddMetadataFlags(pflags, &opts.Metadata)

--- a/projects/gloo/cli/pkg/cmd/get/upstream.go
+++ b/projects/gloo/cli/pkg/cmd/get/upstream.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
@@ -10,8 +11,8 @@ import (
 
 func Upstream(opts *options.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "upstream",
-		Aliases: []string{"u", "us", "upstreams"},
+		Use:     constants.UPSTREAM_COMMAND.Use,
+		Aliases: constants.UPSTREAM_COMMAND.Aliases,
 		Short:   "read an upstream or list upstreams in a namespace",
 		Long:    "usage: glooctl get upstream [NAME] [--namespace=namespace] [-o FORMAT] [-o FORMAT]",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/projects/gloo/cli/pkg/cmd/get/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/get/virtualservice.go
@@ -3,6 +3,7 @@ package get
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/go-utils/errors"
 
@@ -11,8 +12,8 @@ import (
 
 func VirtualService(opts *options.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "virtualservice",
-		Aliases: []string{"vs", "virtualservices"},
+		Use:     constants.UPSTREAM_COMMAND.Use,
+		Aliases: constants.UPSTREAM_COMMAND.Aliases,
 		Short:   "read a virtualservice or list virtualservices in a namespace",
 		Long:    "usage: glooctl get virtualservice [NAME] [--namespace=namespace] [-o FORMAT]",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/projects/gloo/cli/pkg/cmd/get/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/get/virtualservice.go
@@ -12,8 +12,8 @@ import (
 
 func VirtualService(opts *options.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     constants.UPSTREAM_COMMAND.Use,
-		Aliases: constants.UPSTREAM_COMMAND.Aliases,
+		Use:     constants.VIRTUAL_SERVICE_COMMAND.Use,
+		Aliases: constants.VIRTUAL_SERVICE_COMMAND.Aliases,
 		Short:   "read a virtualservice or list virtualservices in a namespace",
 		Long:    "usage: glooctl get virtualservice [NAME] [--namespace=namespace] [-o FORMAT]",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/projects/gloo/cli/pkg/cmd/install/root.go
+++ b/projects/gloo/cli/pkg/cmd/install/root.go
@@ -2,15 +2,16 @@ package install
 
 import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/go-utils/cliutils"
 	"github.com/spf13/cobra"
 )
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "install",
-		Short: "install gloo on different platforms",
-		Long:  "choose which system to install Gloo onto. options include: kubernetes",
+		Use:   constants.INSTALL_COMMAND.Use,
+		Short: constants.INSTALL_COMMAND.Short,
+		Long:  constants.INSTALL_COMMAND.Long,
 	}
 	cmd.AddCommand(KubeCmd(opts))
 	cliutils.ApplyOptions(cmd, optionsFunc)

--- a/projects/gloo/cli/pkg/cmd/upgrade/cmd.go
+++ b/projects/gloo/cli/pkg/cmd/upgrade/cmd.go
@@ -3,10 +3,11 @@ package upgrade
 import (
 	"context"
 	"fmt"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"net/http"
 	"os"
 	"runtime"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 
 	"github.com/solo-io/go-utils/cliutils"
 

--- a/projects/gloo/cli/pkg/cmd/upgrade/cmd.go
+++ b/projects/gloo/cli/pkg/cmd/upgrade/cmd.go
@@ -3,6 +3,7 @@ package upgrade
 import (
 	"context"
 	"fmt"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"net/http"
 	"os"
 	"runtime"
@@ -19,9 +20,9 @@ import (
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "upgrade",
-		Aliases: []string{"ug"},
-		Short:   "upgrade glooctl binary",
+		Use:     constants.UPGRADE_COMMAND.Use,
+		Aliases: constants.UPGRADE_COMMAND.Aliases,
+		Short:   constants.UPGRADE_COMMAND.Short,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return upgradeGlooCtl(opts.Top.Ctx, opts.Upgrade)
 		},

--- a/projects/gloo/cli/pkg/constants/commands.go
+++ b/projects/gloo/cli/pkg/constants/commands.go
@@ -29,6 +29,11 @@ var (
 		Short:   "interact with the Gloo Gateway/Ingress",
 	}
 
+	SECRET_COMMAND = cobra.Command{
+		Use:     "secret",
+		Aliases: []string{"s", "secret"},
+	}
+
 	ADD_COMMAND = cobra.Command{
 		Use:     "add",
 		Aliases: []string{"a"},

--- a/projects/gloo/cli/pkg/constants/commands.go
+++ b/projects/gloo/cli/pkg/constants/commands.go
@@ -1,0 +1,70 @@
+package constants
+
+import "github.com/spf13/cobra"
+
+var (
+	VIRTUAL_SERVICE_COMMAND = cobra.Command{
+		Use:     "virtualservice",
+		Aliases: []string{"vs", "virtualservices"},
+	}
+
+	UPSTREAM_COMMAND = cobra.Command{
+		Use:     "upstream",
+		Aliases: []string{"u", "us", "upstreams"},
+	}
+
+	PROXY_COMMAND = cobra.Command{
+		Use:     "proxy",
+		Aliases: []string{"p", "proxies"},
+	}
+
+	ROUTE_COMMAND = cobra.Command{
+		Use:     "route",
+		Aliases: []string{"r", "routes"},
+	}
+
+	GATEWAY_COMMAND = cobra.Command{
+		Use:     "gateway",
+		Aliases: []string{"gw"},
+		Short:   "interact with the Gloo Gateway/Ingress",
+	}
+
+	ADD_COMMAND = cobra.Command{
+		Use:     "add",
+		Aliases: []string{"a"},
+		Short:   "adds configuration to a top-level Gloo resource",
+	}
+
+	CREATE_COMMAND = cobra.Command{
+		Use:     "create",
+		Aliases: []string{"c"},
+		Short:   "Create a Gloo resource",
+		Long:    "Gloo resources be created from files (including stdin)",
+	}
+
+	DELETE_COMMAND = cobra.Command{
+		Use:     "delete",
+		Aliases: []string{"d"},
+		Short:   "Delete a Gloo resource",
+	}
+
+	GET_COMMAND = cobra.Command{
+		Use:     "get",
+		Aliases: []string{"g"},
+		Short:   "Display one or a list of Gloo resources",
+	}
+
+	INSTALL_COMMAND = cobra.Command{
+		Use:   "install",
+		Short: "install gloo on different platforms",
+		Long:  "choose which system to install Gloo onto. options include: kubernetes",
+	}
+
+	UPGRADE_COMMAND = cobra.Command{
+		Use:     "upgrade",
+		Aliases: []string{"ug"},
+		Short:   "upgrade glooctl binary",
+	}
+
+
+)

--- a/projects/gloo/cli/pkg/constants/commands.go
+++ b/projects/gloo/cli/pkg/constants/commands.go
@@ -65,6 +65,4 @@ var (
 		Aliases: []string{"ug"},
 		Short:   "upgrade glooctl binary",
 	}
-
-
 )


### PR DESCRIPTION
created a file of "const" names for all of the commands.
This is important for a couple of reasons:
1) these values are re-used across this repo and it is important to maintain uniformity
2) these values can be used to swap commands in and out using the new options funcs, and go-utils