### PR TITLE
allow empty grpc service spec

### DIFF
--- a/docs/v1/github.com/solo-io/gloo/projects/gloo/api/v1/plugins/grpc/grpc.proto.sk.md
+++ b/docs/v1/github.com/solo-io/gloo/projects/gloo/api/v1/plugins/grpc/grpc.proto.sk.md
@@ -21,10 +21,10 @@
 ### <a name="ServiceSpec">ServiceSpec</a>
 
  
-Service spec describing GRPC upstreams. This will usually be filled automatically via function
-discovery (if the upstream supports reflection).
-If your upstream services is a GRPC service, use this service spec (an empty spec is fine), to 
-make sure that traffic to it is routed with http2.
+Service spec describing GRPC upstreams. This will usually be filled
+automatically via function discovery (if the upstream supports reflection).
+If your upstream service is a GRPC service, use this service spec (an empty
+spec is fine), to make sure that traffic to it is routed with http2.
 
 ```yaml
 "descriptors": bytes

--- a/docs/v1/github.com/solo-io/gloo/projects/gloo/api/v1/plugins/grpc/grpc.proto.sk.md
+++ b/docs/v1/github.com/solo-io/gloo/projects/gloo/api/v1/plugins/grpc/grpc.proto.sk.md
@@ -20,7 +20,11 @@
 ---
 ### <a name="ServiceSpec">ServiceSpec</a>
 
-
+ 
+Service spec describing GRPC upstreams. This will usually be filled automatically via function
+discovery (if the upstream supports reflection).
+If your upstream services is a GRPC service, use this service spec (an empty spec is fine), to 
+make sure that traffic to it is routed with http2.
 
 ```yaml
 "descriptors": bytes
@@ -30,8 +34,8 @@
 
 | Field | Type | Description | Default |
 | ----- | ---- | ----------- |----------- | 
