### PR TITLE
Better ci ginko flags

### DIFF
--- a/changelog/v0.18.38/better-ginko-ci-flags.yaml
+++ b/changelog/v0.18.38/better-ginko-ci-flags.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Use better ginko flags for CI
+    issueLink: https://github.com/solo-io/gloo/issues/1153

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -120,7 +120,7 @@ steps:
   - 'DOCKER_CONFIG=/workspace/.docker/'
   - 'HELM_HOME=/root/.helm'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', '-failFast', '-race']
+  args: ['-r', '-failFast', '--randomizeAllSpecs', '--randomizeSuites', '--trace', '--race', '--progress']
   waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-zone']
   secretEnv: ['AWS_ARN_ROLE_1']
   id: 'test'
@@ -167,7 +167,7 @@ steps:
     - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
     - 'RUN_KUBE2E_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast']
+  args: ['-r', 'test/kube2e', '-failFast', '--randomizeAllSpecs', '--randomizeSuites', '--trace', '--race', '--progress']
   waitFor: ['build-test-assets', 'set-zone']
   id: 'regression-tests'
 - name: gcr.io/cloud-builders/gcloud
@@ -187,7 +187,7 @@ steps:
     - 'RUN_KUBE2E_TESTS=1'
     - 'CLUSTER_LOCK_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast']
+  args: ['-r', 'test/kube2e', '-failFast', '--randomizeAllSpecs', '--randomizeSuites', '--trace', '--race', '--progress']
   waitFor: ['build-test-assets', 'get-credentials']
   id: 'regression-tests-cluster-lock'
 


### PR DESCRIPTION
the randomization should help identify test flakes more easily. we can use the --seed flag to reproduce test flakes once identified

--trace should help make the `printTrimmedStack` pre fail handler obsolete
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1153