### PR TITLE
Remove hideous color codes from Ginkgo output

### DIFF
--- a/changelog/v0.18.44/ci-no-color-output.yaml
+++ b/changelog/v0.18.44/ci-no-color-output.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Remove colors from Ginkgo CI output.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -167,7 +167,7 @@ steps:
     - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
     - 'RUN_KUBE2E_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress', '--noColor']
+  args: ['-r', '--noColor', '-failFast', '-trace', '-progress', 'test/kube2e']
   waitFor: ['build-test-assets', 'set-zone']
   id: 'regression-tests'
 - name: gcr.io/cloud-builders/gcloud
@@ -187,7 +187,7 @@ steps:
     - 'RUN_KUBE2E_TESTS=1'
     - 'CLUSTER_LOCK_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress', '--noColor']
+  args: ['-r', '--noColor', '-failFast', '-trace', '-progress', 'test/kube2e']
   waitFor: ['build-test-assets', 'get-credentials']
   id: 'regression-tests-cluster-lock'
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -52,7 +52,7 @@ steps:
   waitFor: ['dep']
   id: 'check-code-and-docs-gen'
 
-# Run all the tests with ginkgo -r -failFast -trace -progress
+# Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-ginkgo container provides everything else needed for running tests
 - name: gcr.io/cloud-builders/gsutil
@@ -120,7 +120,7 @@ steps:
   - 'DOCKER_CONFIG=/workspace/.docker/'
   - 'HELM_HOME=/root/.helm'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', '-failFast', '-trace', '-progress', '-race']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '--noColor']
   waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-zone']
   secretEnv: ['AWS_ARN_ROLE_1']
   id: 'test'
@@ -167,7 +167,7 @@ steps:
     - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
     - 'RUN_KUBE2E_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress']
+  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress', '--noColor']
   waitFor: ['build-test-assets', 'set-zone']
   id: 'regression-tests'
 - name: gcr.io/cloud-builders/gcloud
@@ -187,7 +187,7 @@ steps:
     - 'RUN_KUBE2E_TESTS=1'
     - 'CLUSTER_LOCK_TESTS=1'
   dir: './gopath/src/github.com/solo-io/gloo'
-  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress']
+  args: ['-r', 'test/kube2e', '-failFast', '-trace', '-progress', '--noColor']
   waitFor: ['build-test-assets', 'get-credentials']
   id: 'regression-tests-cluster-lock'
 


### PR DESCRIPTION
Currently the test steps of our CI builds output a lot of color codes:
```
Step #11 - "test": [1568747335] [1mPlugin Interface Suite[0m - 2/2 specs [32m•[0m[32m•[0m [32mSUCCESS![0m 1.648952ms PASS
Step #11 - "test": [1568747335] [1mAls Suite[0m - 6/6 specs [32m•[0m[32m•[0m[32m•[0m[32m•[0m[32m•[0m[32m•[0m [32mSUCCESS![0m 19.035596ms PASS
```

These are nice in a terminal that renders them, but in CI they make the output unreadable. Adding a `--noColor` flag to `ginkgo` should get rid of them.