### PR TITLE
Add make targets for tagged helm charts, add valet config to push tagged docker images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 vendor
 _output
 _test
+_artifacts
 .idea
 site
 .firebase

--- a/Makefile
+++ b/Makefile
@@ -567,4 +567,5 @@ save-tagged-helm:
 
 .PHONY: fetch-tagged-helm
 fetch-tagged-helm:
+	mkdir -p $(HELM_SYNC_DIR)
 	gsutil -m rsync -r gs://solo-public-tagged-helm/ './_output/helm'

--- a/Makefile
+++ b/Makefile
@@ -544,11 +544,15 @@ build-kind-chart:
 
 
 #----------------------------------------------------------------------------------
-# Build assets for non-release charts (meant to be invoked locally)
+# Build assets for non-release charts (meant to be invoked on your dev machine)
 #----------------------------------------------------------------------------------
 
-# Must be run locally because TAGGED_VERSION depends on `git describe --tags`, and CI doesn't have git locally
-# Sample invocation: TAGGED_VERSION=$(git describe --tags) GCLOUD_PROJECT_ID=solo-public make clean build-tagged-chart
+# Must be run on your dev machine because TAGGED_VERSION depends on `git describe --tags`, and our CI doesn't clone
+# the repo or have any git context
+
+# Sample invocation:
+# TAGGED_VERSION=$(git describe --tags) GCLOUD_PROJECT_ID=solo-public make clean fetch-tagged-helm build-tagged-chart save-tagged-helm
+
 .PHONY: build-tagged-chart
 build-tagged-chart:
 	mkdir -p $(TEST_ASSET_DIR)

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -1,26 +1,13 @@
 # For building Gloo artifacts with Valet
-# From the root of the repo:
-# valet build -v $(git describe --tags --dirty | cut -c 2-)
 
-
-# Code is commented out so that we only build required components for
-# GlooE to depend on a hash/revision of Gloo
-
-# Make sure repo is clean (git status returns clean) and run:
-# valet build -v $(git describe --tags --dirty)
+# Make sure repo is clean (`git status` returns clean) and run:
+# valet build -v $(git describe --tags)
 
 build:
   go:
     version: github.com/solo-io/gloo/pkg/version.Version
     gcFlags: "all=-N -l"
     binaries:
-      - name: glooctl
-        #os: [linux, darwin, windows]
-        os: [linux]
-        entrypoint: projects/gloo/cli/cmd/main.go
-        upload: true
-        #tests:
-        #  - path: install/test
       - name: gloo
         entrypoint: projects/gloo/cmd/main.go
       - name: gateway
@@ -29,10 +16,6 @@ build:
         entrypoint: jobs/certgen/cmd/main.go
       - name: discovery
         entrypoint: projects/discovery/cmd/main.go
-#      - name: envoyinit
-#        entrypoint: projects/envoyinit/cmd/main.go
-#      - name: ingress
-#        entrypoint: projects/ingress/cmd/main.go
       - name: gateway-conversion
         entrypoint: projects/gateway/pkg/conversion/cmd/main.go
       - name: access-logger
@@ -49,24 +32,9 @@ docker:
       dockerfile: jobs/certgen/cmd/Dockerfile
     - name: discovery
       dockerfile: projects/discovery/cmd/Dockerfile
-    #- name: gloo-envoy-wrapper
-    #  dockerfile: projects/envoyinit/cmd/Dockerfile
     - name: gateway-conversion
       dockerfile: projects/gateway/pkg/conversion/cmd/Dockerfile
     - name: access-logger
       dockerfile: projects/accesslogger/cmd/Dockerfile
