### PR TITLE
Use log-only validation in gateway kube e2e test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -528,12 +528,9 @@
   revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
-  digest = "1:a507e8646bf3775af6f7e7b2a62a5e67d1c6a8f00754f87e66b96181b7f3d747"
+  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
   name = "github.com/golang/mock"
-  packages = [
-    "gomock",
-    "mockgen/model",
-  ]
+  packages = ["gomock"]
   pruneopts = "UT"
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
@@ -2719,7 +2716,6 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
-    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/ptypes/any",
@@ -2839,9 +2835,9 @@
     "google.golang.org/grpc/status",
     "gopkg.in/AlecAivazis/survey.v1",
     "gopkg.in/AlecAivazis/survey.v1/terminal",
+    "istio.io/gogo-genproto/prometheus",
     "k8s.io/api/admission/v1beta1",
     "k8s.io/api/admissionregistration/v1beta1",
-    "istio.io/gogo-genproto/prometheus",
     "k8s.io/api/apps/v1",
     "k8s.io/api/batch/v1",
     "k8s.io/api/core/v1",

--- a/changelog/v0.20.3/disable-validation-tests.yaml
+++ b/changelog/v0.20.3/disable-validation-tests.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Temporarily use log-only validation mode in kube e2e test due to frequent test flakes.

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -92,19 +92,22 @@ func StartTestHelper() {
 		return errors.New("glooctl check detected a problem with the installation")
 	}, "20s", "4s").Should(BeNil())
 
-	// enable strict validation
-	// this can be removed once we enable validation by default
-	// set projects/gateway/pkg/syncer.AcceptAllResourcesByDefault is set to false
-	settingsClient := clienthelpers.MustSettingsClient()
-	settings, err := settingsClient.Read(testHelper.InstallNamespace, "default", clients.ReadOpts{})
-	Expect(err).NotTo(HaveOccurred())
+	// TODO(ilackarms): by default validation is log-only. Re-enable validation for gateway e2e in a follow-up PR
+	if false {
+		// enable strict validation
+		// this can be removed once we enable validation by default
+		// set projects/gateway/pkg/syncer.AcceptAllResourcesByDefault is set to false
+		settingsClient := clienthelpers.MustSettingsClient()
+		settings, err := settingsClient.Read(testHelper.InstallNamespace, "default", clients.ReadOpts{})
+		Expect(err).NotTo(HaveOccurred())
 
-	Expect(settings.Gateway).NotTo(BeNil())
-	Expect(settings.Gateway.Validation).NotTo(BeNil())
-	settings.Gateway.Validation.AlwaysAccept = &types.BoolValue{Value: false}
+		Expect(settings.Gateway).NotTo(BeNil())
+		Expect(settings.Gateway.Validation).NotTo(BeNil())
+		settings.Gateway.Validation.AlwaysAccept = &types.BoolValue{Value: false}
 
-	_, err = settingsClient.Write(settings, clients.WriteOpts{OverwriteExisting: true})
-	Expect(err).NotTo(HaveOccurred())
+		_, err = settingsClient.Write(settings, clients.WriteOpts{OverwriteExisting: true})
+		Expect(err).NotTo(HaveOccurred())
+	}
 }
 
 func TearDownTestHelper() {

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -1007,7 +1007,8 @@ var _ = Describe("Kube2e: gateway", func() {
 		})
 	})
 
-	Context("tests for the validation server", func() {
+	// TODO(marco): enable when validation flakes are resolved
+	XContext("tests for the validation server", func() {
 		testValidation := func(yam, expectedErr string) {
 			out, err := install.KubectlApplyOut([]byte(yam))
 			if expectedErr == "" {


### PR DESCRIPTION
Due to the frequent flakes caused by strict validation in the gateway e2e tests, this PR configures the validator to run in log-only mode during these tests. This change is temporary and will be reverted as soon as we fix the issue (see #1323).

The flakes are a result of the implementation of the validator. The validator evaluates each resource in an ordered fashion, but when `kube` manifests are applied (or our tests run) they do not currently order the resources. In this case, the validator returns errors due to inconsistent / missing dependencies.
