### PR TITLE
Fix helm naming convention

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1207,17 +1207,6 @@
   version = "v0.0.3"
 
 [[projects]]
-  digest = "1:36aebe90a13cf9128280ac834399b8bebf83685283c78df279d61c46bb2a8d83"
-  name = "github.com/mattn/go-zglob"
-  packages = [
-    ".",
-    "fastwalk",
-  ]
-  pruneopts = "UT"
-  revision = "2ea3427bfa539cca900ca2768d8663ecc8a708c1"
-  version = "v0.0.1"
-
-[[projects]]
   digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
@@ -2743,7 +2732,6 @@
     "github.com/knative/serving/pkg/client/clientset/versioned/typed/networking/v1alpha1",
     "github.com/knative/serving/pkg/client/informers/externalversions",
     "github.com/knative/serving/pkg/client/listers/networking/v1alpha1",
-    "github.com/mattn/go-zglob",
     "github.com/mitchellh/hashstructure",
     "github.com/olekukonko/tablewriter",
     "github.com/onsi/ginkgo",

--- a/changelog/v0.17.2/helm-naming-convention.yaml
+++ b/changelog/v0.17.2/helm-naming-convention.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update values-gateway-template to use proper helm naming conventions
+    issueLink: https://github.com/solo-io/gloo/issues/827

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	valuesTemplate        = "install/helm/gloo/values-gateway-template.yaml"
-	valuesOutput          = "install/helm/gloo/values.yaml"
+	gatewayValuesTemplate = "install/helm/gloo/values-gateway-template.yaml"
+	gatewayValuesOutput   = "install/helm/gloo/values.yaml"
 	knativeValuesTemplate = "install/helm/gloo/values-knative-template.yaml"
 	knativeValuesOutput   = "install/helm/gloo/values-knative.yaml"
 	ingressValuesTemplate = "install/helm/gloo/values-ingress-template.yaml"
