### PR TITLE
Manifest needs to happen before release target

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -103,7 +103,7 @@ steps:
   id: 'compile'
 
 - name: 'gcr.io/$PROJECT_ID/go-make'
-  args: ['docker-push', 'release', 'deploy-site', 'manifest']
+  args: ['docker-push', 'manifest', 'release', 'deploy-site']
   env:
   - 'TAGGED_VERSION=$TAG_NAME'
   - 'PROJECT_ROOT=github.com/solo-io/gloo'


### PR DESCRIPTION
v0.6.7 release build failed because the release target pushes yaml artifacts that are produced by the manifest target. 