### PR TITLE
ALPN only for listeners

### DIFF
--- a/projects/gloo/pkg/utils/ssl.go
+++ b/projects/gloo/pkg/utils/ssl.go
@@ -38,6 +38,9 @@ func (s *SslConfigTranslator) ResolveDownstreamSslConfig(dc *v1.SslConfig) (*env
 	if common.ValidationContextType != nil {
 		requireClientCert = &gogo_types.BoolValue{Value: true}
 	}
+	// show alpn for downstreams.
+	// placing it on upstreams maybe problematic if they do not expose alpn.
+	common.AlpnProtocols = []string{"h2", "http/1.1"}
 	return &envoyauth.DownstreamTlsContext{
 		CommonTlsContext:         common,
 		RequireClientCertificate: requireClientCert,
@@ -103,8 +106,7 @@ func (s *SslConfigTranslator) ResolveCommonSslConfig(cs CertSource) (*envoyauth.
 
 	tlsContext := &envoyauth.CommonTlsContext{
 		// default params
-		TlsParams:     &envoyauth.TlsParameters{},
-		AlpnProtocols: []string{"h2", "http/1.1"},
+		TlsParams: &envoyauth.TlsParameters{},
 	}
 
 	if certChainData != nil && privateKeyData != nil {

--- a/projects/gloo/pkg/utils/ssl_test.go
+++ b/projects/gloo/pkg/utils/ssl_test.go
@@ -149,6 +149,18 @@ var _ = Describe("Ssl", func() {
 			Expect(cfg.RequireClientCertificate.GetValue()).To(BeTrue())
 		})
 
+		It("should set alpn for downstream config", func() {
+			cfg, err := configTranslator.ResolveDownstreamSslConfig(downstreamCfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CommonTlsContext.AlpnProtocols).To(Equal([]string{"h2", "http/1.1"}))
+		})
+
+		It("should NOT set alpn for upstream config", func() {
+			cfg, err := configTranslator.ResolveUpstreamSslConfig(upstreamCfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.CommonTlsContext.AlpnProtocols).To(BeEmpty())
+		})
+
 		It("should not set require client cert for downstream config with no rootca", func() {
 			tlsSecret.RootCa = ""
 			cfg, err := configTranslator.ResolveDownstreamSslConfig(downstreamCfg)


### PR DESCRIPTION
it seems that setting alpn on the upstream is not a good idea if the upstream doesnt support it.