### PR TITLE
Generalize

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -28,7 +28,7 @@
 
 [[constraint]]
   name = "github.com/solo-io/go-utils"
-  version = "0.5.0"
+  version = "0.5.1"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/Makefile
+++ b/Makefile
@@ -382,10 +382,10 @@ push-kind-images: docker
 # The Kube2e tests will use the generated Gloo Chart to install Gloo to the GKE test cluster.
 
 .PHONY: build-test-assets
-build-test-assets: push-test-images build-test-chart
+build-test-assets: push-test-images build-test-chart $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/glooctl-darwin-amd64
 
 .PHONY: build-kind-assets
-build-kind-assets: push-kind-images build-kind-chart
+build-kind-assets: push-kind-images build-kind-chart $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/glooctl-darwin-amd64
 
 TEST_DOCKER_TARGETS := gateway-docker-test ingress-docker-test discovery-docker-test gloo-docker-test gloo-envoy-wrapper-docker-test
 
@@ -408,14 +408,14 @@ gloo-envoy-wrapper-docker-test: $(OUTPUT_DIR)/envoyinit-linux-amd64 $(OUTPUT_DIR
 	docker push $(GCR_REPO_PREFIX)/gloo-envoy-wrapper:$(TEST_IMAGE_TAG)
 
 .PHONY: build-test-chart
-build-test-chart: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/glooctl-darwin-amd64
+build-test-chart:
 	mkdir -p $(TEST_ASSET_DIR)
 	go run install/helm/gloo/generate.go $(TEST_IMAGE_TAG) $(GCR_REPO_PREFIX)
 	helm package --destination $(TEST_ASSET_DIR) $(HELM_DIR)/gloo
 	helm repo index $(TEST_ASSET_DIR)
 
 .PHONY: build-kind-chart
-build-kind-chart: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/glooctl-darwin-amd64
+build-kind-chart:
 	mkdir -p $(TEST_ASSET_DIR)
 	go run install/helm/gloo/generate.go $(VERSION)
 	helm package --destination $(TEST_ASSET_DIR) $(HELM_DIR)/gloo

--- a/changelog/v0.12.1/generalize-install-for-glooe.yaml
+++ b/changelog/v0.12.1/generalize-install-for-glooe.yaml
@@ -1,3 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: Generalizes the install library so glooe can use it and remove redundant code.

--- a/changelog/v0.12.1/generalize-install-for-glooe.yaml
+++ b/changelog/v0.12.1/generalize-install-for-glooe.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Generalizes the install library so glooe can use it and remove redundant code. 

--- a/changelog/v0.12.1/generalize-install-for-glooe.yaml
+++ b/changelog/v0.12.1/generalize-install-for-glooe.yaml
@@ -1,3 +1,3 @@
 changelog:
   - type: NON_USER_FACING
-    description: Generalizes the install library so glooe can use it and remove redundant code. 
+    description: Generalizes the install library so glooe can use it and remove redundant code.

--- a/changelog/v0.13.0/generalize-install-for-glooe.yaml
+++ b/changelog/v0.13.0/generalize-install-for-glooe.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Generalizes the install library so glooe can use it and remove redundant code.
+  - type: BREAKING_CHANGE
+    description: Glooctl install library has been refactored.
+    issueLink: https://github.com/solo-io/gloo/pull/597

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -113,6 +113,7 @@ steps:
   - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster'
   - 'RUN_KUBE_TESTS=1'
   - 'DOCKER_CONFIG=/workspace/.docker/'
+  - 'HELM_HOME=/root/.helm'
   dir: './gopath/src/github.com/solo-io/gloo'
   args: ['-r', '-failFast', '-race']
   waitFor: ['get-envoy', 'setup-aws-creds', 'setup-helm', 'check-code-and-docs-gen']

--- a/install/helm/gloo/templates/0-namespace.yaml
+++ b/install/helm/gloo/templates/0-namespace.yaml
@@ -3,4 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Release.Namespace }}
+  labels:
+    app: gloo
 {{- end}}

--- a/pkg/cliutil/install/filters.go
+++ b/pkg/cliutil/install/filters.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/helm/helm/pkg/hooks"
 	"github.com/solo-io/go-utils/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"k8s.io/helm/pkg/manifest"
 )
@@ -172,7 +172,7 @@ func KnativeResourceFilterFunction(skipKnative bool) ManifestFilterFunc {
 	}
 }
 
