### PR TITLE
Use secret converter in glooctl

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2592,7 +2592,6 @@
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/controller",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd",
-    "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/solo.io/v1",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecret",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/memory",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/vault",

--- a/changelog/v0.18.38/use-secret-converter-in-glooctl.yaml
+++ b/changelog/v0.18.38/use-secret-converter-in-glooctl.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Use secret converter in glooctl to flatten aws secrets and write proper tls secrets.
+    issueLink: https://github.com/solo-io/gloo/issues/1138

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -3,10 +3,11 @@ package helpers
 import (
 	"context"
 	"fmt"
-	kubeconverters "github.com/solo-io/gloo/projects/gloo/pkg/api/converters/kube"
 	"os"
 	"sync"
 	"time"
+
+	kubeconverters "github.com/solo-io/gloo/projects/gloo/pkg/api/converters/kube"
 
 	"github.com/hashicorp/consul/api"
 	vaultapi "github.com/hashicorp/vault/api"

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"context"
 	"fmt"
+	kubeconverters "github.com/solo-io/gloo/projects/gloo/pkg/api/converters/kube"
 	"os"
 	"sync"
 	"time"
@@ -392,9 +393,16 @@ func secretClient() (v1.SecretClient, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	converterChain := kubeconverters.NewSecretConverterChain(
+		new(kubeconverters.TLSSecretConverter),
+		new(kubeconverters.AwsSecretConverter),
+	)
+
 	secretClient, err := v1.NewSecretClient(&factory.KubeSecretClientFactory{
-		Clientset: clientset,
-		Cache:     coreCache,
+		Clientset:       clientset,
+		Cache:           coreCache,
+		SecretConverter: converterChain,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating Secrets client")

--- a/projects/gloo/pkg/api/converters/kube/secretconverter.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter.go
@@ -146,36 +146,35 @@ func (t *AwsSecretConverter) FromKubeSecret(ctx context.Context, rc *kubesecret.
 }
 
 func (t *AwsSecretConverter) ToKubeSecret(ctx context.Context, rc *kubesecret.ResourceClient, resource resources.Resource) (*kubev1.Secret, error) {
-	if glooSecret, ok := resource.(*v1.Secret); ok {
-		if awsGlooSecret, ok := glooSecret.Kind.(*v1.Secret_Aws); ok {
-			objectMeta := kubeutils.ToKubeMeta(glooSecret.Metadata)
-			delete(objectMeta.Annotations, annotationKey)
-			if len(objectMeta.Annotations) == 0 {
-				objectMeta.Annotations = nil
-			}
-			awsBytes, err := protoutils.MarshalBytes(awsGlooSecret.Aws)
-			if err != nil {
-				return nil, err
-			}
-			awsBytes, err = yaml.JSONToYAML(awsBytes)
-			if err != nil {
-				return nil, err
-			}
-
-			kubeSecret := &kubev1.Secret{
-				ObjectMeta: objectMeta,
-				Type:       kubev1.SecretTypeOpaque,
-				Data: map[string][]byte{
-					// duplicate aws creds in the original nested structure that gloo expects but also
-					// flatten it to make easier to use in other k8s resources (e.g., mount as pod env vars)
-					AwsNestedConfigName: awsBytes,
-					AwsAccessKeyName:    []byte(awsGlooSecret.Aws.AccessKey),
-					AwsSecretKeyName:    []byte(awsGlooSecret.Aws.SecretKey),
-				},
-			}
-			return kubeSecret, nil
-		}
+	glooSecret, ok := resource.(*v1.Secret)
+	if !ok {
+	  return nil, nil
+	}
+	awsGlooSecret, ok := glooSecret.Kind.(*v1.Secret_Aws)
+	if !ok {
+	  return nil, nil
+	}
+	objectMeta := kubeutils.ToKubeMeta(glooSecret.Metadata)
+	delete(objectMeta.Annotations, annotationKey)
+	if len(objectMeta.Annotations) == 0 {
+		objectMeta.Annotations = nil
+	}
+	awsBytes, err := protoutils.MarshalBytes(awsGlooSecret.Aws)
+	if err != nil {
+		return nil, err
+	}
+	awsBytes, err = yaml.JSONToYAML(awsBytes)
+	if err != nil {
+		return nil, err
 	}
 
-	return nil, nil
+	kubeSecret := &kubev1.Secret{
+		ObjectMeta: objectMeta,
+		Type:       kubev1.SecretTypeOpaque,
+		Data: map[string][]byte{
+			AwsAccessKeyName:    []byte(awsGlooSecret.Aws.AccessKey),
+			AwsSecretKeyName:    []byte(awsGlooSecret.Aws.SecretKey),
+		},
+	}
+	return kubeSecret, nil
 }

--- a/projects/gloo/pkg/api/converters/kube/secretconverter.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter.go
@@ -116,8 +116,8 @@ type AwsSecretConverter struct{}
 var _ kubesecret.SecretConverter = &AwsSecretConverter{}
 
 const (
-	AwsAccessKeyName    = "aws_access_key_id"
-	AwsSecretKeyName    = "aws_secret_access_key"
+	AwsAccessKeyName = "aws_access_key_id"
+	AwsSecretKeyName = "aws_secret_access_key"
 )
 
 func (t *AwsSecretConverter) FromKubeSecret(ctx context.Context, rc *kubesecret.ResourceClient, secret *kubev1.Secret) (resources.Resource, error) {

--- a/projects/gloo/pkg/api/converters/kube/secretconverter.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter.go
@@ -116,7 +116,6 @@ type AwsSecretConverter struct{}
 var _ kubesecret.SecretConverter = &AwsSecretConverter{}
 
 const (
-	AwsNestedConfigName = "aws"
 	AwsAccessKeyName    = "aws_access_key_id"
 	AwsSecretKeyName    = "aws_secret_access_key"
 )

--- a/projects/gloo/pkg/api/converters/kube/secretconverter.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter.go
@@ -148,11 +148,11 @@ func (t *AwsSecretConverter) FromKubeSecret(ctx context.Context, rc *kubesecret.
 func (t *AwsSecretConverter) ToKubeSecret(ctx context.Context, rc *kubesecret.ResourceClient, resource resources.Resource) (*kubev1.Secret, error) {
 	glooSecret, ok := resource.(*v1.Secret)
 	if !ok {
-	  return nil, nil
+		return nil, nil
 	}
 	awsGlooSecret, ok := glooSecret.Kind.(*v1.Secret_Aws)
 	if !ok {
-	  return nil, nil
+		return nil, nil
 	}
 	objectMeta := kubeutils.ToKubeMeta(glooSecret.Metadata)
 	delete(objectMeta.Annotations, annotationKey)
@@ -172,8 +172,8 @@ func (t *AwsSecretConverter) ToKubeSecret(ctx context.Context, rc *kubesecret.Re
 		ObjectMeta: objectMeta,
 		Type:       kubev1.SecretTypeOpaque,
 		Data: map[string][]byte{
-			AwsAccessKeyName:    []byte(awsGlooSecret.Aws.AccessKey),
-			AwsSecretKeyName:    []byte(awsGlooSecret.Aws.SecretKey),
+			AwsAccessKeyName: []byte(awsGlooSecret.Aws.AccessKey),
+			AwsSecretKeyName: []byte(awsGlooSecret.Aws.SecretKey),
 		},
 	}
 	return kubeSecret, nil

--- a/projects/gloo/pkg/api/converters/kube/secretconverter.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter.go
@@ -2,6 +2,7 @@ package kubeconverters
 
 import (
 	"context"
+
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/go-utils/protoutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecret"

--- a/projects/gloo/pkg/api/converters/kube/secretconverter_test.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter_test.go
@@ -2,6 +2,7 @@ package kubeconverters_test
 
 import (
 	"context"
+
 	"github.com/solo-io/go-utils/protoutils"
 	"sigs.k8s.io/yaml"
 

--- a/projects/gloo/pkg/api/converters/kube/secretconverter_test.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter_test.go
@@ -3,9 +3,6 @@ package kubeconverters_test
 import (
 	"context"
 
-	"github.com/solo-io/go-utils/protoutils"
-	"sigs.k8s.io/yaml"
-
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecret"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 
@@ -14,7 +11,7 @@ import (
 
 	. "github.com/solo-io/gloo/projects/gloo/pkg/api/converters/kube"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
-	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -87,13 +84,11 @@ var _ = Describe("SecretConverter", func() {
 
 	})
 
-	It("should round trip kube aws secret back to kube aws secret", func() {
+	It("should round trip kube aws secret to gloo aws secret and back to kube aws secret", func() {
 		awsSecret := &v1.AwsSecret{
 			AccessKey: "access",
 			SecretKey: "secret",
 		}
-		awsBytes, _ := protoutils.MarshalBytes(awsSecret)
-		awsBytes, _ = yaml.JSONToYAML(awsBytes)
 		kubeSecret := &kubev1.Secret{
 			Type: kubev1.SecretTypeOpaque,
 			ObjectMeta: metav1.ObjectMeta{
@@ -102,7 +97,6 @@ var _ = Describe("SecretConverter", func() {
 				Labels:    map[string]string{},
 			},
 			Data: map[string][]byte{
-				AwsNestedConfigName: awsBytes,
 				AwsAccessKeyName:    []byte(awsSecret.AccessKey),
 				AwsSecretKeyName:    []byte(awsSecret.SecretKey),
 			},

--- a/projects/gloo/pkg/api/converters/kube/secretconverter_test.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter_test.go
@@ -97,8 +97,8 @@ var _ = Describe("SecretConverter", func() {
 				Labels:    map[string]string{},
 			},
 			Data: map[string][]byte{
-				AwsAccessKeyName:    []byte(awsSecret.AccessKey),
-				AwsSecretKeyName:    []byte(awsSecret.SecretKey),
+				AwsAccessKeyName: []byte(awsSecret.AccessKey),
+				AwsSecretKeyName: []byte(awsSecret.SecretKey),
 			},
 		}
 		var awsConverter AwsSecretConverter


### PR DESCRIPTION
cc @ilackarms 

### Goal
- Turns on secret converter in glooctl
- Additionally implements the gloo aws secret -> k8s aws secret logic, allowing us to flatten aws secret creds for mounting as env vars in pods

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1138