### PR TITLE
Make sure version is set when building CLI

### DIFF
--- a/changelog/v0.10.2/fix-artifact-version.yaml
+++ b/changelog/v0.10.2/fix-artifact-version.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fixes a regression in the release process where release artifacts weren't properly versioned, causing install to not behave as expected.
+    issueLink: https://github.com/solo-io/gloo/issues/508

--- a/ci/upload_github_release_assets.go
+++ b/ci/upload_github_release_assets.go
@@ -1,8 +1,18 @@
 package main
 
-import "github.com/solo-io/go-utils/githubutils"
+import (
+	"fmt"
+	"github.com/solo-io/go-utils/githubutils"
+	"github.com/solo-io/go-utils/logger"
+	"github.com/solo-io/go-utils/versionutils"
+	"os/exec"
+	"runtime"
+	"strings"
+)
 
 func main() {
+	validateReleaseVersionOfCli()
+
 	assets := make([]githubutils.ReleaseAssetSpec, 6)
 	assets[0] = githubutils.ReleaseAssetSpec{
 		Name:       "glooctl-linux-amd64",
@@ -38,5 +48,18 @@ func main() {
 		SkipAlreadyExists: true,
 	}
 	githubutils.UploadReleaseAssetCli(&spec)
+}
+
+func validateReleaseVersionOfCli() {
+	releaseVersion := versionutils.GetReleaseVersionOrExitGracefully().String()[1:]
+	name := fmt.Sprintf("_output/glooctl-%s-amd64", runtime.GOOS)
+	cmd := exec.Command(name, "--version")
+	bytes, err := cmd.Output()
+	if err != nil {
+		logger.Fatalf("Error while trying to validate artifact version. Error was: %s", err.Error())
+	}
+	if !strings.HasSuffix(string(bytes), fmt.Sprintf("version %s\n", releaseVersion)) {
+		logger.Fatalf("Unexpected version output for glooctl: %s", string(bytes))
+	}
 }
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -145,6 +145,7 @@ steps:
     - 'BUILD_ID=$BUILD_ID'
     - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
     - 'HELM_HOME=/root/.helm'
+    - 'TAGGED_VERSION=$TAG_NAME'
   dir: './gopath/src/github.com/solo-io/gloo'
   waitFor: ['compile']
   id: 'build-test-assets'


### PR DESCRIPTION
Currently the CLI is built by the regression testing step, which does not set the version. 