### PR TITLE
check hash in validator on update, skip validating nil proxy

### DIFF
--- a/changelog/v0.20.6/fix-knative-manifest-parsing.yaml
+++ b/changelog/v0.20.6/fix-knative-manifest-parsing.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: fix nil pointer when validating nil proxy
+    issueLink: https://github.com/solo-io/gloo/issues/1369
+  - type: FIX
+    description: check resource hash in validator (prevents validating status updates)
+    issueLink: https://github.com/solo-io/gloo/issues/1368

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -233,7 +233,7 @@ secrets:
     QUAY_IO_PASSWORD: CiQABlzmSRx5TcOqbldXa/d/+bkmAfpNAWa3PTS06WvuloZL+vASaQCCPGSGCogonVZVEUNx4G3YJtWi18gSuNx4PvLe08q8xAflTMFkjsyQirAOK3Y2oCvgYwiw/ITcuydjkpMjxDygFyENXS9FKFJoAXHlPQE5qidKr8xxmxF5ezhmjGB0gjyjXIIkbSEnBg==
     AWS_ARN_ROLE_1: CiQABlzmSTKWrIEGaH8UvsX3Wp8pz8ClQODVSjIZAiHuE9gNhM4SXACCPGSGCDSNJtdfkA0BLLmKTJLIM06XXEOV4iIooqlLfo9p7EOzOwqZaV9DFygO8/oKQqTFstc1vKgOz7YHrMaCx3GzqiHN2u//UmHRpvIwrDDfuIP5XNa0aOrj
 
-timeout: 3600s
+timeout: 4200s
 tags: ['gloo']
 options:
   machineType: 'N1_HIGHCPU_32'

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -187,6 +187,11 @@ func (v *validator) validateSnapshot(ctx context.Context, apply applyResource) (
 			continue
 		}
 
+		// a nil proxy may have been returned if 0 listeners were created
+		if proxy == nil {
+			continue
+		}
+
 		// validate the proxy with gloo
 		var proxyReport *validation.ProxyValidationServiceResponse
 		err := retry.Do(func() error {
@@ -241,6 +246,11 @@ func (v *validator) ValidateVirtualService(ctx context.Context, vs *v1.VirtualSe
 		var isUpdate bool
 		for i, existingVs := range snap.VirtualServices {
 			if vsRef == existingVs.GetMetadata().Ref() {
+				// check that the hash has changed; ignore irrelevant update such as status
+				if vs.Hash() == existingVs.Hash() {
+					return nil, nil, core.ResourceRef{}
+				}
+
 				// replace the existing virtual service in the snapshot
 				snap.VirtualServices[i] = vs
 				isUpdate = true
@@ -312,6 +322,11 @@ func (v *validator) ValidateRouteTable(ctx context.Context, rt *v1.RouteTable) (
 		var isUpdate bool
 		for i, existingRt := range snap.RouteTables {
 			if rtRef == existingRt.GetMetadata().Ref() {
+				// check that the hash has changed; ignore irrelevant update such as status
+				if rt.Hash() == existingRt.Hash() {
+					return nil, nil, core.ResourceRef{}
+				}
+
 				// replace the existing route table in the snapshot
 				snap.RouteTables[i] = rt
 				isUpdate = true
@@ -385,6 +400,11 @@ func (v *validator) ValidateGateway(ctx context.Context, gw *v2.Gateway) (ProxyR
 		var isUpdate bool
 		for i, existingGw := range snap.Gateways {
 			if gwRef == existingGw.GetMetadata().Ref() {
+				// check that the hash has changed; ignore irrelevant update such as status
+				if gw.Hash() == existingGw.Hash() {
+					return nil, nil, core.ResourceRef{}
+				}
+
 				// replace the existing gateway in the snapshot
 				snap.Gateways[i] = gw
 				isUpdate = true

--- a/projects/gateway/pkg/validation/validator_test.go
+++ b/projects/gateway/pkg/validation/validator_test.go
@@ -61,6 +61,10 @@ var _ = Describe("Validator", func() {
 				snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
+
+				// change something to change the hash
+				snap.RouteTables[0].Metadata.Labels = map[string]string{"change": "my mind"}
+
 				proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))
@@ -76,6 +80,10 @@ var _ = Describe("Validator", func() {
 					snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
 					err := v.Sync(context.TODO(), snap)
 					Expect(err).NotTo(HaveOccurred())
+
+					// change something to change the hash
+					snap.RouteTables[0].Metadata.Labels = map[string]string{"change": "my mind"}
+
 					proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to communicate with Gloo Proxy validation server"))
@@ -199,6 +207,10 @@ var _ = Describe("Validator", func() {
 				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
+
+				// change something to change the hash
+				snap.VirtualServices[0].Metadata.Labels = map[string]string{"change": "my mind"}
+
 				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0])
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))
@@ -313,6 +325,10 @@ var _ = Describe("Validator", func() {
 				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
+
+				// change something to change the hash
+				snap.Gateways[0].Metadata.Labels = map[string]string{"change": "my mind"}
+
 				proxyReports, err := v.ValidateGateway(context.TODO(), snap.Gateways[0])
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))


### PR DESCRIPTION
2 fixes for validation:

- validator checks the hash of an updated object. if the hash has not changed (e.g. due to status update), the validator admits. **this would be improved if we used subresources for status**

- do not attempt to validate nil proxy (if no errors occurred but no listeners were created, proxy validation can panic)
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1369
resolves https://github.com/solo-io/gloo/issues/1368