### PR TITLE
Fix url for virtualboxminikube

### DIFF
--- a/projects/gloo/cli/pkg/cmd/gateway/gateway_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/gateway_suite_test.go
@@ -1,0 +1,13 @@
+package gateway_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestGateway(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gateway Suite")
+}

--- a/projects/gloo/cli/pkg/cmd/gateway/url.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/url.go
@@ -57,7 +57,8 @@ func getIngressHost(opts *options.Options) (string, error) {
 	svc, err := kube.CoreV1().Services(opts.Metadata.Namespace).Get(opts.Proxy.Name, metav1.GetOptions{})
 	if err != nil {
 		return "", errors.Wrapf(err, "could not detect '%v' service in %v namespace. "+
-			"Check that Gloo has been installed properly and is running with 'kubectl get pod -n gloo-system'", opts.Proxy.Name)
+			"Check that Gloo has been installed properly and is running with 'kubectl get pod -n gloo-system'",
+			opts.Proxy.Name, opts.Metadata.Namespace)
 	}
 	var svcPort *v1.ServicePort
 	switch len(svc.Spec.Ports) {

--- a/projects/gloo/cli/pkg/cmd/gateway/url.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/url.go
@@ -7,6 +7,8 @@ import (
 	"os/exec"
 	"strings"
 
+	"k8s.io/apimachinery/pkg/labels"
+
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/solo-io/go-utils/cliutils"
@@ -80,7 +82,7 @@ func getIngressHost(opts *options.Options) (string, error) {
 	if len(svc.Status.LoadBalancer.Ingress) == 0 || opts.Proxy.LocalCluster {
 		// assume nodeport on kubernetes
 		// TODO: support more types of NodePort services
-		host, err = getNodeIp()
+		host, err = getNodeIp(svc, kube)
 		if err != nil {
 			return "", errors.Wrapf(err, "")
 		}
@@ -96,13 +98,52 @@ func getIngressHost(opts *options.Options) (string, error) {
 
 }
 
-func getNodeIp() (string, error) {
-	kubectl := exec.Command("kubectl", "get", "node", "--output", "jsonpath={.items[0].status.addresses[0].address}")
+func getNodeIp(svc *v1.Service, kube kubernetes.Interface) (string, error) {
+	// pick a node where one of our pods is running
+	pods, err := kube.CoreV1().Pods(svc.Name).List(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(svc.Spec.Selector).String(),
+	})
+	if err != nil {
+		return "", err
+	}
+	var nodeName string
+	for _, pod := range pods.Items {
+		if pod.Spec.NodeName != "" {
+			nodeName = pod.Spec.NodeName
+			break
+		}
+	}
+	if nodeName == "" {
+		return "", errors.Errorf("no node found for %v's pods. ensure at least one pod has been deployed "+
+			"for the %v service", svc.Name, svc.Name)
+	}
+	// special case for minikube
+	// we run `minikube ip` which avoids an issue where
+	// we get a NAT network IP when the minikube provider is virtualbox
+	if nodeName == "minikube" {
+		return minikubeIp()
+	}
+
+	node, err := kube.CoreV1().Nodes().Get(nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	for _, addr := range node.Status.Addresses {
+		return addr.Address, nil
+	}
+
+	return "", errors.Errorf("no active addresses found for node %v", node.Name)
+}
+
+func minikubeIp() (string, error) {
+	minikubeCmd := exec.Command("minikube", "ip")
 
 	hostname := &bytes.Buffer{}
 
-	kubectl.Stdout = hostname
-	kubectl.Stderr = os.Stderr
-	err := kubectl.Run()
+	minikubeCmd.Stdout = hostname
+	minikubeCmd.Stderr = os.Stderr
+	err := minikubeCmd.Run()
+
 	return strings.TrimSuffix(hostname.String(), "\n"), err
 }

--- a/projects/gloo/cli/pkg/cmd/gateway/url.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/url.go
@@ -100,7 +100,7 @@ func getIngressHost(opts *options.Options) (string, error) {
 
 func getNodeIp(svc *v1.Service, kube kubernetes.Interface) (string, error) {
 	// pick a node where one of our pods is running
-	pods, err := kube.CoreV1().Pods(svc.Name).List(metav1.ListOptions{
+	pods, err := kube.CoreV1().Pods(svc.Namespace).List(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(svc.Spec.Selector).String(),
 	})
 	if err != nil {

--- a/projects/gloo/cli/pkg/cmd/gateway/url_test.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/url_test.go
@@ -1,0 +1,21 @@
+package gateway_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
+)
+
+var _ = Describe("Url", func() {
+	It("returns the correct url of a proxy pod", func() {
+
+		// install gateway first
+		err := testutils.Glooctl("install gateway --release 0.6.19")
+		Expect(err).NotTo(HaveOccurred())
+
+		addr, err := testutils.GlooctlOut("proxy url")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(addr).To(HavePrefix("http://"))
+	})
+})

--- a/projects/gloo/cli/pkg/testutils/utils.go
+++ b/projects/gloo/cli/pkg/testutils/utils.go
@@ -1,6 +1,9 @@
 package testutils
 
 import (
+	"bytes"
+	"io"
+	"os"
 	"os/exec"
 	"strings"
 
@@ -13,6 +16,34 @@ func Glooctl(args string) error {
 	app := cmd.GlooCli("test")
 	app.SetArgs(strings.Split(args, " "))
 	return app.Execute()
+}
+func GlooctlOut(args string) (string, error) {
+	stdOut := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		return "", err
+	}
+	os.Stdout = w
+
+	app := cmd.GlooCli("test")
+	app.SetArgs(strings.Split(args, " "))
+	err = app.Execute()
+
+	outC := make(chan string)
+
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// back to normal state
+	w.Close()
+	os.Stdout = stdOut // restoring the real stdout
+	out := <-outC
+
+	return strings.TrimSuffix(out, "\n"), nil
 }
 
 func Make(dir, args string) error {


### PR DESCRIPTION
fixes `glooctl proxy url` command for the case when minikube is running in virtualbox with a NAT network

currently the command returns the NAT ip which is internal / not accessible from the host computer