### PR TITLE
initial tests for glooctl

### DIFF
--- a/projects/gloo/cli/pkg/argsutils/metadata.go
+++ b/projects/gloo/cli/pkg/argsutils/metadata.go
@@ -12,9 +12,10 @@ func MetadataArgsParse(opts *options.Options, args []string) error {
 	}
 	switch {
 	case opts.Metadata.Name != "":
-		return nil
 	case opts.Metadata.Name == "" && len(args) > 0:
 		opts.Metadata.Name = args[0]
+	default:
+		return errors.Errorf("name must be specified in flag (--name) or via first arg")
 	}
-	return errors.Errorf("name must be specified in flag (--name) or via first arg")
+	return nil
 }

--- a/projects/gloo/cli/pkg/cmd/add/add_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/add/add_suite_test.go
@@ -1,0 +1,13 @@
+package add_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestAdd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Add Suite")
+}

--- a/projects/gloo/cli/pkg/cmd/add/route.go
+++ b/projects/gloo/cli/pkg/cmd/add/route.go
@@ -11,6 +11,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/aws"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/rest"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/transformation"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
@@ -79,8 +80,13 @@ func selectOrCreateVirtualService(opts *options.Options) (*gatewayv1.VirtualServ
 		}
 	}
 
-	// TODO: edge case: check that a vs does not already exist with a * domain
-	// no vs exist with default domain
+	if opts.Metadata.Name == "" {
+		opts.Metadata.Name = "default"
+	}
+	if opts.Metadata.Namespace == "" {
+		opts.Metadata.Name = defaults.GlooSystem
+	}
+
 	fmt.Printf("creating virtualservice %v with default domain *\n", opts.Metadata.Name)
 	return &gatewayv1.VirtualService{
 		Metadata: opts.Metadata,

--- a/projects/gloo/cli/pkg/cmd/add/route_test.go
+++ b/projects/gloo/cli/pkg/cmd/add/route_test.go
@@ -1,0 +1,35 @@
+package add_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
+)
+
+var _ = Describe("Upstream", func() {
+
+	BeforeEach(func() {
+		helpers.MemoryResourceClient = &factory.MemoryResourceClientFactory{
+			Cache: memory.NewInMemoryResourceCache(),
+		}
+	})
+
+	BeforeEach(func() {
+		err := testutils.Glooctl("create upstream static default-petstore-8080 --static-hosts jsonplaceholder.typicode.com:80")
+		Expect(err).NotTo(HaveOccurred())
+
+	})
+
+	It("should create static upstream", func() {
+		err := testutils.Glooctl("add route --path-exact /sample-route-1 --dest-name default-petstore-8080 --prefix-rewrite /api/pets")
+		Expect(err).NotTo(HaveOccurred())
+
+		up, err := helpers.MustVirtualServiceClient().Read("gloo-system", "default", clients.ReadOpts{})
+		Expect(up.Metadata.Name).To(Equal("default"))
+	})
+})

