### PR TITLE
Speed up Helm tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -350,8 +350,12 @@ INSTALL_NAMESPACE ?= gloo-system
 manifest: prepare-helm install/gloo-gateway.yaml install/gloo-knative.yaml update-helm-chart
 
 # creates Chart.yaml, values.yaml, values-knative.yaml, values-ingress.yaml. See install/helm/gloo/README.md for more info.
-prepare-helm:
+.PHONY: prepare-helm
+prepare-helm: $(OUTPUT_DIR)/.helm-prepared
+
+$(OUTPUT_DIR)/.helm-prepared:
 	go run install/helm/gloo/generate.go $(VERSION)
+	touch $@
 
 update-helm-chart:
 	mkdir -p $(HELM_SYNC_DIR)/charts

--- a/changelog/v0.18.45/fix-helm-test.yaml
+++ b/changelog/v0.18.45/fix-helm-test.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Speed up the Helm tests.
+  issueLink: https://github.com/solo-io/gloo/issues/1226

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -1,14 +1,13 @@
 package test
 
 import (
+	"github.com/solo-io/go-utils/testutils"
 	"io/ioutil"
+	v1 "k8s.io/api/core/v1"
 	"os"
 	"os/exec"
 	"sync"
 	"testing"
-
-	"github.com/solo-io/go-utils/testutils"
-	v1 "k8s.io/api/core/v1"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -64,7 +63,7 @@ func renderManifest(helmFlags string) TestManifest {
 
 	f, err := ioutil.TempFile("", "*.yaml")
 	ExpectWithOffset(2, err).NotTo(HaveOccurred())
-	f.Close()
+	_ = f.Close()
 	manifestYaml := f.Name()
 	defer os.Remove(manifestYaml)
 


### PR DESCRIPTION
The problem had nothing to do with lock, but rather with running a slow make target 60+ times. Locally this fix brings down the execution time for the suite from over 100s to ~6s. In CI the suite took up to 800s, let's hope to see the same improvement factor!