### PR TITLE
Fix settings CRD template

### DIFF
--- a/changelog/v0.13.18/fix-settings-helm-template.yaml
+++ b/changelog/v0.13.18/fix-settings-helm-template.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix bug that caused gloo to always watch all namespace regardless of the value set on thr settings CRD.
+    issueLink: https://github.com/solo-io/gloo/issues/694

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -20,9 +20,11 @@ spec:
 {{- toYaml .Values.settings.extensions | nindent 4 }}
 {{- end }}
 
+{{- with .Values.settings.watchNamespaces }}
   watchNamespaces:
-  {{- range .Values.settings.watchNamespaces }}
+  {{- range . }}
   - {{ . }}
   {{- end }}
+{{- end }}
 
 {{- end }}

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -20,9 +20,9 @@ spec:
 {{- toYaml .Values.settings.extensions | nindent 4 }}
 {{- end }}
 
-{{- with .Values.settings.watchNamespaces }}
   watchNamespaces:
+  {{- range .Values.settings.watchNamespaces }}
   - {{ . }}
-{{- end }}
+  {{- end }}
 
 {{- end }}


### PR DESCRIPTION
Fix bug that caused gloo to always watch all namespace regardless of the value set on thr settings CRD.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/694