-var ExcludeKnative ManifestFilterFunc = KnativeResourceFilterFunction(true)
+var ExcludeKnative = KnativeResourceFilterFunction(true)
 
 var ExcludeNonKnative ManifestFilterFunc = func(input []manifest.Manifest) (output []manifest.Manifest, err error) {
 	for _, man := range input {

--- a/pkg/cliutil/install/filters.go
+++ b/pkg/cliutil/install/filters.go
@@ -75,7 +75,7 @@ var nonPreInstallMatcher ResourceMatcherFunc = func(resource ResourceType) (bool
 
 var excludeByMatcher = func(input []manifest.Manifest, matches ResourceMatcherFunc) (output []manifest.Manifest, allResourceNames []string, err error) {
 	for _, man := range input {
-		content, resourceNames, err := ExcludeManifestContentByMatcher(man.Content, matches)
+		content, resourceNames, err := excludeManifestContentByMatcher(man.Content, matches)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -89,7 +89,7 @@ var excludeByMatcher = func(input []manifest.Manifest, matches ResourceMatcherFu
 	return
 }
 
-var ExcludeManifestContentByMatcher = func(input string, matches ResourceMatcherFunc) (output string, resourceNames []string, err error) {
+var excludeManifestContentByMatcher = func(input string, matches ResourceMatcherFunc) (output string, resourceNames []string, err error) {
 	var nonMatching []string
 	for _, doc := range strings.Split(input, "---") {
 

--- a/pkg/cliutil/install/kubernetes.go
+++ b/pkg/cliutil/install/kubernetes.go
@@ -67,7 +67,10 @@ func WaitForCrdsToBeRegistered(crds []string, timeout, interval time.Duration) e
 
 //noinspection GoNameStartsWithPackageName
 func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expectedLabels map[string]string, excludeResources ResourceMatcherFunc) error {
-	manifestString := string(manifest)
+	manifestString, err := filterExcludedResources(string(manifest), excludeResources)
+	if err != nil {
+		return errors.Wrapf(err, "filtering excluded resources from manifest")
+	}
 	if isEmptyManifest(manifestString) {
 		return nil
 	}
@@ -85,8 +88,9 @@ func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expe
 	return nil
 }
 
-func filterExcludedResources(manifest string, excludeResources ResourceMatcherFunc) error {
-
+func filterExcludedResources(manifest string, excludeResources ResourceMatcherFunc) (string, error) {
+	content, _, err := excludeManifestContentByMatcher(manifest, excludeResources)
+	return content, err
 }
 
 func validateManifest(manifestString string, allowedKinds []string, expectedLabels map[string]string) error {

--- a/pkg/cliutil/install/kubernetes.go
+++ b/pkg/cliutil/install/kubernetes.go
@@ -66,7 +66,7 @@ func WaitForCrdsToBeRegistered(crds []string, timeout, interval time.Duration) e
 }
 
 //noinspection GoNameStartsWithPackageName
-func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expectedLabels map[string]string) error {
+func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expectedLabels map[string]string, excludeResources ResourceMatcherFunc) error {
 	manifestString := string(manifest)
 	if isEmptyManifest(manifestString) {
 		return nil
@@ -83,6 +83,10 @@ func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expe
 		return errors.Wrapf(err, "running kubectl apply on manifest")
 	}
 	return nil
+}
+
+func filterExcludedResources(manifest string, excludeResources ResourceMatcherFunc) error {
+
 }
 
 func validateManifest(manifestString string, allowedKinds []string, expectedLabels map[string]string) error {

--- a/pkg/cliutil/install/kubernetes.go
+++ b/pkg/cliutil/install/kubernetes.go
@@ -2,96 +2,10 @@ package install
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"time"
-
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
-	"github.com/solo-io/go-utils/errors"
-	"github.com/solo-io/go-utils/kubeutils"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 )
-
-func CheckKnativeInstallation() (isInstalled bool, isOurs bool, err error) {
-	restCfg, err := kubeutils.GetConfig("", "")
-	if err != nil {
-		return false, false, err
-	}
-	kube, err := kubernetes.NewForConfig(restCfg)
-	if err != nil {
-		return false, false, err
-	}
-	namespaces, err := kube.CoreV1().Namespaces().List(metav1.ListOptions{})
-	if err != nil {
-		return false, false, err
-	}
-	for _, ns := range namespaces.Items {
-		if ns.Name == constants.KnativeServingNamespace {
-			ours := ns.Labels != nil && ns.Labels["app"] == "gloo"
-			return true, ours, nil
-		}
-	}
-	return false, false, nil
-}
-
-// Blocks until the given CRDs have been registered.
-func WaitForCrdsToBeRegistered(crds []string, timeout, interval time.Duration) error {
-	if len(crds) == 0 {
-		return nil
-	}
-
-	// TODO: think about improving
-	// Just pick the last crd in the list an wait for it to be created. It is reasonable to assume that by the time we
-	// get to applying the manifest the other ones will be ready as well.
-	crdName := crds[len(crds)-1]
-
-	elapsed := time.Duration(0)
-	for {
-		select {
-		case <-time.After(interval):
-			if err := Kubectl(nil, "get", crdName); err == nil {
-				return nil
-			}
-			elapsed += interval
-			if elapsed > timeout {
-				return errors.Errorf("failed to confirm knative crd registration after %v", timeout)
-			}
-		}
-	}
-}
-
-//noinspection GoNameStartsWithPackageName
-func InstallManifest(manifest []byte, isDryRun bool, excludeResources ResourceMatcherFunc) error {
-	manifestString, err := filterExcludedResources(string(manifest), excludeResources)
-	if err != nil {
-		return errors.Wrapf(err, "filtering excluded resources from manifest")
-	}
-	if IsEmptyManifest(manifestString) {
-		return nil
-	}
-	if isDryRun {
-		fmt.Printf("%s", manifestString)
-		// For safety, print a YAML separator so multiple invocations of this function will produce valid output
-		fmt.Println("\n---")
-		return nil
-	}
-
-	if err := KubectlApply([]byte(manifestString)); err != nil {
-		return errors.Wrapf(err, "running kubectl apply on manifest")
-	}
-	return nil
-}
-
-func filterExcludedResources(manifest string, excludeResources ResourceMatcherFunc) (string, error) {
-	if excludeResources == nil {
-		return manifest, nil
-	}
-	content, _, err := excludeManifestContentByMatcher(manifest, excludeResources)
-	return content, err
-}
 
 func KubectlApply(manifest []byte) error {
 	return Kubectl(bytes.NewBuffer(manifest), "apply", "-f", "-")

--- a/pkg/cliutil/install/kubernetes.go
+++ b/pkg/cliutil/install/kubernetes.go
@@ -76,13 +76,13 @@ func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expe
 	}
 	validateManifest(manifestString, allowedKinds, expectedLabels)
 	if isDryRun {
-		fmt.Printf("%s", manifest)
+		fmt.Printf("%s", manifestString)
 		// For safety, print a YAML separator so multiple invocations of this function will produce valid output
 		fmt.Println("\n---")
 		return nil
 	}
 
-	if err := kubectlApply(manifest); err != nil {
+	if err := kubectlApply([]byte(manifestString)); err != nil {
 		return errors.Wrapf(err, "running kubectl apply on manifest")
 	}
 	return nil

--- a/pkg/cliutil/install/kubernetes.go
+++ b/pkg/cliutil/install/kubernetes.go
@@ -74,7 +74,9 @@ func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expe
 	if isEmptyManifest(manifestString) {
 		return nil
 	}
-	validateManifest(manifestString, allowedKinds, expectedLabels)
+	if err := validateManifest(manifestString, allowedKinds, expectedLabels); err != nil {
+		return err
+	}
 	if isDryRun {
 		fmt.Printf("%s", manifestString)
 		// For safety, print a YAML separator so multiple invocations of this function will produce valid output

--- a/pkg/cliutil/install/kubernetes.go
+++ b/pkg/cliutil/install/kubernetes.go
@@ -89,6 +89,9 @@ func InstallManifest(manifest []byte, isDryRun bool, allowedKinds []string, expe
 }
 
 func filterExcludedResources(manifest string, excludeResources ResourceMatcherFunc) (string, error) {
+	if excludeResources == nil {
+		return manifest, nil
+	}
 	content, _, err := excludeManifestContentByMatcher(manifest, excludeResources)
 	return content, err
 }

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -1,6 +1,7 @@
 package install_test
 
 import (
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -11,3 +12,10 @@ func TestInstall(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Install Suite")
 }
+
+// NOTE: This needs to be run from the root of the repo as the working directory
+var _ = BeforeSuite(func() {
+	err := testutils.Make("", "build-test-chart BUILD_ID=unit-testing")
+	Expect(err).NotTo(HaveOccurred())
+})
+

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -1,8 +1,9 @@
 package install_test
 
 import (
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	"testing"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -18,4 +19,3 @@ var _ = BeforeSuite(func() {
 	err := testutils.Make("", "build-test-chart BUILD_ID=unit-testing")
 	Expect(err).NotTo(HaveOccurred())
 })
-

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -17,6 +17,7 @@ func TestInstall(t *testing.T) {
 }
 
 var RootDir string
+var file string
 
 // NOTE: This needs to be run from the root of the repo as the working directory
 var _ = BeforeSuite(func() {
@@ -25,5 +26,12 @@ var _ = BeforeSuite(func() {
 	RootDir = filepath.Join(cwd, "../../../../../..")
 
 	err = testutils.Make(RootDir, "build-test-chart BUILD_ID=unit-testing")
+	Expect(err).NotTo(HaveOccurred())
+
+	file = filepath.Join(RootDir, "_test/gloo-test-unit-testing.tgz")
+})
+
+var _ = AfterSuite(func() {
+	err := os.Remove(file)
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -1,6 +1,8 @@
 package install_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
@@ -14,8 +16,14 @@ func TestInstall(t *testing.T) {
 	RunSpecs(t, "Install Suite")
 }
 
+var RootDir string
+
 // NOTE: This needs to be run from the root of the repo as the working directory
 var _ = BeforeSuite(func() {
-	err := testutils.Make("", "build-test-chart BUILD_ID=unit-testing")
+	cwd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred())
+	RootDir = filepath.Join(cwd, "../../../../../..")
+
+	err = testutils.Make(RootDir, "build-test-chart BUILD_ID=unit-testing")
 	Expect(err).NotTo(HaveOccurred())
 })

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -2,10 +2,11 @@ package install_test
 
 import (
 	"fmt"
+	"path/filepath"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
-	"path/filepath"
 )
 
 // NOTE: This needs to be run from the repo root to find the test asset created in the BeforeSuite

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -2,6 +2,7 @@ package install_test
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -8,15 +8,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 )
 
-// NOTE: This needs to be run from the repo root to find the test asset created in the BeforeSuite
-
 var _ = Describe("Install", func() {
-
-	/**
-	NOTE: If these tests start failing, it could mean we've added a new kind of resource that gets created at install time.
-	These are strictly validated in the CLI installer so they can be cleaned up correctly during uninstall. To fix that issue,
-	add the new kind to the installKinds slice here: projects/gloo/cli/pkg/cmd/install/util.go
-	*/
 
 	It("shouldn't get errors for gateway dry run", func() {
 		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway --file %s --dry-run", file))

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -1,14 +1,22 @@
 package install_test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
+	"path/filepath"
 )
 
 // NOTE: This needs to be run from the repo root to find the test asset created in the BeforeSuite
 
 var _ = Describe("Install", func() {
+
+	var file string
+
+	BeforeEach(func() {
+		file = filepath.Join(RootDir, "_test/gloo-test-unit-testing.tgz")
+	})
 
 	/**
 	NOTE: If these tests start failing, it could mean we've added a new kind of resource that gets created at install time.
@@ -17,17 +25,17 @@ var _ = Describe("Install", func() {
 	*/
 
 	It("shouldn't get errors for gateway dry run", func() {
-		_, err := testutils.GlooctlOut("install gateway --file _test/gloo-test-unit-testing.tgz --dry-run")
+		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway --file %s --dry-run", file))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("shouldn't get errors for knative dry run", func() {
-		_, err := testutils.GlooctlOut("install knative --file _test/gloo-test-unit-testing.tgz --dry-run")
+		_, err := testutils.GlooctlOut(fmt.Sprintf("install knative --file %s --dry-run", file))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("shouldn't get errors for ingress dry run", func() {
-		_, err := testutils.GlooctlOut("install ingress --file _test/gloo-test-unit-testing.tgz --dry-run")
+		_, err := testutils.GlooctlOut(fmt.Sprintf("install ingress --file %s --dry-run", file))
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -2,8 +2,6 @@ package install_test
 
 import (
 	"fmt"
-	"path/filepath"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
@@ -12,12 +10,6 @@ import (
 // NOTE: This needs to be run from the repo root to find the test asset created in the BeforeSuite
 
 var _ = Describe("Install", func() {
-
-	var file string
-
-	BeforeEach(func() {
-		file = filepath.Join(RootDir, "_test/gloo-test-unit-testing.tgz")
-	})
 
 	/**
 	NOTE: If these tests start failing, it could mean we've added a new kind of resource that gets created at install time.

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -49,12 +49,12 @@ var _ = Describe("Install", func() {
 	It("should error when not providing file with valid extension", func() {
 		_, err := testutils.GlooctlOut("install gateway --file foo")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("installing gloo in gateway mode: installing Gloo from helm chart: unsupported file extension for Helm chart URI: [foo]. Extension must either be .tgz or .tar.gz"))
+		Expect(err.Error()).To(ContainSubstring("installing gloo in gateway mode: unsupported file extension for Helm chart URI: [foo]. Extension must either be .tgz or .tar.gz"))
 	})
 
 	It("should error when not providing valid file", func() {
 		_, err := testutils.GlooctlOut("install gateway --file foo.tgz")
 		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("installing gloo in gateway mode: installing Gloo from helm chart: retrieving gloo helm chart archive"))
+		Expect(err.Error()).To(ContainSubstring("installing gloo in gateway mode: retrieving gloo helm chart archive: opening file"))
 	})
 })

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -6,6 +6,8 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 )
 
+// NOTE: This needs to be run from the repo root to find the test asset created in the BeforeSuite
+
 var _ = Describe("Install", func() {
 
 	/**
@@ -15,17 +17,17 @@ var _ = Describe("Install", func() {
 	*/
 
 	It("shouldn't get errors for gateway dry run", func() {
-		_, err := testutils.GlooctlOut("install gateway --file https://storage.googleapis.com/solo-public-helm/charts/gloo-0.11.1.tgz --dry-run")
+		_, err := testutils.GlooctlOut("install gateway --file _test/gloo-test-unit-testing.tgz --dry-run")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("shouldn't get errors for knative dry run", func() {
-		_, err := testutils.GlooctlOut("install knative --file https://storage.googleapis.com/solo-public-helm/charts/gloo-0.11.1.tgz --dry-run")
+		_, err := testutils.GlooctlOut("install knative --file _test/gloo-test-unit-testing.tgz --dry-run")
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("shouldn't get errors for ingress dry run", func() {
-		_, err := testutils.GlooctlOut("install ingress --file https://storage.googleapis.com/solo-public-helm/charts/gloo-0.11.1.tgz --dry-run")
+		_, err := testutils.GlooctlOut("install ingress --file _test/gloo-test-unit-testing.tgz --dry-run")
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -1,0 +1,221 @@
+package install
+
+import (
+	"fmt"
+	"github.com/pkg/errors"
+	"github.com/solo-io/gloo/pkg/cliutil/install"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"k8s.io/helm/pkg/chartutil"
+	"k8s.io/helm/pkg/manifest"
+	"k8s.io/helm/pkg/proto/hapi/chart"
+	"k8s.io/helm/pkg/renderutil"
+	"path"
+	"strings"
+	"time"
+)
+
+type KubeInstallClient interface {
+	KubectlApply(manifest []byte) error
+	WaitForCrdsToBeRegistered(crds []string, timeout, interval time.Duration) error
+	CheckKnativeInstallation() (bool, bool, error) // isInstalled, isOurs, error
+}
+
+type DefaultKubeInstallClient struct {}
+
+func (i *DefaultKubeInstallClient) KubectlApply(manifest []byte) error {
+	return install.KubectlApply(manifest)
+}
+
+func (i *DefaultKubeInstallClient) WaitForCrdsToBeRegistered(crds []string, timeout, interval time.Duration) error {
+	return install.WaitForCrdsToBeRegistered(crds, timeout, interval)
+}
+
+func (i *DefaultKubeInstallClient) CheckKnativeInstallation() (bool, bool, error) {
+	return install.CheckKnativeInstallation()
+}
+
+type ManifestInstaller interface {
+	InstallManifest(manifest []byte) error
+	InstallCrds(crdNames []string, manifest []byte) error
+}
+
+type KubeManifestInstaller struct {
+	KubeInstallClient KubeInstallClient
+}
+
+func (i *KubeManifestInstaller) InstallManifest(manifest []byte) error {
+	if install.IsEmptyManifest(string(manifest)) {
+		return nil
+	}
+	if err := i.KubeInstallClient.KubectlApply(manifest); err != nil {
+		return errors.Wrapf(err, "running kubectl apply on manifest")
+	}
+	return nil
+}
+
+func (i *KubeManifestInstaller) InstallCrds(crdNames []string, manifest []byte) error {
+	if err := i.InstallManifest(manifest); err != nil {
+		return err
+	}
+	if err := i.KubeInstallClient.WaitForCrdsToBeRegistered(crdNames, time.Second*5, time.Millisecond*500); err != nil {
+		return errors.Wrapf(err, "waiting for crds to be registered")
+	}
+	return nil
+}
+
+type DryRunManifestInstaller struct {}
+
+func (i *DryRunManifestInstaller) InstallManifest(manifest []byte) error {
+	manifestString := string(manifest)
+	if install.IsEmptyManifest(manifestString) {
+		return nil
+	}
+	fmt.Printf("%s", manifestString)
+	// For safety, print a YAML separator so multiple invocations of this function will produce valid output
+	fmt.Println("\n---")
+	return nil
+}
+
+func (i *DryRunManifestInstaller) InstallCrds(crdNames []string, manifest []byte) error {
+	return i.InstallManifest(manifest)
+}
+
+type KnativeInstallStatus struct {
+	isInstalled bool
+	isOurs      bool
+}
+
+type GlooStagedInstaller interface {
+	DoCrdInstall() error
+	DoPreInstall() error
+	DoInstall() error
+	DoKnativeInstall() error
+}
+
+type DefaultGlooStagedInstaller struct {
+	chart *chart.Chart
+	values *chart.Config
+	renderOpts renderutil.Options
+	knativeInstallStatus KnativeInstallStatus
+	excludeResources install.ResourceMatcherFunc
+	manifestInstaller ManifestInstaller
+}
+
+func NewGlooStagedInstaller(opts *options.Options, spec GlooInstallSpec, client KubeInstallClient) (GlooStagedInstaller, error) {
+	if path.Ext(spec.HelmArchiveUri) != ".tgz" && !strings.HasSuffix(spec.HelmArchiveUri, ".tar.gz") {
+		return nil, errors.Errorf("unsupported file extension for Helm chart URI: [%s]. Extension must either be .tgz or .tar.gz", spec.HelmArchiveUri)
+	}
+
+	chart, err := install.GetHelmArchive(spec.HelmArchiveUri)
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving gloo helm chart archive")
+	}
+
+	values, err := install.GetValuesFromFileIncludingExtra(chart, spec.ValueFileName, spec.ExtraValues)
+	if err != nil {
+		return nil, errors.Wrapf(err, "retrieving value file: %s", spec.ValueFileName)
+	}
+
+	// These are the .Release.* variables used during rendering
+	renderOpts := renderutil.Options{
+		ReleaseOptions: chartutil.ReleaseOptions{
+			Namespace: opts.Install.Namespace,
+			Name:      spec.ProductName,
+		},
+	}
+
+	isInstalled, isOurs, err := client.CheckKnativeInstallation()
+	if err != nil {
+		return nil, err
+	}
+	knativeInstallStatus := KnativeInstallStatus{
+		isInstalled: isInstalled,
+		isOurs: isOurs,
+	}
+
+	var manifestInstaller ManifestInstaller
+	if opts.Install.DryRun {
+		manifestInstaller = &DryRunManifestInstaller{}
+	} else {
+		manifestInstaller = &KubeManifestInstaller{
+			KubeInstallClient: client,
+		}
+	}
+
+	return &DefaultGlooStagedInstaller{
+		chart: chart,
+		values: values,
+		renderOpts: renderOpts,
+		knativeInstallStatus: knativeInstallStatus,
+		excludeResources: nil,
+		manifestInstaller: manifestInstaller,
+	}, nil
+}
+
+func (i *DefaultGlooStagedInstaller) DoCrdInstall() error {
+
+	// Keep only CRDs and collect the names
+	var crdNames []string
+	excludeNonCrdsAndCollectCrdNames := func(input []manifest.Manifest) ([]manifest.Manifest, error) {
+		manifests, resourceNames, err := install.ExcludeNonCrds(input)
+		crdNames = resourceNames
+		return manifests, err
+	}
+
+	// Render and install CRD manifests
+	crdManifestBytes, err := install.RenderChart(i.chart, i.values, i.renderOpts,
+		install.ExcludeNotes,
+		install.KnativeResourceFilterFunction(i.knativeInstallStatus.isInstalled),
+		excludeNonCrdsAndCollectCrdNames,
+		install.ExcludeEmptyManifests)
+	if err != nil {
+		return errors.Wrapf(err, "rendering crd manifests")
+	}
+
+	return i.manifestInstaller.InstallCrds(crdNames, crdManifestBytes)
+}
+
+func (i *DefaultGlooStagedInstaller) DoPreInstall() error {
+	// Render and install Gloo manifest
+	manifestBytes, err := install.RenderChart(i.chart, i.values, i.renderOpts,
+		install.ExcludeNotes,
+		install.ExcludeKnative,
+		install.IncludeOnlyPreInstall,
+		install.ExcludeEmptyManifests,
+		install.ExcludeMatchingResources(i.excludeResources))
+	if err != nil {
+		return err
+	}
+	return i.manifestInstaller.InstallManifest(manifestBytes)
+}
+
+func (i *DefaultGlooStagedInstaller) DoInstall() error {
+	// Render and install Gloo manifest
+	manifestBytes, err := install.RenderChart(i.chart, i.values, i.renderOpts,
+		install.ExcludeNotes,
+		install.ExcludeKnative,
+		install.ExcludePreInstall,
+		install.ExcludeCrds,
+		install.ExcludeEmptyManifests,
+		install.ExcludeMatchingResources(i.excludeResources))
+	if err != nil {
+		return err
+	}
+	return i.manifestInstaller.InstallManifest(manifestBytes)
+}
+
+// This is a bit tricky. The manifest is already filtered based on the values file. If the values file includes
+// knative stuff, then we may want to do a knative install -- if there isn't an install already, or if there is
+// an install and it's ours (i.e. an upgrade)
+func (i *DefaultGlooStagedInstaller) DoKnativeInstall() error {
+	// Exclude everything but knative non-crds
+	manifestBytes, err := install.RenderChart(i.chart, i.values, i.renderOpts,
+		install.ExcludeNonKnative,
+		install.KnativeResourceFilterFunction(i.knativeInstallStatus.isInstalled && !i.knativeInstallStatus.isOurs),
+		install.ExcludeCrds)
+	if err != nil {
+		return err
+	}
+	return i.manifestInstaller.InstallManifest(manifestBytes)
+}
+

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -22,7 +22,7 @@ import (
 type KubeInstallClient interface {
 	KubectlApply(manifest []byte) error
 	WaitForCrdsToBeRegistered(crds []string, timeout, interval time.Duration) error
-	CheckKnativeInstallation() (bool, bool, error) // isInstalled, isOurs, error
+	CheckKnativeInstallation() (isInstalled bool, isOurs bool, err error)
 }
 
 type DefaultKubeInstallClient struct{}

--- a/projects/gloo/cli/pkg/cmd/install/installer_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer_test.go
@@ -58,13 +58,13 @@ var _ = Describe("Install", func() {
 
 	expectKinds := func(resources []install2.ResourceType, kinds []string) {
 		for _, resource := range resources {
-			Expect(kinds).To(ContainElement(resource.Kind))
+			ExpectWithOffset(1, kinds).To(ContainElement(resource.Kind))
 		}
 	}
 
 	expectNames := func(resources []install2.ResourceType, names []string) {
 		for _, resource := range resources {
-			Expect(names).To(ContainElement(resource.Metadata.Name))
+			ExpectWithOffset(1, names).To(ContainElement(resource.Metadata.Name))
 		}
 	}
 
@@ -73,8 +73,8 @@ var _ = Describe("Install", func() {
 			actualLabels := resource.Metadata.Labels
 			for k, v := range labels {
 				val, ok := actualLabels[k]
-				Expect(ok).To(BeTrue())
-				Expect(v).To(BeEquivalentTo(val))
+				ExpectWithOffset(1, ok).To(BeTrue())
+				ExpectWithOffset(1, v).To(BeEquivalentTo(val))
 			}
 		}
 	}
@@ -82,7 +82,7 @@ var _ = Describe("Install", func() {
 	expectNamespace := func(resources []install2.ResourceType, namespace string) {
 		for _, resource := range resources {
 			if resource.Metadata.Namespace != "" {
-				Expect(resource.Metadata.Namespace).To(BeEquivalentTo(namespace))
+				ExpectWithOffset(1, resource.Metadata.Namespace).To(BeEquivalentTo(namespace))
 			}
 		}
 	}

--- a/projects/gloo/cli/pkg/cmd/install/installer_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer_test.go
@@ -1,23 +1,24 @@
 package install_test
 
 import (
+	"path/filepath"
+	"time"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	install2 "github.com/solo-io/gloo/pkg/cliutil/install"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
-	"path/filepath"
-	"time"
 )
 
 type MockInstallClient struct {
-	expectedCrds []string
-	applied bool
-	waited bool
-	resources []install2.ResourceType
+	expectedCrds     []string
+	applied          bool
+	waited           bool
+	resources        []install2.ResourceType
 	knativeInstalled bool
-	knativeOurs bool
+	knativeOurs      bool
 }
 
 func (i *MockInstallClient) KubectlApply(manifest []byte) error {
@@ -43,9 +44,9 @@ func (i *MockInstallClient) CheckKnativeInstallation() (bool, bool, error) {
 var _ = Describe("Install", func() {
 
 	var (
-		file string
+		file      string
 		installer install.GlooStagedInstaller
-		opts options.Options
+		opts      options.Options
 		validator MockInstallClient
 	)
 
@@ -102,7 +103,7 @@ var _ = Describe("Install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(validator.applied).To(BeTrue())
 			Expect(validator.waited).To(BeTrue())
-			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectKinds(validator.resources, []string{"CustomResourceDefinition"})
 			expectNames(validator.resources, install.GlooCrdNames)
 		})
 
@@ -147,7 +148,7 @@ var _ = Describe("Install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(validator.applied).To(BeTrue())
 			Expect(validator.waited).To(BeTrue())
-			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectKinds(validator.resources, []string{"CustomResourceDefinition"})
 			expectNames(validator.resources, install.GlooCrdNames)
 		})
 
@@ -195,7 +196,7 @@ var _ = Describe("Install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(validator.applied).To(BeTrue())
 			Expect(validator.waited).To(BeTrue())
-			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectKinds(validator.resources, []string{"CustomResourceDefinition"})
 			expectNames(validator.resources, allCrds)
 		})
 
@@ -231,9 +232,9 @@ var _ = Describe("Install", func() {
 			spec, err := install.GetInstallSpec(&opts, constants.KnativeValuesFileName)
 			Expect(err).NotTo(HaveOccurred())
 			validator = MockInstallClient{
-				expectedCrds: install.GlooCrdNames,
+				expectedCrds:     install.GlooCrdNames,
 				knativeInstalled: true,
-				knativeOurs: true,
+				knativeOurs:      true,
 			}
 			installer, err = install.NewGlooStagedInstaller(&opts, *spec, &validator)
 			Expect(err).NotTo(HaveOccurred())
@@ -244,7 +245,7 @@ var _ = Describe("Install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(validator.applied).To(BeTrue())
 			Expect(validator.waited).To(BeTrue())
-			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectKinds(validator.resources, []string{"CustomResourceDefinition"})
 			expectNames(validator.resources, install.GlooCrdNames)
 		})
 
@@ -280,7 +281,7 @@ var _ = Describe("Install", func() {
 			spec, err := install.GetInstallSpec(&opts, constants.KnativeValuesFileName)
 			Expect(err).NotTo(HaveOccurred())
 			validator = MockInstallClient{
-				expectedCrds: install.GlooCrdNames,
+				expectedCrds:     install.GlooCrdNames,
 				knativeInstalled: true,
 			}
 			installer, err = install.NewGlooStagedInstaller(&opts, *spec, &validator)
@@ -292,7 +293,7 @@ var _ = Describe("Install", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(validator.applied).To(BeTrue())
 			Expect(validator.waited).To(BeTrue())
-			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectKinds(validator.resources, []string{"CustomResourceDefinition"})
 			expectNames(validator.resources, install.GlooCrdNames)
 		})
 

--- a/projects/gloo/cli/pkg/cmd/install/installer_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer_test.go
@@ -1,0 +1,324 @@
+package install_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	install2 "github.com/solo-io/gloo/pkg/cliutil/install"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
+	"path/filepath"
+	"time"
+)
+
+type MockInstallClient struct {
+	expectedCrds []string
+	applied bool
+	waited bool
+	resources []install2.ResourceType
+	knativeInstalled bool
+	knativeOurs bool
+}
+
+func (i *MockInstallClient) KubectlApply(manifest []byte) error {
+	Expect(i.applied).To(BeFalse())
+	i.applied = true
+	resources, err := install2.GetResources(string(manifest))
+	Expect(err).NotTo(HaveOccurred())
+	i.resources = resources
+	return nil
+}
+
+func (i *MockInstallClient) WaitForCrdsToBeRegistered(crds []string, timeout, interval time.Duration) error {
+	Expect(i.waited).To(BeFalse())
+	i.waited = true
+	Expect(crds).To(ConsistOf(i.expectedCrds))
+	return nil
+}
+
+func (i *MockInstallClient) CheckKnativeInstallation() (bool, bool, error) {
+	return i.knativeInstalled, i.knativeOurs, nil
+}
+
+var _ = Describe("Install", func() {
+
+	var (
+		file string
+		installer install.GlooStagedInstaller
+		opts options.Options
+		validator MockInstallClient
+	)
+
+	BeforeEach(func() {
+		file = filepath.Join(RootDir, "_test/gloo-test-unit-testing.tgz")
+		opts.Install.Namespace = "gloo-system"
+		opts.Install.HelmChartOverride = file
+	})
+
+	expectKinds := func(resources []install2.ResourceType, kinds []string) {
+		for _, resource := range resources {
+			Expect(kinds).To(ContainElement(resource.Kind))
+		}
+	}
+
+	expectNames := func(resources []install2.ResourceType, names []string) {
+		for _, resource := range resources {
+			Expect(names).To(ContainElement(resource.Metadata.Name))
+		}
+	}
+
+	expectLabels := func(resources []install2.ResourceType, labels map[string]string) {
+		for _, resource := range resources {
+			actualLabels := resource.Metadata.Labels
+			for k, v := range labels {
+				val, ok := actualLabels[k]
+				Expect(ok).To(BeTrue())
+				Expect(v).To(BeEquivalentTo(val))
+			}
+		}
+	}
+
+	expectNamespace := func(resources []install2.ResourceType, namespace string) {
+		for _, resource := range resources {
+			if resource.Metadata.Namespace != "" {
+				Expect(resource.Metadata.Namespace).To(BeEquivalentTo(namespace))
+			}
+		}
+	}
+
+	Context("Gateway with default values", func() {
+		BeforeEach(func() {
+			spec, err := install.GetInstallSpec(&opts, constants.GatewayValuesFileName)
+			Expect(err).NotTo(HaveOccurred())
+			validator = MockInstallClient{
+				expectedCrds: install.GlooCrdNames,
+			}
+			installer, err = install.NewGlooStagedInstaller(&opts, *spec, &validator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("installs expected crds for gloo", func() {
+			err := installer.DoCrdInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeTrue())
+			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectNames(validator.resources, install.GlooCrdNames)
+		})
+
+		It("does nothing on preinstall", func() {
+			err := installer.DoPreInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+			Expect(validator.resources).To(BeEmpty())
+		})
+
+		It("installs expected kinds for gloo", func() {
+			err := installer.DoInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeFalse())
+			expectKinds(validator.resources, install.GlooInstallKinds)
+			expectLabels(validator.resources, install.ExpectedLabels)
+		})
+
+		It("skips knative install", func() {
+			err := installer.DoKnativeInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+		})
+	})
+
+	Context("Ingress with default values", func() {
+		BeforeEach(func() {
+			spec, err := install.GetInstallSpec(&opts, constants.IngressValuesFileName)
+			Expect(err).NotTo(HaveOccurred())
+			validator = MockInstallClient{
+				expectedCrds: install.GlooCrdNames,
+			}
+			installer, err = install.NewGlooStagedInstaller(&opts, *spec, &validator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("installs expected crds for gloo", func() {
+			err := installer.DoCrdInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeTrue())
+			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectNames(validator.resources, install.GlooCrdNames)
+		})
+
+		It("does nothing on preinstall", func() {
+			err := installer.DoPreInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+			Expect(validator.resources).To(BeEmpty())
+		})
+
+		It("installs expected kinds for gloo", func() {
+			err := installer.DoInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeFalse())
+			expectKinds(validator.resources, install.GlooInstallKinds)
+			expectLabels(validator.resources, install.ExpectedLabels)
+		})
+
+		It("skips knative install", func() {
+			err := installer.DoKnativeInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+		})
+	})
+
+	Context("Knative with default values and no previous knative", func() {
+
+		allCrds := append(install.GlooCrdNames, install.KnativeCrdNames...)
+
+		BeforeEach(func() {
+			spec, err := install.GetInstallSpec(&opts, constants.KnativeValuesFileName)
+			Expect(err).NotTo(HaveOccurred())
+			validator = MockInstallClient{
+				expectedCrds: allCrds,
+			}
+			installer, err = install.NewGlooStagedInstaller(&opts, *spec, &validator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("installs all crds", func() {
+			err := installer.DoCrdInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeTrue())
+			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectNames(validator.resources, allCrds)
+		})
+
+		It("does nothing on preinstall", func() {
+			err := installer.DoPreInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+			Expect(validator.resources).To(BeEmpty())
+		})
+
+		It("installs expected kinds for gloo", func() {
+			err := installer.DoInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeFalse())
+			expectKinds(validator.resources, install.GlooInstallKinds)
+			expectLabels(validator.resources, install.ExpectedLabels)
+		})
+
+		It("does knative install when not already installed", func() {
+			err := installer.DoKnativeInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeFalse())
+			expectNamespace(validator.resources, "knative-serving")
+		})
+	})
+
+	Context("Knative with default values and previous knative (ours)", func() {
+
+		BeforeEach(func() {
+			spec, err := install.GetInstallSpec(&opts, constants.KnativeValuesFileName)
+			Expect(err).NotTo(HaveOccurred())
+			validator = MockInstallClient{
+				expectedCrds: install.GlooCrdNames,
+				knativeInstalled: true,
+				knativeOurs: true,
+			}
+			installer, err = install.NewGlooStagedInstaller(&opts, *spec, &validator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("installs gloo crds only", func() {
+			err := installer.DoCrdInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeTrue())
+			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectNames(validator.resources, install.GlooCrdNames)
+		})
+
+		It("does nothing on preinstall", func() {
+			err := installer.DoPreInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+			Expect(validator.resources).To(BeEmpty())
+		})
+
+		It("installs expected kinds for gloo", func() {
+			err := installer.DoInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeFalse())
+			expectKinds(validator.resources, install.GlooInstallKinds)
+			expectLabels(validator.resources, install.ExpectedLabels)
+		})
+
+		It("does apply knative", func() {
+			err := installer.DoKnativeInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeFalse())
+			expectNamespace(validator.resources, "knative-serving")
+		})
+	})
+
+	Context("Knative with default values and previous knative (not ours)", func() {
+
+		BeforeEach(func() {
+			spec, err := install.GetInstallSpec(&opts, constants.KnativeValuesFileName)
+			Expect(err).NotTo(HaveOccurred())
+			validator = MockInstallClient{
+				expectedCrds: install.GlooCrdNames,
+				knativeInstalled: true,
+			}
+			installer, err = install.NewGlooStagedInstaller(&opts, *spec, &validator)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("installs gloo crds only", func() {
+			err := installer.DoCrdInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeTrue())
+			expectKinds(validator.resources, []string { "CustomResourceDefinition" })
+			expectNames(validator.resources, install.GlooCrdNames)
+		})
+
+		It("does nothing on preinstall", func() {
+			err := installer.DoPreInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+			Expect(validator.resources).To(BeEmpty())
+		})
+
+		It("installs expected kinds for gloo", func() {
+			err := installer.DoInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeTrue())
+			Expect(validator.waited).To(BeFalse())
+			expectKinds(validator.resources, install.GlooInstallKinds)
+			expectLabels(validator.resources, install.ExpectedLabels)
+		})
+
+		It("does nothing on knative install", func() {
+			err := installer.DoKnativeInstall()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validator.applied).To(BeFalse())
+			Expect(validator.waited).To(BeFalse())
+			Expect(validator.resources).To(BeEmpty())
+		})
+	})
+})

--- a/projects/gloo/cli/pkg/cmd/install/uninstall.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall.go
@@ -71,7 +71,7 @@ func deleteNamespace(cli install.KubeCli, namespace string) error {
 }
 
 func uninstallKnativeIfNecessary(cli install.KubeCli) error {
-	installClient := DefaultKubeInstallClient{}
+	installClient := DefaultGlooKubeInstallClient{}
 	knativeExists, isOurInstall, err := installClient.CheckKnativeInstallation()
 	if err != nil {
 		return errors.Wrapf(err, "finding knative installation")

--- a/projects/gloo/cli/pkg/cmd/install/uninstall.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall.go
@@ -71,7 +71,8 @@ func deleteNamespace(cli install.KubeCli, namespace string) error {
 }
 
 func uninstallKnativeIfNecessary(cli install.KubeCli) error {
-	knativeExists, isOurInstall, err := install.CheckKnativeInstallation()
+	installClient := DefaultKubeInstallClient{}
+	knativeExists, isOurInstall, err := installClient.CheckKnativeInstallation()
 	if err != nil {
 		return errors.Wrapf(err, "finding knative installation")
 	}

--- a/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
@@ -37,7 +37,7 @@ func (k *MockKubectl) Kubectl(stdin io.Reader, args ...string) error {
 var _ = Describe("Uninstall", func() {
 
 	const (
-		deleteCrds = "delete crd gateways.gateway.solo.io proxies.gateway.solo.io settings.gateway.solo.io upstreams.gateway.solo.io virtualservices.gateway.solo.io"
+		deleteCrds = "delete crd gateways.gateway.solo.io proxies.gloo.solo.io settings.gloo.solo.io upstreams.gloo.solo.io virtualservices.gateway.solo.io"
 	)
 
 	var flagSet *pflag.FlagSet

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -50,9 +50,7 @@ func init() {
 	// When we install, make sure we know what we're installing, so we can later uninstall correctly.
 	// This validation is tested by projects/gloo/cli/pkg/cmd/install/install_test.go
 	GlooInstallKinds = append(GlooSystemKinds, "Namespace")
-	for _, kind := range GlooRbacKinds {
-		GlooInstallKinds = append(GlooInstallKinds, kind)
-	}
+	GlooInstallKinds = append(GlooInstallKinds, GlooRbacKinds...)
 
 	GlooPreInstallKinds = []string{
 		"Settings",

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -29,8 +29,9 @@ var (
 	// These will get cleaned up by uninstall if delete-crds or all is chosen
 	GlooCrdNames []string
 
-	preInstallKinds []string
-	installKinds   []string
+	// Set up during pre-install (settings only)
+	GlooPreInstallKinds []string
+	GlooInstallKinds   []string
 	ExpectedLabels map[string]string
 )
 
@@ -48,9 +49,13 @@ func init() {
 
 	// When we install, make sure we know what we're installing, so we can later uninstall correctly.
 	// This validation is tested by projects/gloo/cli/pkg/cmd/install/install_test.go
-	installKinds = append(GlooSystemKinds, "Namespace")
+	GlooInstallKinds = append(GlooSystemKinds, "Namespace")
 	for _, kind := range GlooRbacKinds {
-		installKinds = append(installKinds, kind)
+		GlooInstallKinds = append(GlooInstallKinds, kind)
+	}
+
+	GlooPreInstallKinds = []string{
+		"Settings",
 	}
 
 	GlooCrdNames = []string{
@@ -97,8 +102,8 @@ func installGloo(opts *options.Options, valueFileName string) error {
 		ValueFileName: valueFileName,
 		ProductName: "gloo",
 		ExpectedLabels: ExpectedLabels,
-		PreInstallKinds: preInstallKinds,
-		InstallKinds: installKinds,
+		PreInstallKinds: GlooPreInstallKinds,
+		InstallKinds: GlooInstallKinds,
 		Crds: GlooCrdNames,
 		ExtraValues: nil,
 	}

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -74,6 +74,7 @@ type GlooInstallSpec struct {
 	PreInstallKinds []string
 	InstallKinds    []string
 	Crds            []string
+	ExtraValues     map[string]string
 }
 
 // Entry point for all three GLoo installation commands
@@ -99,6 +100,7 @@ func installGloo(opts *options.Options, valueFileName string) error {
 		PreInstallKinds: preInstallKinds,
 		InstallKinds: installKinds,
 		Crds: GlooCrdNames,
+		ExtraValues: nil,
 	}
 
 	return InstallGloo(opts, installSpec)
@@ -130,7 +132,7 @@ func installFromUri(opts *options.Options, spec GlooInstallSpec) error {
 		return errors.Wrapf(err, "retrieving gloo helm chart archive")
 	}
 
-	values, err := install.GetValuesFromFile(chart, spec.ValueFileName)
+	values, err := install.GetValuesFromFileIncludingExtra(chart, spec.ValueFileName, spec.ExtraValues)
 	if err != nil {
 		return errors.Wrapf(err, "retrieving value file: %s", spec.ValueFileName)
 	}

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"fmt"
+
 	"github.com/solo-io/gloo/pkg/cliutil/install"
 	"github.com/solo-io/gloo/pkg/version"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
@@ -54,7 +55,7 @@ func init() {
 		"virtualservices.gateway.solo.io",
 	}
 
-	KnativeCrdNames = []string {
+	KnativeCrdNames = []string{
 		"virtualservices.networking.istio.io",
 		"clusteringresses.networking.internal.knative.dev",
 		"configurations.serving.knative.dev",
@@ -137,4 +138,3 @@ func InstallGloo(opts *options.Options, spec GlooInstallSpec) error {
 
 	return installer.DoInstall()
 }
-

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -31,8 +31,8 @@ var (
 
 	// Set up during pre-install (settings only)
 	GlooPreInstallKinds []string
-	GlooInstallKinds   []string
-	ExpectedLabels map[string]string
+	GlooInstallKinds    []string
+	ExpectedLabels      map[string]string
 )
 
 func init() {
@@ -97,14 +97,14 @@ func installGloo(opts *options.Options, valueFileName string) error {
 	}
 
 	installSpec := GlooInstallSpec{
-		HelmArchiveUri: helmChartArchiveUri,
-		ValueFileName: valueFileName,
-		ProductName: "gloo",
-		ExpectedLabels: ExpectedLabels,
-		PreInstallKinds: GlooPreInstallKinds,
-		InstallKinds: GlooInstallKinds,
-		Crds: GlooCrdNames,
-		ExtraValues: nil,
+		HelmArchiveUri:   helmChartArchiveUri,
+		ValueFileName:    valueFileName,
+		ProductName:      "gloo",
+		ExpectedLabels:   ExpectedLabels,
+		PreInstallKinds:  GlooPreInstallKinds,
+		InstallKinds:     GlooInstallKinds,
+		Crds:             GlooCrdNames,
+		ExtraValues:      nil,
 		ExcludeResources: nil,
 	}
 

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -72,14 +72,15 @@ func init() {
 }
 
 type GlooInstallSpec struct {
-	ProductName     string // gloo or glooe
-	HelmArchiveUri  string
-	ValueFileName   string
-	ExpectedLabels  map[string]string
-	PreInstallKinds []string
-	InstallKinds    []string
-	Crds            []string
-	ExtraValues     map[string]string
+	ProductName      string // gloo or glooe
+	HelmArchiveUri   string
+	ValueFileName    string
+	ExpectedLabels   map[string]string
+	PreInstallKinds  []string
+	InstallKinds     []string
+	Crds             []string
+	ExtraValues      map[string]string
+	ExcludeResources install.ResourceMatcherFunc
 }
 
 // Entry point for all three GLoo installation commands
@@ -106,6 +107,7 @@ func installGloo(opts *options.Options, valueFileName string) error {
 		InstallKinds: GlooInstallKinds,
 		Crds: GlooCrdNames,
 		ExtraValues: nil,
+		ExcludeResources: nil,
 	}
 
 	return InstallGloo(opts, installSpec)
@@ -204,7 +206,7 @@ func doCrdInstall(
 			return err
 		}
 	}
-	if err := install.InstallManifest(crdManifestBytes, opts.Install.DryRun, []string{"CustomResourceDefinition"}, nil); err != nil {
+	if err := install.InstallManifest(crdManifestBytes, opts.Install.DryRun, []string{"CustomResourceDefinition"}, nil, nil); err != nil {
 		return errors.Wrapf(err, "installing crd manifests")
 	}
 	// Only run if this is not a dry run
@@ -241,7 +243,7 @@ func doGlooPreInstall(
 	if err != nil {
 		return err
 	}
-	return install.InstallManifest(manifestBytes, opts.Install.DryRun, spec.PreInstallKinds, spec.ExpectedLabels)
+	return install.InstallManifest(manifestBytes, opts.Install.DryRun, spec.PreInstallKinds, spec.ExpectedLabels, spec.ExcludeResources)
 }
 
 func doGlooInstall(
@@ -260,7 +262,7 @@ func doGlooInstall(
 	if err != nil {
 		return err
 	}
-	return install.InstallManifest(manifestBytes, opts.Install.DryRun, spec.InstallKinds, spec.ExpectedLabels)
+	return install.InstallManifest(manifestBytes, opts.Install.DryRun, spec.InstallKinds, spec.ExpectedLabels, spec.ExcludeResources)
 }
 
 func doKnativeInstall(
@@ -275,5 +277,5 @@ func doKnativeInstall(
 	if err != nil {
 		return err
 	}
-	return install.InstallManifest(manifestBytes, opts.Install.DryRun, nil, nil)
+	return install.InstallManifest(manifestBytes, opts.Install.DryRun, nil, nil, nil)
 }

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -85,7 +85,7 @@ func installGloo(opts *options.Options, valueFileName string) error {
 	if err != nil {
 		return err
 	}
-	kubeInstallClient := DefaultKubeInstallClient{}
+	kubeInstallClient := DefaultGlooKubeInstallClient{}
 	return InstallGloo(opts, *spec, &kubeInstallClient)
 }
 
@@ -119,7 +119,7 @@ func getGlooVersion(opts *options.Options) (string, error) {
 	return version.Version, nil
 }
 
-func InstallGloo(opts *options.Options, spec GlooInstallSpec, client KubeInstallClient) error {
+func InstallGloo(opts *options.Options, spec GlooInstallSpec, client GlooKubeInstallClient) error {
 	installer, err := NewGlooStagedInstaller(opts, spec, client)
 	if err != nil {
 		return err

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -2,23 +2,11 @@ package install
 
 import (
 	"fmt"
-	"path"
-	"strings"
-	"time"
-
-	"github.com/solo-io/gloo/pkg/cliutil"
-
-	"k8s.io/helm/pkg/proto/hapi/chart"
-
 	"github.com/solo-io/gloo/pkg/cliutil/install"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
-	"github.com/solo-io/go-utils/errors"
-	"k8s.io/helm/pkg/chartutil"
-	"k8s.io/helm/pkg/manifest"
-	"k8s.io/helm/pkg/renderutil"
-
 	"github.com/solo-io/gloo/pkg/version"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
+	"github.com/solo-io/go-utils/errors"
 )
 
 var (
@@ -33,6 +21,8 @@ var (
 	GlooPreInstallKinds []string
 	GlooInstallKinds    []string
 	ExpectedLabels      map[string]string
+
+	KnativeCrdNames []string
 )
 
 func init() {
@@ -58,10 +48,21 @@ func init() {
 
 	GlooCrdNames = []string{
 		"gateways.gateway.solo.io",
-		"proxies.gateway.solo.io",
-		"settings.gateway.solo.io",
-		"upstreams.gateway.solo.io",
+		"proxies.gloo.solo.io",
+		"settings.gloo.solo.io",
+		"upstreams.gloo.solo.io",
 		"virtualservices.gateway.solo.io",
+	}
+
+	KnativeCrdNames = []string {
+		"virtualservices.networking.istio.io",
+		"clusteringresses.networking.internal.knative.dev",
+		"configurations.serving.knative.dev",
+		"images.caching.internal.knative.dev",
+		"podautoscalers.autoscaling.internal.knative.dev",
+		"revisions.serving.knative.dev",
+		"routes.serving.knative.dev",
+		"services.serving.knative.dev",
 	}
 
 	ExpectedLabels = map[string]string{
@@ -73,21 +74,24 @@ type GlooInstallSpec struct {
 	ProductName      string // gloo or glooe
 	HelmArchiveUri   string
 	ValueFileName    string
-	ExpectedLabels   map[string]string
-	PreInstallKinds  []string
-	InstallKinds     []string
-	Crds             []string
 	ExtraValues      map[string]string
 	ExcludeResources install.ResourceMatcherFunc
 }
 
 // Entry point for all three GLoo installation commands
 func installGloo(opts *options.Options, valueFileName string) error {
+	spec, err := GetInstallSpec(opts, valueFileName)
+	if err != nil {
+		return err
+	}
+	return InstallGloo(opts, *spec)
+}
 
+func GetInstallSpec(opts *options.Options, valueFileName string) (*GlooInstallSpec, error) {
 	// Get Gloo release version
 	glooVersion, err := getGlooVersion(opts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Get location of Gloo helm chart
@@ -96,19 +100,13 @@ func installGloo(opts *options.Options, valueFileName string) error {
 		helmChartArchiveUri = helmChartOverride
 	}
 
-	installSpec := GlooInstallSpec{
+	return &GlooInstallSpec{
 		HelmArchiveUri:   helmChartArchiveUri,
 		ValueFileName:    valueFileName,
 		ProductName:      "gloo",
-		ExpectedLabels:   ExpectedLabels,
-		PreInstallKinds:  GlooPreInstallKinds,
-		InstallKinds:     GlooInstallKinds,
-		Crds:             GlooCrdNames,
 		ExtraValues:      nil,
 		ExcludeResources: nil,
-	}
-
-	return InstallGloo(opts, installSpec)
+	}, nil
 }
 
 func getGlooVersion(opts *options.Options) (string, error) {
@@ -120,160 +118,23 @@ func getGlooVersion(opts *options.Options) (string, error) {
 }
 
 func InstallGloo(opts *options.Options, spec GlooInstallSpec) error {
-	if err := installFromUri(opts, spec); err != nil {
-		return errors.Wrapf(err, "installing Gloo from helm chart")
-	}
-	return nil
-}
-
-func installFromUri(opts *options.Options, spec GlooInstallSpec) error {
-
-	if path.Ext(spec.HelmArchiveUri) != ".tgz" && !strings.HasSuffix(spec.HelmArchiveUri, ".tar.gz") {
-		return errors.Errorf("unsupported file extension for Helm chart URI: [%s]. Extension must either be .tgz or .tar.gz", spec.HelmArchiveUri)
-	}
-
-	chart, err := install.GetHelmArchive(spec.HelmArchiveUri)
-	if err != nil {
-		return errors.Wrapf(err, "retrieving gloo helm chart archive")
-	}
-
-	values, err := install.GetValuesFromFileIncludingExtra(chart, spec.ValueFileName, spec.ExtraValues)
-	if err != nil {
-		return errors.Wrapf(err, "retrieving value file: %s", spec.ValueFileName)
-	}
-
-	// These are the .Release.* variables used during rendering
-	renderOpts := renderutil.Options{
-		ReleaseOptions: chartutil.ReleaseOptions{
-			Namespace: opts.Install.Namespace,
-			Name:      spec.ProductName,
-		},
-	}
-
-	skipKnativeInstall, err := install.SkipKnativeInstall()
+	installer, err := NewGlooStagedInstaller(opts, spec, &DefaultKubeInstallClient{})
 	if err != nil {
 		return err
 	}
 
-	if err := doCrdInstall(opts, spec, chart, values, renderOpts, skipKnativeInstall); err != nil {
+	if err := installer.DoCrdInstall(); err != nil {
 		return err
 	}
 
-	if err := doGlooPreInstall(opts, spec, chart, values, renderOpts); err != nil {
+	if err := installer.DoPreInstall(); err != nil {
 		return err
 	}
 
-	if !skipKnativeInstall {
-		if err := doKnativeInstall(opts, chart, values, renderOpts); err != nil {
-			return err
-		}
-	}
-
-	return doGlooInstall(opts, spec, chart, values, renderOpts)
-}
-
-func doCrdInstall(
-	opts *options.Options,
-	spec GlooInstallSpec,
-	chart *chart.Chart,
-	values *chart.Config,
-	renderOpts renderutil.Options,
-	skipKnativeInstall bool) error {
-
-	// Keep only CRDs and collect the names
-	var crdNames []string
-	excludeNonCrdsAndCollectCrdNames := func(input []manifest.Manifest) ([]manifest.Manifest, error) {
-		manifests, resourceNames, err := install.ExcludeNonCrds(input)
-		crdNames = resourceNames
-		return manifests, err
-	}
-
-	// Render and install CRD manifests
-	crdManifestBytes, err := install.RenderChart(chart, values, renderOpts,
-		install.ExcludeNotes,
-		install.KnativeResourceFilterFunction(skipKnativeInstall),
-		excludeNonCrdsAndCollectCrdNames,
-		install.ExcludeEmptyManifests)
-	if err != nil {
-		return errors.Wrapf(err, "rendering crd manifests")
-	}
-
-	// TODO: we currently skip validation when installing knative, we could enumerate knative CRDs and validate those too
-	if skipKnativeInstall {
-		if err := validateCrds(spec, crdNames); err != nil {
-			return err
-		}
-	}
-	if err := install.InstallManifest(crdManifestBytes, opts.Install.DryRun, []string{"CustomResourceDefinition"}, nil, nil); err != nil {
-		return errors.Wrapf(err, "installing crd manifests")
-	}
-	// Only run if this is not a dry run
-	if !opts.Install.DryRun {
-		if err := install.WaitForCrdsToBeRegistered(crdNames, time.Second*5, time.Millisecond*500); err != nil {
-			return errors.Wrapf(err, "waiting for crds to be registered")
-		}
-	}
-
-	return nil
-}
-
-func validateCrds(spec GlooInstallSpec, crdNames []string) error {
-	for _, crdName := range crdNames {
-		if !cliutil.Contains(spec.Crds, crdName) {
-			return errors.Errorf("Unknown crd %s", crdName)
-		}
-	}
-	return nil
-}
-
-func doGlooPreInstall(
-	opts *options.Options,
-	spec GlooInstallSpec,
-	chart *chart.Chart,
-	values *chart.Config,
-	renderOpts renderutil.Options) error {
-	// Render and install Gloo manifest
-	manifestBytes, err := install.RenderChart(chart, values, renderOpts,
-		install.ExcludeNotes,
-		install.KnativeResourceFilterFunction(true),
-		install.IncludeOnlyPreInstall,
-		install.ExcludeEmptyManifests)
-	if err != nil {
+	if err := installer.DoKnativeInstall(); err != nil {
 		return err
 	}
-	return install.InstallManifest(manifestBytes, opts.Install.DryRun, spec.PreInstallKinds, spec.ExpectedLabels, spec.ExcludeResources)
+
+	return installer.DoInstall()
 }
 
-func doGlooInstall(
-	opts *options.Options,
-	spec GlooInstallSpec,
-	chart *chart.Chart,
-	values *chart.Config,
-	renderOpts renderutil.Options) error {
-	// Render and install Gloo manifest
-	manifestBytes, err := install.RenderChart(chart, values, renderOpts,
-		install.ExcludeNotes,
-		install.KnativeResourceFilterFunction(true),
-		install.ExcludePreInstall,
-		install.ExcludeCrds,
-		install.ExcludeEmptyManifests)
-	if err != nil {
-		return err
-	}
-	return install.InstallManifest(manifestBytes, opts.Install.DryRun, spec.InstallKinds, spec.ExpectedLabels, spec.ExcludeResources)
-}
-
-func doKnativeInstall(
-	opts *options.Options,
-	chart *chart.Chart,
-	values *chart.Config,
-	renderOpts renderutil.Options) error {
-	// Exclude everything but knative non-crds
-	manifestBytes, err := install.RenderChart(chart, values, renderOpts,
-		install.ExcludeNonKnative,
-		install.ExcludeCrds)
-	if err != nil {
-		return err
-	}
-	return install.InstallManifest(manifestBytes, opts.Install.DryRun, nil, nil, nil)
-}

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -85,7 +85,8 @@ func installGloo(opts *options.Options, valueFileName string) error {
 	if err != nil {
 		return err
 	}
-	return InstallGloo(opts, *spec)
+	kubeInstallClient := DefaultKubeInstallClient{}
+	return InstallGloo(opts, *spec, &kubeInstallClient)
 }
 
 func GetInstallSpec(opts *options.Options, valueFileName string) (*GlooInstallSpec, error) {
@@ -118,8 +119,8 @@ func getGlooVersion(opts *options.Options) (string, error) {
 	return version.Version, nil
 }
 
-func InstallGloo(opts *options.Options, spec GlooInstallSpec) error {
-	installer, err := NewGlooStagedInstaller(opts, spec, &DefaultKubeInstallClient{})
+func InstallGloo(opts *options.Options, spec GlooInstallSpec, client KubeInstallClient) error {
+	installer, err := NewGlooStagedInstaller(opts, spec, client)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
A few changes that enable more general installs (for now just targeting gloo + glooe), including:
- Customizing allowed CRDs
- Customizing types allowed during pre-install and install phases
- Customizing expected labels
- Supporting final post-filtering logic (i.e. for Glooe to filter out PVCs that already exist)
