### PR TITLE
add readiness probe to gloo and gateway deployments (#1323)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -528,12 +528,9 @@
   revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
-  digest = "1:a507e8646bf3775af6f7e7b2a62a5e67d1c6a8f00754f87e66b96181b7f3d747"
+  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
   name = "github.com/golang/mock"
-  packages = [
-    "gomock",
-    "mockgen/model",
-  ]
+  packages = ["gomock"]
   pruneopts = "UT"
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
@@ -2719,7 +2716,6 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
-    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/ptypes/any",

--- a/changelog/v0.20.3/fix-validation-test-flake.yaml
+++ b/changelog/v0.20.3/fix-validation-test-flake.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Gateway waits for Gloo validation server to become available during setup
+    issueLink: https://github.com/solo-io/gloo/issues/1322

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -69,6 +69,12 @@ spec:
           - name: START_STATS_SERVER
             value: "true"
         {{- end}}
+        readinessProbe:
+          tcpSocket:
+            port: {{ .Values.gloo.deployment.xdsPort }}
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
       {{- if $image.pullSecret }}
       imagePullSecrets:
         - name: {{ $image.pullSecret }}

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -72,6 +72,12 @@ spec:
         volumeMounts:
           - mountPath: /etc/gateway/validation-certs
             name: validation-certs
+        readinessProbe:
+          tcpSocket:
+            port: 8443
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
       volumes:
         - name: validation-certs
           secret:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -732,6 +732,12 @@ spec:
         volumeMounts:
           - mountPath: /etc/gateway/validation-certs
             name: validation-certs
+        readinessProbe:
+          tcpSocket:
+            port: 8443
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          failureThreshold: 10
       volumes:
         - name: validation-certs
           secret:
@@ -898,6 +904,16 @@ metadata:
 							v1.ResourceCPU:    resource.MustParse("500m"),
 						},
 					}
+					deploy.Spec.Template.Spec.Containers[0].ReadinessProbe = &v1.Probe{
+						Handler: v1.Handler{
+							TCPSocket: &v1.TCPSocketAction{
+								Port: intstr.FromInt(9977),
+							},
+						},
+						InitialDelaySeconds: 1,
+						PeriodSeconds:       2,
+						FailureThreshold:    10,
+					}
 					deploy.Spec.Template.Spec.ServiceAccountName = "gloo"
 					glooDeployment = deploy
 				})
@@ -996,20 +1012,23 @@ metadata:
 						Value: "true",
 					})
 
+					deploy.Spec.Template.Spec.Containers[0].ReadinessProbe = &v1.Probe{
+						Handler: v1.Handler{
+							TCPSocket: &v1.TCPSocketAction{
+								Port: intstr.FromInt(8443),
+							},
+						},
+						InitialDelaySeconds: 1,
+						PeriodSeconds:       2,
+						FailureThreshold:    10,
+					}
+
 					gatewayDeployment = deploy
 				})
 
 				It("has a creates a deployment", func() {
 					helmFlags := "--namespace " + namespace + " --set namespace.create=true"
 					prepareMakefile(helmFlags)
-					testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
-				})
-
-				It("disables probes", func() {
-					helmFlags := "--namespace " + namespace + " --set namespace.create=true --set gateway.deployment.probes=false"
-					prepareMakefile(helmFlags)
-					gatewayDeployment.Spec.Template.Spec.Containers[0].ReadinessProbe = nil
-					gatewayDeployment.Spec.Template.Spec.Containers[0].LivenessProbe = nil
 					testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
 				})
 
@@ -1274,6 +1293,16 @@ metadata:
 											RunAsNonRoot:             pointer.BoolPtr(true),
 											ReadOnlyRootFilesystem:   pointer.BoolPtr(true),
 											AllowPrivilegeEscalation: pointer.BoolPtr(false),
+										},
+										ReadinessProbe: &v1.Probe{
+											Handler: v1.Handler{
+												TCPSocket: &v1.TCPSocketAction{
+													Port: intstr.FromInt(9977),
+												},
+											},
+											InitialDelaySeconds: 1,
+											PeriodSeconds:       2,
+											FailureThreshold:    10,
 										},
 									},
 								},

