### PR TITLE
Fix ingress namespace bug

### DIFF
--- a/changelog/v0.8.4/3.yaml
+++ b/changelog/v0.8.4/3.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: "ingresses only picked up in default namespace"
+  issueLink: https://github.com/solo-io/gloo/issues/476

--- a/projects/clusteringress/pkg/api/v1/translator_snapshot.sk.go
+++ b/projects/clusteringress/pkg/api/v1/translator_snapshot.sk.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"fmt"
+
 	gloo_solo_io "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 
 	"github.com/solo-io/solo-kit/pkg/utils/hashutils"
@@ -50,4 +52,41 @@ func (s TranslatorSnapshot) HashFields() []zap.Field {
 	fields = append(fields, zap.Uint64("clusteringresses", s.hashClusteringresses()))
 
 	return append(fields, zap.Uint64("snapshotHash", s.Hash()))
+}
+
+type TranslatorSnapshotStringer struct {
+	Version          uint64
+	Secrets          []string
+	Upstreams        []string
+	Clusteringresses []string
+}
+
+func (ss TranslatorSnapshotStringer) String() string {
+	s := fmt.Sprintf("TranslatorSnapshot %v\n", ss.Version)
+
+	s += fmt.Sprintf("  Secrets %v\n", len(ss.Secrets))
+	for _, name := range ss.Secrets {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Upstreams %v\n", len(ss.Upstreams))
+	for _, name := range ss.Upstreams {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Clusteringresses %v\n", len(ss.Clusteringresses))
+	for _, name := range ss.Clusteringresses {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	return s
+}
+
+func (s TranslatorSnapshot) Stringer() TranslatorSnapshotStringer {
+	return TranslatorSnapshotStringer{
+		Version:          s.Hash(),
+		Secrets:          s.Secrets.List().NamespacesDotNames(),
+		Upstreams:        s.Upstreams.List().NamespacesDotNames(),
+		Clusteringresses: s.Clusteringresses.Names(),
+	}
 }

--- a/projects/gateway/pkg/api/v1/api_snapshot.sk.go
+++ b/projects/gateway/pkg/api/v1/api_snapshot.sk.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/solo-io/solo-kit/pkg/utils/hashutils"
 	"go.uber.org/zap"
 )
@@ -40,4 +42,34 @@ func (s ApiSnapshot) HashFields() []zap.Field {
 	fields = append(fields, zap.Uint64("virtualServices", s.hashVirtualServices()))
 
 	return append(fields, zap.Uint64("snapshotHash", s.Hash()))
+}
+
+type ApiSnapshotStringer struct {
+	Version         uint64
+	Gateways        []string
+	VirtualServices []string
+}
+
+func (ss ApiSnapshotStringer) String() string {
+	s := fmt.Sprintf("ApiSnapshot %v\n", ss.Version)
+
+	s += fmt.Sprintf("  Gateways %v\n", len(ss.Gateways))
+	for _, name := range ss.Gateways {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  VirtualServices %v\n", len(ss.VirtualServices))
+	for _, name := range ss.VirtualServices {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	return s
+}
+
+func (s ApiSnapshot) Stringer() ApiSnapshotStringer {
+	return ApiSnapshotStringer{
+		Version:         s.Hash(),
+		Gateways:        s.Gateways.List().NamespacesDotNames(),
+		VirtualServices: s.VirtualServices.List().NamespacesDotNames(),
+	}
 }

--- a/projects/gloo/pkg/api/v1/api_snapshot.sk.go
+++ b/projects/gloo/pkg/api/v1/api_snapshot.sk.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/solo-io/solo-kit/pkg/utils/hashutils"
 	"go.uber.org/zap"
 )
@@ -64,4 +66,55 @@ func (s ApiSnapshot) HashFields() []zap.Field {
 	fields = append(fields, zap.Uint64("upstreams", s.hashUpstreams()))
 
 	return append(fields, zap.Uint64("snapshotHash", s.Hash()))
+}
+
+type ApiSnapshotStringer struct {
+	Version   uint64
+	Artifacts []string
+	Endpoints []string
+	Proxies   []string
+	Secrets   []string
+	Upstreams []string
+}
+
+func (ss ApiSnapshotStringer) String() string {
+	s := fmt.Sprintf("ApiSnapshot %v\n", ss.Version)
+
+	s += fmt.Sprintf("  Artifacts %v\n", len(ss.Artifacts))
+	for _, name := range ss.Artifacts {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Endpoints %v\n", len(ss.Endpoints))
+	for _, name := range ss.Endpoints {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Proxies %v\n", len(ss.Proxies))
+	for _, name := range ss.Proxies {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Secrets %v\n", len(ss.Secrets))
+	for _, name := range ss.Secrets {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Upstreams %v\n", len(ss.Upstreams))
+	for _, name := range ss.Upstreams {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	return s
+}
+
+func (s ApiSnapshot) Stringer() ApiSnapshotStringer {
+	return ApiSnapshotStringer{
+		Version:   s.Hash(),
+		Artifacts: s.Artifacts.List().NamespacesDotNames(),
+		Endpoints: s.Endpoints.List().NamespacesDotNames(),
+		Proxies:   s.Proxies.List().NamespacesDotNames(),
+		Secrets:   s.Secrets.List().NamespacesDotNames(),
+		Upstreams: s.Upstreams.List().NamespacesDotNames(),
+	}
 }

--- a/projects/gloo/pkg/api/v1/discovery_snapshot.sk.go
+++ b/projects/gloo/pkg/api/v1/discovery_snapshot.sk.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/solo-io/solo-kit/pkg/utils/hashutils"
 	"go.uber.org/zap"
 )
@@ -40,4 +42,34 @@ func (s DiscoverySnapshot) HashFields() []zap.Field {
 	fields = append(fields, zap.Uint64("upstreams", s.hashUpstreams()))
 
 	return append(fields, zap.Uint64("snapshotHash", s.Hash()))
+}
+
+type DiscoverySnapshotStringer struct {
+	Version   uint64
+	Secrets   []string
+	Upstreams []string
+}
+
+func (ss DiscoverySnapshotStringer) String() string {
+	s := fmt.Sprintf("DiscoverySnapshot %v\n", ss.Version)
+
+	s += fmt.Sprintf("  Secrets %v\n", len(ss.Secrets))
+	for _, name := range ss.Secrets {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Upstreams %v\n", len(ss.Upstreams))
+	for _, name := range ss.Upstreams {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	return s
+}
+
+func (s DiscoverySnapshot) Stringer() DiscoverySnapshotStringer {
+	return DiscoverySnapshotStringer{
+		Version:   s.Hash(),
+		Secrets:   s.Secrets.List().NamespacesDotNames(),
+		Upstreams: s.Upstreams.List().NamespacesDotNames(),
+	}
 }

--- a/projects/gloo/pkg/api/v1/setup_snapshot.sk.go
+++ b/projects/gloo/pkg/api/v1/setup_snapshot.sk.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/solo-io/solo-kit/pkg/utils/hashutils"
 	"go.uber.org/zap"
 )
@@ -32,4 +34,27 @@ func (s SetupSnapshot) HashFields() []zap.Field {
 	fields = append(fields, zap.Uint64("settings", s.hashSettings()))
 
 	return append(fields, zap.Uint64("snapshotHash", s.Hash()))
+}
+
+type SetupSnapshotStringer struct {
+	Version  uint64
+	Settings []string
+}
+
+func (ss SetupSnapshotStringer) String() string {
+	s := fmt.Sprintf("SetupSnapshot %v\n", ss.Version)
+
+	s += fmt.Sprintf("  Settings %v\n", len(ss.Settings))
+	for _, name := range ss.Settings {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	return s
+}
+
+func (s SetupSnapshot) Stringer() SetupSnapshotStringer {
+	return SetupSnapshotStringer{
+		Version:  s.Hash(),
+		Settings: s.Settings.List().NamespacesDotNames(),
+	}
 }

--- a/projects/ingress/pkg/api/ingress/resource_client.go
+++ b/projects/ingress/pkg/api/ingress/resource_client.go
@@ -187,7 +187,6 @@ func (rc *ResourceClient) Delete(namespace, name string, opts clients.DeleteOpts
 
 func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resources.ResourceList, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 
 	ingressObjList, err := rc.kube.ExtensionsV1beta1().Ingresses(namespace).List(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
@@ -216,7 +215,6 @@ func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resourc
 
 func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 	watch, err := rc.kube.ExtensionsV1beta1().Ingresses(namespace).Watch(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
 	})

--- a/projects/ingress/pkg/api/service/resource_client.go
+++ b/projects/ingress/pkg/api/service/resource_client.go
@@ -187,7 +187,6 @@ func (rc *ResourceClient) Delete(namespace, name string, opts clients.DeleteOpts
 
 func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resources.ResourceList, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 
 	svcObjList, err := rc.kube.CoreV1().Services(namespace).List(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
@@ -216,7 +215,6 @@ func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resourc
 
 func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 	watch, err := rc.kube.CoreV1().Services(namespace).Watch(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
 	})

--- a/projects/ingress/pkg/api/v1/status_snapshot.sk.go
+++ b/projects/ingress/pkg/api/v1/status_snapshot.sk.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"fmt"
+
 	"github.com/solo-io/solo-kit/pkg/utils/hashutils"
 	"go.uber.org/zap"
 )
@@ -40,4 +42,34 @@ func (s StatusSnapshot) HashFields() []zap.Field {
 	fields = append(fields, zap.Uint64("ingresses", s.hashIngresses()))
 
 	return append(fields, zap.Uint64("snapshotHash", s.Hash()))
+}
+
+type StatusSnapshotStringer struct {
+	Version   uint64
+	Services  []string
+	Ingresses []string
+}
+
+func (ss StatusSnapshotStringer) String() string {
+	s := fmt.Sprintf("StatusSnapshot %v\n", ss.Version)
+
+	s += fmt.Sprintf("  Services %v\n", len(ss.Services))
+	for _, name := range ss.Services {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Ingresses %v\n", len(ss.Ingresses))
+	for _, name := range ss.Ingresses {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	return s
+}
+
+func (s StatusSnapshot) Stringer() StatusSnapshotStringer {
+	return StatusSnapshotStringer{
+		Version:   s.Hash(),
+		Services:  s.Services.List().NamespacesDotNames(),
+		Ingresses: s.Ingresses.List().NamespacesDotNames(),
+	}
 }

--- a/projects/ingress/pkg/api/v1/translator_snapshot.sk.go
+++ b/projects/ingress/pkg/api/v1/translator_snapshot.sk.go
@@ -3,6 +3,8 @@
 package v1
 
 import (
+	"fmt"
+
 	gloo_solo_io "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 
 	"github.com/solo-io/solo-kit/pkg/utils/hashutils"
@@ -50,4 +52,41 @@ func (s TranslatorSnapshot) HashFields() []zap.Field {
 	fields = append(fields, zap.Uint64("ingresses", s.hashIngresses()))
 
 	return append(fields, zap.Uint64("snapshotHash", s.Hash()))
+}
+
+type TranslatorSnapshotStringer struct {
+	Version   uint64
+	Secrets   []string
+	Upstreams []string
+	Ingresses []string
+}
+
+func (ss TranslatorSnapshotStringer) String() string {
+	s := fmt.Sprintf("TranslatorSnapshot %v\n", ss.Version)
+
+	s += fmt.Sprintf("  Secrets %v\n", len(ss.Secrets))
+	for _, name := range ss.Secrets {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Upstreams %v\n", len(ss.Upstreams))
+	for _, name := range ss.Upstreams {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	s += fmt.Sprintf("  Ingresses %v\n", len(ss.Ingresses))
+	for _, name := range ss.Ingresses {
+		s += fmt.Sprintf("    %v\n", name)
+	}
+
+	return s
+}
+
+func (s TranslatorSnapshot) Stringer() TranslatorSnapshotStringer {
+	return TranslatorSnapshotStringer{
+		Version:   s.Hash(),
+		Secrets:   s.Secrets.List().NamespacesDotNames(),
+		Upstreams: s.Upstreams.List().NamespacesDotNames(),
+		Ingresses: s.Ingresses.List().NamespacesDotNames(),
+	}
 }


### PR DESCRIPTION
An empty namespace was being defaulted to `default` in the ingress resource client list & watch functions.

Fixes #476 