### PR TITLE
Fail early if the ENVOY_IMAGE_TAG env var is not set in end to end tests

### DIFF
--- a/changelog/v0.20.3/envoy-image-env-var.yaml
+++ b/changelog/v0.20.3/envoy-image-env-var.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fail end to end tests early if the ENVOY_IMAGE_TAG env var is not set
+    issueLink: https://github.com/solo-io/gloo/issues/1311

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -333,7 +333,7 @@ func (ei *EnvoyInstance) Clean() error {
 func (ei *EnvoyInstance) runContainer() error {
 	envoyImageTag := os.Getenv("ENVOY_IMAGE_TAG")
 	if envoyImageTag == "" {
-		envoyImageTag = "latest"
+		return errors.New("Must set the ENVOY_IMAGE_TAG env var")
 	}
 
 	image := "quay.io/solo-io/gloo-envoy-wrapper:" + envoyImageTag


### PR DESCRIPTION

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1311