### PR TITLE
Keepalive for all

### DIFF
--- a/changelog/v0.13.30/keepalive-all.yaml
+++ b/changelog/v0.13.30/keepalive-all.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Add tcp keepalive to knative and ingress projects.
+    issueLink: https://github.com/solo-io/gloo/pull/728

--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -31,6 +31,8 @@ data:
                     address: gloo
                     port_value: {{ .Values.gloo.deployment.xdsPort }}
         http2_protocol_options: {}
+        upstream_connection_options:
+          tcp_keepalive: {}
         type: STRICT_DNS
     dynamic_resources:
       ads_config:

--- a/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
@@ -30,6 +30,8 @@ data:
                     address: gloo
                     port_value: {{ .Values.gloo.deployment.xdsPort }}
         http2_protocol_options: {}
+        upstream_connection_options:
+          tcp_keepalive: {}
         type: STRICT_DNS
     dynamic_resources:
       ads_config:


### PR DESCRIPTION
#708 added tcp keepalive for gateway, this adds it also to knative and ingress.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/pull/728