### PR TITLE
use underscore instead of dot for cluster name.

### DIFF
--- a/changelog/v0.13.26/udnerscore.yaml
+++ b/changelog/v0.13.26/udnerscore.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Use underscores instead of dots in the cluster name, for better prometheus stats.
+    issueLink: https://github.com/solo-io/gloo/pull/712

--- a/projects/gloo/pkg/translator/utils.go
+++ b/projects/gloo/pkg/translator/utils.go
@@ -1,6 +1,8 @@
 package translator
 
 import (
+	fmt "fmt"
+
 	envoylistener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	envoyutil "github.com/envoyproxy/go-control-plane/pkg/util"
 	"github.com/gogo/protobuf/proto"
@@ -9,7 +11,8 @@ import (
 )
 
 func UpstreamToClusterName(upstream core.ResourceRef) string {
-	return upstream.Key()
+	// Don't use dots in the name as it messes up promethues stats
+	return fmt.Sprintf("%s_%s", upstream.Name, upstream.Namespace)
 }
 
 func NewFilterWithConfig(name string, config proto.Message) (envoylistener.Filter, error) {

--- a/projects/gloo/pkg/translator/utils.go
+++ b/projects/gloo/pkg/translator/utils.go
@@ -11,7 +11,7 @@ import (
 )
 
 func UpstreamToClusterName(upstream core.ResourceRef) string {
-	// Don't use dots in the name as it messes up promethues stats
+	// Don't use dots in the name as it messes up prometheus stats
 	return fmt.Sprintf("%s_%s", upstream.Name, upstream.Namespace)
 }
 


### PR DESCRIPTION
otherwise promethues stats are not parsed correctly by envoy.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/pull/712