### PR TITLE
Allow routes from different virtual services with same SslConfig.

### DIFF
--- a/changelog/v0.13.31/allow_identical_sslconfig.yaml
+++ b/changelog/v0.13.31/allow_identical_sslconfig.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Allow two virtual services on the same host with identical SslConfigs to be merged
+    issueLink: 

--- a/changelog/v0.13.32/allow_identical_sslconfig.yaml
+++ b/changelog/v0.13.32/allow_identical_sslconfig.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: NEW_FEATURE
     description: Allow two virtual services on the same host with identical SslConfigs to be merged
-    issueLink: 
+    issueLink: https://github.com/solo-io/gloo/issues/731

--- a/projects/gateway/pkg/translator/translator.go
+++ b/projects/gateway/pkg/translator/translator.go
@@ -150,8 +150,8 @@ func validateAndMergeVirtualServices(ns string, gateway *v1.Gateway, virtualServ
 			routes = append(routes, vs.VirtualHost.Routes...)
 			if sslConfig == nil {
 				sslConfig = vs.SslConfig
-			} else if vs.SslConfig != nil {
-				resourceErrs.AddError(gateway, fmt.Errorf("more than one ssl config is present in virtual service of these domains: %s", k))
+			} else if !vs.SslConfig.Equal(sslConfig) {
+				resourceErrs.AddError(gateway, fmt.Errorf("more than one distinct ssl config is present in virtual service of these domains: %s", k))
 			}
 
 			havePlugins := vs.VirtualHost != nil &&

--- a/projects/gateway/pkg/translator/translator_test.go
+++ b/projects/gateway/pkg/translator/translator_test.go
@@ -228,14 +228,28 @@ var _ = Describe("Translator", func() {
 			Expect(listener.VirtualHosts[0].Routes).To(HaveLen(1))
 		})
 
-		It("should error with both having ssl config", func() {
+		It("should error when two virtual services conflict", func() {
 			snap.Gateways[0].Ssl = true
 			snap.VirtualServices[0].SslConfig = new(gloov1.SslConfig)
 			snap.VirtualServices[1].SslConfig = new(gloov1.SslConfig)
+			snap.VirtualServices[0].SslConfig.SniDomains = []string{"bar"}
+			snap.VirtualServices[1].SslConfig.SniDomains = []string{"foo"}
 
 			_, errs := Translate(context.Background(), ns, snap)
 
 			Expect(errs.Validate()).To(HaveOccurred())
+		})
+
+		It("should error when two virtual services conflict", func() {
+			snap.Gateways[0].Ssl = true
+			snap.VirtualServices[0].SslConfig = new(gloov1.SslConfig)
+			snap.VirtualServices[1].SslConfig = new(gloov1.SslConfig)
+			snap.VirtualServices[0].SslConfig.SniDomains = []string{"foo"}
+			snap.VirtualServices[1].SslConfig.SniDomains = []string{"foo"}
+
+			_, errs := Translate(context.Background(), ns, snap)
+
+			Expect(errs.Validate()).NotTo(HaveOccurred())
 		})
 
 	})


### PR DESCRIPTION
This addresses one of the issues raised in https://github.com/solo-io/gloo/issues/731, that virtual services with non-conflicting SslConfigs for the same virtual host are not allowed to be merged.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/731