@@ -80,7 +80,7 @@ func writeYaml(obj interface{}, path string) error {
 
 func readGatewayConfig() (*generate.Config, error) {
 	var config generate.Config
-	if err := readYaml(valuesTemplate, &config); err != nil {
+	if err := readYaml(gatewayValuesTemplate, &config); err != nil {
 		return nil, err
 	}
 	return &config, nil
@@ -120,7 +120,7 @@ func generateGatewayValuesYaml(version, repositoryPrefix string) error {
 
 	}
 
-	return writeYaml(cfg, valuesOutput)
+	return writeYaml(cfg, gatewayValuesOutput)
 }
 
 // install with knative only

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	gatewayValuesTemplate = "install/helm/gloo/values-gateway-template.yaml"
-	gatewayValuesOutput   = "install/helm/gloo/values.yaml"
+	valuesTemplate        = "install/helm/gloo/values-gateway-template.yaml"
+	valuesOutput          = "install/helm/gloo/values.yaml"
 	knativeValuesTemplate = "install/helm/gloo/values-knative-template.yaml"
 	knativeValuesOutput   = "install/helm/gloo/values-knative.yaml"
 	ingressValuesTemplate = "install/helm/gloo/values-ingress-template.yaml"
@@ -80,7 +80,7 @@ func writeYaml(obj interface{}, path string) error {
 
 func readGatewayConfig() (*generate.Config, error) {
 	var config generate.Config
-	if err := readYaml(gatewayValuesTemplate, &config); err != nil {
+	if err := readYaml(valuesTemplate, &config); err != nil {
 		return nil, err
 	}
 	return &config, nil
@@ -120,7 +120,7 @@ func generateGatewayValuesYaml(version, repositoryPrefix string) error {
 
 	}
 
-	return writeYaml(cfg, gatewayValuesOutput)
+	return writeYaml(cfg, valuesOutput)
 }
 
 // install with knative only

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -8,7 +8,7 @@ type Config struct {
 	Gloo           *Gloo                   `json:"gloo,omitempty"`
 	Discovery      *Discovery              `json:"discovery,omitempty"`
 	Gateway        *Gateway                `json:"gateway,omitempty"`
-	GatewayProxies map[string]GatewayProxy `json:"gatewayProxies,omitempty"`
+	GatewayProxies []GatewayProxy          `json:"gatewayProxies,omitempty"`
 	Ingress        *Ingress                `json:"ingress,omitempty"`
 	IngressProxy   *IngressProxy           `json:"ingressProxy,omitempty"`
 	K8s            *K8s                    `json:"k8s,omitempty"`
@@ -94,6 +94,7 @@ type GatewayDeployment struct {
 }
 
 type GatewayProxy struct {
+	Name       string                  `json:"name,omitempty"`
 	Deployment *GatewayProxyDeployment `json:"deployment,omitempty"`
 	ConfigMap  *GatewayProxyConfigMap  `json:"configMap,omitempty"`
 	Service    *GatewayProxyService    `json:"service,omitempty"`

--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: gloo
-    gloo: gateway-proxy
+    gloo: {{ $spec.name }}
 data:
 {{ if (empty .Values.ingressProxy.configMap.data) }}
   envoy.yaml: |

--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -15,7 +15,7 @@ data:
       cluster: ingress
       id: "{{ `{{.PodName}}.{{.PodNamespace}}` }}"
       metadata:
-        # this line must match !
+        # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
         role: "{{ `{{.PodNamespace}}` }}~ingress-proxy"
     static_resources:
       clusters:

--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -7,16 +7,16 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: gloo
-    gloo: {{ $spec.name }}
+    gloo: ingress-proxy
 data:
 {{ if (empty .Values.ingressProxy.configMap.data) }}
   envoy.yaml: |
     node:
       cluster: ingress
-      id: "{{ "{{" }}.PodName{{ "}}" }}.{{ "{{" }}.PodNamespace{{ "}}" }}"
+      id: "{{ `{{.PodName}}.{{.PodNamespace}}` }}"
       metadata:
         # this line must match !
-        role: "{{ "{{" }}.PodNamespace{{ "}}" }}~ingress-proxy"
+        role: "{{ `{{.PodNamespace}}` }}~ingress-proxy"
     static_resources:
       clusters:
       - name: xds_cluster

--- a/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
@@ -12,10 +12,10 @@ data:
   envoy.yaml: |
     node:
       cluster: clusteringress
-      id: "{{ "{{" }}.PodName{{ "}}" }}.{{ "{{" }}.PodNamespace{{ "}}" }}"
+      id: "{{ `{{.PodName}}.{{.PodNamespace}}` }}"
       metadata:
         # this line must match !
-        role: "{{ "{{" }}.PodNamespace{{ "}}" }}~clusteringress-proxy"
+        role: "{{ `{{.PodNamespace}}` }}~clusteringress-proxy"
     static_resources:
       clusters:
       - name: xds_cluster

--- a/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
@@ -14,7 +14,7 @@ data:
       cluster: clusteringress
       id: "{{ `{{.PodName}}.{{.PodNamespace}}` }}"
       metadata:
-        # this line must match !
+        # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
         role: "{{ `{{.PodNamespace}}` }}~clusteringress-proxy"
     static_resources:
       clusters:

--- a/install/helm/gloo/templates/3-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/3-gloo-deployment.yaml
@@ -53,5 +53,5 @@ spec:
         {{- end}}
       {{- if .Values.gloo.deployment.image.pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.gloo.deployment.image.pullSecret }}{{end}}
-
+        - name: {{ .Values.gloo.deployment.image.pullSecret }}
+      {{- end}}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -48,7 +48,7 @@ spec:
               fieldPath: metadata.name
         image: {{ $spec.deployment.image.repository }}:{{ $spec.deployment.image.tag }}
         imagePullPolicy: {{ $spec.deployment.image.pullPolicy }}
-        name: gateway-proxy
+        name: {{ $spec.name }}
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -1,23 +1,23 @@
 {{- if .Values.gateway.enabled }}
-{{- range $key, $spec := .Values.gatewayProxies }}
+{{- range $index, $spec := .Values.gatewayProxies }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
     app: gloo
-    gloo: {{ $key }}
-  name: {{ $key }}
+    gloo: {{ $spec.name }}
+  name: {{ $spec.name }}
   namespace: {{ $.Release.Namespace }}
 spec:
   replicas: {{ $spec.deployment.replicas }}
   selector:
     matchLabels:
-      gloo: {{ $key }}
+      gloo: {{ $spec.name }}
   template:
     metadata:
       labels:
-        gloo: {{ $key }}
+        gloo: {{ $spec.name }}
 {{ $annotationExist := false}}
 {{- if $spec.deployment.extraAnnotations }}
 {{ $annotationExist = true}}
@@ -74,7 +74,7 @@ spec:
         - name: {{ $spec.deployment.image.pullSecret }}{{end}}
       volumes:
       - configMap:
-          name: {{ $key }}-envoy-config
+          name: {{ $spec.name }}-envoy-config
         name: envoy-config
 {{- end }}
 {{- end }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.gateway.enabled }}
-{{- range $key, $spec := .Values.gatewayProxies }}
+{{- range $index, $spec := .Values.gatewayProxies }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app: gloo
-    gloo: {{ $key }}
-  name: {{ $key }}
+    gloo: {{ $spec.name }}
+  name: {{ $spec.name }}
   namespace: {{ $.Release.Namespace }}
 {{- if $spec.service.extraAnnotations }}
   annotations:
@@ -26,7 +26,7 @@ spec:
     protocol: TCP
     name: https
   selector:
-    gloo: {{ $key }}
+    gloo: {{ $spec.name }}
   type: {{ $spec.service.type }}
   {{- if and (eq $spec.service.type "ClusterIP") $spec.service.clusterIP }}
   clusterIP: {{ $spec.service.clusterIP }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -1,15 +1,15 @@
 {{- if .Values.gateway.enabled }}
-{{- range $key, $spec := .Values.gatewayProxies }}
+{{- range $index, $spec := .Values.gatewayProxies }}
 ---
 # config_map
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $key }}-envoy-config
+  name: {{ $spec.name }}-envoy-config
   namespace: {{ $.Release.Namespace }}
   labels:
     app: gloo
-    gloo: {{ $key }}
+    gloo: {{ $spec.name }}
 data:
 {{ if (empty $spec.configMap.data) }}
   envoy.yaml: |

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -15,10 +15,10 @@ data:
   envoy.yaml: |
     node:
       cluster: gateway
-      id: "{{ "{{" }}.PodName{{ "}}" }}.{{ "{{" }}.PodNamespace{{ "}}" }}"
+      id: "{{ `{{.PodName }}.{{.PodNamespace}}` }}"
       metadata:
-        # this line must match !
-        role: "{{ "{{" }}.PodNamespace{{ "}}" }}~{{ $spec.name }}"
+        # role's value is the key for the in memory xds cache (envoy.go)
+        role: "{{ `{{.PodNamespace}}` }}~{{ $spec.name }}"
     static_resources:
 
 {{- if $spec.deployment.stats }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -18,7 +18,7 @@ data:
       id: "{{ "{{" }}.PodName{{ "}}" }}.{{ "{{" }}.PodNamespace{{ "}}" }}"
       metadata:
         # this line must match !
-        role: "{{ "{{" }}.PodNamespace{{ "}}" }}~gateway-proxy"
+        role: "{{ "{{" }}.PodNamespace{{ "}}" }}~{{ $spec.name }}"
     static_resources:
 
 {{- if $spec.deployment.stats }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -15,9 +15,9 @@ data:
   envoy.yaml: |
     node:
       cluster: gateway
-      id: "{{ `{{.PodName }}.{{.PodNamespace}}` }}"
+      id: "{{ `{{.PodName}}.{{.PodNamespace}}` }}"
       metadata:
-        # role's value is the key for the in memory xds cache (envoy.go)
+        # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
         role: "{{ `{{.PodNamespace}}` }}~{{ $spec.name }}"
     static_resources:
 

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -45,7 +45,7 @@ gateway:
     stats: true
 
 gatewayProxies:
-  gateway-proxy:
+  gatewayProxy:
     deployment:
       image:
         repository: quay.io/solo-io/gloo-envoy-wrapper

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -45,7 +45,7 @@ gateway:
     stats: true
 
 gatewayProxies:
-  gatewayProxy:
+  - name: gateway-proxy
     deployment:
       image:
         repository: quay.io/solo-io/gloo-envoy-wrapper

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -47,7 +47,7 @@ func MustMake(dir string, args ...string) {
 
 var _ = SynchronizedBeforeSuite(
 	func() []byte {
-		MustMake(".", "-C", "../..", "install/gloo-gateway.yaml", "HELMFLAGS=--namespace "+namespace+" --set namespace.create=true --set gatewayProxies.gateway-proxy.service.extraAnnotations.test=test")
+		MustMake(".", "-C", "../..", "install/gloo-gateway.yaml", "HELMFLAGS=--namespace "+namespace+" --set namespace.create=true")
 		return nil
 	},
 	func(_ []byte) {

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	. "github.com/onsi/ginkgo"
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -12,17 +13,17 @@ var _ = Describe("Helm Test", func() {
 
 	Describe("gateway proxy extra annotations and crds", func() {
 		labels := map[string]string{
-			"gloo": "gateway-proxy",
+			"gloo": translator.GatewayProxyName,
 			"app":  "gloo",
 		}
 		selector := map[string]string{
-			"gloo": "gateway-proxy",
+			"gloo": translator.GatewayProxyName,
 		}
 
 		It("has a namespace", func() {
 			rb := ResourceBuilder{
 				Namespace: namespace,
-				Name:      "gateway-proxy",
+				Name:      translator.GatewayProxyName,
 				Labels:    labels,
 				Service: ServiceSpec{
 					Ports: []PortSpec{

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -42,7 +42,6 @@ var _ = Describe("Helm Test", func() {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.Ports[0].TargetPort = intstr.FromInt(8080)
 			svc.Spec.Ports[1].TargetPort = intstr.FromInt(8443)
-			svc.Annotations = map[string]string{"test": "test"}
 			testManifest.ExpectService(svc)
 		})
 	})

--- a/projects/gloo/cli/pkg/cmd/gateway/root.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/root.go
@@ -1,6 +1,7 @@
 package gateway
 
 import (
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/flagutils"
@@ -15,7 +16,7 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 		Short:   "interact with proxy instances managed by Gloo",
 		Long:    "these commands can be used to interact directly with the Proxies Gloo is managing. They are useful for interacting with and debugging the proxies (Envoy instances) directly.",
 	}
-	cmd.PersistentFlags().StringVar(&opts.Proxy.Name, "name", "gateway-proxy", "the name of the proxy service/deployment to use")
+	cmd.PersistentFlags().StringVar(&opts.Proxy.Name, "name", translator.GatewayProxyName, "the name of the proxy service/deployment to use")
 	cmd.PersistentFlags().StringVar(&opts.Proxy.Port, "port", "http", "the name of the service port to connect to")
 
 	flagutils.AddNamespaceFlag(cmd.PersistentFlags(), &opts.Metadata.Namespace)

--- a/projects/gloo/pkg/syncer/translator_syncer_test.go
+++ b/projects/gloo/pkg/syncer/translator_syncer_test.go
@@ -1,6 +1,7 @@
 package syncer_test
 
 import (
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 
@@ -35,7 +36,7 @@ var _ = Describe("Translate Proxy", func() {
 		proxy := &v1.Proxy{
 			Metadata: core.Metadata{
 				Namespace: "gloo-system",
-				Name:      "gateway-proxy",
+				Name:      translator.GatewayProxyName,
 			},
 		}
 

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"context"
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 
 	"github.com/solo-io/gloo/pkg/utils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/common/kubernetes"
@@ -85,7 +86,7 @@ var _ = Describe("Gateway", func() {
 			Eventually(
 				func() (int, error) {
 					numdisable := 0
-					proxy, err := testClients.ProxyClient.Read(writeNamespace, "gateway-proxy", clients.ReadOpts{})
+					proxy, err := testClients.ProxyClient.Read(writeNamespace, translator.GatewayProxyName, clients.ReadOpts{})
 					if err != nil {
 						return 0, err
 					}
@@ -137,7 +138,7 @@ var _ = Describe("Gateway", func() {
 			// Wait for proxy to be accepted
 			var proxy *gloov1.Proxy
 			Eventually(func() bool {
-				proxy, err = testClients.ProxyClient.Read(writeNamespace, "gateway-proxy", clients.ReadOpts{})
+				proxy, err = testClients.ProxyClient.Read(writeNamespace, translator.GatewayProxyName, clients.ReadOpts{})
 				if err != nil {
 					return false
 				}

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"context"
+
 	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 
 	"github.com/solo-io/gloo/pkg/utils"

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -3,6 +3,7 @@ package e2e_test
 import (
 	"context"
 	"fmt"
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -426,7 +427,7 @@ func getTrivialProxyForService(ns string, bindPort uint32, service core.Resource
 func getTrivialProxy(ns string, bindPort uint32) *gloov1.Proxy {
 	return &gloov1.Proxy{
 		Metadata: core.Metadata{
-			Name:      "gateway-proxy",
+			Name:      translator.GatewayProxyName,
 			Namespace: ns,
 		},
 		Listeners: []*gloov1.Listener{{

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -3,12 +3,13 @@ package e2e_test
 import (
 	"context"
 	"fmt"
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
 	"strings"
+
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/stats"
 

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -47,7 +47,7 @@ import (
 var _ = Describe("Kube2e: gateway", func() {
 
 	const (
-		gatewayProxy = "gateway-proxy"
+		gatewayProxy = translator.GatewayProxyName
 		gatewayPort  = int(80)
 	)
 
@@ -288,7 +288,6 @@ var _ = Describe("Kube2e: gateway", func() {
 					return gatewayClient.Read(testHelper.InstallNamespace, defaultGateway.Metadata.Name, clients.ReadOpts{})
 				}, "15s", "0.5s").Should(Not(BeNil()))
 
-				gatewayProxy := "gateway-proxy"
 				gatewayPort := int(443)
 				caFile := ToFile(helpers.Certificate())
 				//noinspection GoUnhandledErrorResult
@@ -301,8 +300,8 @@ var _ = Describe("Kube2e: gateway", func() {
 					Protocol:          "https",
 					Path:              "/",
 					Method:            "GET",
-					Host:              gatewayProxy,
-					Service:           gatewayProxy,
+					Host:              translator.GatewayProxyName,
+					Service:           translator.GatewayProxyName,
 					Port:              gatewayPort,
 					CaFile:            "/tmp/ca.crt",
 					ConnectionTimeout: 1,

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -2,6 +2,7 @@ package gateway_test
 
 import (
 	"fmt"
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"sort"
 	"time"
 
@@ -32,7 +33,7 @@ import (
 var _ = Describe("Robustness tests", func() {
 
 	const (
-		gatewayProxy = "gateway-proxy"
+		gatewayProxy = translator.GatewayProxyName
 		gatewayPort  = int(80)
 	)
 
@@ -179,7 +180,7 @@ var _ = Describe("Robustness tests", func() {
 
 		By("wait for proxy to be accepted")
 		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, "gateway-proxy", clients.ReadOpts{Ctx: ctx})
+			proxy, err := proxyClient.Read(namespace, translator.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 			if err != nil {
 				return err
 			}
@@ -234,7 +235,7 @@ var _ = Describe("Robustness tests", func() {
 
 		By("wait for proxy to be rejected")
 		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, "gateway-proxy", clients.ReadOpts{Ctx: ctx})
+			proxy, err := proxyClient.Read(namespace, translator.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 			if err != nil {
 				return err
 			}

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -2,9 +2,10 @@ package gateway_test
 
 import (
 	"fmt"
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"sort"
 	"time"
+
+	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 
 	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/go-utils/testutils/helper"


### PR DESCRIPTION
### Goal
Updates our template gateway proxy helm values file to use proper helm naming conventions, so once `generate.go` renders our values files then they will match helm naming conventions as well.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/827