--- a/projects/gateway/pkg/validation/robust_client.go
+++ b/projects/gateway/pkg/validation/robust_client.go
@@ -1,0 +1,100 @@
+package validation
+
+import (
+	"context"
+	"sync"
+
+	"github.com/avast/retry-go"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
+	"github.com/solo-io/go-utils/contextutils"
+	"github.com/solo-io/go-utils/errors"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type ClientConstructor func() (client validation.ProxyValidationServiceClient, e error)
+
+// connectionRefreshingValidationClient wraps a validation.ProxyValidationServiceClient (grpc Connection)
+// if a connection error occurs during an api call, the connectionRefreshingValidationClient
+// attempts to reestablish the connection & retry the call before returning the error
+type connectionRefreshingValidationClient struct {
+	lock                      sync.RWMutex
+	validationClient          validation.ProxyValidationServiceClient
+	constructValidationClient ClientConstructor
+}
+
+// the constructor returned here is not threadsafe; call from a lock
+func RetryOnUnavailableClientConstructor(ctx context.Context, serverAddress string) ClientConstructor {
+	var cancel = func() {}
+	return func() (client validation.ProxyValidationServiceClient, e error) {
+		// cancel the previous client if it exists
+		cancel()
+		contextutils.LoggerFrom(ctx).Infow("starting proxy validation client... this may take a moment",
+			zap.String("validation_server", serverAddress))
+		var clientCtx context.Context
+		clientCtx, cancel = context.WithCancel(ctx)
+
+		cc, err := grpc.DialContext(clientCtx, serverAddress, grpc.WithInsecure(), grpc.WithBlock())
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to initialize grpc connection to validation server.")
+		}
+
+		return validation.NewProxyValidationServiceClient(cc), nil
+	}
+}
+
+func NewConnectionRefreshingValidationClient(constructValidationClient func() (validation.ProxyValidationServiceClient, error)) (*connectionRefreshingValidationClient, error) {
+	vc, err := constructValidationClient()
+	if err != nil {
+		return nil, err
+	}
+	return &connectionRefreshingValidationClient{
+		constructValidationClient: constructValidationClient,
+		validationClient:          vc,
+	}, nil
+}
+
+func (c *connectionRefreshingValidationClient) ValidateProxy(ctx context.Context, proxy *validation.ProxyValidationServiceRequest, opts ...grpc.CallOption) (*validation.ProxyValidationServiceResponse, error) {
+	ctx = contextutils.WithLogger(ctx, "robust-validation-client")
+
+	var validationClient validation.ProxyValidationServiceClient
+	var proxyReport *validation.ProxyValidationServiceResponse
+	var reinstantiateClientErr error
+	if err := retry.Do(func() error {
+		c.lock.RLock()
+		defer c.lock.RUnlock()
+		validationClient = c.validationClient
+		var err error
+		proxyReport, err = validationClient.ValidateProxy(ctx, proxy, opts...)
+		return err
+	}, retry.RetryIf(func(e error) bool {
+		if reinstantiateClientErr != nil {
+			contextutils.LoggerFrom(ctx).Warnw("failed to create new validation client during retry", zap.Error(reinstantiateClientErr))
+			return false
+		}
+		return isUnavailableErr(e)
+	}), retry.OnRetry(func(n uint, err error) {
+		if !isUnavailableErr(err) {
+			return
+		}
+		c.lock.Lock()
+		defer c.lock.Unlock()
+		// if someone already changed my client, do not replace it
+		if validationClient == c.validationClient {
+			c.validationClient, reinstantiateClientErr = c.constructValidationClient()
+		}
+	})); err != nil {
+		return nil, err
+	}
+	return proxyReport, nil
+}
+
+func isUnavailableErr(err error) bool {
+	switch status.Code(err) {
+	case codes.Unavailable, codes.FailedPrecondition, codes.Aborted:
+		return true
+	}
+	return false
+}

