### PR TITLE
Add sanitizer interface for sanitizing xds snapshot

### DIFF
--- a/changelog/v0.20.3/sanitizer.yaml
+++ b/changelog/v0.20.3/sanitizer.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add sanitizer interface for sanitizing xds snapshot

--- a/projects/gloo/pkg/syncer/envoy_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/envoy_translator_syncer.go
@@ -8,7 +8,6 @@ import (
 	"github.com/gorilla/mux"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
-	"github.com/solo-io/gloo/projects/gloo/pkg/translator"
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/go-utils/errors"
@@ -86,7 +85,7 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1.ApiSnapshot) 
 
 		key := xds.SnapshotKey(proxy)
 
-		xdsSnapshot, err = validateSnapshot(snap, xdsSnapshot, reports, logger)
+		xdsSnapshot, err = s.sanitizer.SanitizeSnapshot(ctx, snap, xdsSnapshot, reports)
 		if err != nil {
 			logger.Warnf("proxy %v was rejected due to invalid config: %v\n"+
 				"Attempting to update only EDS information", proxy.Metadata.Ref().Key(), err)
@@ -145,58 +144,6 @@ func (s *translatorSyncer) ServeXdsSnapshots() error {
 		_, _ = fmt.Fprintf(w, log.Sprintf("%v", s.latestSnap))
 	})
 	return http.ListenAndServe(":10010", r)
-}
-
-// If there are any errors on upstreams, this function tries to remove the correspondent clusters and endpoints from
-// the xDS snapshot. If the snapshot is still consistent after these mutations and there are no errors related to other
-// resources, we are good to send it to Envoy.
-func validateSnapshot(glooSnapshot *v1.ApiSnapshot, xdsSnapshot envoycache.Snapshot, errs reporter.ResourceReports, logger *zap.SugaredLogger) (envoycache.Snapshot, error) {
-	resourcesErr := errs.Validate()
-	if resourcesErr == nil {
-		return xdsSnapshot, nil
-	}
-
-	logger.Debug("removing errored upstreams and checking consistency")
-
-	clusters := xdsSnapshot.GetResources(xds.ClusterType)
-	endpoints := xdsSnapshot.GetResources(xds.EndpointType)
-
-	// Find all the errored upstreams and remove them from the xDS snapshot
-	for _, up := range glooSnapshot.Upstreams.AsInputResources() {
-		if errs[up].Errors != nil {
-			clusterName := translator.UpstreamToClusterName(up.GetMetadata().Ref())
-			// remove cluster and endpoints
-			delete(clusters.Items, clusterName)
-			delete(endpoints.Items, clusterName)
-		}
-	}
-
-	// TODO(marco): the function accepts and return a Snapshot interface, but then swaps in its own implementation.
-	//  This breaks the abstraction and mocking the snapshot becomes impossible. We should have a generic way of
-	//  creating snapshots.
-	xdsSnapshot = xds.NewSnapshotFromResources(
-		endpoints,
-		clusters,
-		xdsSnapshot.GetResources(xds.RouteType),
-		xdsSnapshot.GetResources(xds.ListenerType),
-	)
-
-	// If the snapshot is not consistent,
-	if xdsSnapshot.Consistent() != nil {
-		return xdsSnapshot, resourcesErr
-	}
-
-	// Remove errors related to upstreams
-	for _, up := range glooSnapshot.Upstreams.AsInputResources() {
-		if errs[up].Errors != nil {
-			delete(errs, up)
-		}
-	}
-
-	// Snapshot is consistent, so check if we have errors not related to the upstreams
-	resourcesErr = errs.Validate()
-
-	return xdsSnapshot, resourcesErr
 }
 
 // TODO(marco): should we update CDS resources as well?

