### PR TITLE
Bump default GlooE version installed by the CLI to 0.20.4 (#1387)

### DIFF
--- a/changelog/v0.21.0/bump-glooe-tag.yaml
+++ b/changelog/v0.21.0/bump-glooe-tag.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  description: The default version of GlooE installed by the CLI is now 0.20.4.
+  issueLink: https://github.com/solo-io/gloo/issues/1386

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,4 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.20.1"
+const EnterpriseTag = "0.20.4"


### PR DESCRIPTION
port of https://github.com/solo-io/gloo/pull/1387 to `feature-rc1`
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1386