### PR TITLE
Revert the kubeconfig namespace fix from 9030c51a57297598a0884af33fbc…

### DIFF
--- a/projects/gloo/cli/pkg/flagutils/metadata.go
+++ b/projects/gloo/cli/pkg/flagutils/metadata.go
@@ -1,11 +1,8 @@
 package flagutils
 
 import (
-	"github.com/pkg/errors"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
-	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"github.com/solo-io/solo-kit/pkg/utils/log"
 	"github.com/spf13/pflag"
 )
 
@@ -19,27 +16,5 @@ func addNameFlag(set *pflag.FlagSet, strptr *string) {
 }
 
 func AddNamespaceFlag(set *pflag.FlagSet, strptr *string) {
-	// attempt to get current config context and use that as the default
-	defaultNs, err := getNamespaceFromCurrentContext()
-	if err != nil {
-		log.Warnf("failed to retrieve kubeconfig namespace, falling back to %v", defaultNs)
-		defaultNs = defaults.GlooSystem
-	}
-
-	set.StringVarP(strptr, "namespace", "n", defaultNs, "namespace for reading or writing resources")
-}
-
-func getNamespaceFromCurrentContext() (string, error) {
-	kubeCfg, err := kubeutils.GetKubeConfig("", "")
-	if err != nil {
-		return "", err
-	}
-	if kubeCfg.CurrentContext == "" {
-		return "", errors.Errorf("no current context set in kubeconfig")
-	}
-	kCtx, ok := kubeCfg.Contexts[kubeCfg.CurrentContext]
-	if !ok {
-		return "", errors.Errorf("ctx %v not found in kubeconfig, even though it's the current context", kubeCfg.CurrentContext)
-	}
-	return kCtx.Namespace, nil
+	set.StringVarP(strptr, "namespace", "n", defaults.GlooSystem, "namespace for reading or writing resources")
 }


### PR DESCRIPTION
…53d7726424fa; ideally we can get behavior like https://github.com/solo-io/gloo/issues/267

This PR is just part of the solution to solve the aforementioned issue. 