### PR TITLE
Increasing the timeout for happy path test

### DIFF
--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Happypath", func() {
 				return nil, nil
 			}
 
-			Eventually(getupstream, "15s", "0.5s").ShouldNot(BeNil())
+			Eventually(getupstream, "30s", "0.5s").ShouldNot(BeNil())
 
 			up, err := getupstream()
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Currently this test occasionally flakes out (see #264). Trying to see if the
frequency of flakes is reduced by giving discovery longer to work.