### PR TITLE
Take advantage of this seldom-used changelog feature

### DIFF
--- a/changelog/v0.18.0/summary.md
+++ b/changelog/v0.18.0/summary.md
@@ -1,0 +1,3 @@
+In Gloo 0.18.0, we added support for TCP proxying, which required a breaking change to the gateway API. 
+Please check out https://gloo.solo.io/upgrading/0.18.0/ for details on how to seamlessly upgrade Gloo, 
+automatically convert existing configuration, and migrate traffic while avoiding downtime. 


### PR DESCRIPTION
Add changelog summary for v0.18.0, in light of https://github.com/solo-io/gloo/pull/808 and https://github.com/solo-io/solo-docs/pull/401

(cherry picked from commit 84def3163eac06efaa650885e62885f33d6517e0)