### PR TITLE
Bump default GlooE version installed by the CLI to 0.20.4

### DIFF
--- a/changelog/v0.20.7/bump-glooe-tag.yaml
+++ b/changelog/v0.20.7/bump-glooe-tag.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  description: The default version of GlooE installed by the CLI is now 0.20.3.
+  issueLink: https://github.com/solo-io/gloo/issues/1386

--- a/changelog/v0.20.7/bump-glooe-tag.yaml
+++ b/changelog/v0.20.7/bump-glooe-tag.yaml
@@ -1,4 +1,4 @@
 changelog:
 - type: NEW_FEATURE
-  description: The default version of GlooE installed by the CLI is now 0.20.3.
+  description: The default version of GlooE installed by the CLI is now 0.20.4.
   issueLink: https://github.com/solo-io/gloo/issues/1386

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,4 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.20.3"
+const EnterpriseTag = "0.20.4"

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,4 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.20.1"
+const EnterpriseTag = "0.20.3"


### PR DESCRIPTION
The default version of GlooE installed by the CLI is now 0.20.3
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1386