### PR TITLE
Move to kebab case so we can keep gateway proxies as a map

### DIFF
--- a/changelog/v0.17.4/gateway-proxy-kebab-case.yaml
+++ b/changelog/v0.17.4/gateway-proxy-kebab-case.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Use map structure in values-gateway-template yaml so gateway proxy values can be easily overridden.
+    issueLink: https://github.com/solo-io/gloo/issues/857

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -1,17 +1,17 @@
 package generate
 
 type Config struct {
-	Namespace      *Namespace     `json:"namespace,omitempty"`
-	Rbac           *Rbac          `json:"rbac,omitempty"`
-	Crds           *Crds          `json:"crds,omitempty"`
-	Settings       *Settings      `json:"settings,omitempty"`
-	Gloo           *Gloo          `json:"gloo,omitempty"`
-	Discovery      *Discovery     `json:"discovery,omitempty"`
-	Gateway        *Gateway       `json:"gateway,omitempty"`
-	GatewayProxies []GatewayProxy `json:"gatewayProxies,omitempty"`
-	Ingress        *Ingress       `json:"ingress,omitempty"`
-	IngressProxy   *IngressProxy  `json:"ingressProxy,omitempty"`
-	K8s            *K8s           `json:"k8s,omitempty"`
+	Namespace      *Namespace              `json:"namespace,omitempty"`
+	Rbac           *Rbac                   `json:"rbac,omitempty"`
+	Crds           *Crds                   `json:"crds,omitempty"`
+	Settings       *Settings               `json:"settings,omitempty"`
+	Gloo           *Gloo                   `json:"gloo,omitempty"`
+	Discovery      *Discovery              `json:"discovery,omitempty"`
+	Gateway        *Gateway                `json:"gateway,omitempty"`
+	GatewayProxies map[string]GatewayProxy `json:"gatewayProxies,omitempty"`
+	Ingress        *Ingress                `json:"ingress,omitempty"`
+	IngressProxy   *IngressProxy           `json:"ingressProxy,omitempty"`
+	K8s            *K8s                    `json:"k8s,omitempty"`
 }
 
 type Namespace struct {
@@ -93,7 +93,6 @@ type GatewayDeployment struct {
 }
 
 type GatewayProxy struct {
-	Name        string                   `json:"name,omitempty"`
 	Kind        *GatewayProxyKind        `json:"kind,omitempty"`
 	PodTemplate *GatewayProxyPodTemplate `json:"podTemplate,omitempty"`
 	ConfigMap   *GatewayProxyConfigMap   `json:"configMap,omitempty"`

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.gateway.enabled }}
-{{- range $index, $spec := .Values.gatewayProxies }}
+{{- range $name, $spec := .Values.gatewayProxies }}
 ---
 apiVersion: apps/v1
 {{- if $spec.kind.deployment}}
@@ -10,8 +10,8 @@ kind: DaemonSet
 metadata:
   labels:
     app: gloo
-    gloo: {{ $spec.name }}
-  name: {{ $spec.name }}
+    gloo: {{ $name | kebabcase }}
+  name: {{ $name | kebabcase }}
   namespace: {{ $.Release.Namespace }}
 spec:
   {{- if $spec.kind.deployment}}
@@ -19,11 +19,11 @@ spec:
   {{- end}}
   selector:
     matchLabels:
-      gloo: {{ $spec.name }}
+      gloo: {{ $name | kebabcase }}
   template:
     metadata:
       labels:
-        gloo: {{ $spec.name }}
+        gloo: {{ $name | kebabcase }}
 {{ $annotationExist := false}}
 {{- if $spec.podTemplate.extraAnnotations }}
 {{ $annotationExist = true}}
@@ -54,7 +54,7 @@ spec:
               fieldPath: metadata.name
         image: {{ $spec.podTemplate.image.repository }}:{{ $spec.podTemplate.image.tag }}
         imagePullPolicy: {{ $spec.podTemplate.image.pullPolicy }}
-        name: {{ $spec.name }}
+        name: {{ $name | kebabcase }}
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
@@ -105,7 +105,7 @@ spec:
         - name: {{ $spec.podTemplate.image.pullSecret }}{{end}}
       volumes:
       - configMap:
-          name: {{ $spec.name }}-envoy-config
+          name: {{ $name | kebabcase }}-envoy-config
         name: envoy-config
 {{- end }}
 {{- end }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,13 +1,13 @@
 {{- if .Values.gateway.enabled }}
-{{- range $index, $spec := .Values.gatewayProxies }}
+{{- range $name, $spec := .Values.gatewayProxies }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   labels:
     app: gloo
-    gloo: {{ $spec.name }}
-  name: {{ $spec.name }}
+    gloo: {{ $name | kebabcase }}
+  name: {{ $name | kebabcase }}
   namespace: {{ $.Release.Namespace }}
 {{- if $spec.service.extraAnnotations }}
   annotations:
@@ -26,7 +26,7 @@ spec:
     protocol: TCP
     name: https
   selector:
-    gloo: {{ $spec.name }}
+    gloo: {{ $name | kebabcase }}
   type: {{ $spec.service.type }}
   {{- if and (eq $spec.service.type "ClusterIP") $spec.service.clusterIP }}
   clusterIP: {{ $spec.service.clusterIP }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -1,15 +1,15 @@
 {{- if .Values.gateway.enabled }}
-{{- range $index, $spec := .Values.gatewayProxies }}
+{{- range $name, $spec := .Values.gatewayProxies }}
 ---
 # config_map
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $spec.name }}-envoy-config
+  name: {{ $name | kebabcase }}-envoy-config
   namespace: {{ $.Release.Namespace }}
   labels:
     app: gloo
-    gloo: {{ $spec.name }}
+    gloo: {{ $name | kebabcase }}
 data:
 {{ if (empty $spec.configMap.data) }}
   envoy.yaml: |

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -18,7 +18,7 @@ data:
       id: "{{ `{{.PodName}}.{{.PodNamespace}}` }}"
       metadata:
         # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
-        role: "{{ `{{.PodNamespace}}` }}~{{ $spec.name }}"
+        role: "{{ `{{.PodNamespace}}` }}~{{ $name | kebabcase }}"
     static_resources:
 
 {{- if $spec.podTemplate.stats }}

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -45,7 +45,7 @@ gateway:
     stats: true
 
 gatewayProxies:
-  - name: gateway-proxy
+  gatewayProxy:
     kind:
        deployment:
          replicas: 1

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -47,7 +47,7 @@ func MustMake(dir string, args ...string) {
 
 var _ = SynchronizedBeforeSuite(
 	func() []byte {
-		MustMake(".", "-C", "../..", "install/gloo-gateway.yaml", "HELMFLAGS=--namespace "+namespace+" --set namespace.create=true")
+		MustMake(".", "-C", "../..", "install/gloo-gateway.yaml", "HELMFLAGS=--namespace "+namespace+" --set namespace.create=true  --set gatewayProxies.gatewayProxy.service.extraAnnotations.test=test")
 		return nil
 	},
 	func(_ []byte) {

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Helm Test", func() {
 			svc.Spec.Type = v1.ServiceTypeLoadBalancer
 			svc.Spec.Ports[0].TargetPort = intstr.FromInt(8080)
 			svc.Spec.Ports[1].TargetPort = intstr.FromInt(8443)
+			svc.Annotations = map[string]string{"test": "test"}
 			testManifest.ExpectService(svc)
 		})
 	})


### PR DESCRIPTION
Moves our `gatewayProxies` yaml back to using a map for easy overrides, but this time we leverage the `kebabcase` sprig function to abide by proper helm naming conventions without changing the name of our kube resources.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/857