--- a/projects/gloo/cli/pkg/cmd/add/route_test.go
+++ b/projects/gloo/cli/pkg/cmd/add/route_test.go
@@ -7,16 +7,12 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 )
 
 var _ = Describe("Upstream", func() {
 
 	BeforeEach(func() {
-		helpers.MemoryResourceClient = &factory.MemoryResourceClientFactory{
-			Cache: memory.NewInMemoryResourceCache(),
-		}
+		helpers.UseMemoryClients()
 	})
 
 	BeforeEach(func() {

--- a/projects/gloo/cli/pkg/cmd/create/create_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/create/create_suite_test.go
@@ -1,0 +1,13 @@
+package create_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCreate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Create Suite")
+}

--- a/projects/gloo/cli/pkg/cmd/create/upstream_test.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream_test.go
@@ -7,16 +7,12 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 )
 
 var _ = Describe("Upstream", func() {
 
 	BeforeEach(func() {
-		helpers.MemoryResourceClient = &factory.MemoryResourceClientFactory{
-			Cache: memory.NewInMemoryResourceCache(),
-		}
+		helpers.UseMemoryClients()
 	})
 
 	It("should create static upstream", func() {

--- a/projects/gloo/cli/pkg/cmd/create/upstream_test.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("Upstream", func() {
 
-	BeforeSuite(func() {
+	BeforeEach(func() {
 		helpers.MemoryResourceClient = &factory.MemoryResourceClientFactory{
 			Cache: memory.NewInMemoryResourceCache(),
 		}

--- a/projects/gloo/cli/pkg/cmd/create/upstream_test.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream_test.go
@@ -1,0 +1,38 @@
+package create_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
+)
+
+func Glooctl(args string) error {
+	app := cmd.GlooCli("test")
+	app.SetArgs(strings.Split(args, " "))
+	return app.Execute()
+}
+
+var _ = Describe("Upstream", func() {
+
+	BeforeSuite(func() {
+		helpers.MemoryResourceClient = &factory.MemoryResourceClientFactory{
+			Cache: memory.NewInMemoryResourceCache(),
+		}
+	})
+
+	It("should create static upstream", func() {
+		err := Glooctl("create upstream static jsonplaceholder-80 --static-hosts jsonplaceholder.typicode.com:80")
+		Expect(err).NotTo(HaveOccurred())
+
+		up, err := helpers.MustUpstreamClient().Read("default", "jsonplaceholder-80", clients.ReadOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(up.Metadata.Name).To(Equal("jsonplaceholder-80"))
+	})
+})

--- a/projects/gloo/cli/pkg/cmd/create/upstream_test.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Upstream", func() {
 		err := Glooctl("create upstream static jsonplaceholder-80 --static-hosts jsonplaceholder.typicode.com:80")
 		Expect(err).NotTo(HaveOccurred())
 
-		up, err := helpers.MustUpstreamClient().Read("default", "jsonplaceholder-80", clients.ReadOpts{})
+		up, err := helpers.MustUpstreamClient().Read("gloo-system", "jsonplaceholder-80", clients.ReadOpts{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(up.Metadata.Name).To(Equal("jsonplaceholder-80"))
 	})

--- a/projects/gloo/cli/pkg/cmd/create/upstream_test.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream_test.go
@@ -1,23 +1,15 @@
 package create_test
 
 import (
-	"strings"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 )
-
-func Glooctl(args string) error {
-	app := cmd.GlooCli("test")
-	app.SetArgs(strings.Split(args, " "))
-	return app.Execute()
-}
 
 var _ = Describe("Upstream", func() {
 
@@ -28,7 +20,7 @@ var _ = Describe("Upstream", func() {
 	})
 
 	It("should create static upstream", func() {
-		err := Glooctl("create upstream static jsonplaceholder-80 --static-hosts jsonplaceholder.typicode.com:80")
+		err := testutils.Glooctl("create upstream static jsonplaceholder-80 --static-hosts jsonplaceholder.typicode.com:80")
 		Expect(err).NotTo(HaveOccurred())
 
 		up, err := helpers.MustUpstreamClient().Read("gloo-system", "jsonplaceholder-80", clients.ReadOpts{})

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -6,6 +6,7 @@ import (
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
 	"github.com/solo-io/solo-kit/pkg/errors"
@@ -29,7 +30,7 @@ func MustGetNamespaces() []string {
 // Note: requires RBAC permission to list namespaces at the cluster level
 func GetNamespaces() ([]string, error) {
 	if MemoryResourceClient != nil {
-		return []string{"default"}, nil
+		return []string{"default", defaults.GlooSystem}, nil
 	}
 
 	cfg, err := kubeutils.GetConfig("", "")

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+var MemoryResourceClient *factory.MemoryResourceClientFactory
+
 func MustGetNamespaces() []string {
 	ns, err := GetNamespaces()
 	if err != nil {
@@ -26,6 +28,10 @@ func MustGetNamespaces() []string {
 
 // Note: requires RBAC permission to list namespaces at the cluster level
 func GetNamespaces() ([]string, error) {
+	if MemoryResourceClient != nil {
+		return []string{"default"}, nil
+	}
+
 	cfg, err := kubeutils.GetConfig("", "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
@@ -54,6 +60,10 @@ func MustUpstreamClient() v1.UpstreamClient {
 }
 
 func UpstreamClient() (v1.UpstreamClient, error) {
+	if MemoryResourceClient != nil {
+		return v1.NewUpstreamClient(MemoryResourceClient)
+	}
+
 	cfg, err := kubeutils.GetConfig("", "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
@@ -82,6 +92,10 @@ func MustProxyClient() v1.ProxyClient {
 }
 
 func ProxyClient() (v1.ProxyClient, error) {
+	if MemoryResourceClient != nil {
+		return v1.NewProxyClient(MemoryResourceClient)
+	}
+
 	cfg, err := kubeutils.GetConfig("", "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
@@ -110,6 +124,10 @@ func MustVirtualServiceClient() gatewayv1.VirtualServiceClient {
 }
 
 func VirtualServiceClient() (gatewayv1.VirtualServiceClient, error) {
+	if MemoryResourceClient != nil {
+		return gatewayv1.NewVirtualServiceClient(MemoryResourceClient)
+	}
+
 	cfg, err := kubeutils.GetConfig("", "")
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
@@ -138,6 +156,10 @@ func MustSecretClient() v1.SecretClient {
 }
 
 func secretClient() (v1.SecretClient, error) {
+	if MemoryResourceClient != nil {
+		return v1.NewSecretClient(MemoryResourceClient)
+	}
+
 	clientset, err := getKubernetesClient()
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -9,6 +9,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 	"github.com/solo-io/solo-kit/pkg/errors"
 	"github.com/solo-io/solo-kit/pkg/utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/utils/log"
@@ -17,7 +18,13 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-var MemoryResourceClient *factory.MemoryResourceClientFactory
+var memoryResourceClient *factory.MemoryResourceClientFactory
+
+func UseMemoryClients() {
+	memoryResourceClient = &factory.MemoryResourceClientFactory{
+		Cache: memory.NewInMemoryResourceCache(),
+	}
+}
 
 func MustGetNamespaces() []string {
 	ns, err := GetNamespaces()
@@ -29,7 +36,7 @@ func MustGetNamespaces() []string {
 
 // Note: requires RBAC permission to list namespaces at the cluster level
 func GetNamespaces() ([]string, error) {
-	if MemoryResourceClient != nil {
+	if memoryResourceClient != nil {
 		return []string{"default", defaults.GlooSystem}, nil
 	}
 
@@ -61,8 +68,8 @@ func MustUpstreamClient() v1.UpstreamClient {
 }
 
 func UpstreamClient() (v1.UpstreamClient, error) {
-	if MemoryResourceClient != nil {
-		return v1.NewUpstreamClient(MemoryResourceClient)
+	if memoryResourceClient != nil {
+		return v1.NewUpstreamClient(memoryResourceClient)
 	}
 
 	cfg, err := kubeutils.GetConfig("", "")
@@ -93,8 +100,8 @@ func MustProxyClient() v1.ProxyClient {
 }
 
 func ProxyClient() (v1.ProxyClient, error) {
-	if MemoryResourceClient != nil {
-		return v1.NewProxyClient(MemoryResourceClient)
+	if memoryResourceClient != nil {
+		return v1.NewProxyClient(memoryResourceClient)
 	}
 
 	cfg, err := kubeutils.GetConfig("", "")
@@ -125,8 +132,8 @@ func MustVirtualServiceClient() gatewayv1.VirtualServiceClient {
 }
 
 func VirtualServiceClient() (gatewayv1.VirtualServiceClient, error) {
-	if MemoryResourceClient != nil {
-		return gatewayv1.NewVirtualServiceClient(MemoryResourceClient)
+	if memoryResourceClient != nil {
+		return gatewayv1.NewVirtualServiceClient(memoryResourceClient)
 	}
 
 	cfg, err := kubeutils.GetConfig("", "")
@@ -157,8 +164,8 @@ func MustSecretClient() v1.SecretClient {
 }
 
 func secretClient() (v1.SecretClient, error) {
-	if MemoryResourceClient != nil {
-		return v1.NewSecretClient(MemoryResourceClient)
+	if memoryResourceClient != nil {
+		return v1.NewSecretClient(memoryResourceClient)
 	}
 
 	clientset, err := getKubernetesClient()

--- a/projects/gloo/cli/pkg/testutils/utils.go
+++ b/projects/gloo/cli/pkg/testutils/utils.go
@@ -1,0 +1,13 @@
+package testutils
+
+import (
+	"strings"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd"
+)
+
+func Glooctl(args string) error {
+	app := cmd.GlooCli("test")
+	app.SetArgs(strings.Split(args, " "))
+	return app.Execute()
+}


### PR DESCRIPTION
need to move Glooctl helper function to a proper place

As part of the cli for ext auth I created a way to test the cli in unit tests (as per @rickducott's idea)
I did a sanity and added a static upstream according to here:
https://gloo.solo.io/getting_started/kubernetes/external_api_routing/

but the test seems to fail. @ilackarms can you take a loog?