--- a/projects/gateway/pkg/validation/robust_client_test.go
+++ b/projects/gateway/pkg/validation/robust_client_test.go
@@ -1,0 +1,132 @@
+package validation
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var res = &validation.ProxyValidationServiceResponse{}
+
+type mockValidationService struct {
+	err error
+}
+
+func (s *mockValidationService) ValidateProxy(context.Context, *validation.ProxyValidationServiceRequest) (*validation.ProxyValidationServiceResponse, error) {
+	return res, s.err
+}
+
+func makeListener(errToReturn error, addr string) (string, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	grpcServer := grpc.NewServer()
+	lis, err := net.Listen("tcp", addr)
+	Expect(err).NotTo(HaveOccurred())
+
+	validation.RegisterProxyValidationServiceServer(grpcServer, &mockValidationService{err: errToReturn})
+
+	go func() {
+		fmt.Println("starting")
+		grpcServer.Serve(lis)
+	}()
+	go func() {
+		<-ctx.Done()
+		grpcServer.Stop()
+		fmt.Println("shutting down")
+	}()
+	return lis.Addr().String(), cancel
+}
+
+var _ = Describe("RetryOnUnavailableClientConstructor", func() {
+
+	It("creates a new client and closes the old one", func() {
+		grpcAddr, cancel := makeListener(nil, "127.0.0.1:0")
+
+		rootCtx := context.Background()
+		constructor := RetryOnUnavailableClientConstructor(rootCtx, grpcAddr)
+
+		client, err := constructor()
+		Expect(err).NotTo(HaveOccurred())
+
+		// sanity check
+		resp, err := client.ValidateProxy(rootCtx, &validation.ProxyValidationServiceRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(Equal(res))
+
+		// shut down the server
+		cancel()
+
+		resp, err = client.ValidateProxy(rootCtx, &validation.ProxyValidationServiceRequest{})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Unavailable))
+
+		// let the client connection retry backoff get long enough so
+		time.Sleep(time.Millisecond * 10000)
+		// recreate the listener on the same port
+		grpcAddr, cancel = makeListener(nil, grpcAddr)
+
+		// conn should still be refused
+		resp, err = client.ValidateProxy(rootCtx, &validation.ProxyValidationServiceRequest{})
+		Expect(err).To(HaveOccurred())
+		Expect(status.Code(err)).To(Equal(codes.Unavailable))
+
+		// new client should reestablish connection
+		client, err = constructor()
+		Expect(err).NotTo(HaveOccurred())
+
+		resp, err = client.ValidateProxy(rootCtx, &validation.ProxyValidationServiceRequest{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(resp).To(Equal(res))
+
+	})
+})
+
+type mockWrappedValidationClient struct {
+	name string
+	err  error
+}
+
+func (c *mockWrappedValidationClient) ValidateProxy(ctx context.Context, in *validation.ProxyValidationServiceRequest, opts ...grpc.CallOption) (*validation.ProxyValidationServiceResponse, error) {
+	return res, c.err
+}
+
+var _ = Describe("RobustClient", func() {
+	It("swaps out the client when it returns a connection error", func() {
+		original := &mockWrappedValidationClient{name: "original"}
+		robustClient, _ := NewConnectionRefreshingValidationClient(func() (client validation.ProxyValidationServiceClient, e error) {
+			return original, nil
+		})
+
+		rootCtx := context.Background()
+
+		resp, err := robustClient.ValidateProxy(rootCtx, &validation.ProxyValidationServiceRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(Equal(res))
+
+		// make the original client return an error
+		original.err = status.Error(codes.Unavailable, "oh no, an error")
+		// update the constructor func with a new client
+		replacement := &mockWrappedValidationClient{name: "replacement"}
+		robustClient.constructValidationClient = func() (client validation.ProxyValidationServiceClient, e error) {
+			return replacement, nil
+		}
+
+		// robust client should replace with the working client
+		resp, err = robustClient.ValidateProxy(rootCtx, &validation.ProxyValidationServiceRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(Equal(res))
+
+		robustClient.lock.RLock()
+		Expect(robustClient.validationClient).To(Equal(replacement))
+		robustClient.lock.RUnlock()
+	})
+})

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -72,11 +72,23 @@ type ValidatorConfig struct {
 }
 
 func NewValidatorConfig(translator translator.Translator, validationClient validation.ProxyValidationServiceClient, writeNamespace string, ignoreProxyValidationFailure, allowBrokenLinks bool) ValidatorConfig {
-	return ValidatorConfig{translator: translator, validationClient: validationClient, writeNamespace: writeNamespace, ignoreProxyValidationFailure: ignoreProxyValidationFailure, allowBrokenLinks: allowBrokenLinks}
+	return ValidatorConfig{
+		translator:                   translator,
+		validationClient:             validationClient,
+		writeNamespace:               writeNamespace,
+		ignoreProxyValidationFailure: ignoreProxyValidationFailure,
+		allowBrokenLinks:             allowBrokenLinks,
+	}
 }
 
 func NewValidator(cfg ValidatorConfig) *validator {
-	return &validator{translator: cfg.translator, validationClient: cfg.validationClient, writeNamespace: cfg.writeNamespace, ignoreProxyValidationFailure: cfg.ignoreProxyValidationFailure, allowBrokenLinks: cfg.allowBrokenLinks}
+	return &validator{
+		translator:                   cfg.translator,
+		validationClient:             cfg.validationClient,
+		writeNamespace:               cfg.writeNamespace,
+		ignoreProxyValidationFailure: cfg.ignoreProxyValidationFailure,
+		allowBrokenLinks:             cfg.allowBrokenLinks,
+	}
 }
 
 func (v *validator) ready() bool {

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -27,6 +27,8 @@ import (
 
 var (
 	NoDestinationSpecifiedError = errors.New("must specify at least one weighted destination for multi destination routes")
+
+	SubsetsMisconfiguredErr = errors.New("route has a subset config, but the upstream does not.")
 )
 
 func (t *translator) computeRouteConfig(params plugins.Params, proxy *v1.Proxy, listener *v1.Listener, routeCfgName string, listenerReport *validationapi.ListenerReport) *envoyapi.RouteConfiguration {
@@ -179,7 +181,7 @@ func (t *translator) setAction(params plugins.RouteParams, routeReport *validati
 			Route: &envoyroute.RouteAction{},
 		}
 		if err := t.setRouteAction(params, action.RouteAction, out.Action.(*envoyroute.Route_Route).Route, routeReport); err != nil {
-			if pluginutils.IsDestinationNotFoundErr(err) {
+			if isWarningErr(err) {
 				validation.AppendRouteWarning(routeReport,
 					validationapi.RouteReport_Warning_InvalidDestinationWarning,
 					err.Error(),
@@ -202,7 +204,7 @@ func (t *translator) setAction(params plugins.RouteParams, routeReport *validati
 				// plugins can return errors on missing upstream/upstream group
 				// we only want to report errors that are plugin-specific
 				// missing upstream(group) should produce a warning above
-				if pluginutils.IsDestinationNotFoundErr(err) {
+				if isWarningErr(err) {
 					continue
 				}
 				validation.AppendRouteError(routeReport,
@@ -224,7 +226,7 @@ func (t *translator) setAction(params plugins.RouteParams, routeReport *validati
 			}
 			if err := routePlugin.ProcessRouteAction(raParams, in.GetRouteAction(), out.GetRoute()); err != nil {
 				// same as above
-				if pluginutils.IsDestinationNotFoundErr(err) {
+				if isWarningErr(err) {
 					continue
 				}
 				validation.AppendRouteError(routeReport,
@@ -384,7 +386,7 @@ func checkThatSubsetMatchesUpstream(params plugins.Params, dest *v1.Destination)
 
 	// if a route has a subset config, and an upstream doesnt - its an error
 	if subsetConfig == nil {
-		return errors.Errorf("route has a subset config, but the upstream does not.")
+		return SubsetsMisconfiguredErr
 	}
 
 	// make sure that the subset on the route will match a subset on the upstream.
@@ -592,5 +594,16 @@ func DataSourceFromString(str string) *envoycore.DataSource {
 		Specifier: &envoycore.DataSource_InlineString{
 			InlineString: str,
 		},
+	}
+}
+
+func isWarningErr(err error) bool {
+	switch {
+	case err == SubsetsMisconfiguredErr:
+		fallthrough
+	case pluginutils.IsDestinationNotFoundErr(err):
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
* use blocking dial for grpc proxy validation server
* add readiness probe to gloo and gateway
* fix ch, add options for readiness probe
* use a client that retries the connection on an Unavailable grpc error
* use eventaully to handle test race with uds
* fmt
* subset mismatch converted to a warning
* Dep ensure & codegen
* fmt
* Merge branch 'fix-validation-test-flake' of github.com:solo-io/gloo into fix-validation-test-flake
* fix robust client retry logic
* fmt
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1322