### PR TITLE
Sanitize uds upstream names

### DIFF
--- a/changelog/v0.17.1/sanitize-uds-upstreams.yaml
+++ b/changelog/v0.17.1/sanitize-uds-upstreams.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update uds_convert.go to sanitize upstream names
+    issueLink: https://github.com/solo-io/gloo/issues/289

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
@@ -2,11 +2,12 @@ package kubernetes
 
 import (
 	"context"
-	"crypto/md5"
 	"fmt"
 	"reflect"
 	"sort"
 	"strings"
+
+	sanitizer "github.com/solo-io/go-utils/kubeutils"
 
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	kubeplugin "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/kubernetes"
@@ -155,21 +156,13 @@ func UseHttp2(svc *kubev1.Service, port kubev1.ServicePort) bool {
 }
 
 func UpstreamName(serviceNamespace, serviceName string, servicePort int32, extraLabels map[string]string) string {
-	const maxLen = 63
 
 	var labelsTag string
 	if len(extraLabels) > 0 {
 		_, values := keysAndValues(extraLabels)
 		labelsTag = fmt.Sprintf("-%v", strings.Join(values, "-"))
 	}
-	name := fmt.Sprintf("%s-%s%s-%v", serviceNamespace, serviceName, labelsTag, servicePort)
-	if len(name) > maxLen {
-		hash := md5.Sum([]byte(name))
-		hexhash := fmt.Sprintf("%x", hash)
-		name = name[:maxLen-len(hexhash)] + hexhash
-	}
-	name = strings.Replace(name, ".", "-", -1)
-	return name
+	return sanitizer.SanitizeNameV2(fmt.Sprintf("%s-%s%s-%v", serviceNamespace, serviceName, labelsTag, servicePort))
 }
 
 // TODO: move to a utils package

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
@@ -69,12 +69,6 @@ var _ = Describe("UdsConvert", func() {
 		Expect(name).To(Equal(name2))
 	})
 
-	It("should sanitize the same way with truncation", func() {
-		name := UpstreamNameOld(strings.Repeat("y", 120), "gloo-system", 12, map[string]string{"test": "label"})
-		name2 := UpstreamName(strings.Repeat("y", 120), "gloo-system", 12, map[string]string{"test": "label"})
-		Expect(name).To(Equal(name2))
-	})
-
 	It("should ignore ignored labels", func() {
 
 		svcSelector := map[string]string{"app": "foo"}

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
@@ -16,15 +16,15 @@ var _ = Describe("UdsConvert", func() {
 
 		svcSelector := map[string]string{"app": "foo"}
 		podmetas := []map[string]string{
-			map[string]string{"app": "foo", "env": "prod"},
-			map[string]string{"app": "foo", "env": "prod"},
-			map[string]string{"app": "foo", "env": "dev"},
+			{"app": "foo", "env": "prod"},
+			{"app": "foo", "env": "prod"},
+			{"app": "foo", "env": "dev"},
 		}
 		result := GetUniqueLabelSetsForObjects(svcSelector, podmetas)
 		expected := []map[string]string{
-			map[string]string{"app": "foo"},
-			map[string]string{"app": "foo", "env": "prod"},
-			map[string]string{"app": "foo", "env": "dev"},
+			{"app": "foo"},
+			{"app": "foo", "env": "prod"},
+			{"app": "foo", "env": "dev"},
 		}
 		Expect(result).To(Equal(expected))
 	})
@@ -37,7 +37,7 @@ var _ = Describe("UdsConvert", func() {
 		Expect(len(name)).To(BeNumerically("<=", 63))
 	})
 
-	It("should handle colisions", func() {
+	It("should handle collisions", func() {
 		name := UpstreamName(strings.Repeat("y", 120), "gloo-system", 12, nil)
 		name2 := UpstreamName(strings.Repeat("y", 120)+"2", "gloo-system", 12, nil)
 		Expect(name).ToNot(Equal(name2))
@@ -47,12 +47,12 @@ var _ = Describe("UdsConvert", func() {
 
 		svcSelector := map[string]string{"app": "foo"}
 		podmetas := []map[string]string{
-			map[string]string{"app": "foo", "env": "prod", "release": "first"},
+			{"app": "foo", "env": "prod", "release": "first"},
 		}
 		result := GetUniqueLabelSetsForObjects(svcSelector, podmetas)
 		expected := []map[string]string{
-			map[string]string{"app": "foo"},
-			map[string]string{"app": "foo", "env": "prod"},
+			{"app": "foo"},
+			{"app": "foo", "env": "prod"},
 		}
 		Expect(result).To(Equal(expected))
 	})


### PR DESCRIPTION
### Goal
more aggressively sanitize uds upstream names provided to the kubernetes API; remove duplicated logic

### Context
Will open a separate issue regarding concerns in the current implementation of `SanitizeNameV2`:
1. possibly-duplicate names after sanitization
2. frailty w.r.t. future naming regex changes in future versions of kubernetes.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/289