### PR TITLE
Uninstall all nonexistent namespace

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2635,7 +2635,6 @@
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/controller",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd",
-    "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd/solo.io/v1",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/kubesecret",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/memory",
     "github.com/solo-io/solo-kit/pkg/api/v1/clients/vault",

--- a/changelog/v0.18.41/uninstall-nonexistent-namespace.yaml
+++ b/changelog/v0.18.41/uninstall-nonexistent-namespace.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: if we run glooctl uninstall -all with a nonexistent namespace, still uninstall everything instead of erroring out.
+    issueLink: https://github.com/solo-io/gloo/issues/602


### PR DESCRIPTION
Assuming that these are all or nothing:
```GlooCrdNames = []string{
        "gateways.gateway.solo.io.v2",
        "proxies.gloo.solo.io",
        "settings.gloo.solo.io",
        "upstreams.gloo.solo.io",
        "upstreamgroups.gloo.solo.io",
        "virtualservices.gateway.solo.io",
        "routetables.gateway.solo.io",
    }
```
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/602