### PR TITLE
Convert to new usage client

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1405,7 +1405,19 @@
   version = "v0.10.18"
 
 [[projects]]
-  digest = "1:a816c3c4ab0bb06663d8d4ea44d979ba0d0f323260b541c6fd2533fb8211660a"
+  digest = "1:4d1097e99437dae9af7b00925d9067a54afd2200f725013326cd159ef74e15c1"
+  name = "github.com/solo-io/reporting-client"
+  packages = [
+    ".",
+    "pkg/api/v1",
+    "pkg/client",
+  ]
+  pruneopts = "UT"
+  revision = "7ef898bc3df32db0e1ed2dee70a838c955a7b422"
+  version = "v0.0.1"
+
+[[projects]]
+  digest = "1:74ef591481b05a71280bb21afda272bbf7ef6abc2374ce52d36e181b699e4ce0"
   name = "github.com/solo-io/solo-kit"
   packages = [
     "api/external/kubernetes/configmap",
@@ -2784,6 +2796,7 @@
     "github.com/solo-io/go-utils/versionutils",
     "github.com/solo-io/go-utils/versionutils/dep",
     "github.com/solo-io/go-utils/versionutils/git",
+    "github.com/solo-io/reporting-client",
     "github.com/solo-io/solo-kit/api/external/kubernetes/namespace",
     "github.com/solo-io/solo-kit/pkg/api/external/kubernetes/namespace",
     "github.com/solo-io/solo-kit/pkg/api/external/kubernetes/service",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1397,15 +1397,15 @@
   version = "v0.10.18"
 
 [[projects]]
-  digest = "1:8ccc9b38e12d8484ebcadfe7dbe33cf1f1a89bc55640732fda9f2c1fb68d8bdf"
+  digest = "1:a2922a665903e4336f9e8b13eb9134bdda25ed984b3966159d4aa2bf9c5b0e28"
   name = "github.com/solo-io/reporting-client"
   packages = [
     "pkg/api/v1",
     "pkg/client",
   ]
   pruneopts = "UT"
-  revision = "7ef898bc3df32db0e1ed2dee70a838c955a7b422"
-  version = "v0.0.1"
+  revision = "f47eacc21bd62e6bc8bb8954af0dc1817079af0d"
+  version = "v0.0.2"
 
 [[projects]]
   digest = "1:74ef591481b05a71280bb21afda272bbf7ef6abc2374ce52d36e181b699e4ce0"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1354,14 +1354,6 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:c5673cbf44dc752b282c962f514b0cc1b64d0d253cc64dba53b123a8e4bc3c4f"
-  name = "github.com/solo-io/go-checkpoint"
-  packages = ["."]
-  pruneopts = "UT"
-  revision = "b56cd9c812e84da93eb577054ebdf60a27487acb"
-  version = "0.1.0"
-
-[[projects]]
   digest = "1:30d12500ff14fd6945d4451146adb4fa6e62019c7164070924ccf4ec787e4a92"
   name = "github.com/solo-io/go-utils"
   packages = [
@@ -1405,10 +1397,9 @@
   version = "v0.10.18"
 
 [[projects]]
-  digest = "1:4d1097e99437dae9af7b00925d9067a54afd2200f725013326cd159ef74e15c1"
+  digest = "1:8ccc9b38e12d8484ebcadfe7dbe33cf1f1a89bc55640732fda9f2c1fb68d8bdf"
   name = "github.com/solo-io/reporting-client"
   packages = [
-    ".",
     "pkg/api/v1",
     "pkg/client",
   ]
@@ -2767,7 +2758,6 @@
     "github.com/prometheus/client_golang/api/prometheus/v1",
     "github.com/prometheus/prometheus/discovery/targetgroup",
     "github.com/solo-io/envoy-operator/pkg/downward",
-    "github.com/solo-io/go-checkpoint",
     "github.com/solo-io/go-utils/certutils",
     "github.com/solo-io/go-utils/changelogutils",
     "github.com/solo-io/go-utils/clidoc",
@@ -2796,7 +2786,8 @@
     "github.com/solo-io/go-utils/versionutils",
     "github.com/solo-io/go-utils/versionutils/dep",
     "github.com/solo-io/go-utils/versionutils/git",
-    "github.com/solo-io/reporting-client",
+    "github.com/solo-io/reporting-client/pkg/api/v1",
+    "github.com/solo-io/reporting-client/pkg/client",
     "github.com/solo-io/solo-kit/api/external/kubernetes/namespace",
     "github.com/solo-io/solo-kit/pkg/api/external/kubernetes/namespace",
     "github.com/solo-io/solo-kit/pkg/api/external/kubernetes/service",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,7 +40,7 @@
 
 [[constraint]]
   name = "github.com/solo-io/reporting-client"
-  version = "0.0.1"
+  version = "0.0.2"
 
 [[constraint]]
   name = "github.com/onsi/gomega"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -39,8 +39,8 @@
   version = "1.5.2"
 
 [[constraint]]
-  name = "github.com/solo-io/go-checkpoint"
-  version = "0.1.0"
+  name = "github.com/solo-io/reporting-client"
+  version = "0.0.1"
 
 [[constraint]]
   name = "github.com/onsi/gomega"

--- a/changelog/v0.21.0/new-usage-client.yaml
+++ b/changelog/v0.21.0/new-usage-client.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Switch checkpoint client to new reporting service client
+    issueLink: https://github.com/solo-io/solo-projects/issues/1199

--- a/pkg/utils/setuputils/main_setup.go
+++ b/pkg/utils/setuputils/main_setup.go
@@ -7,15 +7,17 @@ import (
 	"sync"
 	"time"
 
+	"github.com/solo-io/gloo/pkg/utils/usage"
+	"github.com/solo-io/gloo/pkg/version"
+	"github.com/solo-io/reporting-client/pkg/client"
+
 	"go.uber.org/zap"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 
 	"github.com/gogo/protobuf/types"
 	"github.com/solo-io/gloo/pkg/utils/settingsutil"
-	"github.com/solo-io/gloo/pkg/version"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
-	check "github.com/solo-io/go-checkpoint"
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -31,13 +33,18 @@ type SetupOpts struct {
 	SetupFunc     SetupFunc
 	ExitOnError   bool
 	CustomCtx     context.Context
+
+	// optional- if present, report usage with the payload this discovers
+	// should really only provide it in very intentional places- in the gloo pod, and in glooctl
+	// otherwise, we'll provide redundant copies of the usage data
+	UsageReporter client.UsagePayloadReader
 }
 
 var once sync.Once
 
 func Main(opts SetupOpts) error {
 	loggingPrefix := opts.LoggingPrefix
-	check.NewUsageClient().Start(loggingPrefix, version.Version)
+
 	// prevent panic if multiple flag.Parse called concurrently
 	once.Do(func() {
 		flag.Parse()
@@ -48,6 +55,15 @@ func Main(opts SetupOpts) error {
 		ctx = context.Background()
 	}
 	ctx = contextutils.WithLogger(ctx, loggingPrefix)
+
+	if opts.UsageReporter != nil {
+		go func() {
+			errs := StartReportingUsage(opts.CustomCtx, opts.UsageReporter, opts.LoggingPrefix)
+			for err := range errs {
+				contextutils.LoggerFrom(ctx).Errorf("Error while reporting usage: %s", err.Error())
+			}
+		}()
+	}
 
 	settingsClient, err := kubeOrFileSettingsClient(ctx, setupNamespace, setupDir)
 	if err != nil {
@@ -124,4 +140,9 @@ func writeDefaultSettings(defaultNamespace, name string, cli v1.SettingsClient) 
 		return errors.Wrapf(err, "failed to create default settings")
 	}
 	return nil
+}
+
+func StartReportingUsage(ctx context.Context, usagePayloadReader client.UsagePayloadReader, product string) <-chan error {
+	usageClient := client.NewUsageClient(usage.ReportingServiceUrl, usagePayloadReader, usage.LoadInstanceMetadata(product, version.Version))
+	return usageClient.StartReportingUsage(ctx, usage.ReportingDuration)
 }

--- a/pkg/utils/setuputils/main_setup.go
+++ b/pkg/utils/setuputils/main_setup.go
@@ -60,7 +60,7 @@ func Main(opts SetupOpts) error {
 		go func() {
 			errs := StartReportingUsage(opts.CustomCtx, opts.UsageReporter, opts.LoggingPrefix)
 			for err := range errs {
-				contextutils.LoggerFrom(ctx).Errorf("Error while reporting usage: %s", err.Error())
+				contextutils.LoggerFrom(ctx).Errorw("Error while reporting usage", zap.Error(err))
 			}
 		}()
 	}

--- a/pkg/utils/setuputils/main_setup.go
+++ b/pkg/utils/setuputils/main_setup.go
@@ -144,5 +144,5 @@ func writeDefaultSettings(defaultNamespace, name string, cli v1.SettingsClient) 
 
 func StartReportingUsage(ctx context.Context, usagePayloadReader client.UsagePayloadReader, product string) <-chan error {
 	usageClient := client.NewUsageClient(usage.ReportingServiceUrl, usagePayloadReader, usage.LoadInstanceMetadata(product, version.Version))
-	return usageClient.StartReportingUsage(ctx, usage.ReportingDuration)
+	return usageClient.StartReportingUsage(ctx, usage.ReportingPeriod)
 }

--- a/pkg/utils/usage/default_usage_reader.go
+++ b/pkg/utils/usage/default_usage_reader.go
@@ -53,7 +53,7 @@ func (d *DefaultUsageReader) GetPayload() (map[string]string, error) {
 		payload[totalRequests] = fmt.Sprintf("%d", requestsCount)
 	}
 	if connectionsCount > 0 {
-		payload[totalConnections] = fmt.Sprintf("%d", totalConnections)
+		payload[totalConnections] = fmt.Sprintf("%d", connectionsCount)
 	}
 
 	return payload, nil

--- a/pkg/utils/usage/default_usage_reader.go
+++ b/pkg/utils/usage/default_usage_reader.go
@@ -1,0 +1,56 @@
+package usage
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/solo-io/gloo/projects/metrics/pkg/metricsservice"
+	"github.com/solo-io/reporting-client/pkg/client"
+)
+
+const (
+	ReportingServiceUrl = "reporting.solo.io:443"
+	ReportingDuration   = time.Hour * 24
+
+	numEnvoys        = "numActiveEnvoys"
+	totalRequests    = "totalRequests"
+	totalConnections = "totalConnections"
+)
+
+type DefaultUsageReader struct {
+	MetricsStorage metricsservice.StorageClient
+}
+
+var _ client.UsagePayloadReader = &DefaultUsageReader{}
+
+func (d *DefaultUsageReader) GetPayload() (map[string]string, error) {
+	usage, err := d.MetricsStorage.GetUsage()
+	if err != nil {
+		return nil, err
+	}
+
+	payload := map[string]string{}
+
+	envoys := 0
+	requestsCount := uint64(0)
+	connectionsCount := uint64(0)
+
+	for _, envoyUsage := range usage.EnvoyIdToUsage {
+		if envoyUsage.Active {
+			envoys++
+			requestsCount += envoyUsage.EnvoyMetrics.HttpRequests
+			connectionsCount += envoyUsage.EnvoyMetrics.TcpConnections
+		}
+	}
+
+	payload[numEnvoys] = fmt.Sprintf("%d", envoys)
+
+	if requestsCount > 0 {
+		payload[totalRequests] = fmt.Sprintf("%d", requestsCount)
+	}
+	if connectionsCount > 0 {
+		payload[totalConnections] = fmt.Sprintf("%d", totalConnections)
+	}
+
+	return payload, nil
+}

--- a/pkg/utils/usage/default_usage_reader.go
+++ b/pkg/utils/usage/default_usage_reader.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	ReportingServiceUrl = "reporting.solo.io:443"
+	ReportingServiceUrl = "reporting.corp.solo.io:443"
 	ReportingDuration   = time.Hour * 24
 
 	numEnvoys        = "numActiveEnvoys"
@@ -30,6 +30,10 @@ func (d *DefaultUsageReader) GetPayload() (map[string]string, error) {
 	}
 
 	payload := map[string]string{}
+
+	if usage == nil || usage.EnvoyIdToUsage == nil {
+		return payload, nil
+	}
 
 	envoys := 0
 	requestsCount := uint64(0)

--- a/pkg/utils/usage/default_usage_reader.go
+++ b/pkg/utils/usage/default_usage_reader.go
@@ -9,8 +9,13 @@ import (
 )
 
 const (
+	// this is the url for a grpc service
+	// note that grpc name resolution is a little different than for a normal HTTP/1.1 service
+	// https://github.com/grpc/grpc/blob/master/doc/naming.md
 	ReportingServiceUrl = "reporting.corp.solo.io:443"
-	ReportingDuration   = time.Hour * 24
+
+	// report once per period
+	ReportingPeriod = time.Hour * 24
 
 	numEnvoys        = "numActiveEnvoys"
 	totalRequests    = "totalRequests"

--- a/pkg/utils/usage/instance_metadata.go
+++ b/pkg/utils/usage/instance_metadata.go
@@ -1,0 +1,16 @@
+package usage
+
+import (
+	"runtime"
+
+	reportingapi "github.com/solo-io/reporting-client/pkg/api/v1"
+)
+
+func LoadInstanceMetadata(product, version string) *reportingapi.InstanceMetadata {
+	return &reportingapi.InstanceMetadata{
+		Product: product,
+		Version: version,
+		Arch:    runtime.GOARCH,
+		Os:      runtime.GOOS,
+	}
+}

--- a/projects/gloo/cli/cmd/main.go
+++ b/projects/gloo/cli/cmd/main.go
@@ -1,19 +1,34 @@
 package main
 
 import (
+	"context"
 	"os"
+	"strings"
 
-	"github.com/solo-io/gloo/pkg/version"
+	"github.com/solo-io/gloo/pkg/utils/setuputils"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd"
-	check "github.com/solo-io/go-checkpoint"
+)
+
+const (
+	args = "args"
 )
 
 func main() {
-	check.NewUsageClient().Start("glooctl", version.Version)
+	setuputils.StartReportingUsage(context.Background(), &cliUsageReader{}, "glooctl")
+
 	app := cmd.GlooCli()
 	if err := app.Execute(); err != nil {
 		//fmt.Println(err)
 		os.Exit(1)
 	}
+}
+
+type cliUsageReader struct {
+}
+
+func (c *cliUsageReader) GetPayload() (map[string]string, error) {
+	return map[string]string{
+		args: strings.Join(os.Args, "|"),
+	}, nil
 }

--- a/projects/gloo/cli/cmd/main.go
+++ b/projects/gloo/cli/cmd/main.go
@@ -27,6 +27,7 @@ func main() {
 type cliUsageReader struct {
 }
 
+// when reporting usage, also include the args that glooctl was invoked with
 func (c *cliUsageReader) GetPayload() (map[string]string, error) {
 	return map[string]string{
 		args: strings.Join(os.Args, "|"),

--- a/projects/gloo/pkg/setup/setup.go
+++ b/projects/gloo/pkg/setup/setup.go
@@ -2,16 +2,39 @@ package setup
 
 import (
 	"context"
+	"os"
+
+	"github.com/solo-io/gloo/pkg/utils/usage"
+	"github.com/solo-io/gloo/projects/metrics/pkg/metricsservice"
+	"github.com/solo-io/go-utils/contextutils"
+	"github.com/solo-io/reporting-client/pkg/client"
 
 	"github.com/solo-io/gloo/pkg/utils/setuputils"
 	"github.com/solo-io/gloo/projects/gloo/pkg/syncer"
 )
 
 func Main(customCtx context.Context) error {
+	var usageReporter client.UsagePayloadReader
+	metricsStorage, err := metricsservice.NewDefaultConfigMapStorage(os.Getenv("POD_NAMESPACE"))
+	if err != nil {
+		contextutils.LoggerFrom(customCtx).Warnf("Could not create metrics storage loader - will not report usage: %s", err.Error())
+	} else {
+		usageReporter = &usage.DefaultUsageReader{MetricsStorage: metricsStorage}
+	}
+
+	return startSetupLoop(customCtx, usageReporter)
+}
+
+func StartGlooInTest(customCtx context.Context) error {
+	return startSetupLoop(customCtx, nil)
+}
+
+func startSetupLoop(ctx context.Context, usageReporter client.UsagePayloadReader) error {
 	return setuputils.Main(setuputils.SetupOpts{
 		LoggingPrefix: "gloo",
 		SetupFunc:     syncer.NewSetupFunc(),
 		ExitOnError:   true,
-		CustomCtx:     customCtx,
+		CustomCtx:     ctx,
+		UsageReporter: usageReporter,
 	})
 }

--- a/projects/gloo/pkg/setup/setup.go
+++ b/projects/gloo/pkg/setup/setup.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"os"
 
+	"go.uber.org/zap"
+
 	"github.com/solo-io/gloo/pkg/utils/usage"
 	"github.com/solo-io/gloo/projects/metrics/pkg/metricsservice"
 	"github.com/solo-io/go-utils/contextutils"
@@ -17,7 +19,7 @@ func Main(customCtx context.Context) error {
 	var usageReporter client.UsagePayloadReader
 	metricsStorage, err := metricsservice.NewDefaultConfigMapStorage(os.Getenv("POD_NAMESPACE"))
 	if err != nil {
-		contextutils.LoggerFrom(customCtx).Warnf("Could not create metrics storage loader - will not report usage: %s", err.Error())
+		contextutils.LoggerFrom(customCtx).Warnw("Could not create metrics storage loader - will not report usage: %s", zap.Error(err))
 	} else {
 		usageReporter = &usage.DefaultUsageReader{MetricsStorage: metricsStorage}
 	}

--- a/projects/metrics/pkg/metricsservice/metrics_handler.go
+++ b/projects/metrics/pkg/metricsservice/metrics_handler.go
@@ -51,7 +51,7 @@ func (m *metricsHandler) HandleMetrics(ctx context.Context, met *envoymet.Stream
 		return err
 	}
 
-	existingUsage, err := m.storage.GetUsage(ctx)
+	existingUsage, err := m.storage.GetUsage()
 	if err != nil {
 		contextutils.LoggerFrom(ctx).Errorf("Error while retrieving old usage: %s", err.Error())
 		return err
@@ -59,7 +59,7 @@ func (m *metricsHandler) HandleMetrics(ctx context.Context, met *envoymet.Stream
 
 	mergedUsage := m.usageMerger.MergeUsage(met.Identifier.Node.Id, existingUsage, newMetrics)
 
-	err = m.storage.RecordUsage(ctx, mergedUsage)
+	err = m.storage.RecordUsage(mergedUsage)
 	if err != nil {
 		contextutils.LoggerFrom(ctx).Errorf("Error while storing new usage: %s", err.Error())
 		return err

--- a/projects/metrics/pkg/metricsservice/metrics_service_test.go
+++ b/projects/metrics/pkg/metricsservice/metrics_service_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Metrics service", func() {
 			Recv().
 			Return(metrics, nil)
 		storage.EXPECT().
-			GetUsage(context.TODO()).
+			GetUsage().
 			Return(nil, nil)
 
 		expectedUsage := &metricsservice.GlobalUsage{
@@ -91,7 +91,7 @@ var _ = Describe("Metrics service", func() {
 		}
 
 		storage.EXPECT().
-			RecordUsage(context.TODO(), expectedUsage).
+			RecordUsage(expectedUsage).
 			Return(nil)
 
 		err := metricsService.StreamMetrics(metricsStream)
@@ -143,7 +143,7 @@ var _ = Describe("Metrics service", func() {
 			},
 		}
 		storage.EXPECT().
-			GetUsage(context.TODO()).
+			GetUsage().
 			Return(existingUsage, nil)
 
 		expectedUsage := &metricsservice.GlobalUsage{
@@ -162,7 +162,7 @@ var _ = Describe("Metrics service", func() {
 		}
 
 		storage.EXPECT().
-			RecordUsage(context.TODO(), expectedUsage).
+			RecordUsage(expectedUsage).
 			Return(nil)
 
 		err := metricsService.StreamMetrics(metricsStream)

--- a/projects/metrics/pkg/metricsservice/mocks/mock_storage.go
+++ b/projects/metrics/pkg/metricsservice/mocks/mock_storage.go
@@ -5,7 +5,6 @@
 package mocks
 
 import (
-	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -36,30 +35,30 @@ func (m *MockStorageClient) EXPECT() *MockStorageClientMockRecorder {
 }
 
 // GetUsage mocks base method
-func (m *MockStorageClient) GetUsage(arg0 context.Context) (*metricsservice.GlobalUsage, error) {
+func (m *MockStorageClient) GetUsage() (*metricsservice.GlobalUsage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUsage", arg0)
+	ret := m.ctrl.Call(m, "GetUsage")
 	ret0, _ := ret[0].(*metricsservice.GlobalUsage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUsage indicates an expected call of GetUsage
-func (mr *MockStorageClientMockRecorder) GetUsage(arg0 interface{}) *gomock.Call {
+func (mr *MockStorageClientMockRecorder) GetUsage() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsage", reflect.TypeOf((*MockStorageClient)(nil).GetUsage), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUsage", reflect.TypeOf((*MockStorageClient)(nil).GetUsage))
 }
 
 // RecordUsage mocks base method
-func (m *MockStorageClient) RecordUsage(arg0 context.Context, arg1 *metricsservice.GlobalUsage) error {
+func (m *MockStorageClient) RecordUsage(arg0 *metricsservice.GlobalUsage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordUsage", arg0, arg1)
+	ret := m.ctrl.Call(m, "RecordUsage", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordUsage indicates an expected call of RecordUsage
-func (mr *MockStorageClientMockRecorder) RecordUsage(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStorageClientMockRecorder) RecordUsage(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordUsage", reflect.TypeOf((*MockStorageClient)(nil).RecordUsage), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordUsage", reflect.TypeOf((*MockStorageClient)(nil).RecordUsage), arg0)
 }

--- a/test/consulvaulte2e/consul_vault_test.go
+++ b/test/consulvaulte2e/consul_vault_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Consul + Vault Configuration Happy Path e2e", func() {
 		go func() {
 			defer GinkgoRecover()
 			// Start Gloo
-			err = setup.Main(ctx)
+			err = setup.StartGlooInTest(ctx)
 			Expect(err).NotTo(HaveOccurred())
 		}()
 		go func() {


### PR DESCRIPTION
The service is done being stood up in prod. Running this in minikube can successfully report usage to prod over SSL.

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/1199