--- a/projects/gloo/pkg/syncer/sanitizer/snapshot_sanitizer.go
+++ b/projects/gloo/pkg/syncer/sanitizer/snapshot_sanitizer.go
@@ -1,0 +1,26 @@
+package sanitizer
+
+import (
+	"context"
+
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	envoycache "github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
+	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
+)
+
+type XdsSanitizer interface {
+	SanitizeSnapshot(ctx context.Context, glooSnapshot *v1.ApiSnapshot, xdsSnapshot envoycache.Snapshot, reports reporter.ResourceReports) (envoycache.Snapshot, error)
+}
+
+type XdsSanitizers []XdsSanitizer
+
+func (s XdsSanitizers) SanitizeSnapshot(ctx context.Context, glooSnapshot *v1.ApiSnapshot, xdsSnapshot envoycache.Snapshot, reports reporter.ResourceReports) (envoycache.Snapshot, error) {
+	for _, sanitizer := range s {
+		var err error
+		xdsSnapshot, err = sanitizer.SanitizeSnapshot(ctx, glooSnapshot, xdsSnapshot, reports)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return xdsSnapshot, nil
+}

--- a/projects/gloo/pkg/syncer/sanitizer/upstream_removing_sanitizer.go
+++ b/projects/gloo/pkg/syncer/sanitizer/upstream_removing_sanitizer.go
@@ -1,0 +1,66 @@
+package sanitizer
+
+import (
+	"context"
+
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/translator"
+	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
+	"github.com/solo-io/go-utils/contextutils"
+	envoycache "github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
+	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
+)
+
+type InvalidUpstreamRemovingSanitizer struct{}
+
+func NewInvalidUpstreamRemovingSanitizer() *InvalidUpstreamRemovingSanitizer {
+	return &InvalidUpstreamRemovingSanitizer{}
+}
+
+// If there are any errors on upstreams, this function tries to remove the correspondent clusters and endpoints from
+// the xDS snapshot. If the snapshot is still consistent after these mutations and there are no errors related to other
+// resources, we are good to send it to Envoy.
+//
+func (s *InvalidUpstreamRemovingSanitizer) SanitizeSnapshot(ctx context.Context, glooSnapshot *v1.ApiSnapshot, xdsSnapshot envoycache.Snapshot, reports reporter.ResourceReports) (envoycache.Snapshot, error) {
+	ctx = contextutils.WithLogger(ctx, "invalid-upstream-remover")
+
+	resourcesErr := reports.ValidateStrict()
+	if resourcesErr == nil {
+		return xdsSnapshot, nil
+	}
+
+	contextutils.LoggerFrom(ctx).Debug("removing errored upstreams and checking consistency")
+
+	clusters := xdsSnapshot.GetResources(xds.ClusterType)
+	endpoints := xdsSnapshot.GetResources(xds.EndpointType)
+
+	// Find all the errored upstreams and remove them from the xDS snapshot
+	for _, up := range glooSnapshot.Upstreams.AsInputResources() {
+		if reports[up].Errors != nil {
+			clusterName := translator.UpstreamToClusterName(up.GetMetadata().Ref())
+			// remove cluster and endpoints
+			delete(clusters.Items, clusterName)
+			delete(endpoints.Items, clusterName)
+		}
+	}
+
+	// TODO(marco): the function accepts and return a Snapshot interface, but then swaps in its own implementation.
+	//  This breaks the abstraction and mocking the snapshot becomes impossible. We should have a generic way of
+	//  creating snapshots.
+	xdsSnapshot = xds.NewSnapshotFromResources(
+		endpoints,
+		clusters,
+		xdsSnapshot.GetResources(xds.RouteType),
+		xdsSnapshot.GetResources(xds.ListenerType),
+	)
+
+	// If the snapshot is not consistent,
+	if xdsSnapshot.Consistent() != nil {
+		return xdsSnapshot, resourcesErr
+	}
+
+	// Snapshot is consistent, so check if we have errors not related to the upstreams
+	resourcesErr = reports.Validate()
+
+	return xdsSnapshot, resourcesErr
+}

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"fmt"
+	"github.com/solo-io/gloo/projects/gloo/pkg/syncer/sanitizer"
 	"net"
 	"strconv"
 	"strings"
@@ -444,7 +445,11 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 		opts.ValidationServer.Server.SetValidator(validator)
 	}
 
