### PR TITLE
fix constructors for artifact and secret client constructors

### DIFF
--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -6,6 +6,8 @@ import (
 	"strconv"
 	"strings"
 
+	corecache "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 
 	"github.com/gogo/protobuf/types"
@@ -97,8 +99,9 @@ func NewControlPlane(ctx context.Context, grpcServer *grpc.Server, start bool) b
 
 func (s *setupSyncer) Setup(ctx context.Context, kubeCache kube.SharedCache, memCache memory.InMemoryResourceCache, settings *v1.Settings) error {
 	var (
-		cfg       *rest.Config
-		clientset kubernetes.Interface
+		cfg           *rest.Config
+		clientset     kubernetes.Interface
+		kubeCoreCache corecache.KubeCoreCache
 	)
 
 	upstreamFactory, err := bootstrap.ConfigFactoryForSettings(
@@ -124,22 +127,26 @@ func (s *setupSyncer) Setup(ctx context.Context, kubeCache kube.SharedCache, mem
 	}
 
 	secretFactory, err := bootstrap.SecretFactoryForSettings(
+		ctx,
 		settings,
 		memCache,
-		v1.SecretCrd.Plural,
 		&cfg,
 		&clientset,
+		&kubeCoreCache,
+		v1.SecretCrd.Plural,
 	)
 	if err != nil {
 		return err
 	}
 
 	artifactFactory, err := bootstrap.ArtifactFactoryForSettings(
+		ctx,
 		settings,
 		memCache,
-		v1.ArtifactCrd.Plural,
 		&cfg,
 		&clientset,
+		&kubeCoreCache,
+		v1.ArtifactCrd.Plural,
 	)
 	if err != nil {
 		return err

--- a/projects/ingress/pkg/setup/setup_syncer.go
+++ b/projects/ingress/pkg/setup/setup_syncer.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
+
 	"github.com/gogo/protobuf/types"
 	knativeclientset "github.com/knative/serving/pkg/client/clientset/versioned"
 	"github.com/solo-io/gloo/projects/clusteringress/pkg/api/clusteringress"
@@ -30,8 +32,9 @@ import (
 
 func Setup(ctx context.Context, kubeCache kube.SharedCache, inMemoryCache memory.InMemoryResourceCache, settings *gloov1.Settings) error {
 	var (
-		cfg       *rest.Config
-		clientset kubernetes.Interface
+		cfg           *rest.Config
+		clientset     kubernetes.Interface
+		kubeCoreCache cache.KubeCoreCache
 	)
 	proxyFactory, err := bootstrap.ConfigFactoryForSettings(
 		settings,
@@ -56,11 +59,13 @@ func Setup(ctx context.Context, kubeCache kube.SharedCache, inMemoryCache memory
 	}
 
 	secretFactory, err := bootstrap.SecretFactoryForSettings(
+		ctx,
 		settings,
 		inMemoryCache,
-		gloov1.SecretCrd.Plural,
 		&cfg,
 		&clientset,
+		&kubeCoreCache,
+		gloov1.SecretCrd.Plural,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
solo kit v0.2.25 introduced a breaking change to the configmap and secret client factories.

this change fixes them by initializing a `KubeCoreCache` in the `utils.SecretFactoryForSettings` and `utils.ConfigMapFactoryForSettings` helper functions in the same way that rest configs are initialized and then shared there.

tested by running `hyperkube` without any init error