### PR TITLE
Make output dir if not exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ $(OUTPUT_DIR)/.generated-code:
 	go generate ./...
 	gofmt -w $(SUBDIRS)
 	goimports -w $(SUBDIRS)
+	mkdir -p $(OUTPUT_DIR)
 	touch $@
 
 .PHONY: docs/index.md


### PR DESCRIPTION
This was needed for https://github.com/solo-io/solo-projects/pull/285 but running `make generated-code` on CI in gloo currently finishes after a different helm task that makes the output dir. On a fresh clone, if you ran `make generated-code` it would fail because the `_output` dir doesn't exist, so fixing that. 