### PR TITLE
skip crd creation in bootstrap config

### DIFF
--- a/projects/gloo/pkg/bootstrap/utils.go
+++ b/projects/gloo/pkg/bootstrap/utils.go
@@ -45,9 +45,10 @@ func ConfigFactoryForSettings(settings *v1.Settings,
 			*cfg = c
 		}
 		return &factory.KubeResourceClientFactory{
-			Crd:         resourceCrd,
-			Cfg:         *cfg,
-			SharedCache: cache,
+			Crd:             resourceCrd,
+			Cfg:             *cfg,
+			SharedCache:     cache,
+			SkipCrdCreation: true,
 		}, nil
 	case *v1.Settings_DirectoryConfigSource:
 		return &factory.FileResourceClientFactory{


### PR DESCRIPTION
Since this function is being reused in multiple locations we should opt for the less-impactful usage mode.