### PR TITLE
allow disabling function discovery

### DIFF
--- a/changelog/v0.13.30/disable-fds.yaml
+++ b/changelog/v0.13.30/disable-fds.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Allow disabling function discovery. This can now be done with `--set discovery.disable_fds=true` when installing with helm.
+    issueLink: https://github.com/solo-io/gloo/pull/729

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -73,6 +73,7 @@ type GlooDeployment struct {
 
 type Discovery struct {
 	Deployment *DiscoveryDeployment `json:"deployment,omitempty"`
+	DisableFDS bool `json:"disable_fds,omitempty"`
 }
 
 type DiscoveryDeployment struct {

--- a/install/helm/gloo/templates/5-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/5-discovery-deployment.yaml
@@ -43,4 +43,8 @@ spec:
           - name: START_STATS_SERVER
             value: "true"
         {{- end}}
+        {{- if .Values.discovery.disable_fds }}
+          - name: DISABLE_FDS
+            value: "true"
+        {{- end}}
 

--- a/projects/discovery/cmd/main.go
+++ b/projects/discovery/cmd/main.go
@@ -27,8 +27,12 @@ func run() error {
 	go func() {
 		errs <- uds.Main()
 	}()
-	go func() {
-		errs <- fdssetup.Main()
-	}()
+
+	runFunctionDiscovery := (os.Getenv("DISABLE_FDS") != "true")
+	if runFunctionDiscovery {
+		go func() {
+			errs <- fdssetup.Main()
+		}()
+	}
 	return <-errs
 }


### PR DESCRIPTION
Function discovery can create noise on the network as it queries various endpoints. 
This adds an opt-in option to disable it if it is not in use.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/pull/729