### PR TITLE
Fix Knative installation

### DIFF
--- a/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-        image: {{ .Values.settings.integrations.knative.proxy.image }}
+        image: {{ .Values.settings.integrations.knative.proxy.image.repository }}:{{ .Values.settings.integrations.knative.proxy.image.tag }}
         imagePullPolicy: {{ .Values.settings.integrations.knative.proxy.image.pullPolicy }}
         name: clusteringress-proxy
         ports:


### PR DESCRIPTION
At the moment the release yaml file for Knative has an invalid image
descriptor:

```
image: map[pullPolicy:Always repository:soloio/gloo-envoy-wrapper tag:0.6.10]
imagePullPolicy: Always
name: clusteringress-proxy
```

With this change the template is fixed and `gloo install knative` will
work correctly.

Invalid Knative URL: https://github.com/solo-io/gloo/releases/download/v0.6.10/gloo-knative.yaml

Signed-off-by: Eloy Coto <eloy.coto@gmail.com>