### PR TITLE
Use better ginko flags during CI

### DIFF
--- a/changelog/v0.18.41/better-ci-flags.yaml
+++ b/changelog/v0.18.41/better-ci-flags.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Use better ginko flags for CI
+    issueLink: https://github.com/solo-io/gloo/issues/1153
+    resolvesIssue: false

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,7 @@ steps:
   waitFor: ['dep']
   id: 'check-code-and-docs-gen'
 
-# Run all the tests with ginkgo -r
+# Run all the tests with ginkgo -r -failFast -trace -progress
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-ginkgo container provides everything else needed for running tests
 - name: gcr.io/cloud-builders/gsutil
@@ -120,7 +120,7 @@ steps:
   - 'DOCKER_CONFIG=/workspace/.docker/'
   - 'HELM_HOME=/root/.helm'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', '-failFast', '-race']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race']
   waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-zone']
   secretEnv: ['AWS_ARN_ROLE_1']
   id: 'test'
@@ -167,7 +167,7 @@ steps:
     - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
     - 'RUN_KUBE2E_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast']
+  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress']
   waitFor: ['build-test-assets', 'set-zone']
   id: 'regression-tests'
 - name: gcr.io/cloud-builders/gcloud
@@ -187,7 +187,7 @@ steps:
     - 'RUN_KUBE2E_TESTS=1'
     - 'CLUSTER_LOCK_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast']
+  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress']
   waitFor: ['build-test-assets', 'get-credentials']
   id: 'regression-tests-cluster-lock'
 

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -27,7 +27,6 @@ func TestHelm(t *testing.T) {
 	}
 
 	RegisterFailHandler(Fail)
-	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Helm Suite")
 }

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestInstall(t *testing.T) {
 	RegisterFailHandler(Fail)
-	gotestutils.RegisterPreFailHandler(gotestutils.PrintTrimmedStack)
 	gotestutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Install Suite")
 }

--- a/projects/gloo/pkg/plugins/aws/ec2/ec2_suite_test.go
+++ b/projects/gloo/pkg/plugins/aws/ec2/ec2_suite_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestEc2(t *testing.T) {
-	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "EC2 Suite")
 }

--- a/projects/gloo/pkg/plugins/shadowing/shadowing_suite_test.go
+++ b/projects/gloo/pkg/plugins/shadowing/shadowing_suite_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestTracing(t *testing.T) {
-	testutils.RegisterPreFailHandler(testutils.PrintTrimmedStack)
 	testutils.RegisterCommonFailHandlers()
 	RunSpecs(t, "Shadowing Suite")
 }


### PR DESCRIPTION
No need to print trimmed stack in CI if we always print full stack trace