### PR TITLE
UDS discovery for GRPC services

### DIFF
--- a/changelog/v0.13.16/uds_grpc.yaml
+++ b/changelog/v0.13.16/uds_grpc.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Allow upstream discovery discovery grpc services correctly.
+    issueLink: https://github.com/solo-io/gloo/issues/688

--- a/hack/utils/xdsclient/main.go
+++ b/hack/utils/xdsclient/main.go
@@ -124,6 +124,7 @@ func listendpoints(ctx context.Context, conn *grpc.ClientConn) []v2.ClusterLoadA
 		log.Fatalf("endpoints err: %v", err)
 	}
 	var class []v2.ClusterLoadAssignment
+	pp.Printf("version info: %v\n", dresp.VersionInfo)
 
 	for _, anyCla := range dresp.Resources {
 

--- a/projects/gloo/pkg/plugins/consul/plugin.go
+++ b/projects/gloo/pkg/plugins/consul/plugin.go
@@ -5,10 +5,10 @@ import (
 	"net/url"
 
 	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	"github.com/hashicorp/consul/api"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 )
 
 type plugin struct {
@@ -51,16 +51,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 	}
 
 	// consul upstreams use EDS
-	out.ClusterDiscoveryType = &envoyapi.Cluster_Type{
-		Type: envoyapi.Cluster_EDS,
-	}
-	out.EdsClusterConfig = &envoyapi.Cluster_EdsClusterConfig{
-		EdsConfig: &envoycore.ConfigSource{
-			ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
-				Ads: &envoycore.AggregatedConfigSource{},
-			},
-		},
-	}
+	xds.SetEdsOnCluster(out)
 
 	return nil
 }

--- a/projects/gloo/pkg/plugins/kubernetes/plugin.go
+++ b/projects/gloo/pkg/plugins/kubernetes/plugin.go
@@ -5,9 +5,9 @@ import (
 	"net/url"
 
 	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -47,15 +47,6 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 	}
 
 	// configure the cluster to use EDS:ADS and call it a day
-	out.ClusterDiscoveryType = &envoyapi.Cluster_Type{
-		Type: envoyapi.Cluster_EDS,
-	}
-	out.EdsClusterConfig = &envoyapi.Cluster_EdsClusterConfig{
-		EdsConfig: &envoycore.ConfigSource{
-			ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
-				Ads: &envoycore.AggregatedConfigSource{},
-			},
-		},
-	}
+	xds.SetEdsOnCluster(out)
 	return nil
 }

--- a/projects/gloo/pkg/plugins/static/plugin.go
+++ b/projects/gloo/pkg/plugins/static/plugin.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/pluginutils"
+	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/solo-kit/pkg/errors"
 )
@@ -137,16 +138,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 	return nil
 
 	// configure the cluster to use EDS:ADS and call it a day
-	out.ClusterDiscoveryType = &envoyapi.Cluster_Type{
-		Type: envoyapi.Cluster_STATIC,
-	}
-	out.EdsClusterConfig = &envoyapi.Cluster_EdsClusterConfig{
-		EdsConfig: &envoycore.ConfigSource{
-			ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
-				Ads: &envoycore.AggregatedConfigSource{},
-			},
-		},
-	}
+	xds.SetEdsOnCluster(out)
 	return nil
 }
 

--- a/projects/gloo/pkg/translator/clusters.go
+++ b/projects/gloo/pkg/translator/clusters.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/reporter"
 	"go.opencensus.io/trace"
@@ -62,9 +63,7 @@ func (t *translator) initializeCluster(upstream *v1.Upstream, endpoints []*v1.En
 	}
 	// set Type = EDS if we have endpoints for the upstream
 	if len(endpointsForUpstream(upstream, endpoints)) > 0 {
-		out.ClusterDiscoveryType = &envoyapi.Cluster_Type{
-			Type: envoyapi.Cluster_EDS,
-		}
+		xds.SetEdsOnCluster(out)
 	}
 	return out
 }

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -14,6 +14,7 @@ import (
 	types "github.com/gogo/protobuf/types"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	v1plugins "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins"
+	v1grpc "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/grpc"
 	v1kubernetes "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/kubernetes"
 	v1static "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/static"
 	"github.com/solo-io/gloo/projects/gloo/pkg/bootstrap"
@@ -154,6 +155,20 @@ var _ = Describe("Translator", func() {
 
 	}
 
+	Context("service spec", func() {
+		It("changes in service spec should create a different snapshot", func() {
+			translate()
+			oldVersion := snapshot.GetResources(xds.ClusterType).Version
+			svcspec := &v1plugins.ServiceSpec{
+				PluginType: &v1plugins.ServiceSpec_Grpc{
+					Grpc: &v1grpc.ServiceSpec{},
+				},
+			}
+			upstream.UpstreamSpec.UpstreamType.(*v1.UpstreamSpec_Static).SetServiceSpec(svcspec)
+			newVersion := snapshot.GetResources(xds.ClusterType).Version
+			Expect(oldVersion).ToNot(Equal(newVersion))
+		})
+	})
 	Context("route header match", func() {
 		It("should translate header matcher with no value to a PresentMatch", func() {
 

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -159,12 +159,14 @@ var _ = Describe("Translator", func() {
 		It("changes in service spec should create a different snapshot", func() {
 			translate()
 			oldVersion := snapshot.GetResources(xds.ClusterType).Version
+
 			svcspec := &v1plugins.ServiceSpec{
 				PluginType: &v1plugins.ServiceSpec_Grpc{
 					Grpc: &v1grpc.ServiceSpec{},
 				},
 			}
 			upstream.UpstreamSpec.UpstreamType.(*v1.UpstreamSpec_Static).SetServiceSpec(svcspec)
+			translate()
 			newVersion := snapshot.GetResources(xds.ClusterType).Version
 			Expect(oldVersion).ToNot(Equal(newVersion))
 		})

--- a/projects/gloo/pkg/xds/utils.go
+++ b/projects/gloo/pkg/xds/utils.go
@@ -1,0 +1,19 @@
+package xds
+
+import (
+	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+)
+
+func SetEdsOnCluster(out *envoyapi.Cluster) {
+	out.ClusterDiscoveryType = &envoyapi.Cluster_Type{
+		Type: envoyapi.Cluster_EDS,
+	}
+	out.EdsClusterConfig = &envoyapi.Cluster_EdsClusterConfig{
+		EdsConfig: &envoycore.ConfigSource{
+			ConfigSourceSpecifier: &envoycore.ConfigSource_Ads{
+				Ads: &envoycore.AggregatedConfigSource{},
+			},
+		},
+	}
+}


### PR DESCRIPTION
To solves #688, we allow now to upstream discovery to know in advance if the upstream is a grpc upstream.
This is done by reading the port name or an annotation on the service.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/688