### PR TITLE
fix panic on new SetupSync

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1323,7 +1323,7 @@
   revision = "241bc627d5400a0794853220df4fdefeeb2af0e0"
 
 [[projects]]
-  digest = "1:49fa6bb355e585d6e5a2627ed0302ded2f05d68b90878f8c2083a65325a62814"
+  digest = "1:bc65fcacaff08d056e760eee34cf2aa1165fb8f6bffd89d019b5124102f1f394"
   name = "github.com/solo-io/solo-kit"
   packages = [
     "pkg/api/v1/clients",
@@ -1376,8 +1376,8 @@
     "test/tests/typed",
   ]
   pruneopts = "UT"
-  revision = "fe8867e1932dc9480e8b5c715f456b1a665786c0"
-  version = "v0.2.22"
+  revision = "a8be3a112d249730039280d9f50f50fd8b453099"
+  version = "v0.2.24"
 
 [[projects]]
   digest = "1:e01b05ba901239c783dfe56450bcde607fc858908529868259c9a8765dc176d0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -24,7 +24,7 @@
 
 [[constraint]]
   name = "github.com/solo-io/solo-kit"
-  version = "0.2.22"
+  version = "0.2.24"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/pkg/cliutil/nsselect/setup.go
+++ b/pkg/cliutil/nsselect/setup.go
@@ -1,6 +1,7 @@
 package nsselect
 
 import (
+	"context"
 	"fmt"
 
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -21,7 +22,7 @@ func GetUpstreamClient() (*gloov1.UpstreamClient, error) {
 	upstreamClient, err := gloov1.NewUpstreamClient(&factory.KubeResourceClientFactory{
 		Crd:         gloov1.UpstreamCrd,
 		Cfg:         config,
-		SharedCache: kube.NewKubeCache(),
+		SharedCache: kube.NewKubeCache(context.TODO()),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/utils/setuputils/setup_syncer.go
+++ b/pkg/utils/setuputils/setup_syncer.go
@@ -19,7 +19,6 @@ type SetupFunc func(ctx context.Context,
 type SetupSyncer struct {
 	settingsRef   core.ResourceRef
 	setupFunc     SetupFunc
-	kubeCache     kube.SharedCache
 	inMemoryCache memory.InMemoryResourceCache
 }
 
@@ -27,7 +26,6 @@ func NewSetupSyncer(settingsRef core.ResourceRef, setupFunc SetupFunc) *SetupSyn
 	return &SetupSyncer{
 		settingsRef:   settingsRef,
 		setupFunc:     setupFunc,
-		kubeCache:     kube.NewKubeCache(),
 		inMemoryCache: memory.NewInMemoryResourceCache(),
 	}
 }
@@ -37,5 +35,5 @@ func (s *SetupSyncer) Sync(ctx context.Context, snap *v1.SetupSnapshot) error {
 	if err != nil {
 		return errors.Wrapf(err, "finding bootstrap configuration")
 	}
-	return s.setupFunc(ctx, s.kubeCache, s.inMemoryCache, settings)
+	return s.setupFunc(ctx, kube.NewKubeCache(ctx), s.inMemoryCache, settings)
 }

--- a/projects/clusteringress/pkg/api/v1/translator_snapshot_emitter_test.go
+++ b/projects/clusteringress/pkg/api/v1/translator_snapshot_emitter_test.go
@@ -70,7 +70,7 @@ var _ = Describe("V1Emitter", func() {
 		upstreamClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         gloo_solo_io.UpstreamCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		upstreamClient, err = gloo_solo_io.NewUpstreamClient(upstreamClientFactory)
 		Expect(err).NotTo(HaveOccurred())
@@ -78,7 +78,7 @@ var _ = Describe("V1Emitter", func() {
 		clusterIngressClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         ClusterIngressCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		clusterIngressClient, err = NewClusterIngressClient(clusterIngressClientFactory)
 		Expect(err).NotTo(HaveOccurred())

--- a/projects/gateway/pkg/api/v1/api_snapshot_emitter_test.go
+++ b/projects/gateway/pkg/api/v1/api_snapshot_emitter_test.go
@@ -56,7 +56,7 @@ var _ = Describe("V1Emitter", func() {
 		gatewayClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         GatewayCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		gatewayClient, err = NewGatewayClient(gatewayClientFactory)
 		Expect(err).NotTo(HaveOccurred())
@@ -64,7 +64,7 @@ var _ = Describe("V1Emitter", func() {
 		virtualServiceClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         VirtualServiceCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		virtualServiceClient, err = NewVirtualServiceClient(virtualServiceClientFactory)
 		Expect(err).NotTo(HaveOccurred())

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -87,7 +88,7 @@ func registerSettingsCrd() error {
 	settingsClient, err := v1.NewSettingsClient(&factory.KubeResourceClientFactory{
 		Crd:         v1.SettingsCrd,
 		Cfg:         cfg,
-		SharedCache: kube.NewKubeCache(),
+		SharedCache: kube.NewKubeCache(context.TODO()),
 	})
 
 	return settingsClient.Register()

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -76,7 +77,7 @@ func UpstreamClient() (v1.UpstreamClient, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache()
+	cache := kube.NewKubeCache(context.TODO())
 	upstreamClient, err := v1.NewUpstreamClient(&factory.KubeResourceClientFactory{
 		Crd:         v1.UpstreamCrd,
 		Cfg:         cfg,
@@ -108,7 +109,7 @@ func ProxyClient() (v1.ProxyClient, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache()
+	cache := kube.NewKubeCache(context.TODO())
 	proxyClient, err := v1.NewProxyClient(&factory.KubeResourceClientFactory{
 		Crd:         v1.ProxyCrd,
 		Cfg:         cfg,
@@ -140,7 +141,7 @@ func VirtualServiceClient() (gatewayv1.VirtualServiceClient, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache()
+	cache := kube.NewKubeCache(context.TODO())
 	virtualServiceClient, err := gatewayv1.NewVirtualServiceClient(&factory.KubeResourceClientFactory{
 		Crd:         gatewayv1.VirtualServiceCrd,
 		Cfg:         cfg,
@@ -172,7 +173,7 @@ func SettingsClient() (v1.SettingsClient, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache()
+	cache := kube.NewKubeCache(context.TODO())
 	settingsClient, err := v1.NewSettingsClient(&factory.KubeResourceClientFactory{
 		Crd:         v1.SettingsCrd,
 		Cfg:         cfg,

--- a/projects/gloo/pkg/api/v1/api_snapshot_emitter_test.go
+++ b/projects/gloo/pkg/api/v1/api_snapshot_emitter_test.go
@@ -79,7 +79,7 @@ var _ = Describe("V1Emitter", func() {
 		proxyClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         ProxyCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		proxyClient, err = NewProxyClient(proxyClientFactory)
 		Expect(err).NotTo(HaveOccurred())
@@ -96,7 +96,7 @@ var _ = Describe("V1Emitter", func() {
 		upstreamClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         UpstreamCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		upstreamClient, err = NewUpstreamClient(upstreamClientFactory)
 		Expect(err).NotTo(HaveOccurred())

--- a/projects/gloo/pkg/api/v1/discovery_snapshot_emitter_test.go
+++ b/projects/gloo/pkg/api/v1/discovery_snapshot_emitter_test.go
@@ -67,7 +67,7 @@ var _ = Describe("V1Emitter", func() {
 		upstreamClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         UpstreamCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		upstreamClient, err = NewUpstreamClient(upstreamClientFactory)
 		Expect(err).NotTo(HaveOccurred())

--- a/projects/gloo/pkg/api/v1/setup_snapshot_emitter_test.go
+++ b/projects/gloo/pkg/api/v1/setup_snapshot_emitter_test.go
@@ -55,7 +55,7 @@ var _ = Describe("V1Emitter", func() {
 		settingsClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         SettingsCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		settingsClient, err = NewSettingsClient(settingsClientFactory)
 		Expect(err).NotTo(HaveOccurred())

--- a/projects/ingress/pkg/api/v1/translator_snapshot_emitter_test.go
+++ b/projects/ingress/pkg/api/v1/translator_snapshot_emitter_test.go
@@ -70,7 +70,7 @@ var _ = Describe("V1Emitter", func() {
 		upstreamClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         gloo_solo_io.UpstreamCrd,
 			Cfg:         cfg,
-			SharedCache: kuberc.NewKubeCache(),
+			SharedCache: kuberc.NewKubeCache(context.TODO()),
 		}
 		upstreamClient, err = gloo_solo_io.NewUpstreamClient(upstreamClientFactory)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/kube2e/gateway_test.go
+++ b/test/kube2e/gateway_test.go
@@ -1,6 +1,7 @@
 package kube2e_test
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -25,7 +26,7 @@ var _ = Describe("Kube2e: gateway", func() {
 	It("works", func() {
 		cfg, err := kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
-		cache := kube.NewKubeCache()
+		cache := kube.NewKubeCache(context.TODO())
 		gatewayClientFactory := &factory.KubeResourceClientFactory{
 			Crd:         v1.GatewayCrd,
 			Cfg:         cfg,


### PR DESCRIPTION
currently kubecache is shared across "soft" restarts (when settings crd gets updated)

this PR updates with new solo kit where we have replaced 
`context.TODO()` in the KubeCache with a constructor that accepts a context.

when the context is cancelled, the goroutines running for the cache will be terminated.

we use this feature to create a new kubecache on a new SetupSync, where the previous 
cache will have been cancelled by the Setup Event Loop