### PR TITLE
exit on error if setup fails

### DIFF
--- a/projects/discovery/pkg/fds/setup/setup.go
+++ b/projects/discovery/pkg/fds/setup/setup.go
@@ -7,5 +7,9 @@ import (
 )
 
 func Main() error {
-	return setuputils.Main("fds", gloosyncer.NewSetupFuncWithRun(syncer.RunFDS))
+	return setuputils.Main(setuputils.SetupOpts{
+		LoggingPrefix: "fds",
+		SetupFunc:     gloosyncer.NewSetupFuncWithRun(syncer.RunFDS),
+		ExitOnError:   true,
+	})
 }

--- a/projects/discovery/pkg/uds/setup/setup.go
+++ b/projects/discovery/pkg/uds/setup/setup.go
@@ -7,5 +7,9 @@ import (
 )
 
 func Main() error {
-	return setuputils.Main("uds", gloosyncer.NewSetupFuncWithRun(syncer.RunUDS))
+	return setuputils.Main(setuputils.SetupOpts{
+		LoggingPrefix: "uds",
+		SetupFunc:     gloosyncer.NewSetupFuncWithRun(syncer.RunUDS),
+		ExitOnError:   true,
+	})
 }

--- a/projects/gateway/pkg/setup/setup.go
+++ b/projects/gateway/pkg/setup/setup.go
@@ -6,5 +6,9 @@ import (
 )
 
 func Main() error {
-	return setuputils.Main("gateway", syncer.Setup)
+	return setuputils.Main(setuputils.SetupOpts{
+		LoggingPrefix: "gateway",
+		SetupFunc:     syncer.Setup,
+		ExitOnError:   true,
+	})
 }

--- a/projects/gloo/pkg/setup/setup.go
+++ b/projects/gloo/pkg/setup/setup.go
@@ -1,17 +1,14 @@
 package setup
 
 import (
-	"time"
-
-	check "github.com/solo-io/go-checkpoint"
-
 	"github.com/solo-io/gloo/pkg/utils/setuputils"
-	"github.com/solo-io/gloo/pkg/version"
 	"github.com/solo-io/gloo/projects/gloo/pkg/syncer"
 )
 
 func Main() error {
-	start := time.Now()
-	check.CallCheck("gloo", version.Version, start)
-	return setuputils.Main("gloo", syncer.NewSetupFunc())
+	return setuputils.Main(setuputils.SetupOpts{
+		LoggingPrefix: "gloo",
+		SetupFunc:     syncer.NewSetupFunc(),
+		ExitOnError:   true,
+	})
 }

--- a/projects/ingress/pkg/setup/setup.go
+++ b/projects/ingress/pkg/setup/setup.go
@@ -5,5 +5,9 @@ import (
 )
 
 func Main() error {
-	return setuputils.Main("ingress", Setup)
+	return setuputils.Main(setuputils.SetupOpts{
+		LoggingPrefix: "ingress",
+		SetupFunc:     Setup,
+		ExitOnError:   true,
+	})
 }


### PR DESCRIPTION
this changes the util method `setuputils.Main` to accept a single `Opts` parameter. Opts parameter exposes a flag `ExitOnError` telling the setup method to `exit 1` if the setup function fails

the current behavior (probably not desirable) is the error wil be logged but the pod will not crash/be restarted (making it harder to detect setup failures)