### PR TITLE
Allow gloo tests to print debug logs during pre fail handling

### DIFF
--- a/changelog/v0.18.12/gloo-debug-log-fail-handler.yaml
+++ b/changelog/v0.18.12/gloo-debug-log-fail-handler.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Allow gloo tests to print gloo debug logs during pre fail handling

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -16,10 +16,7 @@ import (
 
 func TestHelm(t *testing.T) {
 	RegisterFailHandler(Fail)
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Helm Suite")
 }

--- a/pkg/cliutil/logger_test_util.go
+++ b/pkg/cliutil/logger_test_util.go
@@ -2,7 +2,7 @@ package cliutil
 
 import (
 	"fmt"
-	"github.com/solo-io/solo-kit/test/helpers"
+	"github.com/solo-io/go-utils/testutils"
 	"io/ioutil"
 	"os"
 )
@@ -13,7 +13,7 @@ func RegisterGlooDebugLogPrintHandlerAndClearLogs() {
 }
 
 func RegisterGlooDebugLogPrintHandler() {
-	helpers.RegisterPreFailHandler(printGlooDebugLogs)
+	testutils.RegisterPreFailHandler(printGlooDebugLogs)
 }
 
 func printGlooDebugLogs() {

--- a/pkg/cliutil/logger_test_util.go
+++ b/pkg/cliutil/logger_test_util.go
@@ -17,8 +17,7 @@ func RegisterGlooDebugLogPrintHandler() {
 }
 
 func printGlooDebugLogs() {
-	logsFile := GetLogsPath()
-	logs, _ := ioutil.ReadFile(logsFile)
+	logs, _ := ioutil.ReadFile(GetLogsPath())
 	fmt.Println("*** Gloo debug logs ***")
 	fmt.Println(string(logs))
 	fmt.Println("*** End Gloo debug logs ***")

--- a/pkg/cliutil/logger_test_util.go
+++ b/pkg/cliutil/logger_test_util.go
@@ -1,0 +1,25 @@
+package cliutil
+
+import (
+	"fmt"
+	"github.com/solo-io/solo-kit/test/helpers"
+	"io/ioutil"
+	"os"
+)
+
+func RegisterGlooDebugLogPrintHandlerAndClearLogs() {
+	_ = os.Remove(GetLogsPath())
+	RegisterGlooDebugLogPrintHandler()
+}
+
+func RegisterGlooDebugLogPrintHandler() {
+	helpers.RegisterPreFailHandler(printGlooDebugLogs)
+}
+
+func printGlooDebugLogs() {
+	logsFile := GetLogsPath()
+	logs, _ := ioutil.ReadFile(logsFile)
+	fmt.Println("*** Gloo debug logs ***")
+	fmt.Println(string(logs))
+	fmt.Println("*** End Gloo debug logs ***")
+}

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -14,10 +14,7 @@ import (
 
 func TestInstall(t *testing.T) {
 	RegisterFailHandler(Fail)
-	gotestutils.RegisterPreFailHandler(
-		func() {
-			gotestutils.PrintTrimmedStack()
-		})
+	gotestutils.RegisterPreFailHandler(gotestutils.PrintTrimmedStack)
 	gotestutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Install Suite")
 }

--- a/projects/gloo/pkg/plugins/aws/ec2/ec2_suite_test.go
+++ b/projects/gloo/pkg/plugins/aws/ec2/ec2_suite_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func TestEc2(t *testing.T) {
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "EC2 Suite")
 }

--- a/projects/gloo/pkg/plugins/shadowing/shadowing_suite_test.go
+++ b/projects/gloo/pkg/plugins/shadowing/shadowing_suite_test.go
@@ -9,10 +9,7 @@ import (
 )
 
 func TestTracing(t *testing.T) {
-	testutils.RegisterPreFailHandler(
-		func() {
-			testutils.PrintTrimmedStack()
-		})
+	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Shadowing Suite")
 }

--- a/test/consulvaulte2e/e2e_suite_test.go
+++ b/test/consulvaulte2e/e2e_suite_test.go
@@ -47,6 +47,5 @@ func TestE2e(t *testing.T) {
 
 	helpers.RegisterCommonFailHandlers()
 	helpers.SetupLog()
-	// RegisterFailHandler(Fail)
 	RunSpecs(t, "E2e Suite")
 }

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -38,6 +38,5 @@ func TestE2e(t *testing.T) {
 
 	helpers.RegisterCommonFailHandlers()
 	helpers.SetupLog()
-	// RegisterFailHandler(Fail)
 	RunSpecs(t, "E2e Suite")
 }

--- a/test/helpers/glooctl_debug_dump.go
+++ b/test/helpers/glooctl_debug_dump.go
@@ -1,14 +1,15 @@
-package cliutil
+package helpers
 
 import (
 	"fmt"
+	"github.com/solo-io/gloo/pkg/cliutil"
 	"github.com/solo-io/go-utils/testutils"
 	"io/ioutil"
 	"os"
 )
 
 func RegisterGlooDebugLogPrintHandlerAndClearLogs() {
-	_ = os.Remove(GetLogsPath())
+	_ = os.Remove(cliutil.GetLogsPath())
 	RegisterGlooDebugLogPrintHandler()
 }
 
@@ -17,7 +18,7 @@ func RegisterGlooDebugLogPrintHandler() {
 }
 
 func printGlooDebugLogs() {
-	logs, _ := ioutil.ReadFile(GetLogsPath())
+	logs, _ := ioutil.ReadFile(cliutil.GetLogsPath())
 	fmt.Println("*** Gloo debug logs ***")
 	fmt.Println(string(logs))
 	fmt.Println("*** End Gloo debug logs ***")

--- a/test/helpers/glooctl_debug_dump.go
+++ b/test/helpers/glooctl_debug_dump.go
@@ -2,10 +2,11 @@ package helpers
 
 import (
 	"fmt"
-	"github.com/solo-io/gloo/pkg/cliutil"
-	"github.com/solo-io/go-utils/testutils"
 	"io/ioutil"
 	"os"
+
+	"github.com/solo-io/gloo/pkg/cliutil"
+	"github.com/solo-io/go-utils/testutils"
 )
 
 func RegisterGlooDebugLogPrintHandlerAndClearLogs() {

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/pkg/cliutil"
 	"github.com/solo-io/go-utils/testutils/helper"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
@@ -24,6 +25,7 @@ func TestGateway(t *testing.T) {
 	if testutils.AreTestsDisabled() {
 		return
 	}
+	cliutil.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
 	RunSpecs(t, "Gateway Suite")

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -16,7 +16,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/solo-io/gloo/pkg/cliutil"
 	"github.com/solo-io/go-utils/testutils/helper"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
@@ -25,7 +24,7 @@ func TestGateway(t *testing.T) {
 	if testutils.AreTestsDisabled() {
 		return
 	}
-	cliutil.RegisterGlooDebugLogPrintHandlerAndClearLogs()
+	helpers.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
 	RunSpecs(t, "Gateway Suite")

--- a/test/kube2e/ingress/ingress_suite_test.go
+++ b/test/kube2e/ingress/ingress_suite_test.go
@@ -17,6 +17,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/pkg/cliutil"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
 
@@ -24,6 +25,7 @@ func TestIngress(t *testing.T) {
 	if testutils.AreTestsDisabled() {
 		return
 	}
+	cliutil.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
 	RunSpecs(t, "Ingress Suite")

--- a/test/kube2e/ingress/ingress_suite_test.go
+++ b/test/kube2e/ingress/ingress_suite_test.go
@@ -17,7 +17,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/solo-io/gloo/pkg/cliutil"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
 
@@ -25,7 +24,7 @@ func TestIngress(t *testing.T) {
 	if testutils.AreTestsDisabled() {
 		return
 	}
-	cliutil.RegisterGlooDebugLogPrintHandlerAndClearLogs()
+	helpers.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
 	RunSpecs(t, "Ingress Suite")

--- a/test/kube2e/knative/knative_suite_test.go
+++ b/test/kube2e/knative/knative_suite_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/solo-io/gloo/pkg/cliutil"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
 
@@ -26,7 +25,7 @@ func TestKnative(t *testing.T) {
 	if testutils.AreTestsDisabled() {
 		return
 	}
-	cliutil.RegisterGlooDebugLogPrintHandlerAndClearLogs()
+	helpers.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
 	RunSpecs(t, "Knative Suite")

--- a/test/kube2e/knative/knative_suite_test.go
+++ b/test/kube2e/knative/knative_suite_test.go
@@ -18,6 +18,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/pkg/cliutil"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
 
@@ -25,6 +26,7 @@ func TestKnative(t *testing.T) {
 	if testutils.AreTestsDisabled() {
 		return
 	}
+	cliutil.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
 	RunSpecs(t, "Knative Suite")


### PR DESCRIPTION
Allows test code to register the gloo debug log print fail handler easily using:
```golang
cliutil.RegisterGlooDebugLogPrintHandlerAndClearLogs()
```
Which will generally be preferable to the `cliutil.RegisterGlooDebugLogPrintHandler()` invocation.

This will be particularly helpful in regression/e2e tests that run against live k8s clusters, and useful `kubectl` error messages have been swallowed by `glooctl` debug logging.

Tested against gloo-ee with a branch revision, looks good 👍 