### PR TITLE
Bump default GlooE version to 0.20.1

### DIFF
--- a/changelog/v0.20.3/bump-glooe-tag.yaml
+++ b/changelog/v0.20.3/bump-glooe-tag.yaml
@@ -1,5 +1,5 @@
 changelog:
 - type: NEW_FEATURE
   description: >
-    The default version of GlooE installed by the CLI is now 0.20.0.
+    The default version of GlooE installed by the CLI is now 0.20.1.
   issueLink: https://github.com/solo-io/gloo/issues/1272

--- a/changelog/v0.20.3/bump-glooe-tag.yaml
+++ b/changelog/v0.20.3/bump-glooe-tag.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NEW_FEATURE
+  description: >
+    The default version of GlooE installed by the CLI is now 0.20.0.
+  issueLink: https://github.com/solo-io/gloo/issues/1272

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,4 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.19.0"
+const EnterpriseTag = "0.20.0"

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,4 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.20.0"
+const EnterpriseTag = "0.20.1"

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,11 +1,4 @@
 package version
 
-const (
-	// When updating the EnterpriseTag value, also update GlooTagInEnterprise
-	EnterpriseTag       = "0.19.0"
-	GlooTagInEnterprise = "0.19.2"
-	// TODO - util for synchronizing these versions
-
-	UiImageTag    = EnterpriseTag
-	UiGlooVersion = GlooTagInEnterprise
-)
+// The version of GlooE installed by the CLI
+const EnterpriseTag = "0.19.0"


### PR DESCRIPTION
This changes the default version of GlooE installed by the CLI to 0.20.0.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1272