-	translationSync := NewTranslatorSyncer(t, opts.ControlPlane.SnapshotCache, xdsHasher, rpt, opts.DevMode, syncerExtensions)
+	xdsSanitizer := sanitizer.XdsSanitizers{
+		sanitizer.NewInvalidUpstreamRemovingSanitizer(),
+	}
+
+	translationSync := NewTranslatorSyncer(t, opts.ControlPlane.SnapshotCache, xdsHasher, xdsSanitizer, rpt, opts.DevMode, syncerExtensions)
 
 	syncers := v1.ApiSyncers{
 		translationSync,

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -3,10 +3,11 @@ package syncer
 import (
 	"context"
 	"fmt"
-	"github.com/solo-io/gloo/projects/gloo/pkg/syncer/sanitizer"
 	"net"
 	"strconv"
 	"strings"
+
+	"github.com/solo-io/gloo/projects/gloo/pkg/syncer/sanitizer"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/ratelimit"
 	"github.com/solo-io/gloo/projects/metrics/pkg/metricsservice"

--- a/projects/gloo/pkg/syncer/translator_syncer.go
+++ b/projects/gloo/pkg/syncer/translator_syncer.go
@@ -3,6 +3,8 @@ package syncer
 import (
 	"context"
 
+	"github.com/solo-io/gloo/projects/gloo/pkg/syncer/sanitizer"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/ratelimit"
 
 	"github.com/hashicorp/go-multierror"
@@ -22,6 +24,7 @@ var (
 
 type translatorSyncer struct {
 	translator translator.Translator
+	sanitizer  sanitizer.XdsSanitizer
 	xdsCache   envoycache.SnapshotCache
 	xdsHasher  *xds.ProxyKeyHasher
 	reporter   reporter.Reporter
@@ -41,13 +44,14 @@ type TranslatorSyncerExtension interface {
 	Sync(ctx context.Context, snap *v1.ApiSnapshot, xdsCache envoycache.SnapshotCache) error
 }
 
-func NewTranslatorSyncer(translator translator.Translator, xdsCache envoycache.SnapshotCache, xdsHasher *xds.ProxyKeyHasher, reporter reporter.Reporter, devMode bool, extensions []TranslatorSyncerExtension) v1.ApiSyncer {
+func NewTranslatorSyncer(translator translator.Translator, xdsCache envoycache.SnapshotCache, xdsHasher *xds.ProxyKeyHasher, sanitizer sanitizer.XdsSanitizer, reporter reporter.Reporter, devMode bool, extensions []TranslatorSyncerExtension) v1.ApiSyncer {
 	s := &translatorSyncer{
 		translator: translator,
 		xdsCache:   xdsCache,
 		xdsHasher:  xdsHasher,
 		reporter:   reporter,
 		extensions: extensions,
+		sanitizer:  sanitizer,
 	}
 	if devMode {
 		// TODO(ilackarms): move this somewhere else?

--- a/projects/gloo/pkg/syncer/translator_syncer_test.go
+++ b/projects/gloo/pkg/syncer/translator_syncer_test.go
@@ -1,7 +1,7 @@
 package syncer_test
 
 import (
-	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+	v2 "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
@@ -23,72 +23,125 @@ import (
 
 var _ = Describe("Translate Proxy", func() {
 
-	It("writes the reports the translator spits out and calls SetSnapshot on the cache", func() {
-		ref := "syncer-test"
+	var (
+		xdsCache    *mockXdsCache
+		sanitizer   *mockXdsSanitizer
+		syncer      v1.ApiSyncer
+		snap        *v1.ApiSnapshot
+		proxyClient v1.ProxyClient
+		proxyName   = "proxy-name"
+		ref         = "syncer-test"
+		ns          = "any-ns"
+	)
+
+	BeforeEach(func() {
+		xdsCache = &mockXdsCache{}
+		sanitizer = &mockXdsSanitizer{}
+
 		resourceClientFactory := &factory.MemoryResourceClientFactory{
 			Cache: memory.NewInMemoryResourceCache(),
 		}
-		proxyClient, err := resourceClientFactory.NewResourceClient(factory.NewResourceClientParams{ResourceType: &v1.Proxy{}})
-		Expect(err).NotTo(HaveOccurred())
+
+		proxyClient, _ = v1.NewProxyClient(resourceClientFactory)
 
 		upstreamClient, err := resourceClientFactory.NewResourceClient(factory.NewResourceClientParams{ResourceType: &v1.Upstream{}})
 		Expect(err).NotTo(HaveOccurred())
 
 		proxy := &v1.Proxy{
 			Metadata: core.Metadata{
-				Namespace: "gloo-system",
-				Name:      defaults.GatewayProxyName,
+				Namespace: ns,
+				Name:      proxyName,
 			},
 		}
 
-		c := &mockXdsCache{}
-		rep := reporter.NewReporter(ref, proxyClient, upstreamClient)
-
-		sanitizer := &mockXdsSanitizer{}
+		rep := reporter.NewReporter(ref, proxyClient.BaseClient(), upstreamClient)
 
 		xdsHasher := &xds.ProxyKeyHasher{}
-		s := NewTranslatorSyncer(&mockTranslator{true}, c, xdsHasher, sanitizer, rep, false, nil)
-		snap := &v1.ApiSnapshot{
+		syncer = NewTranslatorSyncer(&mockTranslator{true}, xdsCache, xdsHasher, sanitizer, rep, false, nil)
+		snap = &v1.ApiSnapshot{
 			Proxies: v1.ProxyList{
 				proxy,
 			},
 		}
-		err = s.Sync(context.Background(), snap)
+		err = syncer.Sync(context.Background(), snap)
 		Expect(err).NotTo(HaveOccurred())
 
 		proxies, err := proxyClient.List(proxy.GetMetadata().Namespace, clients.ListOpts{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(proxies).To(HaveLen(1))
 		Expect(proxies[0]).To(BeAssignableToTypeOf(&v1.Proxy{}))
-		Expect(proxies[0].(*v1.Proxy).Status).To(Equal(core.Status{
+		Expect(proxies[0].Status).To(Equal(core.Status{
 			State:      2,
 			Reason:     "1 error occurred:\n\t* hi, how ya doin'?\n\n",
 			ReportedBy: ref,
 		}))
 
 		// NilSnapshot is always consistent, so snapshot will always be set as part of endpoints update
-		Expect(c.called).To(BeTrue())
+		Expect(xdsCache.called).To(BeTrue())
 
 		// update rv for proxy
 		p1, err := proxyClient.Read(proxy.Metadata.Namespace, proxy.Metadata.Name, clients.ReadOpts{})
 		Expect(err).NotTo(HaveOccurred())
-		snap.Proxies[0] = p1.(*v1.Proxy)
+		snap.Proxies[0] = p1
 
-		s = NewTranslatorSyncer(&mockTranslator{false}, c, xdsHasher, sanitizer, rep, false, nil)
-		err = s.Sync(context.Background(), snap)
+		syncer = NewTranslatorSyncer(&mockTranslator{false}, xdsCache, xdsHasher, sanitizer, rep, false, nil)
+
+		err = syncer.Sync(context.Background(), snap)
 		Expect(err).NotTo(HaveOccurred())
 
-		proxies, err = proxyClient.List(proxy.GetMetadata().Namespace, clients.ListOpts{})
+	})
+
+	It("writes the reports the translator spits out and calls SetSnapshot on the cache", func() {
+		proxies, err := proxyClient.List(ns, clients.ListOpts{})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(proxies).To(HaveLen(1))
 		Expect(proxies[0]).To(BeAssignableToTypeOf(&v1.Proxy{}))
-		Expect(proxies[0].(*v1.Proxy).Status).To(Equal(core.Status{
+		Expect(proxies[0].Status).To(Equal(core.Status{
 			State:      1,
 			ReportedBy: ref,
 		}))
 
-		Expect(c.called).To(BeTrue())
+		Expect(xdsCache.called).To(BeTrue())
+	})
+
+	It("updates the cache with the sanitized snapshot", func() {
+		sanitizer.snap = envoycache.NewEasyGenericSnapshot("easy")
+		err := syncer.Sync(context.Background(), snap)
+		Expect(err).NotTo(HaveOccurred())
+
 		Expect(sanitizer.called).To(BeTrue())
+		Expect(xdsCache.setSnap).To(BeEquivalentTo(sanitizer.snap))
+	})
+
+	It("uses listeners and routes from the previous snapshot when sanitization fails", func() {
+		sanitizer.err = errors.Errorf("we ran out of coffee")
+
+		oldXdsSnap := xds.NewSnapshotFromResources(
+			envoycache.NewResources("", nil),
+			envoycache.NewResources("", nil),
+			envoycache.NewResources("", nil),
+			envoycache.NewResources("old listeners from before the war", []envoycache.Resource{
+				xds.NewEnvoyResource(&v2.RouteConfiguration{}),
+			}),
+		)
+
+		// return this old snapshot when the syncer asks for it
+		xdsCache.getSnap = oldXdsSnap
+		err := syncer.Sync(context.Background(), snap)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(sanitizer.called).To(BeTrue())
+		Expect(xdsCache.called).To(BeTrue())
+
+		oldListeners := oldXdsSnap.GetResources(xds.ListenerType)
+		newListeners := xdsCache.setSnap.GetResources(xds.ListenerType)
+
+		Expect(oldListeners).To(Equal(newListeners))
+
+		oldRoutes := oldXdsSnap.GetResources(xds.RouteType)
+		newRoutes := xdsCache.setSnap.GetResources(xds.RouteType)
+
+		Expect(oldRoutes).To(Equal(newRoutes))
 	})
 })
 
@@ -109,6 +162,10 @@ var _ envoycache.SnapshotCache = &mockXdsCache{}
 
 type mockXdsCache struct {
 	called bool
+	// snap that is set
+	setSnap envoycache.Snapshot
+	// snap that is returned
+	getSnap envoycache.Snapshot
 }
 
 func (*mockXdsCache) CreateWatch(envoycache.Request) (value chan envoycache.Response, cancel func()) {
@@ -129,10 +186,14 @@ func (*mockXdsCache) GetStatusKeys() []string {
 
 func (c *mockXdsCache) SetSnapshot(node string, snapshot envoycache.Snapshot) error {
 	c.called = true
+	c.setSnap = snapshot
 	return nil
 }
 
 func (c *mockXdsCache) GetSnapshot(node string) (envoycache.Snapshot, error) {
+	if c.getSnap != nil {
+		return c.getSnap, nil
+	}
 	return &envoycache.NilSnapshot{}, nil
 }
 
@@ -142,9 +203,17 @@ func (*mockXdsCache) ClearSnapshot(node string) {
 
 type mockXdsSanitizer struct {
 	called bool
+	snap   envoycache.Snapshot
+	err    error
 }
 
 func (s *mockXdsSanitizer) SanitizeSnapshot(ctx context.Context, glooSnapshot *v1.ApiSnapshot, xdsSnapshot envoycache.Snapshot, reports reporter.ResourceReports) (envoycache.Snapshot, error) {
 	s.called = true
+	if s.snap != nil {
+		return s.snap, nil
+	}
+	if s.err != nil {
+		return nil, s.err
+	}
 	return xdsSnapshot, nil
 }


### PR DESCRIPTION
i plan to add more "sanitizing" of xds snapshots to the gloo translator syncer.

currently, we have some sanitizing already going on: we remove all clusters from the snapshot who correspond to errored upstreams

this PR moves that behavior to an interface type we can extend