-| `descriptors` | `bytes` | TODO(yuval-k): ideally this should be google.protobuf.FileDescriptorSet but that doesn't work with gogoproto.equal_all. |  |
-| `grpc_services` | [[]grpc.plugins.gloo.solo.io.ServiceSpec.GrpcService](grpc.proto.sk.md#GrpcService) |  |  |
+| `descriptors` | `bytes` | Descriptors that contain information of the services listed below. this is a serialized google.protobuf.FileDescriptorSet |  |
+| `grpc_services` | [[]grpc.plugins.gloo.solo.io.ServiceSpec.GrpcService](grpc.proto.sk.md#GrpcService) | List of services used by this upstream. For a grpc upstream where you don't need to use Gloo's function routing, this can be an empty list. These services must be present in the descriptors. |  |
 
 
 
@@ -39,7 +43,8 @@
 ---
 ### <a name="GrpcService">GrpcService</a>
 
-
+ 
+Describes a grpc service
 
 ```yaml
 "package_name": string
@@ -50,9 +55,9 @@
 
 | Field | Type | Description | Default |
 | ----- | ---- | ----------- |----------- | 
-| `package_name` | `string` |  |  |
-| `service_name` | `string` |  |  |
-| `function_names` | `[]string` |  |  |
+| `package_name` | `string` | The package of this service. |  |
+| `service_name` | `string` | The service name of this service. |  |
+| `function_names` | `[]string` | The functions available in this service. |  |
 
 
 
@@ -61,7 +66,7 @@
 ### <a name="DestinationSpec">DestinationSpec</a>
 
  
-This is only for upstream with Grpc service spec
+This is only for upstream with Grpc service spec.
 
 ```yaml
 "package": string
@@ -73,10 +78,10 @@ This is only for upstream with Grpc service spec
 
 | Field | Type | Description | Default |
 | ----- | ---- | ----------- |----------- | 
-| `package` | `string` |  |  |
-| `service` | `string` |  |  |
-| `function` | `string` |  |  |
-| `parameters` | [.transformation.plugins.gloo.solo.io.Parameters](../transformation/parameters.proto.sk.md#Parameters) |  |  |
+| `package` | `string` | The proto package of the function. |  |
+| `service` | `string` | The name of the service of the function. |  |
+| `function` | `string` | The name of the function. |  |
+| `parameters` | [.transformation.plugins.gloo.solo.io.Parameters](../transformation/parameters.proto.sk.md#Parameters) | Parameters describe how to extract the function parameters from the request. |  |
 
 
 

--- a/projects/gloo/api/v1/plugins/grpc/grpc.proto
+++ b/projects/gloo/api/v1/plugins/grpc/grpc.proto
@@ -8,43 +8,44 @@ option (gogoproto.equal_all) = true;
 
 import "github.com/solo-io/gloo/projects/gloo/api/v1/plugins/transformation/parameters.proto";
 
-// Service spec describing GRPC upstreams. This will usually be filled automatically via function
-// discovery (if the upstream supports reflection).
-// If your upstream services is a GRPC service, use this service spec (an empty spec is fine), to 
-// make sure that traffic to it is routed with http2.
+// Service spec describing GRPC upstreams. This will usually be filled
+// automatically via function discovery (if the upstream supports reflection).
+// If your upstream service is a GRPC service, use this service spec (an empty
+// spec is fine), to make sure that traffic to it is routed with http2.
 message ServiceSpec {
-    // TODO(yuval-k): ideally this should be google.protobuf.FileDescriptorSet 
-    // but that doesn't work with gogoproto.equal_all.
+  // TODO(yuval-k): ideally this should be google.protobuf.FileDescriptorSet
+  // but that doesn't work with gogoproto.equal_all.
 
-    // Descriptors that contain information of the services listed below.
-    // this is a serialized google.protobuf.FileDescriptorSet
-    bytes descriptors = 1;
+  // Descriptors that contain information of the services listed below.
+  // this is a serialized google.protobuf.FileDescriptorSet
+  bytes descriptors = 1;
 
-    // Describes a grpc service 
-    message GrpcService {
+  // Describes a grpc service
+  message GrpcService {
     // The package of this service.
     string package_name = 1;
     // The service name of this service.
     string service_name = 2;
     // The functions available in this service.
     repeated string function_names = 3;
-    }
+  }
 
-    // List of services used by this upstream. For a grpc upstream where you don't need to use 
-    // Gloo's function routing, this can be an empty list.
-    // These services must be present in the descriptors.
-    repeated GrpcService grpc_services = 2;
+  // List of services used by this upstream. For a grpc upstream where you don't
+  // need to use Gloo's function routing, this can be an empty list. These
+  // services must be present in the descriptors.
+  repeated GrpcService grpc_services = 2;
 }
 
 // This is only for upstream with Grpc service spec.
 message DestinationSpec {
-    // The proto package of the function.
-    string package  = 1;
-    // The name of the service of the function.
-    string service  = 2;
-    // The name of the function.
-    string function = 3;
+  // The proto package of the function.
+  string package = 1;
+  // The name of the service of the function.
+  string service = 2;
+  // The name of the function.
+  string function = 3;
 
-    // Parameters describe how to extract the function parameters from the request.
-    transformation.plugins.gloo.solo.io.Parameters parameters = 4;
+  // Parameters describe how to extract the function parameters from the
+  // request.
+  transformation.plugins.gloo.solo.io.Parameters parameters = 4;
 }

--- a/projects/gloo/api/v1/plugins/grpc/grpc.proto
+++ b/projects/gloo/api/v1/plugins/grpc/grpc.proto
@@ -8,25 +8,43 @@ option (gogoproto.equal_all) = true;
 
 import "github.com/solo-io/gloo/projects/gloo/api/v1/plugins/transformation/parameters.proto";
 
+// Service spec describing GRPC upstreams. This will usually be filled automatically via function
+// discovery (if the upstream supports reflection).
+// If your upstream services is a GRPC service, use this service spec (an empty spec is fine), to 
+// make sure that traffic to it is routed with http2.
 message ServiceSpec {
     // TODO(yuval-k): ideally this should be google.protobuf.FileDescriptorSet 
     // but that doesn't work with gogoproto.equal_all.
+
+    // Descriptors that contain information of the services listed below.
+    // this is a serialized google.protobuf.FileDescriptorSet
     bytes descriptors = 1;
 
+    // Describes a grpc service 
     message GrpcService {
-        string package_name = 1;
-        string service_name = 2;
-        repeated string function_names = 3;
+    // The package of this service.
+    string package_name = 1;
+    // The service name of this service.
+    string service_name = 2;
+    // The functions available in this service.
+    repeated string function_names = 3;
     }
 
+    // List of services used by this upstream. For a grpc upstream where you don't need to use 
+    // Gloo's function routing, this can be an empty list.
+    // These services must be present in the descriptors.
     repeated GrpcService grpc_services = 2;
 }
 
-// This is only for upstream with Grpc service spec
+// This is only for upstream with Grpc service spec.
 message DestinationSpec {
+    // The proto package of the function.
     string package  = 1;
+    // The name of the service of the function.
     string service  = 2;
+    // The name of the function.
     string function = 3;
 
+    // Parameters describe how to extract the function parameters from the request.
     transformation.plugins.gloo.solo.io.Parameters parameters = 4;
 }

--- a/projects/gloo/pkg/api/v1/plugins/grpc/grpc.pb.go
+++ b/projects/gloo/pkg/api/v1/plugins/grpc/grpc.pb.go
@@ -24,10 +24,17 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
+// Service spec describing GRPC upstreams. This will usually be filled automatically via function
+// discovery (if the upstream supports reflection).
+// If your upstream services is a GRPC service, use this service spec (an empty spec is fine), to
+// make sure that traffic to it is routed with http2.
 type ServiceSpec struct {
-	// TODO(yuval-k): ideally this should be google.protobuf.FileDescriptorSet
-	// but that doesn't work with gogoproto.equal_all.
-	Descriptors          []byte                     `protobuf:"bytes,1,opt,name=descriptors,proto3" json:"descriptors,omitempty"`
+	// Descriptors that contain information of the services listed below.
+	// this is a serialized google.protobuf.FileDescriptorSet
+	Descriptors []byte `protobuf:"bytes,1,opt,name=descriptors,proto3" json:"descriptors,omitempty"`
+	// List of services used by this upstream. For a grpc upstream where you don't need to use
+	// Gloo's function routing, this can be an empty list.
+	// These services must be present in the descriptors.
 	GrpcServices         []*ServiceSpec_GrpcService `protobuf:"bytes,2,rep,name=grpc_services,json=grpcServices,proto3" json:"grpc_services,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                   `json:"-"`
 	XXX_unrecognized     []byte                     `json:"-"`
@@ -72,9 +79,13 @@ func (m *ServiceSpec) GetGrpcServices() []*ServiceSpec_GrpcService {
 	return nil
 }
 
+// Describes a grpc service
 type ServiceSpec_GrpcService struct {
-	PackageName          string   `protobuf:"bytes,1,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
-	ServiceName          string   `protobuf:"bytes,2,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
+	// The package of this service.
+	PackageName string `protobuf:"bytes,1,opt,name=package_name,json=packageName,proto3" json:"package_name,omitempty"`
+	// The service name of this service.
+	ServiceName string `protobuf:"bytes,2,opt,name=service_name,json=serviceName,proto3" json:"service_name,omitempty"`
+	// The functions available in this service.
 	FunctionNames        []string `protobuf:"bytes,3,rep,name=function_names,json=functionNames,proto3" json:"function_names,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
@@ -126,11 +137,15 @@ func (m *ServiceSpec_GrpcService) GetFunctionNames() []string {
 	return nil
 }
 
-// This is only for upstream with Grpc service spec
+// This is only for upstream with Grpc service spec.
 type DestinationSpec struct {
-	Package              string                     `protobuf:"bytes,1,opt,name=package,proto3" json:"package,omitempty"`
-	Service              string                     `protobuf:"bytes,2,opt,name=service,proto3" json:"service,omitempty"`
-	Function             string                     `protobuf:"bytes,3,opt,name=function,proto3" json:"function,omitempty"`
+	// The proto package of the function.
+	Package string `protobuf:"bytes,1,opt,name=package,proto3" json:"package,omitempty"`
+	// The name of the service of the function.
+	Service string `protobuf:"bytes,2,opt,name=service,proto3" json:"service,omitempty"`
+	// The name of the function.
+	Function string `protobuf:"bytes,3,opt,name=function,proto3" json:"function,omitempty"`
+	// Parameters describe how to extract the function parameters from the request.
 	Parameters           *transformation.Parameters `protobuf:"bytes,4,opt,name=parameters,proto3" json:"parameters,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                   `json:"-"`
 	XXX_unrecognized     []byte                     `json:"-"`

--- a/projects/gloo/pkg/api/v1/plugins/grpc/grpc.pb.go
+++ b/projects/gloo/pkg/api/v1/plugins/grpc/grpc.pb.go
@@ -24,17 +24,17 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
-// Service spec describing GRPC upstreams. This will usually be filled automatically via function
-// discovery (if the upstream supports reflection).
-// If your upstream services is a GRPC service, use this service spec (an empty spec is fine), to
-// make sure that traffic to it is routed with http2.
+// Service spec describing GRPC upstreams. This will usually be filled
+// automatically via function discovery (if the upstream supports reflection).
+// If your upstream service is a GRPC service, use this service spec (an empty
+// spec is fine), to make sure that traffic to it is routed with http2.
 type ServiceSpec struct {
 	// Descriptors that contain information of the services listed below.
 	// this is a serialized google.protobuf.FileDescriptorSet
 	Descriptors []byte `protobuf:"bytes,1,opt,name=descriptors,proto3" json:"descriptors,omitempty"`
-	// List of services used by this upstream. For a grpc upstream where you don't need to use
-	// Gloo's function routing, this can be an empty list.
-	// These services must be present in the descriptors.
+	// List of services used by this upstream. For a grpc upstream where you don't
+	// need to use Gloo's function routing, this can be an empty list. These
+	// services must be present in the descriptors.
 	GrpcServices         []*ServiceSpec_GrpcService `protobuf:"bytes,2,rep,name=grpc_services,json=grpcServices,proto3" json:"grpc_services,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                   `json:"-"`
 	XXX_unrecognized     []byte                     `json:"-"`
@@ -145,7 +145,8 @@ type DestinationSpec struct {
 	Service string `protobuf:"bytes,2,opt,name=service,proto3" json:"service,omitempty"`
 	// The name of the function.
 	Function string `protobuf:"bytes,3,opt,name=function,proto3" json:"function,omitempty"`
-	// Parameters describe how to extract the function parameters from the request.
+	// Parameters describe how to extract the function parameters from the
+	// request.
 	Parameters           *transformation.Parameters `protobuf:"bytes,4,opt,name=parameters,proto3" json:"parameters,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}                   `json:"-"`
 	XXX_unrecognized     []byte                     `json:"-"`

--- a/projects/gloo/pkg/plugins/grpc/plugin.go
+++ b/projects/gloo/pkg/plugins/grpc/plugin.go
@@ -80,9 +80,11 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 		return nil
 	}
 	grpcSpec := grpcWrapper.Grpc
+	out.Http2ProtocolOptions = &envoycore.Http2ProtocolOptions{}
 
-	if len(grpcSpec.GrpcServices) == 0 {
-		return errors.New("service_info.properties.service_names cannot be empty")
+	if grpcSpec == nil || len(grpcSpec.GrpcServices) == 0 {
+		// no services, this just marks the upstream as a grpc one.
+		return nil
 	}
 	descriptors, err := convertProto(grpcSpec.Descriptors)
 	if err != nil {
@@ -106,8 +108,6 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 		Descriptors: descriptors,
 		Spec:        grpcSpec,
 	}
-
-	out.Http2ProtocolOptions = &envoycore.Http2ProtocolOptions{}
 
 	return nil
 }

--- a/projects/gloo/pkg/plugins/grpc/plugin_test.go
+++ b/projects/gloo/pkg/plugins/grpc/plugin_test.go
@@ -59,12 +59,14 @@ var _ = Describe("Plugin", func() {
 
 	It("should not mark none grpc upstreams as http2", func() {
 		upstreamSpec.ServiceSpec.PluginType = nil
-		p.ProcessUpstream(params, upstream, out)
+		err := p.ProcessUpstream(params, upstream, out)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(out.Http2ProtocolOptions).To(BeNil())
 	})
 
 	It("should mark grpc upstreams as http2", func() {
-		p.ProcessUpstream(params, upstream, out)
+		err := p.ProcessUpstream(params, upstream, out)
+		Expect(err).NotTo(HaveOccurred())
 		Expect(out.Http2ProtocolOptions).NotTo(BeNil())
 	})
 

--- a/projects/gloo/pkg/plugins/grpc/plugin_test.go
+++ b/projects/gloo/pkg/plugins/grpc/plugin_test.go
@@ -1,0 +1,71 @@
+package grpc
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	pluginsv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins"
+	v1grpc "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/grpc"
+	v1static "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/static"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
+	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+)
+
+var _ = Describe("Plugin", func() {
+
+	var (
+		p            *plugin
+		params       plugins.Params
+		upstream     *v1.Upstream
+		upstreamSpec *v1static.UpstreamSpec
+		out          *envoyapi.Cluster
+		grpcSepc     *pluginsv1.ServiceSpec_Grpc
+	)
+
+	BeforeEach(func() {
+		p = new(plugin)
+		out = new(envoyapi.Cluster)
+
+		grpcSepc = &pluginsv1.ServiceSpec_Grpc{
+			Grpc: &v1grpc.ServiceSpec{},
+		}
+
+		p.Init(plugins.InitParams{})
+		upstreamSpec = &v1static.UpstreamSpec{
+			ServiceSpec: &pluginsv1.ServiceSpec{
+				PluginType: grpcSepc,
+			},
+			Hosts: []*v1static.Host{{
+				Addr: "localhost",
+				Port: 1234,
+			}},
+		}
+		upstream = &v1.Upstream{
+			Metadata: core.Metadata{
+				Name:      "test",
+				Namespace: "default",
+			},
+			UpstreamSpec: &v1.UpstreamSpec{
+				UpstreamType: &v1.UpstreamSpec_Static{
+					Static: upstreamSpec,
+				},
+			},
+		}
+
+	})
+
+	It("should not mark none grpc upstreams as http2", func() {
+		upstreamSpec.ServiceSpec.PluginType = nil
+		p.ProcessUpstream(params, upstream, out)
+		Expect(out.Http2ProtocolOptions).To(BeNil())
+	})
+
+	It("should mark grpc upstreams as http2", func() {
+		p.ProcessUpstream(params, upstream, out)
+		Expect(out.Http2ProtocolOptions).NotTo(BeNil())
+	})
+
+})


### PR DESCRIPTION
The purpose of this change is to allow marking upstreams as grpc so that envoy is configured correctly.
i think this might be needed for exauth purposes.