### PR TITLE
Allow the cluster to dynamically assign user ids to containers

### DIFF
--- a/changelog/v0.18.42/dynamic-user-id.yaml
+++ b/changelog/v0.18.42/dynamic-user-id.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Allow container user ids to be dynamically set by the cluster
+    issueLink: https://github.com/solo-io/customers/issues/5

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -105,9 +105,11 @@ type Gloo struct {
 }
 
 type GlooDeployment struct {
-	Image   *Image `json:"image,omitempty"`
-	XdsPort int    `json:"xdsPort,omitempty" desc:"port where gloo serves xDS API to Envoy"`
-	Stats   bool   `json:"stats" desc:"enable prometheus stats"`
+	Image          *Image  `json:"image,omitempty"`
+	XdsPort        int     `json:"xdsPort,omitempty" desc:"port where gloo serves xDS API to Envoy"`
+	Stats          bool    `json:"stats" desc:"enable prometheus stats"`
+	FloatingUserId bool    `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
+	RunAsUser      float64 `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
 	*DeploymentSpec
 }
 
@@ -118,8 +120,10 @@ type Discovery struct {
 }
 
 type DiscoveryDeployment struct {
-	Image *Image `json:"image,omitempty"`
-	Stats bool   `json:"stats" desc:"enable prometheus stats"`
+	Image          *Image  `json:"image,omitempty"`
+	Stats          bool    `json:"stats" desc:"enable prometheus stats"`
+	FloatingUserId bool    `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
+	RunAsUser      float64 `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
 	*DeploymentSpec
 }
 
@@ -137,8 +141,10 @@ type ServiceAccount struct {
 }
 
 type GatewayDeployment struct {
-	Image *Image `json:"image,omitempty"`
-	Stats bool   `json:"stats" desc:"enable prometheus stats"`
+	Image          *Image  `json:"image,omitempty"`
+	Stats          bool    `json:"stats" desc:"enable prometheus stats"`
+	FloatingUserId bool    `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
+	RunAsUser      float64 `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
 	*DeploymentSpec
 }
 
@@ -184,6 +190,8 @@ type GatewayProxyPodTemplate struct {
 	Resources        *ResourceRequirements `json:"resources"`
 	DisableNetBind   bool                  `json:"disableNetBind" desc:"don't add the NET_BIND_SERVICE capability to the pod. This means that the gateway proxy will not be able to bind to ports below 1024"`
 	RunUnprivileged  bool                  `json:"runUnprivileged" desc:"run envoy as an unprivileged user`
+	FloatingUserId   bool                  `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
+	RunAsUser        float64               `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
 }
 
 type GatewayProxyService struct {

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -46,7 +46,7 @@ spec:
           runAsNonRoot: true
           {{- /* set floatingUserId to true in the helm install to let the pod be assigned a dynamic user ID */ -}}
           {{- /* see https://github.com/helm/helm/issues/1707#issuecomment-520357573 */ -}}
-          {{- /* the user id may be set quite high- openshift wants a userids that may get printed as scientific notation */}}
+          {{- /* the user id may be set quite high -- openshift wants userids that may get printed as scientific notation */}}
           {{- if not .Values.gloo.deployment.floatingUserId }}
           runAsUser: {{ printf "%.0f" .Values.gloo.deployment.runAsUser -}}
           {{- end }}

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -44,7 +44,12 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 10101
+          {{- /* set floatingUserId to true in the helm install to let the pod be assigned a dynamic user ID */ -}}
+          {{- /* see https://github.com/helm/helm/issues/1707#issuecomment-520357573 */ -}}
+          {{- /* the user id may be set quite high- openshift wants a userids that may get printed as scientific notation */}}
+          {{- if not .Values.gloo.deployment.floatingUserId }}
+          runAsUser: {{ printf "%.0f" .Values.gloo.deployment.runAsUser -}}
+          {{- end }}
           capabilities:
             drop:
             - ALL

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -40,7 +40,9 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 10101
+          {{- if not .Values.discovery.deployment.floatingUserId }}
+          runAsUser: {{ printf "%.0f" .Values.discovery.deployment.runAsUser -}}
+          {{- end }}
           capabilities:
             drop:
             - ALL

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -41,7 +41,9 @@ spec:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false
           runAsNonRoot: true
-          runAsUser: 10101
+          {{- if not .Values.gateway.deployment.floatingUserId }}
+          runAsUser: {{ printf "%.0f" .Values.gateway.deployment.runAsUser -}}
+          {{- end }}
           capabilities:
             drop:
             - ALL

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -100,7 +100,9 @@ spec:
           allowPrivilegeEscalation: false
           {{- if $spec.podTemplate.runUnprivileged }}
           runAsNonRoot: true
-          runAsUser: 10101
+          {{- if not $spec.podTemplate.floatingUserId }}
+          runAsUser: {{ printf "%.0f" $spec.podTemplate.runAsUser -}}
+          {{- end }}
           {{- end}}
           capabilities:
             drop:

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -21,6 +21,7 @@ gloo:
     xdsPort: 9977
     replicas: 1
     stats: true
+    runAsUser: 10101
 
 discovery:
   enabled: true
@@ -29,6 +30,7 @@ discovery:
       repository: discovery
     replicas: 1
     stats: true
+    runAsUser: 10101
 
 gateway:
   enabled: true
@@ -38,6 +40,7 @@ gateway:
       repository: gateway
     replicas: 1
     stats: true
+    runAsUser: 10101
   conversionJob:
     image:
       repository: gateway-conversion
@@ -55,6 +58,7 @@ gatewayProxies:
         repository: gloo-envoy-wrapper
       httpPort: 8080
       httpsPort: 8443
+      runAsUser: 10101
     service:
       type: LoadBalancer
       # clusterIP: None


### PR DESCRIPTION
Built the helm chart with setting `floatingUserId` to true, and installed into openshift. The pods were all running with dynamically-assigned user ids.

I also verified that the output of `helm template ......` does not contain any `runAsUser` settings when I turn on all of these `floatingUserId` options. AmEx's action to resolve this was to remove all those fields, so presumably this is the same effect as what they did manually.

```
~/go/src/github.com/solo-io/gloo > kubectl -n gloo-system get pods discovery-76d589d7cc-ssgwz gateway-v2-867f8fc88f-t2zqj gloo-d8dc8f9dc-rd7t5 -o json | jq '.items[].spec.containers[].securityContext.runAsUser'
1000160000
1000160000
1000160000
```

BOT NOTES: 
resolves https://github.com/solo-io/customers/issues/5