### PR TITLE
Fix ingress namespace bug

### DIFF
--- a/changelog/v0.8.4/3.yaml
+++ b/changelog/v0.8.4/3.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: "ingresses only picked up in default namespace"
+  issueLink: https://github.com/solo-io/gloo/issues/476

--- a/projects/ingress/pkg/api/ingress/resource_client.go
+++ b/projects/ingress/pkg/api/ingress/resource_client.go
@@ -187,7 +187,6 @@ func (rc *ResourceClient) Delete(namespace, name string, opts clients.DeleteOpts
 
 func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resources.ResourceList, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 
 	ingressObjList, err := rc.kube.ExtensionsV1beta1().Ingresses(namespace).List(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
@@ -216,7 +215,6 @@ func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resourc
 
 func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 	watch, err := rc.kube.ExtensionsV1beta1().Ingresses(namespace).Watch(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
 	})

--- a/projects/ingress/pkg/api/service/resource_client.go
+++ b/projects/ingress/pkg/api/service/resource_client.go
@@ -187,7 +187,6 @@ func (rc *ResourceClient) Delete(namespace, name string, opts clients.DeleteOpts
 
 func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resources.ResourceList, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 
 	svcObjList, err := rc.kube.CoreV1().Services(namespace).List(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
@@ -216,7 +215,6 @@ func (rc *ResourceClient) List(namespace string, opts clients.ListOpts) (resourc
 
 func (rc *ResourceClient) Watch(namespace string, opts clients.WatchOpts) (<-chan resources.ResourceList, <-chan error, error) {
 	opts = opts.WithDefaults()
-	namespace = clients.DefaultNamespaceIfEmpty(namespace)
 	watch, err := rc.kube.CoreV1().Services(namespace).Watch(metav1.ListOptions{
 		LabelSelector: labels.SelectorFromSet(opts.Selector).String(),
 	})


### PR DESCRIPTION
An empty namespace was being defaulted to `default` in the ingress resource client list & watch functions.

Fixes #476 