### PR TITLE
Fix ratelimit (enterprise-only) translator syncer setup

### DIFF
--- a/changelog/v0.18.44/fix-ratelimit-translator-syncer.yaml
+++ b/changelog/v0.18.44/fix-ratelimit-translator-syncer.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: fix ratelimit setting propagation with new config location
+    issueLink: https://github.com/solo-io/gloo/issues/1209

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/ratelimit"
 	"net"
 	"strconv"
 	"strings"
@@ -358,8 +359,13 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 	logger := contextutils.LoggerFrom(watchOpts.Ctx)
 
 	var syncerExtensions []TranslatorSyncerExtension
+	var rlDescriptorSettings ratelimit.EnvoySettings
+	if rlDescSettings := opts.Settings.GetRatelimitDescriptors(); rlDescSettings != nil {
+		rlDescriptorSettings = *rlDescSettings
+	}
 	params := TranslatorSyncerExtensionParams{
 		SettingExtensions: opts.Settings.Extensions,
+		RateLimitDescriptorSettings: rlDescriptorSettings,
 	}
 	for _, syncerExtensionFactory := range extensions.SyncerExtensions {
 		syncerExtension, err := syncerExtensionFactory(watchOpts.Ctx, params)

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -359,13 +359,11 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 	logger := contextutils.LoggerFrom(watchOpts.Ctx)
 
 	var syncerExtensions []TranslatorSyncerExtension
-	var rlDescriptorSettings ratelimit.EnvoySettings
-	if rlDescSettings := opts.Settings.GetRatelimitDescriptors(); rlDescSettings != nil {
-		rlDescriptorSettings = *rlDescSettings
-	}
 	params := TranslatorSyncerExtensionParams{
 		SettingExtensions: opts.Settings.Extensions,
-		RateLimitDescriptorSettings: rlDescriptorSettings,
+		RateLimitDescriptorSettings: ratelimit.EnvoySettings{
+			CustomConfig: opts.Settings.GetRatelimitDescriptors().GetCustomConfig(),
+		},
 	}
 	for _, syncerExtensionFactory := range extensions.SyncerExtensions {
 		syncerExtension, err := syncerExtensionFactory(watchOpts.Ctx, params)

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -2,10 +2,11 @@ package syncer
 
 import (
 	"context"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/ratelimit"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/ratelimit"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/validation"
 


### PR DESCRIPTION
only affects the newly added ratelimit config location (flattened on the settings object, outside of opaque extensions)

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1209