### PR TITLE
Add support for Custom Auth

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -293,7 +293,7 @@
   version = "v1.12.0"
 
 [[projects]]
-  digest = "1:2695bddd58c6dafde2d0cc89255214c5e273ccb34dfec353e0f843e9c5cf9831"
+  digest = "1:4c866af489df27390e3a4dd51ad42d40f3fef1838de424793067f2c0cd6ce18f"
   name = "github.com/envoyproxy/go-control-plane"
   packages = [
     "envoy/api/v2",
@@ -319,6 +319,7 @@
     "envoy/config/trace/v2",
     "envoy/data/accesslog/v2",
     "envoy/service/accesslog/v2",
+    "envoy/service/auth/v2",
     "envoy/service/discovery/v2",
     "envoy/service/metrics/v2",
     "envoy/type",
@@ -2700,6 +2701,7 @@
     "github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v2alpha",
     "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v2",
     "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2",
+    "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2",
     "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v2",
     "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v2",
     "github.com/envoyproxy/go-control-plane/envoy/type",
@@ -2713,6 +2715,7 @@
     "github.com/go-openapi/swag",
     "github.com/go-swagger/go-swagger/examples/2.0/petstore/server/api",
     "github.com/gogo/googleapis/google/api",
+    "github.com/gogo/googleapis/google/rpc",
     "github.com/gogo/protobuf/gogoproto",
     "github.com/gogo/protobuf/jsonpb",
     "github.com/gogo/protobuf/proto",

--- a/changelog/v0.20.7/activate-custom-auth-plugin.yaml
+++ b/changelog/v0.20.7/activate-custom-auth-plugin.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  description: >
+    Add support for custom authentication. You can now provide your own external authentication/authorization server and
+    configure Gloo to call it on the virtual hosts, routes, and weighted destinations that you want to secure.
+  issueLink: https://github.com/solo-io/gloo/issues/1396

--- a/changelog/v0.20.7/process-custom-auth-configs.yaml
+++ b/changelog/v0.20.7/process-custom-auth-configs.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: Process custom Ext Auth configuration on virtual hosts, routes, and weighted destinations.
+  issueLink: https://github.com/solo-io/gloo/issues/1396
+  resolvesIssue: false

--- a/projects/gloo/pkg/plugins/extauth/plugin.go
+++ b/projects/gloo/pkg/plugins/extauth/plugin.go
@@ -2,9 +2,12 @@ package extauth
 
 import (
 	"github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	envoyauth "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	extauthv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/pluginutils"
 )
 
 const (
@@ -37,14 +40,143 @@ func (p *Plugin) HttpFilters(params plugins.Params, _ *v1.HttpListener) ([]plugi
 	return BuildHttpFilters(p.extAuthSettings, params.Snapshot.Upstreams)
 }
 
+// This function generates the ext_authz PerFilterConfig for this virtual host. If the ext_authz filter was not
+// configured on the listener, do nothing. If the filter is configured and the virtual host does not define
+// an extauth configuration OR explicitly disables extauth, we disable the ext_authz filter.
+// This is done to disable authentication by default on a virtual host and its child resources (routes, weighted
+// destinations). Extauth is currently opt-in.
 func (p *Plugin) ProcessVirtualHost(params plugins.VirtualHostParams, in *v1.VirtualHost, out *route.VirtualHost) error {
-	return nil
+
+	// Ext_authz filter is not configured on listener, do nothing
+	if !p.isExtAuthzFilterConfigured(params.Snapshot.Upstreams) {
+		return nil
+	}
+
+	// If extauth is explicitly disabled on this virtual host, disable it
+	if in.GetVirtualHostPlugins().GetExtauth().GetDisable() {
+		return markVirtualHostNoAuth(out)
+	}
+
+	customAuthConfig := in.GetVirtualHostPlugins().GetExtauth().GetCustomAuth()
+
+	// No extauth config on this virtual host, disable it
+	if customAuthConfig == nil {
+		return markVirtualHostNoAuth(out)
+	}
+
+	config := &envoyauth.ExtAuthzPerRoute{
+		Override: &envoyauth.ExtAuthzPerRoute_CheckSettings{
+			CheckSettings: &envoyauth.CheckSettings{
+				ContextExtensions: customAuthConfig.GetContextExtensions(),
+			},
+		},
+	}
+
+	return pluginutils.SetVhostPerFilterConfig(out, FilterName, config)
 }
 
+// This function generates the ext_authz PerFilterConfig for this route:
+// - if the route defines custom auth configuration, set the filter correspondingly;
+// - if auth is explicitly disabled, disable the filter (will apply by default also to WeightedDestinations);
+// - else, do nothing (will inherit config from parent virtual host).
 func (p *Plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *route.Route) error {
-	return nil
+
+	// Ext_authz is not configured, do nothing
+	if !p.isExtAuthzFilterConfigured(params.Snapshot.Upstreams) {
+		return nil
+	}
+
+	// Extauth is explicitly disabled, disable it on route
+	if in.GetRoutePlugins().GetExtauth().GetDisable() {
+		return markRouteNoAuth(out)
+	}
+
+	customAuthConfig := in.GetRoutePlugins().GetExtauth().GetCustomAuth()
+
+	// No custom config, do nothing
+	if customAuthConfig == nil {
+		return nil
+	}
+
+	config := &envoyauth.ExtAuthzPerRoute{
+		Override: &envoyauth.ExtAuthzPerRoute_CheckSettings{
+			CheckSettings: &envoyauth.CheckSettings{
+				ContextExtensions: customAuthConfig.GetContextExtensions(),
+			},
+		},
+	}
+
+	return pluginutils.SetRoutePerFilterConfig(out, FilterName, config)
 }
 
+// This function generates the ext_authz PerFilterConfig for this weightedDestination:
+// - if the weightedDestination defines custom auth configuration, set the filter correspondingly;
+// - if auth is explicitly disabled, disable the filter;
+// - else, do nothing (will inherit config from parent virtual host and/or route).
 func (p *Plugin) ProcessWeightedDestination(params plugins.RouteParams, in *v1.WeightedDestination, out *route.WeightedCluster_ClusterWeight) error {
-	return nil
+
+	// Ext_authz is not configured, do nothing
+	if !p.isExtAuthzFilterConfigured(params.Snapshot.Upstreams) {
+		return nil
+	}
+
+	// Extauth is explicitly disabled, disable it on weighted destination
+	if in.GetWeightedDestinationPlugins().GetExtauth().GetDisable() {
+		return markWeightedClusterNoAuth(out)
+	}
+
+	customAuthConfig := in.GetWeightedDestinationPlugins().GetExtauth().GetCustomAuth()
+
+	// No custom config, do nothing
+	if customAuthConfig == nil {
+		return nil
+	}
+
+	config := &envoyauth.ExtAuthzPerRoute{
+		Override: &envoyauth.ExtAuthzPerRoute_CheckSettings{
+			CheckSettings: &envoyauth.CheckSettings{
+				ContextExtensions: customAuthConfig.GetContextExtensions(),
+			},
+		},
+	}
+
+	return pluginutils.SetWeightedClusterPerFilterConfig(out, FilterName, config)
+}
+
+func (p *Plugin) isExtAuthzFilterConfigured(upstreams v1.UpstreamList) bool {
+	// Call the same function called by HttpFilters to verify whether the filter was created
+	filters, err := BuildHttpFilters(p.extAuthSettings, upstreams)
+	if err != nil {
+		// If it returned an error, the filter was not configured
+		return false
+	}
+
+	// Check for a filter called "envoy.ext_authz"
+	for _, filter := range filters {
+		if filter.HttpFilter.GetName() == FilterName {
+			return true
+		}
+	}
+
+	return false
+}
+
+func markVirtualHostNoAuth(out *envoyroute.VirtualHost) error {
+	return pluginutils.SetVhostPerFilterConfig(out, FilterName, getNoAuthConfig())
+}
+
+func markWeightedClusterNoAuth(out *envoyroute.WeightedCluster_ClusterWeight) error {
+	return pluginutils.SetWeightedClusterPerFilterConfig(out, FilterName, getNoAuthConfig())
+}
+
+func markRouteNoAuth(out *envoyroute.Route) error {
+	return pluginutils.SetRoutePerFilterConfig(out, FilterName, getNoAuthConfig())
+}
+
+func getNoAuthConfig() *envoyauth.ExtAuthzPerRoute {
+	return &envoyauth.ExtAuthzPerRoute{
+		Override: &envoyauth.ExtAuthzPerRoute_Disabled{
+			Disabled: true,
+		},
+	}
 }

--- a/projects/gloo/pkg/plugins/extauth/plugin_test.go
+++ b/projects/gloo/pkg/plugins/extauth/plugin_test.go
@@ -1,0 +1,323 @@
+package extauth_test
+
+import (
+	"context"
+
+	envoyv2 "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	envoyauth "github.com/envoyproxy/go-control-plane/envoy/config/filter/http/ext_authz/v2"
+	"github.com/envoyproxy/go-control-plane/pkg/util"
+	"github.com/gogo/protobuf/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/pkg/utils"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	extauthv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/static"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	. "github.com/solo-io/gloo/projects/gloo/pkg/plugins/extauth"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+)
+
+// We need to test three possible input values for the ext auth config (the value of the `*Plugins` attributes):
+// - Undefined: no config is provided
+// - Enabled: a valid custom auth config
+// - Disabled: config explicitly disables auth
+type ConfigState int
+
+const (
+	Undefined ConfigState = iota
+	Enabled
+	Disabled
+)
+
+func (c ConfigState) String() string {
+	return [...]string{"Undefined", "Enabled", "Disabled"}[c]
+}
+
+// Maps an expected PerFilterConfig value to a function that can be used to assert it.
+var validationFuncForConfigValue = map[ConfigState]func(e envoyPerFilterConfig) bool{
+	Undefined: IsNotSet,
+	Enabled:   IsEnabled,
+	Disabled:  IsDisabled,
+}
+
+// These tests are aimed at verifying that each resource that supports extauth configurations (virtual hosts, routes, weighted destinations)
+// results in the expected PerFilterConfiguration on the corresponding Envoy resource (virtual hosts, routes, weighted cluster).
+//
+// Since the outcome on one resource is currently independent from the outcome on its parent (or children), we currently
+// only test the three different input types (enabled, disabled, undefined) on each of the three resources (9 tests).
+// It should be relatively easy to update these tests cover more scenarios (potentially all 3^3=27 possible
+// combinations of resources and input types), should the need ever arise in the future.
+var _ = Describe("Process Custom Extauth configuration", func() {
+
+	DescribeTable("virtual host extauth filter configuration",
+		func(input, expected ConfigState) {
+			pluginContext := getPluginContext(input, Undefined, Undefined)
+
+			var out envoyv2.VirtualHost
+			err := pluginContext.PluginInstance.ProcessVirtualHost(pluginContext.VirtualHostParams, pluginContext.VirtualHost, &out)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
+		},
+		Entry("undefined -> disable", Undefined, Disabled), // This is a special case for virtual hosts
+		Entry("disabled -> disable", Disabled, Disabled),
+		Entry("enabled -> enable", Enabled, Enabled),
+	)
+
+	DescribeTable("route extauth filter configuration",
+		func(input, expected ConfigState) {
+			pluginContext := getPluginContext(Undefined, input, Undefined)
+
+			var out envoyv2.Route
+			err := pluginContext.PluginInstance.ProcessRoute(pluginContext.RouteParams, pluginContext.Route, &out)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
+		},
+		Entry("undefined -> don't set", Undefined, Undefined),
+		Entry("disabled -> disable", Disabled, Disabled),
+		Entry("enabled -> enable", Enabled, Enabled),
+	)
+
+	DescribeTable("weighted destination extauth filter configuration",
+		func(input, expected ConfigState) {
+			pluginContext := getPluginContext(Undefined, Undefined, input)
+
+			var out envoyv2.WeightedCluster_ClusterWeight
+			err := pluginContext.PluginInstance.ProcessWeightedDestination(pluginContext.RouteParams, pluginContext.WeightedDestination, &out)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
+		},
+		Entry("undefined -> don't set", Undefined, Undefined),
+		Entry("disabled -> disable", Disabled, Disabled),
+		Entry("enabled -> enable", Enabled, Enabled),
+	)
+})
+
+type pluginContext struct {
+	PluginInstance      *Plugin
+	VirtualHost         *gloov1.VirtualHost
+	VirtualHostParams   plugins.VirtualHostParams
+	Route               *gloov1.Route
+	RouteParams         plugins.RouteParams
+	WeightedDestination *gloov1.WeightedDestination
+}
+
+func getPluginContext(authOnVirtualHost, authOnRoute, authOnWeightedDest ConfigState) *pluginContext {
+	ctx := context.TODO()
+
+	extAuthServerUpstream := &gloov1.Upstream{
+		Metadata: core.Metadata{
+			Name:      "extauth",
+			Namespace: "default",
+		},
+		UpstreamSpec: &gloov1.UpstreamSpec{
+			UpstreamType: &gloov1.UpstreamSpec_Static{
+				Static: &static.UpstreamSpec{
+					Hosts: []*static.Host{{
+						Addr: "test",
+						Port: 1234,
+					}},
+				},
+			},
+		},
+	}
+
+	// ----------------------------------------------------------------------------
+	// Build auth configurations objects. Which objects are set on which resources
+	// is determined by the arguments passed to this function.
+	// ----------------------------------------------------------------------------
+	enableCustomAuth := &extauthv1.ExtAuthExtension{
+		Spec: &extauthv1.ExtAuthExtension_CustomAuth{
+			CustomAuth: &v1.CustomAuth{
+				ContextExtensions: map[string]string{
+					"some": "context",
+				},
+			},
+		},
+	}
+
+	disableAuth := &extauthv1.ExtAuthExtension{
+		Spec: &extauthv1.ExtAuthExtension_Disable{
+			Disable: true,
+		},
+	}
+
+	// ----------------------------------------------------------------------------
+	// Weighted destination (we just need one)
+	// ----------------------------------------------------------------------------
+	weightedDestination := &gloov1.WeightedDestination{
+		Destination: &gloov1.Destination{
+			DestinationType: &gloov1.Destination_Upstream{
+				Upstream: utils.ResourceRefPtr(extAuthServerUpstream.Metadata.Ref()),
+			},
+		},
+		Weight:                     1,
+		WeightedDestinationPlugins: &gloov1.WeightedDestinationPlugins{}, // will be set below
+	}
+
+	// ----------------------------------------------------------------------------
+	// Route
+	// ----------------------------------------------------------------------------
+	route := &gloov1.Route{
+		Matcher: &gloov1.Matcher{
+			PathSpecifier: &gloov1.Matcher_Prefix{
+				Prefix: "/",
+			},
+		},
+		Action: &gloov1.Route_RouteAction{
+			RouteAction: &gloov1.RouteAction{
+				Destination: &gloov1.RouteAction_Multi{
+					Multi: &gloov1.MultiDestination{
+						Destinations: []*gloov1.WeightedDestination{weightedDestination},
+					},
+				},
+			},
+		},
+		RoutePlugins: &gloov1.RoutePlugins{}, // will be set below
+	}
+
+	// ----------------------------------------------------------------------------
+	// Virtual Host
+	// ----------------------------------------------------------------------------
+	virtualHost := &gloov1.VirtualHost{
+		Name:               "virt1",
+		Domains:            []string{"*"},
+		Routes:             []*gloov1.Route{route},
+		VirtualHostPlugins: &gloov1.VirtualHostPlugins{}, // will be set below
+	}
+
+	// ----------------------------------------------------------------------------
+	// Set extauth plugins based on the input arguments
+	// ----------------------------------------------------------------------------
+
+	switch authOnWeightedDest {
+	case Enabled:
+		weightedDestination.WeightedDestinationPlugins = &gloov1.WeightedDestinationPlugins{Extauth: enableCustomAuth}
+	case Disabled:
+		weightedDestination.WeightedDestinationPlugins = &gloov1.WeightedDestinationPlugins{Extauth: disableAuth}
+	}
+
+	switch authOnRoute {
+	case Enabled:
+		route.RoutePlugins.Extauth = enableCustomAuth
+	case Disabled:
+		route.RoutePlugins.Extauth = disableAuth
+	}
+
+	switch authOnVirtualHost {
+	case Enabled:
+		virtualHost.VirtualHostPlugins.Extauth = enableCustomAuth
+	case Disabled:
+		virtualHost.VirtualHostPlugins.Extauth = disableAuth
+	}
+
+	// ----------------------------------------------------------------------------
+	// Proxy
+	// ----------------------------------------------------------------------------
+	proxy := &gloov1.Proxy{
+		Metadata: core.Metadata{
+			Name:      "proxy",
+			Namespace: "default",
+		},
+		Listeners: []*gloov1.Listener{{
+			Name: "default",
+			ListenerType: &gloov1.Listener_HttpListener{
+				HttpListener: &gloov1.HttpListener{
+					VirtualHosts: []*gloov1.VirtualHost{virtualHost},
+				},
+			},
+		}},
+	}
+
+	// ----------------------------------------------------------------------------
+	// Define the different plugin param objects
+	// that will be passed to the Process* functions
+	// ----------------------------------------------------------------------------
+	params := plugins.Params{
+		Ctx: ctx,
+		Snapshot: &gloov1.ApiSnapshot{
+			Proxies:   gloov1.ProxyList{proxy},
+			Upstreams: gloov1.UpstreamList{extAuthServerUpstream},
+		},
+	}
+	virtualHostParams := plugins.VirtualHostParams{
+		Params:   params,
+		Proxy:    proxy,
+		Listener: proxy.Listeners[0],
+	}
+	routeParams := plugins.RouteParams{
+		VirtualHostParams: virtualHostParams,
+		VirtualHost:       virtualHost,
+	}
+
+	plugin := NewCustomAuthPlugin()
+	initParams := plugins.InitParams{Ctx: ctx}
+
+	usRef := extAuthServerUpstream.Metadata.Ref()
+	settings := &extauthv1.Settings{
+		ExtauthzServerRef: &usRef,
+	}
+
+	initParams.Settings = &gloov1.Settings{Extauth: settings}
+	err := plugin.Init(initParams)
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	return &pluginContext{
+		PluginInstance:      plugin,
+		VirtualHost:         virtualHost,
+		VirtualHostParams:   virtualHostParams,
+		Route:               route,
+		RouteParams:         routeParams,
+		WeightedDestination: weightedDestination,
+	}
+}
+
+type envoyPerFilterConfig interface {
+	GetPerFilterConfig() map[string]*types.Struct
+}
+
+// Returns true if the ext_authz filter is explicitly disabled
+func IsDisabled(e envoyPerFilterConfig) bool {
+	if e.GetPerFilterConfig() == nil {
+		return false
+	}
+	if _, ok := e.GetPerFilterConfig()[FilterName]; !ok {
+		return false
+	}
+	var cfg envoyauth.ExtAuthzPerRoute
+	err := util.StructToMessage(e.GetPerFilterConfig()[FilterName], &cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	return cfg.GetDisabled()
+}
+
+// Returns true if the ext_authz filter is enabled and if the ContextExtensions have the expected number of entries.
+func IsEnabled(e envoyPerFilterConfig) bool {
+	if e.GetPerFilterConfig() == nil {
+		return false
+	}
+	if _, ok := e.GetPerFilterConfig()[FilterName]; !ok {
+		return false
+	}
+	var cfg envoyauth.ExtAuthzPerRoute
+	err := util.StructToMessage(e.GetPerFilterConfig()[FilterName], &cfg)
+	Expect(err).NotTo(HaveOccurred())
+
+	if cfg.GetCheckSettings() == nil {
+		return false
+	}
+
+	ctxExtensions := cfg.GetCheckSettings().ContextExtensions
+	return len(ctxExtensions) == 1 && ctxExtensions["some"] == "context"
+}
+
+// Returns true if no PerFilterConfig is set for the ext_authz filter
+func IsNotSet(e envoyPerFilterConfig) bool {
+	if e.GetPerFilterConfig() == nil {
+		return true
+	}
+	_, ok := e.GetPerFilterConfig()[FilterName]
+	return !ok
+}

--- a/projects/gloo/pkg/plugins/registry/registry.go
+++ b/projects/gloo/pkg/plugins/registry/registry.go
@@ -10,6 +10,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/basicroute"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/consul"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/cors"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/extauth"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/faultinjection"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/grpc"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/hcm"
@@ -63,6 +64,7 @@ var globalRegistry = func(opts bootstrap.Opts, pluginExtensions ...plugins.Plugi
 		shadowing.NewPlugin(),
 		headers.NewPlugin(),
 		healthcheck.NewPlugin(),
+		extauth.NewCustomAuthPlugin(),
 	)
 	if opts.KubeClient != nil {
 		reg.plugins = append(reg.plugins, kubernetes.NewPlugin(opts.KubeClient, opts.KubeCoreCache))

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -3,6 +3,9 @@ package e2e_test
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/http"
+
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"github.com/gogo/googleapis/google/rpc"
 	. "github.com/onsi/ginkgo"
@@ -19,8 +22,6 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"google.golang.org/grpc"
-	"net"
-	"net/http"
 )
 
 var _ = Describe("CustomAuth", func() {

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -1,0 +1,366 @@
+package e2e_test
+
+import (
+	"context"
+	"fmt"
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	"github.com/gogo/googleapis/google/rpc"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	"github.com/solo-io/gloo/pkg/utils"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/static"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/transformation"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
+	"github.com/solo-io/gloo/test/services"
+	"github.com/solo-io/gloo/test/v1helpers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"google.golang.org/grpc"
+	"net"
+	"net/http"
+)
+
+var _ = Describe("CustomAuth", func() {
+
+	var (
+		ctx           context.Context
+		cancel        context.CancelFunc
+		envoyInstance *services.EnvoyInstance
+		testUpstream  *v1helpers.TestUpstream
+		testClients   services.TestClients
+		srv           *grpc.Server
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+
+		// Initialize Envoy instance
+		envoyInstance, err := envoyFactory.NewEnvoyInstance()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Start custom extauth server and create upstream for it
+		srv, err = startCustomExtauthServer(8095)
+		Expect(err).NotTo(HaveOccurred())
+
+		customAuthServerUs := &gloov1.Upstream{
+			Metadata: core.Metadata{
+				Name:      "custom-auth",
+				Namespace: "default",
+			},
+			UpstreamSpec: &gloov1.UpstreamSpec{
+				UseHttp2: true,
+				UpstreamType: &gloov1.UpstreamSpec_Static{
+					Static: &static.UpstreamSpec{
+						Hosts: []*static.Host{{
+							// this is a safe way of referring to localhost
+							Addr: envoyInstance.GlooAddr,
+							Port: 8095,
+						}},
+					},
+				},
+			},
+		}
+		authUsRef := customAuthServerUs.Metadata.Ref()
+
+		// Start Gloo
+		testClients = services.RunGlooGatewayUdsFds(ctx, &services.RunOptions{
+			NsToWrite: defaults.GlooSystem,
+			NsToWatch: []string{"default", defaults.GlooSystem},
+			WhatToRun: services.What{
+				DisableGateway: true,
+				DisableFds:     true,
+				DisableUds:     true,
+			},
+			ExtauthSettings: &v1.Settings{
+				ExtauthzServerRef: &authUsRef,
+			},
+		})
+
+		// Create static upstream for auth server
+		_, err = testClients.UpstreamClient.Write(customAuthServerUs, clients.WriteOpts{Ctx: ctx})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Run envoy
+		err = envoyInstance.Run(testClients.GlooPort)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a test upstream
+		testUpstream = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())
+		_, err = testClients.UpstreamClient.Write(testUpstream.Upstream, clients.WriteOpts{Ctx: ctx})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a proxy routing to the upstream and wait for it to be accepted
+		proxy := getProxyExtAuth("default", "proxy", defaults.HttpPort, testUpstream.Upstream.Metadata.Ref())
+
+		_, err = testClients.ProxyClient.Write(proxy, clients.WriteOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() (core.Status, error) {
+			proxy, err := testClients.ProxyClient.Read(proxy.Metadata.Namespace, proxy.Metadata.Name, clients.ReadOpts{})
+			if err != nil {
+				return core.Status{}, err
+			}
+
+			return proxy.Status, nil
+		}, "60s", "0.1s").Should(MatchFields(IgnoreExtras, Fields{
+			"Reason": BeEmpty(),
+			"State":  Equal(core.Status_Accepted),
+		}))
+	})
+
+	AfterEach(func() {
+		cancel()
+
+		if envoyInstance != nil {
+			_ = envoyInstance.Clean()
+		}
+
+		srv.GracefulStop()
+	})
+
+	It("works as expected", func() {
+		client := &http.Client{}
+
+		getRequest := func(prefix string) *http.Request {
+			req, err := http.NewRequest("GET", fmt.Sprintf("http://%s:%d/%s", "localhost", defaults.HttpPort, prefix), nil)
+			Expect(err).NotTo(HaveOccurred())
+			return req
+		}
+
+		expectResponseForUser := func(req *http.Request, username string, expectedStatus int) {
+			req.Header.Set("user", username)
+
+			Eventually(func() (int, error) {
+				resp, err := client.Do(req)
+				if err != nil {
+					return 0, err
+				}
+				return resp.StatusCode, nil
+			}, "5s", "0.5s").Should(Equal(expectedStatus))
+		}
+		publicRoute := getRequest("public")
+		userRoute := getRequest("user")
+		adminRoute := getRequest("admin")
+
+		// Public route, everyone allowed
+		expectResponseForUser(publicRoute, "unknown", http.StatusOK)
+		expectResponseForUser(publicRoute, "john", http.StatusOK)
+		expectResponseForUser(publicRoute, "jane", http.StatusOK)
+
+		// User route, only users and admins are allowed
+		expectResponseForUser(userRoute, "unknown", http.StatusForbidden)
+		expectResponseForUser(userRoute, "john", http.StatusOK)
+		expectResponseForUser(userRoute, "jane", http.StatusOK)
+
+		// Admin route, only admins are allowed
+		expectResponseForUser(adminRoute, "unknown", http.StatusForbidden)
+		expectResponseForUser(adminRoute, "john", http.StatusForbidden)
+		expectResponseForUser(adminRoute, "jane", http.StatusOK)
+
+	})
+})
+
+func getProxyExtAuth(namespace, name string, envoyPort uint32, upstream core.ResourceRef) *gloov1.Proxy {
+	return &gloov1.Proxy{
+		Metadata: core.Metadata{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Listeners: []*gloov1.Listener{{
+			Name:        "listener",
+			BindAddress: "0.0.0.0",
+			BindPort:    envoyPort,
+			ListenerType: &gloov1.Listener_HttpListener{
+				HttpListener: &gloov1.HttpListener{
+					VirtualHosts: []*gloov1.VirtualHost{
+						{
+							Name:    "gloo-system.virt1",
+							Domains: []string{"*"},
+							VirtualHostPlugins: &gloov1.VirtualHostPlugins{
+								Extauth: &v1.ExtAuthExtension{
+									Spec: &v1.ExtAuthExtension_CustomAuth{
+										CustomAuth: &v1.CustomAuth{
+											ContextExtensions: map[string]string{
+												"must-be": "user", // Only authenticated users can access this vhost
+											},
+										},
+									},
+								},
+							},
+							Routes: []*gloov1.Route{
+								{ // This route can be accessed by users
+									Matcher: &gloov1.Matcher{
+										PathSpecifier: &gloov1.Matcher_Prefix{
+											Prefix: "/user",
+										},
+									},
+									RoutePlugins: &gloov1.RoutePlugins{
+										PrefixRewrite: &transformation.PrefixRewrite{
+											PrefixRewrite: "/",
+										},
+									},
+									Action: &gloov1.Route_RouteAction{
+										RouteAction: &gloov1.RouteAction{
+											Destination: &gloov1.RouteAction_Single{
+												Single: &gloov1.Destination{
+													DestinationType: &gloov1.Destination_Upstream{
+														Upstream: utils.ResourceRefPtr(upstream),
+													},
+												},
+											},
+										},
+									},
+								},
+								{ // This route can be accessed only by admins
+									Matcher: &gloov1.Matcher{
+										PathSpecifier: &gloov1.Matcher_Prefix{
+											Prefix: "/admin",
+										},
+									},
+									RoutePlugins: &gloov1.RoutePlugins{
+										PrefixRewrite: &transformation.PrefixRewrite{
+											PrefixRewrite: "/",
+										},
+										Extauth: &v1.ExtAuthExtension{
+											Spec: &v1.ExtAuthExtension_CustomAuth{
+												CustomAuth: &v1.CustomAuth{
+													ContextExtensions: map[string]string{
+														"must-be": "admin", // Only authenticated users can access this vhost
+													},
+												},
+											},
+										},
+									},
+									Action: &gloov1.Route_RouteAction{
+										RouteAction: &gloov1.RouteAction{
+											Destination: &gloov1.RouteAction_Single{
+												Single: &gloov1.Destination{
+													DestinationType: &gloov1.Destination_Upstream{
+														Upstream: utils.ResourceRefPtr(upstream),
+													},
+												},
+											},
+										},
+									},
+								},
+								{ // This route can be accessed by anyone
+									Matcher: &gloov1.Matcher{
+										PathSpecifier: &gloov1.Matcher_Prefix{
+											Prefix: "/public",
+										},
+									},
+									RoutePlugins: &gloov1.RoutePlugins{
+										PrefixRewrite: &transformation.PrefixRewrite{
+											PrefixRewrite: "/",
+										},
+										Extauth: &v1.ExtAuthExtension{
+											Spec: &v1.ExtAuthExtension_Disable{
+												Disable: true,
+											},
+										},
+									},
+									Action: &gloov1.Route_RouteAction{
+										RouteAction: &gloov1.RouteAction{
+											Destination: &gloov1.RouteAction_Single{
+												Single: &gloov1.Destination{
+													DestinationType: &gloov1.Destination_Upstream{
+														Upstream: utils.ResourceRefPtr(upstream),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}},
+	}
+}
+
+func startCustomExtauthServer(port uint) (*grpc.Server, error) {
+	srv := grpc.NewServer()
+	pb.RegisterAuthorizationServer(srv, &customAuthServer{
+		// maps a username to a user type
+		users: map[string]string{
+			"john": "user",
+			"jane": "admin",
+		},
+	})
+
+	addr := fmt.Sprintf(":%d", port)
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+		defer GinkgoRecover()
+		err := srv.Serve(lis)
+		Expect(err).ToNot(HaveOccurred())
+	}()
+	return srv, nil
+}
+
+var (
+	deny  = &pb.CheckResponse{Status: &rpc.Status{Code: int32(rpc.PERMISSION_DENIED)}}
+	allow = &pb.CheckResponse{Status: &rpc.Status{Code: int32(rpc.OK)}}
+)
+
+// This custom auth server expects requests to provide the username in a "user" header.
+// It checks the username against an internal set of users and denies the request if the user is not known or
+// if they don't match the expected user type.
+type customAuthServer struct {
+	users map[string]string // maps a username to a user type
+}
+
+func (c *customAuthServer) Check(ctx context.Context, request *pb.CheckRequest) (*pb.CheckResponse, error) {
+	ctxExtensions := request.GetAttributes().GetContextExtensions()
+
+	if len(ctxExtensions) == 0 {
+		return deny, nil
+	}
+
+	requiredUserType, ok := ctxExtensions["must-be"]
+	if !ok {
+		return deny, nil
+	}
+
+	headers := request.GetAttributes().GetRequest().GetHttp().GetHeaders()
+	if len(headers) == 0 {
+		return deny, nil
+	}
+
+	username, ok := headers["user"]
+	if !ok {
+		return deny, nil
+	}
+
+	actualUserType, ok := c.users[username]
+	if !ok {
+		return deny, nil
+	}
+
+	// If we require an admin, only admin users are allowed
+	if requiredUserType == "admin" {
+		if actualUserType == "admin" {
+			return allow, nil
+		}
+		return deny, nil
+	}
+
+	// If we require a user, both users and admin users are allowed
+	if requiredUserType == "user" {
+		if actualUserType == "admin" || actualUserType == "user" {
+			return allow, nil
+		}
+		return deny, nil
+	}
+
+	return deny, nil
+}

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -554,7 +554,7 @@ var _ = Describe("Kube2e: gateway", func() {
 			for _, svc := range createdServices {
 				// now set subset config on an upstream:
 				up, _ := getUpstream(svc)
-				spec := up.UpstreamSpec.UpstreamType.(*gloov1.UpstreamSpec_Kube).Kube.ServiceSpec
+				spec := up.GetUpstreamSpec().GetKube().GetServiceSpec()
 				Expect(spec).ToNot(BeNil())
 				Expect(spec.GetGrpc()).ToNot(BeNil())
 			}
@@ -781,7 +781,7 @@ var _ = Describe("Kube2e: gateway", func() {
 				if err != nil {
 					return err
 				}
-				vsList, err := virtualServiceClient.List(vs.Metadata.Namespace, clients.ListOpts{Ctx: ctx})
+				vsList, err := virtualServiceClient.List(vs.GetMetadata().Namespace, clients.ListOpts{Ctx: ctx})
 				if err != nil {
 					return err
 				}

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	extauthv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
 	"net"
 	"time"
 
@@ -94,6 +95,7 @@ type RunOptions struct {
 	Cache            memory.InMemoryResourceCache
 	KubeClient       kubernetes.Interface
 	ConsulClient     consul.ConsulWatcher
+	ExtauthSettings  *extauthv1.Settings
 }
 
 //noinspection GoUnhandledErrorResult
@@ -112,6 +114,7 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 	settings := &gloov1.Settings{
 		WatchNamespaces:    runOptions.NsToWatch,
 		DiscoveryNamespace: runOptions.NsToWrite,
+		Extauth:            runOptions.ExtauthSettings,
 	}
 	ctx = settingsutil.WithSettings(ctx, settings)
 
@@ -126,6 +129,7 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 
 	glooOpts.Settings = &gloov1.Settings{
 		Extensions: runOptions.ExtensionConfigs,
+		Extauth:    runOptions.ExtauthSettings,
 	}
 	glooOpts.ControlPlane.StartGrpcServer = true
 	glooOpts.ValidationServer.StartGrpcServer = true

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -1,9 +1,10 @@
 package services
 
 import (
-	extauthv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
 	"net"
 	"time"
+
+	extauthv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/upstreams/consul"
 


### PR DESCRIPTION
Add support for custom authentication. You can now provide your own external authentication/authorization server and configure Gloo to call it on the `virtual hosts`, `routes`, and `weighted destinations` that you want to secure.