### PR TITLE
Disable usage stats

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -374,6 +374,14 @@
   version = "v1.0.0"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   digest = "1:2cd7915ab26ede7d95b8749e6b1f933f1c6d5398030684e6505940a10f31cfda"
   name = "github.com/ghodss/yaml"
   packages = ["."]
@@ -815,12 +823,13 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:12247a2e99a060cc692f6680e5272c8adf0b8f572e6bce0d7095e624c958a240"
+  digest = "1:a361611b8c8c75a1091f00027767f7779b29cb37c456a71b8f2604c88057ab40"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
     "hcl/ast",
     "hcl/parser",
+    "hcl/printer",
     "hcl/scanner",
     "hcl/strconv",
     "hcl/token",
@@ -1037,6 +1046,14 @@
   pruneopts = "UT"
   revision = "db8e3cd836b82e82e0a9c8edc6896967dd31374f"
   version = "v1.1.3"
+
+[[projects]]
+  digest = "1:5a0ef768465592efca0412f7e838cdc0826712f8447e70e6ccc52eb441e9ab13"
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "de8848e004dd33dc07a2947b3d76f618a7fc7ef1"
+  version = "v1.8.1"
 
 [[projects]]
   branch = "master"
@@ -1491,6 +1508,14 @@
   version = "v1.2.1"
 
 [[projects]]