-
-#helm:
-#  charts:
-#    - name: gloo
-#      directory: install/helm/gloo
-#      generator: install/helm/gloo/generate.go
-#      manifests:
-#        - name: gloo-gateway.yaml
-#        - name: gloo-ingress.yaml
-#          values: values-ingress.yaml
-#        - name: gloo-knative.yaml
-#          values: values-knative.yaml
-#      upload: true
 
 productName: gloo

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -1,0 +1,68 @@
+# For building Gloo artifacts with Valet
+# From the root of the repo:
+# valet build -v $(git describe --tags --dirty | cut -c 2-)
+
+
+# Code is commented out so that we only build required components for
+# GlooE to depend on a hash/revision of Gloo
+
+# Make sure repo is clean (git status returns clean) and run:
+# valet build -v $(git describe --tags --dirty)
+
+build:
+  go:
+    version: github.com/solo-io/gloo/pkg/version.Version
+    gcFlags: "all=-N -l"
+    binaries:
+      - name: glooctl
+        #os: [linux, darwin, windows]
+        os: [linux]
+        entrypoint: projects/gloo/cli/cmd/main.go
+        upload: true
+        #tests:
+        #  - path: install/test
+#      - name: gloo
+#        entrypoint: projects/gloo/cmd/main.go
+      - name: gateway
+        entrypoint: projects/gateway/cmd/main.go
+      - name: certgen
+        entrypoint: jobs/certgen/cmd/main.go
+      - name: discovery
+        entrypoint: projects/discovery/cmd/main.go
+#      - name: envoyinit
+#        entrypoint: projects/envoyinit/cmd/main.go
+#      - name: ingress
+#        entrypoint: projects/ingress/cmd/main.go
+#      - name: gateway-conversion
+#        entrypoint: projects/gateway/pkg/conversion/cmd/main.go
+
+docker:
+  registries: [quay.io/solo-io]
+  containers:
+    #- name: gloo
+    #  dockerfile: projects/gloo/cmd/Dockerfile
+    - name: gateway
+      dockerfile: projects/gateway/cmd/Dockerfile
+    - name: certgen
+      dockerfile: jobs/certgen/cmd/Dockerfile
+    - name: discovery
+      dockerfile: projects/discovery/cmd/Dockerfile
+    #- name: gloo-envoy-wrapper
+    #  dockerfile: projects/envoyinit/cmd/Dockerfile
+    #- name: gateway-conversion
+    #  dockerfile: projects/gateway/pkg/conversion/cmd/Dockerfile
+
+#helm:
+#  charts:
+#    - name: gloo
+#      directory: install/helm/gloo
+#      generator: install/helm/gloo/generate.go
+#      manifests:
+#        - name: gloo-gateway.yaml
+#        - name: gloo-ingress.yaml
+#          values: values-ingress.yaml
+#        - name: gloo-knative.yaml
+#          values: values-knative.yaml
+#      upload: true
+
+productName: gloo

--- a/artifacts.yaml
+++ b/artifacts.yaml
@@ -21,8 +21,8 @@ build:
         upload: true
         #tests:
         #  - path: install/test
-#      - name: gloo
-#        entrypoint: projects/gloo/cmd/main.go
+      - name: gloo
+        entrypoint: projects/gloo/cmd/main.go
       - name: gateway
         entrypoint: projects/gateway/cmd/main.go
       - name: certgen
@@ -33,14 +33,16 @@ build:
 #        entrypoint: projects/envoyinit/cmd/main.go
 #      - name: ingress
 #        entrypoint: projects/ingress/cmd/main.go
-#      - name: gateway-conversion
-#        entrypoint: projects/gateway/pkg/conversion/cmd/main.go
+      - name: gateway-conversion
+        entrypoint: projects/gateway/pkg/conversion/cmd/main.go
+      - name: access-logger
+        entrypoint: projects/accesslogger/cmd/main.go
 
 docker:
   registries: [quay.io/solo-io]
   containers:
-    #- name: gloo
-    #  dockerfile: projects/gloo/cmd/Dockerfile
+    - name: gloo
+      dockerfile: projects/gloo/cmd/Dockerfile
     - name: gateway
       dockerfile: projects/gateway/cmd/Dockerfile
     - name: certgen
@@ -49,8 +51,10 @@ docker:
       dockerfile: projects/discovery/cmd/Dockerfile
     #- name: gloo-envoy-wrapper
     #  dockerfile: projects/envoyinit/cmd/Dockerfile
-    #- name: gateway-conversion
-    #  dockerfile: projects/gateway/pkg/conversion/cmd/Dockerfile
+    - name: gateway-conversion
+      dockerfile: projects/gateway/pkg/conversion/cmd/Dockerfile
+    - name: access-logger
+      dockerfile: projects/accesslogger/cmd/Dockerfile
 
 #helm:
 #  charts:

--- a/changelog/v0.21.0/push-tagged-helm-charts.yaml
+++ b/changelog/v0.21.0/push-tagged-helm-charts.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Adds local make targets to make tagged helm charts and push to a tagged helm repo


### PR DESCRIPTION
### Changes
Adds new make targets meant to be invoked locally that:
* build a tagged helm chart
* push tagged helm charts to a separate public helm repo
* download helm charts and sync from this new repo

Also adds:
* valet config to push tagged docker images

### Context
We need this so GlooE can depend on revisions of Gloo rather than just release tags.

Opted for a separate helm repo to prevent polluting the current helm repo.

The helm charts are versioned using the output from `git describe --tags`, which has the format `<last tag semver>-<#commits since last tag>-<short sha>`.

We can't run this in CI because we don't clone the repo as part of CI (we just start from a tarball)

I'm open to adding a git glone stage to our CI so we can upload helm charts to the tagged repo on every push if:
* we are ok with the additional time taken on each build to clone the repo
* we are ok with the bloat and large size the tagged helm repository will inevitably grow to

In the meantime, when we need to depend on revisions of Gloo in other projects, we can just upload the requisite helm charts from a local make target and reference that tagged helm chart in GlooE. The same will be done with a valet build of the docker images