+  digest = "1:08d65904057412fc0270fc4812a1c90c594186819243160dc779a402d4b6d0bc"
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
   digest = "1:e01b05ba901239c783dfe56450bcde607fc858908529868259c9a8765dc176d0"
   name = "github.com/spf13/cobra"
   packages = [
@@ -1502,12 +1527,28 @@
   version = "v0.0.3"
 
 [[projects]]
+  digest = "1:1b753ec16506f5864d26a28b43703c58831255059644351bbcb019b843950900"
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1"
+  version = "v1.1.0"
+
+[[projects]]
   digest = "1:9424f440bba8f7508b69414634aef3b2b3a877e522d8a4624692412805407bb7"
   name = "github.com/spf13/pflag"
   packages = ["."]
   pruneopts = "UT"
   revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
   version = "v1.0.1"
+
+[[projects]]
+  digest = "1:11118bd196646c6515fea3d6c43f66162833c6ae4939bfb229b9956d91c6cf17"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "b5bf975e5823809fb22c7644d008757f78a4259e"
+  version = "v1.4.0"
 
 [[projects]]
   digest = "1:e4ed0afd67bf7be353921665cdac50834c867ff1bba153efc0745b755a7f5905"
@@ -2833,6 +2874,7 @@
     "github.com/spf13/afero",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
+    "github.com/spf13/viper",
     "go.opencensus.io/plugin/ocgrpc",
     "go.opencensus.io/stats",
     "go.opencensus.io/stats/view",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -533,9 +533,12 @@
   revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
-  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
+  digest = "1:a507e8646bf3775af6f7e7b2a62a5e67d1c6a8f00754f87e66b96181b7f3d747"
   name = "github.com/golang/mock"
-  packages = ["gomock"]
+  packages = [
+    "gomock",
+    "mockgen/model",
+  ]
   pruneopts = "UT"
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
@@ -2728,6 +2731,7 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
+    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/ptypes/any",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1402,15 +1402,15 @@
   version = "v0.10.19"
 
 [[projects]]
-  digest = "1:a2922a665903e4336f9e8b13eb9134bdda25ed984b3966159d4aa2bf9c5b0e28"
+  digest = "1:f35421a8443efa2170aa6dadad19ba11cfc52f72fb0bb04f8eace6b60cb29ef9"
   name = "github.com/solo-io/reporting-client"
   packages = [
     "pkg/api/v1",
     "pkg/client",
   ]
   pruneopts = "UT"
-  revision = "f47eacc21bd62e6bc8bb8954af0dc1817079af0d"
-  version = "v0.0.2"
+  revision = "36dd39d2795b04bae1e8a3482da6c4a27ce721b7"
+  version = "v0.0.3"
 
 [[projects]]
   digest = "1:df93a6697867045de75247ce33d1c528cc0ff50a2dd2084d7d816efbd64ee5ed"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -103,3 +103,6 @@
   name = "k8s.io/klog"
   revision = "9cbb78b20423182f9e5b2a214dd255f5e117d2d1"
   source = "github.com/stefanprodan/klog"
+[[constraint]]
+  name = "github.com/spf13/viper"
+  version = "1.4.0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -40,7 +40,7 @@
 
 [[constraint]]
   name = "github.com/solo-io/reporting-client"
-  version = "0.0.2"
+  version = "0.0.3"
 
 [[constraint]]
   name = "github.com/onsi/gomega"

--- a/changelog/v0.21.0/allow-usage-stats-disable.yaml
+++ b/changelog/v0.21.0/allow-usage-stats-disable.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Allow usage stats collection to be disabled at install time
+    issueLink: https://github.com/solo-io/solo-projects/issues/1226

--- a/docs/content/cli/glooctl.md
+++ b/docs/content/cli/glooctl.md
@@ -14,7 +14,7 @@ glooctl is the unified CLI for Gloo.
 ### Options
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -h, --help                help for glooctl
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl.md
+++ b/docs/content/cli/glooctl.md
@@ -14,9 +14,10 @@ glooctl is the unified CLI for Gloo.
 ### Options
 
 ```
-  -h, --help                help for glooctl
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -h, --help                       help for glooctl
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl.md
+++ b/docs/content/cli/glooctl.md
@@ -14,10 +14,10 @@ glooctl is the unified CLI for Gloo.
 ### Options
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -h, --help                       help for glooctl
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -h, --help                help for glooctl
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl.md
+++ b/docs/content/cli/glooctl.md
@@ -14,7 +14,7 @@ glooctl is the unified CLI for Gloo.
 ### Options
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -h, --help                help for glooctl
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_add.md
+++ b/docs/content/cli/glooctl_add.md
@@ -33,7 +33,7 @@ glooctl add [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_add.md
+++ b/docs/content/cli/glooctl_add.md
@@ -33,8 +33,9 @@ glooctl add [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_add.md
+++ b/docs/content/cli/glooctl_add.md
@@ -33,7 +33,7 @@ glooctl add [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_add.md
+++ b/docs/content/cli/glooctl_add.md
@@ -33,9 +33,9 @@ glooctl add [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_add_route.md
+++ b/docs/content/cli/glooctl_add_route.md
@@ -55,6 +55,7 @@ glooctl add route [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_add_route.md
+++ b/docs/content/cli/glooctl_add_route.md
@@ -50,7 +50,7 @@ glooctl add route [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_add_route.md
+++ b/docs/content/cli/glooctl_add_route.md
@@ -50,7 +50,7 @@ glooctl add route [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_add_route.md
+++ b/docs/content/cli/glooctl_add_route.md
@@ -50,12 +50,12 @@ glooctl add route [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_check.md
+++ b/docs/content/cli/glooctl_check.md
@@ -24,7 +24,7 @@ glooctl check [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_check.md
+++ b/docs/content/cli/glooctl_check.md
@@ -24,8 +24,9 @@ glooctl check [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_check.md
+++ b/docs/content/cli/glooctl_check.md
@@ -24,7 +24,7 @@ glooctl check [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_check.md
+++ b/docs/content/cli/glooctl_check.md
@@ -24,9 +24,9 @@ glooctl check [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_completion.md
+++ b/docs/content/cli/glooctl_completion.md
@@ -55,7 +55,7 @@ glooctl completion SHELL [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_completion.md
+++ b/docs/content/cli/glooctl_completion.md
@@ -55,9 +55,9 @@ glooctl completion SHELL [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_completion.md
+++ b/docs/content/cli/glooctl_completion.md
@@ -55,7 +55,7 @@ glooctl completion SHELL [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_completion.md
+++ b/docs/content/cli/glooctl_completion.md
@@ -55,8 +55,9 @@ glooctl completion SHELL [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create.md
+++ b/docs/content/cli/glooctl_create.md
@@ -28,8 +28,9 @@ glooctl create [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create.md
+++ b/docs/content/cli/glooctl_create.md
@@ -28,7 +28,7 @@ glooctl create [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_create.md
+++ b/docs/content/cli/glooctl_create.md
@@ -28,9 +28,9 @@ glooctl create [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create.md
+++ b/docs/content/cli/glooctl_create.md
@@ -28,7 +28,7 @@ glooctl create [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_create_secret.md
+++ b/docs/content/cli/glooctl_create_secret.md
@@ -33,13 +33,13 @@ glooctl create secret [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                name of the resource to read or write
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         name of the resource to read or write
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_secret.md
+++ b/docs/content/cli/glooctl_create_secret.md
@@ -33,7 +33,7 @@ glooctl create secret [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret.md
+++ b/docs/content/cli/glooctl_create_secret.md
@@ -33,12 +33,13 @@ glooctl create secret [flags]
 ### Options inherited from parent commands
 
 ```
-      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         name of the resource to read or write
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                name of the resource to read or write
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_secret.md
+++ b/docs/content/cli/glooctl_create_secret.md
@@ -33,7 +33,7 @@ glooctl create secret [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_apikey.md
+++ b/docs/content/cli/glooctl_create_secret_apikey.md
@@ -26,7 +26,7 @@ glooctl create secret apikey [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_apikey.md
+++ b/docs/content/cli/glooctl_create_secret_apikey.md
@@ -26,7 +26,7 @@ glooctl create secret apikey [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_apikey.md
+++ b/docs/content/cli/glooctl_create_secret_apikey.md
@@ -26,6 +26,7 @@ glooctl create secret apikey [flags]
 ### Options inherited from parent commands
 
 ```
+      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_apikey.md
+++ b/docs/content/cli/glooctl_create_secret_apikey.md
@@ -26,7 +26,7 @@ glooctl create secret apikey [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_aws.md
+++ b/docs/content/cli/glooctl_create_secret_aws.md
@@ -25,6 +25,7 @@ glooctl create secret aws [flags]
 ### Options inherited from parent commands
 
 ```
+      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_aws.md
+++ b/docs/content/cli/glooctl_create_secret_aws.md
@@ -25,7 +25,7 @@ glooctl create secret aws [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_aws.md
+++ b/docs/content/cli/glooctl_create_secret_aws.md
@@ -25,7 +25,7 @@ glooctl create secret aws [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_aws.md
+++ b/docs/content/cli/glooctl_create_secret_aws.md
@@ -25,7 +25,7 @@ glooctl create secret aws [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_azure.md
+++ b/docs/content/cli/glooctl_create_secret_azure.md
@@ -24,7 +24,7 @@ glooctl create secret azure [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_azure.md
+++ b/docs/content/cli/glooctl_create_secret_azure.md
@@ -24,6 +24,7 @@ glooctl create secret azure [flags]
 ### Options inherited from parent commands
 
 ```
+      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_azure.md
+++ b/docs/content/cli/glooctl_create_secret_azure.md
@@ -24,7 +24,7 @@ glooctl create secret azure [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_azure.md
+++ b/docs/content/cli/glooctl_create_secret_azure.md
@@ -24,7 +24,7 @@ glooctl create secret azure [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_oauth.md
+++ b/docs/content/cli/glooctl_create_secret_oauth.md
@@ -24,7 +24,7 @@ glooctl create secret oauth [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_oauth.md
+++ b/docs/content/cli/glooctl_create_secret_oauth.md
@@ -24,7 +24,7 @@ glooctl create secret oauth [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_oauth.md
+++ b/docs/content/cli/glooctl_create_secret_oauth.md
@@ -24,7 +24,7 @@ glooctl create secret oauth [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_oauth.md
+++ b/docs/content/cli/glooctl_create_secret_oauth.md
@@ -24,6 +24,7 @@ glooctl create secret oauth [flags]
 ### Options inherited from parent commands
 
 ```
+      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_tls.md
+++ b/docs/content/cli/glooctl_create_secret_tls.md
@@ -26,6 +26,7 @@ glooctl create secret tls [flags]
 ### Options inherited from parent commands
 
 ```
+      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_tls.md
+++ b/docs/content/cli/glooctl_create_secret_tls.md
@@ -26,7 +26,7 @@ glooctl create secret tls [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics       disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_tls.md
+++ b/docs/content/cli/glooctl_create_secret_tls.md
@@ -26,7 +26,7 @@ glooctl create secret tls [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_secret_tls.md
+++ b/docs/content/cli/glooctl_create_secret_tls.md
@@ -26,7 +26,7 @@ glooctl create secret tls [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string                  set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string                  set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run                        print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                    use interactive mode
       --kubeconfig string              kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream.md
+++ b/docs/content/cli/glooctl_create_upstream.md
@@ -33,12 +33,13 @@ glooctl create upstream [flags]
 ### Options inherited from parent commands
 
 ```
-      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         name of the resource to read or write
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                name of the resource to read or write
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_upstream.md
+++ b/docs/content/cli/glooctl_create_upstream.md
@@ -33,7 +33,7 @@ glooctl create upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream.md
+++ b/docs/content/cli/glooctl_create_upstream.md
@@ -33,13 +33,13 @@ glooctl create upstream [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                name of the resource to read or write
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         name of the resource to read or write
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_upstream.md
+++ b/docs/content/cli/glooctl_create_upstream.md
@@ -33,7 +33,7 @@ glooctl create upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_aws.md
+++ b/docs/content/cli/glooctl_create_upstream_aws.md
@@ -26,7 +26,7 @@ glooctl create upstream aws [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_aws.md
+++ b/docs/content/cli/glooctl_create_upstream_aws.md
@@ -26,7 +26,7 @@ glooctl create upstream aws [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_aws.md
+++ b/docs/content/cli/glooctl_create_upstream_aws.md
@@ -31,6 +31,7 @@ glooctl create upstream aws [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_aws.md
+++ b/docs/content/cli/glooctl_create_upstream_aws.md
@@ -26,12 +26,12 @@ glooctl create upstream aws [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_azure.md
+++ b/docs/content/cli/glooctl_create_upstream_azure.md
@@ -26,12 +26,12 @@ glooctl create upstream azure [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_azure.md
+++ b/docs/content/cli/glooctl_create_upstream_azure.md
@@ -26,7 +26,7 @@ glooctl create upstream azure [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_azure.md
+++ b/docs/content/cli/glooctl_create_upstream_azure.md
@@ -31,6 +31,7 @@ glooctl create upstream azure [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_azure.md
+++ b/docs/content/cli/glooctl_create_upstream_azure.md
@@ -26,7 +26,7 @@ glooctl create upstream azure [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_consul.md
+++ b/docs/content/cli/glooctl_create_upstream_consul.md
@@ -26,7 +26,7 @@ glooctl create upstream consul [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_consul.md
+++ b/docs/content/cli/glooctl_create_upstream_consul.md
@@ -26,12 +26,12 @@ glooctl create upstream consul [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_consul.md
+++ b/docs/content/cli/glooctl_create_upstream_consul.md
@@ -31,6 +31,7 @@ glooctl create upstream consul [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_consul.md
+++ b/docs/content/cli/glooctl_create_upstream_consul.md
@@ -26,7 +26,7 @@ glooctl create upstream consul [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_ec2.md
+++ b/docs/content/cli/glooctl_create_upstream_ec2.md
@@ -36,6 +36,7 @@ glooctl create upstream ec2 [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_ec2.md
+++ b/docs/content/cli/glooctl_create_upstream_ec2.md
@@ -31,7 +31,7 @@ glooctl create upstream ec2 [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_ec2.md
+++ b/docs/content/cli/glooctl_create_upstream_ec2.md
@@ -31,12 +31,12 @@ glooctl create upstream ec2 [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_ec2.md
+++ b/docs/content/cli/glooctl_create_upstream_ec2.md
@@ -31,7 +31,7 @@ glooctl create upstream ec2 [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_kube.md
+++ b/docs/content/cli/glooctl_create_upstream_kube.md
@@ -28,7 +28,7 @@ glooctl create upstream kube [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_kube.md
+++ b/docs/content/cli/glooctl_create_upstream_kube.md
@@ -28,12 +28,12 @@ glooctl create upstream kube [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_kube.md
+++ b/docs/content/cli/glooctl_create_upstream_kube.md
@@ -28,7 +28,7 @@ glooctl create upstream kube [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_kube.md
+++ b/docs/content/cli/glooctl_create_upstream_kube.md
@@ -33,6 +33,7 @@ glooctl create upstream kube [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_static.md
+++ b/docs/content/cli/glooctl_create_upstream_static.md
@@ -26,12 +26,12 @@ glooctl create upstream static [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_static.md
+++ b/docs/content/cli/glooctl_create_upstream_static.md
@@ -26,7 +26,7 @@ glooctl create upstream static [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstream_static.md
+++ b/docs/content/cli/glooctl_create_upstream_static.md
@@ -31,6 +31,7 @@ glooctl create upstream static [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
       --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstream_static.md
+++ b/docs/content/cli/glooctl_create_upstream_static.md
@@ -26,7 +26,7 @@ glooctl create upstream static [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_create_upstreamgroup.md
+++ b/docs/content/cli/glooctl_create_upstreamgroup.md
@@ -30,7 +30,7 @@ glooctl create upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstreamgroup.md
+++ b/docs/content/cli/glooctl_create_upstreamgroup.md
@@ -30,12 +30,13 @@ glooctl create upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         name of the resource to read or write
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                name of the resource to read or write
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_upstreamgroup.md
+++ b/docs/content/cli/glooctl_create_upstreamgroup.md
@@ -30,7 +30,7 @@ glooctl create upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_upstreamgroup.md
+++ b/docs/content/cli/glooctl_create_upstreamgroup.md
@@ -30,13 +30,13 @@ glooctl create upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                name of the resource to read or write
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         name of the resource to read or write
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_virtualservice.md
+++ b/docs/content/cli/glooctl_create_virtualservice.md
@@ -51,13 +51,13 @@ glooctl create virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                name of the resource to read or write
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         name of the resource to read or write
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_virtualservice.md
+++ b/docs/content/cli/glooctl_create_virtualservice.md
@@ -51,12 +51,13 @@ glooctl create virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-      --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         name of the resource to read or write
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-  -o, --output OutputType   output format: (yaml, json, table, kube-yaml, wide) (default table)
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+      --dry-run                    print kubernetes-formatted yaml rather than creating or updating a resource
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                name of the resource to read or write
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+  -o, --output OutputType          output format: (yaml, json, table, kube-yaml, wide) (default table)
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_create_virtualservice.md
+++ b/docs/content/cli/glooctl_create_virtualservice.md
@@ -51,7 +51,7 @@ glooctl create virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_create_virtualservice.md
+++ b/docs/content/cli/glooctl_create_virtualservice.md
@@ -51,7 +51,7 @@ glooctl create virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --dry-run             print kubernetes-formatted yaml rather than creating or updating a resource
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_debug.md
+++ b/docs/content/cli/glooctl_debug.md
@@ -23,7 +23,7 @@ glooctl debug [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_debug.md
+++ b/docs/content/cli/glooctl_debug.md
@@ -23,9 +23,9 @@ glooctl debug [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_debug.md
+++ b/docs/content/cli/glooctl_debug.md
@@ -23,8 +23,9 @@ glooctl debug [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_debug.md
+++ b/docs/content/cli/glooctl_debug.md
@@ -23,7 +23,7 @@ glooctl debug [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_debug_logs.md
+++ b/docs/content/cli/glooctl_debug_logs.md
@@ -27,7 +27,7 @@ glooctl debug logs [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_debug_logs.md
+++ b/docs/content/cli/glooctl_debug_logs.md
@@ -27,7 +27,7 @@ glooctl debug logs [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_debug_logs.md
+++ b/docs/content/cli/glooctl_debug_logs.md
@@ -27,8 +27,9 @@ glooctl debug logs [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_debug_logs.md
+++ b/docs/content/cli/glooctl_debug_logs.md
@@ -27,9 +27,9 @@ glooctl debug logs [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_delete.md
+++ b/docs/content/cli/glooctl_delete.md
@@ -31,7 +31,7 @@ glooctl delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_delete.md
+++ b/docs/content/cli/glooctl_delete.md
@@ -31,7 +31,7 @@ glooctl delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_delete.md
+++ b/docs/content/cli/glooctl_delete.md
@@ -31,9 +31,9 @@ glooctl delete [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_delete.md
+++ b/docs/content/cli/glooctl_delete.md
@@ -31,8 +31,9 @@ glooctl delete [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_delete_proxy.md
+++ b/docs/content/cli/glooctl_delete_proxy.md
@@ -23,7 +23,7 @@ glooctl delete proxy [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_proxy.md
+++ b/docs/content/cli/glooctl_delete_proxy.md
@@ -23,7 +23,7 @@ glooctl delete proxy [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_proxy.md
+++ b/docs/content/cli/glooctl_delete_proxy.md
@@ -28,6 +28,7 @@ glooctl delete proxy [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_delete_proxy.md
+++ b/docs/content/cli/glooctl_delete_proxy.md
@@ -23,12 +23,12 @@ glooctl delete proxy [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_delete_upstream.md
+++ b/docs/content/cli/glooctl_delete_upstream.md
@@ -23,12 +23,12 @@ glooctl delete upstream [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_delete_upstream.md
+++ b/docs/content/cli/glooctl_delete_upstream.md
@@ -23,7 +23,7 @@ glooctl delete upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_upstream.md
+++ b/docs/content/cli/glooctl_delete_upstream.md
@@ -28,6 +28,7 @@ glooctl delete upstream [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_delete_upstream.md
+++ b/docs/content/cli/glooctl_delete_upstream.md
@@ -23,7 +23,7 @@ glooctl delete upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_upstreamgroup.md
+++ b/docs/content/cli/glooctl_delete_upstreamgroup.md
@@ -23,12 +23,12 @@ glooctl delete upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_delete_upstreamgroup.md
+++ b/docs/content/cli/glooctl_delete_upstreamgroup.md
@@ -28,6 +28,7 @@ glooctl delete upstreamgroup [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_delete_upstreamgroup.md
+++ b/docs/content/cli/glooctl_delete_upstreamgroup.md
@@ -23,7 +23,7 @@ glooctl delete upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_upstreamgroup.md
+++ b/docs/content/cli/glooctl_delete_upstreamgroup.md
@@ -23,7 +23,7 @@ glooctl delete upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_virtualservice.md
+++ b/docs/content/cli/glooctl_delete_virtualservice.md
@@ -28,6 +28,7 @@ glooctl delete virtualservice [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_delete_virtualservice.md
+++ b/docs/content/cli/glooctl_delete_virtualservice.md
@@ -23,7 +23,7 @@ glooctl delete virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_virtualservice.md
+++ b/docs/content/cli/glooctl_delete_virtualservice.md
@@ -23,7 +23,7 @@ glooctl delete virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_delete_virtualservice.md
+++ b/docs/content/cli/glooctl_delete_virtualservice.md
@@ -23,12 +23,12 @@ glooctl delete virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit.md
+++ b/docs/content/cli/glooctl_edit.md
@@ -29,7 +29,7 @@ Edit a Gloo resource
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_edit.md
+++ b/docs/content/cli/glooctl_edit.md
@@ -29,9 +29,9 @@ Edit a Gloo resource
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_edit.md
+++ b/docs/content/cli/glooctl_edit.md
@@ -29,8 +29,9 @@ Edit a Gloo resource
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_edit.md
+++ b/docs/content/cli/glooctl_edit.md
@@ -29,7 +29,7 @@ Edit a Gloo resource
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_edit_route.md
+++ b/docs/content/cli/glooctl_edit_route.md
@@ -20,7 +20,7 @@ weight: 5
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_route.md
+++ b/docs/content/cli/glooctl_edit_route.md
@@ -20,7 +20,7 @@ weight: 5
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_route.md
+++ b/docs/content/cli/glooctl_edit_route.md
@@ -20,12 +20,12 @@ weight: 5
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_route.md
+++ b/docs/content/cli/glooctl_edit_route.md
@@ -25,6 +25,7 @@ weight: 5
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_route_externalauth.md
+++ b/docs/content/cli/glooctl_edit_route_externalauth.md
@@ -24,12 +24,12 @@ glooctl edit route externalauth [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -x, --index uint32               edit the route with this index in the virtual service route list
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_edit_route_externalauth.md
+++ b/docs/content/cli/glooctl_edit_route_externalauth.md
@@ -24,7 +24,7 @@ glooctl edit route externalauth [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_route_externalauth.md
+++ b/docs/content/cli/glooctl_edit_route_externalauth.md
@@ -24,7 +24,7 @@ glooctl edit route externalauth [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_route_externalauth.md
+++ b/docs/content/cli/glooctl_edit_route_externalauth.md
@@ -29,6 +29,7 @@ glooctl edit route externalauth [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -x, --index uint32               edit the route with this index in the virtual service route list
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_edit_route_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit.md
@@ -19,12 +19,12 @@ Configure rate-limits for requests that match this route. This is a Gloo Enterpr
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -x, --index uint32               edit the route with this index in the virtual service route list
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_edit_route_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit.md
@@ -19,7 +19,7 @@ Configure rate-limits for requests that match this route. This is a Gloo Enterpr
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_route_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit.md
@@ -19,7 +19,7 @@ Configure rate-limits for requests that match this route. This is a Gloo Enterpr
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_route_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit.md
@@ -24,6 +24,7 @@ Configure rate-limits for requests that match this route. This is a Gloo Enterpr
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -x, --index uint32               edit the route with this index in the virtual service route list
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
@@ -26,12 +26,12 @@ glooctl edit route ratelimit client-config [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -x, --index uint32               edit the route with this index in the virtual service route list
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
@@ -26,7 +26,7 @@ glooctl edit route ratelimit client-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
@@ -31,6 +31,7 @@ glooctl edit route ratelimit client-config [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -x, --index uint32               edit the route with this index in the virtual service route list
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one

--- a/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_route_ratelimit_client-config.md
@@ -26,7 +26,7 @@ glooctl edit route ratelimit client-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings.md
+++ b/docs/content/cli/glooctl_edit_settings.md
@@ -24,6 +24,7 @@ root command for settings
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings.md
+++ b/docs/content/cli/glooctl_edit_settings.md
@@ -19,12 +19,12 @@ root command for settings
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings.md
+++ b/docs/content/cli/glooctl_edit_settings.md
@@ -19,7 +19,7 @@ root command for settings
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings.md
+++ b/docs/content/cli/glooctl_edit_settings.md
@@ -19,7 +19,7 @@ root command for settings
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings_externalauth.md
+++ b/docs/content/cli/glooctl_edit_settings_externalauth.md
@@ -25,7 +25,7 @@ glooctl edit settings externalauth [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings_externalauth.md
+++ b/docs/content/cli/glooctl_edit_settings_externalauth.md
@@ -30,6 +30,7 @@ glooctl edit settings externalauth [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings_externalauth.md
+++ b/docs/content/cli/glooctl_edit_settings_externalauth.md
@@ -25,7 +25,7 @@ glooctl edit settings externalauth [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings_externalauth.md
+++ b/docs/content/cli/glooctl_edit_settings_externalauth.md
@@ -25,12 +25,12 @@ glooctl edit settings externalauth [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit.md
@@ -27,7 +27,7 @@ glooctl edit settings ratelimit [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit.md
@@ -27,12 +27,12 @@ glooctl edit settings ratelimit [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit.md
@@ -32,6 +32,7 @@ glooctl edit settings ratelimit [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit.md
@@ -27,7 +27,7 @@ glooctl edit settings ratelimit [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
@@ -26,7 +26,7 @@ glooctl edit settings ratelimit server-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
@@ -26,12 +26,12 @@ glooctl edit settings ratelimit server-config [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
@@ -31,6 +31,7 @@ glooctl edit settings ratelimit server-config [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
+++ b/docs/content/cli/glooctl_edit_settings_ratelimit_server-config.md
@@ -26,7 +26,7 @@ glooctl edit settings ratelimit server-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_upstream.md
+++ b/docs/content/cli/glooctl_edit_upstream.md
@@ -27,12 +27,12 @@ glooctl edit upstream [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_upstream.md
+++ b/docs/content/cli/glooctl_edit_upstream.md
@@ -27,7 +27,7 @@ glooctl edit upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_upstream.md
+++ b/docs/content/cli/glooctl_edit_upstream.md
@@ -27,7 +27,7 @@ glooctl edit upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_upstream.md
+++ b/docs/content/cli/glooctl_edit_upstream.md
@@ -32,6 +32,7 @@ glooctl edit upstream [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_virtualservice.md
+++ b/docs/content/cli/glooctl_edit_virtualservice.md
@@ -27,7 +27,7 @@ glooctl edit virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_virtualservice.md
+++ b/docs/content/cli/glooctl_edit_virtualservice.md
@@ -32,6 +32,7 @@ glooctl edit virtualservice [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_virtualservice.md
+++ b/docs/content/cli/glooctl_edit_virtualservice.md
@@ -27,7 +27,7 @@ glooctl edit virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_virtualservice.md
+++ b/docs/content/cli/glooctl_edit_virtualservice.md
@@ -27,12 +27,12 @@ glooctl edit virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
@@ -19,12 +19,12 @@ Let gloo know the location of the rate limit server. This is a Gloo Enterprise f
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
@@ -24,6 +24,7 @@ Let gloo know the location of the rate limit server. This is a Gloo Enterprise f
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
@@ -19,7 +19,7 @@ Let gloo know the location of the rate limit server. This is a Gloo Enterprise f
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit.md
@@ -19,7 +19,7 @@ Let gloo know the location of the rate limit server. This is a Gloo Enterprise f
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
@@ -26,12 +26,12 @@ glooctl edit virtualservice ratelimit client-config [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
@@ -31,6 +31,7 @@ glooctl edit virtualservice ratelimit client-config [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
@@ -26,7 +26,7 @@ glooctl edit virtualservice ratelimit client-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
+++ b/docs/content/cli/glooctl_edit_virtualservice_ratelimit_client-config.md
@@ -26,7 +26,7 @@ glooctl edit virtualservice ratelimit client-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get.md
+++ b/docs/content/cli/glooctl_get.md
@@ -32,7 +32,7 @@ glooctl get [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_get.md
+++ b/docs/content/cli/glooctl_get.md
@@ -32,8 +32,9 @@ glooctl get [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_get.md
+++ b/docs/content/cli/glooctl_get.md
@@ -32,7 +32,7 @@ glooctl get [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_get.md
+++ b/docs/content/cli/glooctl_get.md
@@ -32,9 +32,9 @@ glooctl get [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_get_proxy.md
+++ b/docs/content/cli/glooctl_get_proxy.md
@@ -23,7 +23,7 @@ glooctl get proxy [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_proxy.md
+++ b/docs/content/cli/glooctl_get_proxy.md
@@ -23,12 +23,12 @@ glooctl get proxy [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_proxy.md
+++ b/docs/content/cli/glooctl_get_proxy.md
@@ -23,7 +23,7 @@ glooctl get proxy [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_proxy.md
+++ b/docs/content/cli/glooctl_get_proxy.md
@@ -28,6 +28,7 @@ glooctl get proxy [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_routetable.md
+++ b/docs/content/cli/glooctl_get_routetable.md
@@ -23,12 +23,12 @@ glooctl get routetable [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_routetable.md
+++ b/docs/content/cli/glooctl_get_routetable.md
@@ -23,7 +23,7 @@ glooctl get routetable [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_routetable.md
+++ b/docs/content/cli/glooctl_get_routetable.md
@@ -23,7 +23,7 @@ glooctl get routetable [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_routetable.md
+++ b/docs/content/cli/glooctl_get_routetable.md
@@ -28,6 +28,7 @@ glooctl get routetable [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_upstream.md
+++ b/docs/content/cli/glooctl_get_upstream.md
@@ -23,7 +23,7 @@ glooctl get upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_upstream.md
+++ b/docs/content/cli/glooctl_get_upstream.md
@@ -23,12 +23,12 @@ glooctl get upstream [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_upstream.md
+++ b/docs/content/cli/glooctl_get_upstream.md
@@ -28,6 +28,7 @@ glooctl get upstream [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_upstream.md
+++ b/docs/content/cli/glooctl_get_upstream.md
@@ -23,7 +23,7 @@ glooctl get upstream [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_upstreamgroup.md
+++ b/docs/content/cli/glooctl_get_upstreamgroup.md
@@ -23,12 +23,12 @@ glooctl get upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_upstreamgroup.md
+++ b/docs/content/cli/glooctl_get_upstreamgroup.md
@@ -23,7 +23,7 @@ glooctl get upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_upstreamgroup.md
+++ b/docs/content/cli/glooctl_get_upstreamgroup.md
@@ -23,7 +23,7 @@ glooctl get upstreamgroup [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_upstreamgroup.md
+++ b/docs/content/cli/glooctl_get_upstreamgroup.md
@@ -28,6 +28,7 @@ glooctl get upstreamgroup [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_virtualservice.md
+++ b/docs/content/cli/glooctl_get_virtualservice.md
@@ -23,7 +23,7 @@ glooctl get virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_virtualservice.md
+++ b/docs/content/cli/glooctl_get_virtualservice.md
@@ -23,12 +23,12 @@ glooctl get virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_virtualservice.md
+++ b/docs/content/cli/glooctl_get_virtualservice.md
@@ -28,6 +28,7 @@ glooctl get virtualservice [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_virtualservice.md
+++ b/docs/content/cli/glooctl_get_virtualservice.md
@@ -23,7 +23,7 @@ glooctl get virtualservice [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_virtualservice_route.md
+++ b/docs/content/cli/glooctl_get_virtualservice_route.md
@@ -23,12 +23,12 @@ glooctl get virtualservice route [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_get_virtualservice_route.md
+++ b/docs/content/cli/glooctl_get_virtualservice_route.md
@@ -23,7 +23,7 @@ glooctl get virtualservice route [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_virtualservice_route.md
+++ b/docs/content/cli/glooctl_get_virtualservice_route.md
@@ -23,7 +23,7 @@ glooctl get virtualservice route [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_get_virtualservice_route.md
+++ b/docs/content/cli/glooctl_get_virtualservice_route.md
@@ -28,6 +28,7 @@ glooctl get virtualservice route [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_install.md
+++ b/docs/content/cli/glooctl_install.md
@@ -20,9 +20,9 @@ choose which version of Gloo to install.
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install.md
+++ b/docs/content/cli/glooctl_install.md
@@ -20,8 +20,9 @@ choose which version of Gloo to install.
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install.md
+++ b/docs/content/cli/glooctl_install.md
@@ -20,7 +20,7 @@ choose which version of Gloo to install.
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_install.md
+++ b/docs/content/cli/glooctl_install.md
@@ -20,7 +20,7 @@ choose which version of Gloo to install.
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_install_gateway.md
+++ b/docs/content/cli/glooctl_install_gateway.md
@@ -29,9 +29,10 @@ glooctl install gateway [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-  -v, --verbose             If true, output from kubectl commands will print to stdout/stderr
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install_gateway.md
+++ b/docs/content/cli/glooctl_install_gateway.md
@@ -29,10 +29,10 @@ glooctl install gateway [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+  -v, --verbose             If true, output from kubectl commands will print to stdout/stderr
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install_gateway.md
+++ b/docs/content/cli/glooctl_install_gateway.md
@@ -29,7 +29,7 @@ glooctl install gateway [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
   -v, --verbose             If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_gateway.md
+++ b/docs/content/cli/glooctl_install_gateway.md
@@ -29,7 +29,7 @@ glooctl install gateway [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
   -v, --verbose             If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_gateway_enterprise.md
+++ b/docs/content/cli/glooctl_install_gateway_enterprise.md
@@ -24,15 +24,16 @@ glooctl install gateway enterprise [flags]
 ### Options inherited from parent commands
 
 ```
-  -d, --dry-run              Dump the raw installation yaml instead of applying it to kubernetes
-  -f, --file string          Install Gloo from this Helm chart archive file rather than from a release
-  -i, --interactive          use interactive mode
-      --kubeconfig string    kubeconfig to use, if not standard one
-  -n, --namespace string     namespace to install gloo into (default "gloo-system")
-  -u, --upgrade              Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
-      --values string        Values for the Gloo Helm chart
-  -v, --verbose              If true, output from kubectl commands will print to stdout/stderr
-      --with-admin-console   install gloo and a read-only version of its admin console
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -d, --dry-run                    Dump the raw installation yaml instead of applying it to kubernetes
+  -f, --file string                Install Gloo from this Helm chart archive file rather than from a release
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+  -n, --namespace string           namespace to install gloo into (default "gloo-system")
+  -u, --upgrade                    Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
+      --values string              Values for the Gloo Helm chart
+  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
+      --with-admin-console         install gloo and a read-only version of its admin console
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install_gateway_enterprise.md
+++ b/docs/content/cli/glooctl_install_gateway_enterprise.md
@@ -24,7 +24,7 @@ glooctl install gateway enterprise [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string        set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string        set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -d, --dry-run              Dump the raw installation yaml instead of applying it to kubernetes
   -f, --file string          Install Gloo from this Helm chart archive file rather than from a release
   -i, --interactive          use interactive mode

--- a/docs/content/cli/glooctl_install_gateway_enterprise.md
+++ b/docs/content/cli/glooctl_install_gateway_enterprise.md
@@ -24,16 +24,16 @@ glooctl install gateway enterprise [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -d, --dry-run                    Dump the raw installation yaml instead of applying it to kubernetes
-  -f, --file string                Install Gloo from this Helm chart archive file rather than from a release
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-  -n, --namespace string           namespace to install gloo into (default "gloo-system")
-  -u, --upgrade                    Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
-      --values string              Values for the Gloo Helm chart
-  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
-      --with-admin-console         install gloo and a read-only version of its admin console
+  -c, --config string        set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -d, --dry-run              Dump the raw installation yaml instead of applying it to kubernetes
+  -f, --file string          Install Gloo from this Helm chart archive file rather than from a release
+  -i, --interactive          use interactive mode
+      --kubeconfig string    kubeconfig to use, if not standard one
+  -n, --namespace string     namespace to install gloo into (default "gloo-system")
+  -u, --upgrade              Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
+      --values string        Values for the Gloo Helm chart
+  -v, --verbose              If true, output from kubectl commands will print to stdout/stderr
+      --with-admin-console   install gloo and a read-only version of its admin console
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install_gateway_enterprise.md
+++ b/docs/content/cli/glooctl_install_gateway_enterprise.md
@@ -24,7 +24,7 @@ glooctl install gateway enterprise [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string        set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string        set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -d, --dry-run              Dump the raw installation yaml instead of applying it to kubernetes
   -f, --file string          Install Gloo from this Helm chart archive file rather than from a release
   -i, --interactive          use interactive mode

--- a/docs/content/cli/glooctl_install_ingress.md
+++ b/docs/content/cli/glooctl_install_ingress.md
@@ -29,7 +29,7 @@ glooctl install ingress [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
   -v, --verbose             If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_ingress.md
+++ b/docs/content/cli/glooctl_install_ingress.md
@@ -29,9 +29,10 @@ glooctl install ingress [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-  -v, --verbose             If true, output from kubectl commands will print to stdout/stderr
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install_ingress.md
+++ b/docs/content/cli/glooctl_install_ingress.md
@@ -29,10 +29,10 @@ glooctl install ingress [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+  -v, --verbose             If true, output from kubectl commands will print to stdout/stderr
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install_ingress.md
+++ b/docs/content/cli/glooctl_install_ingress.md
@@ -29,7 +29,7 @@ glooctl install ingress [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
   -v, --verbose             If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_knative.md
+++ b/docs/content/cli/glooctl_install_knative.md
@@ -37,7 +37,7 @@ glooctl install knative [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
   -v, --verbose             If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_knative.md
+++ b/docs/content/cli/glooctl_install_knative.md
@@ -37,10 +37,10 @@ glooctl install knative [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+  -v, --verbose             If true, output from kubectl commands will print to stdout/stderr
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_install_knative.md
+++ b/docs/content/cli/glooctl_install_knative.md
@@ -37,7 +37,7 @@ glooctl install knative [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
   -v, --verbose             If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_knative.md
+++ b/docs/content/cli/glooctl_install_knative.md
@@ -37,9 +37,10 @@ glooctl install knative [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-  -v, --verbose             If true, output from kubectl commands will print to stdout/stderr
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+  -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy.md
+++ b/docs/content/cli/glooctl_proxy.md
@@ -22,9 +22,9 @@ these commands can be used to interact directly with the Proxies Gloo is managin
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy.md
+++ b/docs/content/cli/glooctl_proxy.md
@@ -22,7 +22,7 @@ these commands can be used to interact directly with the Proxies Gloo is managin
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_proxy.md
+++ b/docs/content/cli/glooctl_proxy.md
@@ -22,8 +22,9 @@ these commands can be used to interact directly with the Proxies Gloo is managin
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy.md
+++ b/docs/content/cli/glooctl_proxy.md
@@ -22,7 +22,7 @@ these commands can be used to interact directly with the Proxies Gloo is managin
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_proxy_address.md
+++ b/docs/content/cli/glooctl_proxy_address.md
@@ -25,7 +25,7 @@ glooctl proxy address [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_address.md
+++ b/docs/content/cli/glooctl_proxy_address.md
@@ -25,12 +25,12 @@ glooctl proxy address [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-      --port string                the name of the service port to connect to (default "http")
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+      --port string         the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_address.md
+++ b/docs/content/cli/glooctl_proxy_address.md
@@ -25,7 +25,7 @@ glooctl proxy address [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_address.md
+++ b/docs/content/cli/glooctl_proxy_address.md
@@ -25,11 +25,12 @@ glooctl proxy address [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-      --port string         the name of the service port to connect to (default "http")
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+      --port string                the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_dump.md
+++ b/docs/content/cli/glooctl_proxy_dump.md
@@ -23,7 +23,7 @@ glooctl proxy dump [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_dump.md
+++ b/docs/content/cli/glooctl_proxy_dump.md
@@ -23,11 +23,12 @@ glooctl proxy dump [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-      --port string         the name of the service port to connect to (default "http")
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+      --port string                the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_dump.md
+++ b/docs/content/cli/glooctl_proxy_dump.md
@@ -23,12 +23,12 @@ glooctl proxy dump [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-      --port string                the name of the service port to connect to (default "http")
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+      --port string         the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_dump.md
+++ b/docs/content/cli/glooctl_proxy_dump.md
@@ -23,7 +23,7 @@ glooctl proxy dump [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_logs.md
+++ b/docs/content/cli/glooctl_proxy_logs.md
@@ -25,11 +25,12 @@ glooctl proxy logs [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-      --port string         the name of the service port to connect to (default "http")
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+      --port string                the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_logs.md
+++ b/docs/content/cli/glooctl_proxy_logs.md
@@ -25,7 +25,7 @@ glooctl proxy logs [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_logs.md
+++ b/docs/content/cli/glooctl_proxy_logs.md
@@ -25,7 +25,7 @@ glooctl proxy logs [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_logs.md
+++ b/docs/content/cli/glooctl_proxy_logs.md
@@ -25,12 +25,12 @@ glooctl proxy logs [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-      --port string                the name of the service port to connect to (default "http")
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+      --port string         the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_served-config.md
+++ b/docs/content/cli/glooctl_proxy_served-config.md
@@ -23,7 +23,7 @@ glooctl proxy served-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_served-config.md
+++ b/docs/content/cli/glooctl_proxy_served-config.md
@@ -23,11 +23,12 @@ glooctl proxy served-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-      --port string         the name of the service port to connect to (default "http")
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+      --port string                the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_served-config.md
+++ b/docs/content/cli/glooctl_proxy_served-config.md
@@ -23,12 +23,12 @@ glooctl proxy served-config [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-      --port string                the name of the service port to connect to (default "http")
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+      --port string         the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_served-config.md
+++ b/docs/content/cli/glooctl_proxy_served-config.md
@@ -23,7 +23,7 @@ glooctl proxy served-config [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_stats.md
+++ b/docs/content/cli/glooctl_proxy_stats.md
@@ -23,7 +23,7 @@ glooctl proxy stats [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_stats.md
+++ b/docs/content/cli/glooctl_proxy_stats.md
@@ -23,7 +23,7 @@ glooctl proxy stats [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_stats.md
+++ b/docs/content/cli/glooctl_proxy_stats.md
@@ -23,11 +23,12 @@ glooctl proxy stats [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-      --port string         the name of the service port to connect to (default "http")
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+      --port string                the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_stats.md
+++ b/docs/content/cli/glooctl_proxy_stats.md
@@ -23,12 +23,12 @@ glooctl proxy stats [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-      --port string                the name of the service port to connect to (default "http")
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+      --port string         the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_url.md
+++ b/docs/content/cli/glooctl_proxy_url.md
@@ -25,12 +25,12 @@ glooctl proxy url [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
-      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
-      --port string                the name of the service port to connect to (default "http")
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
+      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
+      --port string         the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_url.md
+++ b/docs/content/cli/glooctl_proxy_url.md
@@ -25,11 +25,12 @@ glooctl proxy url [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
-      --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")
-  -n, --namespace string    namespace for reading or writing resources (default "gloo-system")
-      --port string         the name of the service port to connect to (default "http")
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
+      --name string                the name of the proxy service/deployment to use (default "gateway-proxy-v2")
+  -n, --namespace string           namespace for reading or writing resources (default "gloo-system")
+      --port string                the name of the service port to connect to (default "http")
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_proxy_url.md
+++ b/docs/content/cli/glooctl_proxy_url.md
@@ -25,7 +25,7 @@ glooctl proxy url [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_proxy_url.md
+++ b/docs/content/cli/glooctl_proxy_url.md
@@ -25,7 +25,7 @@ glooctl proxy url [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
       --name string         the name of the proxy service/deployment to use (default "gateway-proxy-v2")

--- a/docs/content/cli/glooctl_remove.md
+++ b/docs/content/cli/glooctl_remove.md
@@ -27,8 +27,9 @@ remove configuration items from a top-level Gloo resource
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_remove.md
+++ b/docs/content/cli/glooctl_remove.md
@@ -27,9 +27,9 @@ remove configuration items from a top-level Gloo resource
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_remove.md
+++ b/docs/content/cli/glooctl_remove.md
@@ -27,7 +27,7 @@ remove configuration items from a top-level Gloo resource
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_remove.md
+++ b/docs/content/cli/glooctl_remove.md
@@ -27,7 +27,7 @@ remove configuration items from a top-level Gloo resource
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_remove_route.md
+++ b/docs/content/cli/glooctl_remove_route.md
@@ -29,7 +29,7 @@ glooctl remove route [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_remove_route.md
+++ b/docs/content/cli/glooctl_remove_route.md
@@ -29,7 +29,7 @@ glooctl remove route [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_remove_route.md
+++ b/docs/content/cli/glooctl_remove_route.md
@@ -29,12 +29,12 @@ glooctl remove route [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_remove_route.md
+++ b/docs/content/cli/glooctl_remove_route.md
@@ -34,6 +34,7 @@ glooctl remove route [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_route.md
+++ b/docs/content/cli/glooctl_route.md
@@ -27,7 +27,7 @@ subcommands for interacting with routes within virtual services
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_route.md
+++ b/docs/content/cli/glooctl_route.md
@@ -27,7 +27,7 @@ subcommands for interacting with routes within virtual services
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_route.md
+++ b/docs/content/cli/glooctl_route.md
@@ -27,8 +27,9 @@ subcommands for interacting with routes within virtual services
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_route.md
+++ b/docs/content/cli/glooctl_route.md
@@ -27,9 +27,9 @@ subcommands for interacting with routes within virtual services
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_route_sort.md
+++ b/docs/content/cli/glooctl_route_sort.md
@@ -26,7 +26,7 @@ glooctl route sort [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_route_sort.md
+++ b/docs/content/cli/glooctl_route_sort.md
@@ -26,12 +26,12 @@ glooctl route sort [flags]
 ### Options inherited from parent commands
 
 ```
+  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_route_sort.md
+++ b/docs/content/cli/glooctl_route_sort.md
@@ -26,7 +26,7 @@ glooctl route sort [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string              set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string              set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
       --consul-address string      address of the Consul server. Use with --use-consul (default "127.0.0.1:8500")
       --consul-datacenter string   Datacenter to use. If not provided, the default agent datacenter is used. Use with --use-consul
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")

--- a/docs/content/cli/glooctl_route_sort.md
+++ b/docs/content/cli/glooctl_route_sort.md
@@ -31,6 +31,7 @@ glooctl route sort [flags]
       --consul-root-key string     key prefix for for Consul key-value storage. (default "gloo")
       --consul-scheme string       URI scheme for the Consul server. Use with --use-consul (default "http")
       --consul-token string        Token is used to provide a per-request ACL token which overrides the agent's default token. Use with --use-consul
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
   -i, --interactive                use interactive mode
       --kubeconfig string          kubeconfig to use, if not standard one
       --name string                name of the resource to read or write

--- a/docs/content/cli/glooctl_uninstall.md
+++ b/docs/content/cli/glooctl_uninstall.md
@@ -28,9 +28,9 @@ glooctl uninstall [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_uninstall.md
+++ b/docs/content/cli/glooctl_uninstall.md
@@ -28,8 +28,9 @@ glooctl uninstall [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_uninstall.md
+++ b/docs/content/cli/glooctl_uninstall.md
@@ -28,7 +28,7 @@ glooctl uninstall [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_uninstall.md
+++ b/docs/content/cli/glooctl_uninstall.md
@@ -28,7 +28,7 @@ glooctl uninstall [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_upgrade.md
+++ b/docs/content/cli/glooctl_upgrade.md
@@ -25,7 +25,7 @@ glooctl upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_upgrade.md
+++ b/docs/content/cli/glooctl_upgrade.md
@@ -25,7 +25,7 @@ glooctl upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_upgrade.md
+++ b/docs/content/cli/glooctl_upgrade.md
@@ -25,9 +25,9 @@ glooctl upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_upgrade.md
+++ b/docs/content/cli/glooctl_upgrade.md
@@ -25,8 +25,9 @@ glooctl upgrade [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_version.md
+++ b/docs/content/cli/glooctl_version.md
@@ -25,7 +25,7 @@ glooctl version [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/docs/content/cli/glooctl_version.md
+++ b/docs/content/cli/glooctl_version.md
@@ -25,8 +25,9 @@ glooctl version [flags]
 ### Options inherited from parent commands
 
 ```
-  -i, --interactive         use interactive mode
-      --kubeconfig string   kubeconfig to use, if not standard one
+      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
+  -i, --interactive                use interactive mode
+      --kubeconfig string          kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_version.md
+++ b/docs/content/cli/glooctl_version.md
@@ -25,9 +25,9 @@ glooctl version [flags]
 ### Options inherited from parent commands
 
 ```
-      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
-  -i, --interactive                use interactive mode
-      --kubeconfig string          kubeconfig to use, if not standard one
+  -c, --config string       set the path to the glooctl config file (default "/Users/grahamgoudeau/.gloo/glooctl-config.yaml")
+  -i, --interactive         use interactive mode
+      --kubeconfig string   kubeconfig to use, if not standard one
 ```
 
 ### SEE ALSO

--- a/docs/content/cli/glooctl_version.md
+++ b/docs/content/cli/glooctl_version.md
@@ -25,7 +25,7 @@ glooctl version [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string       set the path to the glooctl config file (default "$HOME/.gloo/glooctl-config.yaml")
+  -c, --config string       set the path to the glooctl config file (default "<home_directory>/.gloo/glooctl-config.yaml")
   -i, --interactive         use interactive mode
       --kubeconfig string   kubeconfig to use, if not standard one
 ```

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -105,13 +105,14 @@ type Gloo struct {
 }
 
 type GlooDeployment struct {
-	Image                 *Image  `json:"image,omitempty"`
-	XdsPort               int     `json:"xdsPort,omitempty" desc:"port where gloo serves xDS API to Envoy"`
-	ValidationPort        int     `json:"validationPort,omitempty" desc:"port where gloo serves gRPC Proxy Validation to Gateway"`
-	Stats                 bool    `json:"stats" desc:"enable prometheus stats"`
-	FloatingUserId        bool    `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
-	RunAsUser             float64 `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
-	ExternalTrafficPolicy string  `json:"externalTrafficPolicy,omitempty" desc:"Set the external traffic policy on the gloo service"`
+	Image                  *Image  `json:"image,omitempty"`
+	XdsPort                int     `json:"xdsPort,omitempty" desc:"port where gloo serves xDS API to Envoy"`
+	ValidationPort         int     `json:"validationPort,omitempty" desc:"port where gloo serves gRPC Proxy Validation to Gateway"`
+	Stats                  bool    `json:"stats" desc:"enable prometheus stats"`
+	FloatingUserId         bool    `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
+	RunAsUser              float64 `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
+	ExternalTrafficPolicy  string  `json:"externalTrafficPolicy,omitempty" desc:"Set the external traffic policy on the gloo service"`
+	DisableUsageStatistics bool    `json:"disableUsageStatistics" desc:"Disable the collection of gloo usage statistics"`
 	*DeploymentSpec
 }
 

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -69,6 +69,10 @@ spec:
           - name: START_STATS_SERVER
             value: "true"
         {{- end}}
+        {{- if .Values.gloo.deployment.disableUsageStatistics }}
+          - name: USAGE_REPORTING_DISABLE
+            value: "true"
+        {{- end}}
         readinessProbe:
           tcpSocket:
             port: {{ .Values.gloo.deployment.xdsPort }}

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -70,7 +70,7 @@ spec:
             value: "true"
         {{- end}}
         {{- if .Values.gloo.deployment.disableUsageStatistics }}
-          - name: USAGE_REPORTING_DISABLE
+          - name: DISABLE_USAGE_REPORTING
             value: "true"
         {{- end}}
         readinessProbe:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/solo-io/reporting-client/pkg/client"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/yaml"
 
@@ -992,6 +994,18 @@ metadata:
 				It("should create a deployment", func() {
 					helmFlags := "--namespace " + namespace + " --set namespace.create=true"
 					prepareMakefile(helmFlags)
+					testManifest.ExpectDeploymentAppsV1(glooDeployment)
+				})
+
+				It("should disable usage stats collection when appropriate", func() {
+					helmFlags := fmt.Sprintf("--namespace %s --set namespace.create=true --set gloo.deployment.disableUsageStatistics=true", namespace)
+					prepareMakefile(helmFlags)
+
+					glooDeployment.Spec.Template.Spec.Containers[0].Env = append(glooDeployment.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{
+						Name:  client.DisableUsageVar,
+						Value: "true",
+					})
+
 					testManifest.ExpectDeploymentAppsV1(glooDeployment)
 				})
 

--- a/pkg/utils/setuputils/main_setup.go
+++ b/pkg/utils/setuputils/main_setup.go
@@ -142,6 +142,7 @@ func writeDefaultSettings(defaultNamespace, name string, cli v1.SettingsClient) 
 	return nil
 }
 
+// does not block the current goroutine
 func StartReportingUsage(ctx context.Context, usagePayloadReader client.UsagePayloadReader, product string) <-chan error {
 	usageClient := client.NewUsageClient(usage.ReportingServiceUrl, usagePayloadReader, usage.LoadInstanceMetadata(product, version.Version))
 	return usageClient.StartReportingUsage(ctx, usage.ReportingPeriod)

--- a/pkg/utils/usage/usage_readers.go
+++ b/pkg/utils/usage/usage_readers.go
@@ -77,6 +77,8 @@ func (c *CliUsageReader) GetPayload() (map[string]string, error) {
 	argsMap := map[string]string{}
 
 	if len(os.Args) > 1 {
+		// don't report the binary name, which will be the first arg
+		// it may contain paths on the user's computer
 		argsMap[args] = strings.Join(os.Args[1:], "|")
 	}
 

--- a/pkg/utils/usage/usage_readers.go
+++ b/pkg/utils/usage/usage_readers.go
@@ -2,6 +2,8 @@ package usage
 
 import (
 	"fmt"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/solo-io/gloo/projects/metrics/pkg/metricsservice"
@@ -20,6 +22,7 @@ const (
 	numEnvoys        = "numActiveEnvoys"
 	totalRequests    = "totalRequests"
 	totalConnections = "totalConnections"
+	args             = "args"
 )
 
 type DefaultUsageReader struct {
@@ -62,4 +65,16 @@ func (d *DefaultUsageReader) GetPayload() (map[string]string, error) {
 	}
 
 	return payload, nil
+}
+
+type CliUsageReader struct {
+}
+
+var _ client.UsagePayloadReader = &CliUsageReader{}
+
+// when reporting usage, also include the args that glooctl was invoked with
+func (c *CliUsageReader) GetPayload() (map[string]string, error) {
+	return map[string]string{
+		args: strings.Join(os.Args, "|"),
+	}, nil
 }

--- a/pkg/utils/usage/usage_readers.go
+++ b/pkg/utils/usage/usage_readers.go
@@ -74,7 +74,11 @@ var _ client.UsagePayloadReader = &CliUsageReader{}
 
 // when reporting usage, also include the args that glooctl was invoked with
 func (c *CliUsageReader) GetPayload() (map[string]string, error) {
-	return map[string]string{
-		args: strings.Join(os.Args, "|"),
-	}, nil
+	argsMap := map[string]string{}
+
+	if len(os.Args) > 1 {
+		argsMap[args] = strings.Join(os.Args[1:], "|")
+	}
+
+	return argsMap, nil
 }

--- a/projects/gloo/cli/cmd/main.go
+++ b/projects/gloo/cli/cmd/main.go
@@ -1,35 +1,15 @@
 package main
 
 import (
-	"context"
 	"os"
-	"strings"
-
-	"github.com/solo-io/gloo/pkg/utils/setuputils"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd"
 )
 
-const (
-	args = "args"
-)
-
 func main() {
-	setuputils.StartReportingUsage(context.Background(), &cliUsageReader{}, "glooctl")
-
 	app := cmd.GlooCli()
 	if err := app.Execute(); err != nil {
 		//fmt.Println(err)
 		os.Exit(1)
 	}
-}
-
-type cliUsageReader struct {
-}
-
-// when reporting usage, also include the args that glooctl was invoked with
-func (c *cliUsageReader) GetPayload() (map[string]string, error) {
-	return map[string]string{
-		args: strings.Join(os.Args, "|"),
-	}, nil
 }

--- a/projects/gloo/cli/pkg/cmd/config_file.go
+++ b/projects/gloo/cli/pkg/cmd/config_file.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	ConfigFileName = "glooctl-config.yaml"
+	ConfigDirName  = ".gloo"
+
+	defaultYaml = `# glooctl configuration file
+# see https://gloo.solo.io/advanced_configuration/glooctl-config/ for more information
+
+`
+	dirPermissions  = 0755
+	filePermissions = 0644
+
+	// note that the available keys in this config file should be kept up to date in our public docs
+	disableUsageReporting = "disableUsageReporting"
+)
+
+func ReadConfigFile(opts *options.Options, cmd *cobra.Command) error {
+	configFilePath := opts.Top.ConfigFilePath
+
+	err := ensureExists(opts.Top.ConfigFilePath)
+	if err != nil {
+		return err
+	}
+
+	viper.SetConfigFile(configFilePath)
+	viper.SetConfigType("yaml")
+	err = viper.ReadInConfig()
+	if err != nil {
+		return err
+	}
+
+	opts.Top.DisableUsageStatistics = viper.GetBool(disableUsageReporting)
+
+	return err
+}
+
+// ensure that both the directory containing the file and the file itself exist
+func ensureExists(fullConfigFilePath string) error {
+	dir, _ := filepath.Split(fullConfigFilePath)
+
+	err := os.MkdirAll(dir, dirPermissions)
+	if err != nil {
+		return err
+	}
+
+	_, err = os.Stat(fullConfigFilePath)
+	if err != nil {
+		// file does not exist
+		return writeDefaultConfig(fullConfigFilePath)
+	}
+
+	// file exists
+	return nil
+}
+
+func writeDefaultConfig(configPath string) error {
+	return ioutil.WriteFile(configPath, []byte(defaultYaml), filePermissions)
+}

--- a/projects/gloo/cli/pkg/cmd/options/options.go
+++ b/projects/gloo/cli/pkg/cmd/options/options.go
@@ -30,14 +30,15 @@ type Options struct {
 }
 
 type Top struct {
-	Interactive bool
-	File        string
-	Output      printTypes.OutputType
-	Ctx         context.Context
-	Verbose     bool   // currently only used by install and uninstall, sends kubectl command output to terminal
-	KubeConfig  string // file to use for kube config, if not standard one.
-	Zip         bool
-	ErrorsOnly  bool
+	Interactive            bool
+	File                   string
+	Output                 printTypes.OutputType
+	Ctx                    context.Context
+	Verbose                bool   // currently only used by install and uninstall, sends kubectl command output to terminal
+	KubeConfig             string // file to use for kube config, if not standard one.
+	Zip                    bool
+	ErrorsOnly             bool
+	DisableUsageStatistics bool
 }
 
 type Install struct {

--- a/projects/gloo/cli/pkg/cmd/options/options.go
+++ b/projects/gloo/cli/pkg/cmd/options/options.go
@@ -39,6 +39,7 @@ type Top struct {
 	Zip                    bool
 	ErrorsOnly             bool
 	DisableUsageStatistics bool
+	ConfigFilePath         string
 }
 
 type Install struct {

--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -63,6 +63,7 @@ func GlooCli() *cobra.Command {
 	optionsFunc := func(app *cobra.Command) {
 		pflags := app.PersistentFlags()
 		pflags.BoolVarP(&opts.Top.Interactive, "interactive", "i", false, "use interactive mode")
+		pflags.BoolVarP(&opts.Top.DisableUsageStatistics, "disable-usage-statistics", "x", false, "disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)")
 
 		app.SuggestionsMinimumDistance = 1
 		app.AddCommand(
@@ -86,6 +87,7 @@ func GlooCli() *cobra.Command {
 
 	preRunFuncs := []PreRunFunc{
 		prerun.SetKubeConfigEnv,
+		prerun.ReportUsage,
 	}
 
 	return App(opts, preRunFuncs, optionsFunc)

--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"context"
+	"os"
+	"path"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/debug"
 
@@ -60,10 +62,13 @@ func GlooCli() *cobra.Command {
 		},
 	}
 
+	home, _ := os.UserHomeDir()
+	defaultConfigPath := path.Join(home, ConfigDirName, ConfigFileName)
+
 	optionsFunc := func(app *cobra.Command) {
 		pflags := app.PersistentFlags()
 		pflags.BoolVarP(&opts.Top.Interactive, "interactive", "i", false, "use interactive mode")
-		pflags.BoolVarP(&opts.Top.DisableUsageStatistics, "disable-usage-statistics", "", false, "disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)")
+		pflags.StringVarP(&opts.Top.ConfigFilePath, "config", "f", defaultConfigPath, "set the path to the glooctl config file")
 
 		app.SuggestionsMinimumDistance = 1
 		app.AddCommand(
@@ -86,6 +91,8 @@ func GlooCli() *cobra.Command {
 	}
 
 	preRunFuncs := []PreRunFunc{
+		// should make sure to read the config file first
+		ReadConfigFile,
 		prerun.SetKubeConfigEnv,
 		prerun.ReportUsage,
 	}

--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -68,7 +68,7 @@ func GlooCli() *cobra.Command {
 	optionsFunc := func(app *cobra.Command) {
 		pflags := app.PersistentFlags()
 		pflags.BoolVarP(&opts.Top.Interactive, "interactive", "i", false, "use interactive mode")
-		pflags.StringVarP(&opts.Top.ConfigFilePath, "config", "f", defaultConfigPath, "set the path to the glooctl config file")
+		pflags.StringVarP(&opts.Top.ConfigFilePath, "config", "c", defaultConfigPath, "set the path to the glooctl config file")
 
 		app.SuggestionsMinimumDistance = 1
 		app.AddCommand(

--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -63,7 +63,7 @@ func GlooCli() *cobra.Command {
 	optionsFunc := func(app *cobra.Command) {
 		pflags := app.PersistentFlags()
 		pflags.BoolVarP(&opts.Top.Interactive, "interactive", "i", false, "use interactive mode")
-		pflags.BoolVarP(&opts.Top.DisableUsageStatistics, "disable-usage-statistics", "x", false, "disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)")
+		pflags.BoolVarP(&opts.Top.DisableUsageStatistics, "disable-usage-statistics", "", false, "disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)")
 
 		app.SuggestionsMinimumDistance = 1
 		app.AddCommand(

--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"context"
-	"os"
-	"path"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/debug"
 
@@ -62,13 +60,10 @@ func GlooCli() *cobra.Command {
 		},
 	}
 
-	home, _ := os.UserHomeDir()
-	defaultConfigPath := path.Join(home, ConfigDirName, ConfigFileName)
-
 	optionsFunc := func(app *cobra.Command) {
 		pflags := app.PersistentFlags()
 		pflags.BoolVarP(&opts.Top.Interactive, "interactive", "i", false, "use interactive mode")
-		pflags.StringVarP(&opts.Top.ConfigFilePath, "config", "c", defaultConfigPath, "set the path to the glooctl config file")
+		pflags.StringVarP(&opts.Top.ConfigFilePath, "config", "c", DefaultConfigPath, "set the path to the glooctl config file")
 
 		app.SuggestionsMinimumDistance = 1
 		app.AddCommand(

--- a/projects/gloo/cli/pkg/prerun/prerun_output.go
+++ b/projects/gloo/cli/pkg/prerun/prerun_output.go
@@ -1,7 +1,11 @@
 package prerun
 
 import (
+	"context"
 	"os"
+
+	"github.com/solo-io/gloo/pkg/utils/setuputils"
+	"github.com/solo-io/gloo/pkg/utils/usage"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/flagutils"
@@ -24,5 +28,14 @@ func SetKubeConfigEnv(opts *options.Options, cmd *cobra.Command) error {
 	if opts.Top.KubeConfig != "" {
 		return os.Setenv("KUBECONFIG", opts.Top.KubeConfig)
 	}
+	return nil
+}
+
+func ReportUsage(opts *options.Options, cmd *cobra.Command) error {
+	if opts.Top.DisableUsageStatistics {
+		return nil
+	}
+
+	_ = setuputils.StartReportingUsage(context.Background(), &usage.CliUsageReader{}, "glooctl")
 	return nil
 }


### PR DESCRIPTION
new output of --help:

```
(⎈ |minikube:gloo-system)~/go/src/github.com/solo-io/gloo > ./_output/glooctl --help
glooctl is the unified CLI for Gloo.
	Find more information at https://solo.io

Usage:
  glooctl [command]

Available Commands:
  add         Adds configuration to a top-level Gloo resource
  check       Checks Gloo resources for errors (requires Gloo running on Kubernetes)
  completion  generate auto completion for your shell
  create      Create a Gloo resource
  debug       Debug a Gloo resource (requires Gloo running on Kubernetes)
  delete      Delete a Gloo resource
  edit        Edit a Gloo resource
  get         Display one or a list of Gloo resources
  help        Help about any command
  install     install gloo on different platforms
  proxy       interact with proxy instances managed by Gloo
  remove      remove configuration items from a top-level Gloo resource
  route       subcommands for interacting with routes within virtual services
  uninstall   uninstall gloo
  upgrade     upgrade glooctl binary
  version     Print current version

Flags:
      --disable-usage-statistics   disable the sending of anonymous usage statistics (https://gloo.solo.io/observability/usage_statistics/)
  -h, --help                       help for glooctl
  -i, --interactive                use interactive mode
      --kubeconfig string          kubeconfig to use, if not standard one

Use "glooctl [command] --help" for more information about a command.
```

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/1226