### PR TITLE
Bump go-utils

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1357,7 +1357,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:675e88637f52e60444ff59ffe3b708e4fa74ae9f587dde5eb5d4eaa907d0664a"
+  digest = "1:ad4681c2ac6e9017882421da2b288ea198003ffbbf342b1bb140209ba1bcea7a"
   name = "github.com/solo-io/go-utils"
   packages = [
     "certutils",
@@ -1391,6 +1391,7 @@
     "testutils/exec",
     "testutils/helper",
     "testutils/kube",
+    "threadsafe",
     "versionutils",
     "versionutils/dep",
     "versionutils/git",
@@ -1398,8 +1399,8 @@
     "vfsutils",
   ]
   pruneopts = "UT"
-  revision = "2fff910b5b9a262eba3177f296923ac04887fa53"
-  version = "v0.10.9"
+  revision = "68c84e0981898f92f0d7c7a846d8f0d82dd4fd9a"
+  version = "v0.10.20"
 
 [[projects]]
   digest = "1:a2922a665903e4336f9e8b13eb9134bdda25ed984b3966159d4aa2bf9c5b0e28"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[override]]
   name = "github.com/solo-io/go-utils"
-  version = "0.10.9"
+  version = "0.10.20"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/changelog/v0.20.9/bump-go-utils.yaml
+++ b/changelog/v0.20.9/bump-go-utils.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: NON_USER_FACING
+  description: Add some cleanup during kube2e test.
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: go-utils
+  dependencyTag: v0.10.20
+  description: Update go-utils to version 0.10.20.

--- a/projects/gateway/pkg/conversion/gateway.go
+++ b/projects/gateway/pkg/conversion/gateway.go
@@ -3,7 +3,7 @@ package conversion
 import (
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gatewayv2 "github.com/solo-io/gloo/projects/gateway/pkg/api/v2"
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
@@ -45,6 +45,6 @@ func (c *gatewayConverter) FromV1ToV2(src *gatewayv1.Gateway) *gatewayv2.Gateway
 				Plugins:         src.Plugins,
 			},
 		},
-		GatewayProxyName: translator.GatewayProxyName,
+		GatewayProxyName: gatewaydefaults.GatewayProxyName,
 	}
 }

--- a/projects/gateway/pkg/conversion/gateway_test.go
+++ b/projects/gateway/pkg/conversion/gateway_test.go
@@ -6,7 +6,7 @@ import (
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gatewayv2 "github.com/solo-io/gloo/projects/gateway/pkg/api/v2"
 	"github.com/solo-io/gloo/projects/gateway/pkg/conversion"
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
+	defaults2 "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/grpc_web"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/hcm"
@@ -67,7 +67,7 @@ var _ = Describe("Gateway Conversion", func() {
 						Plugins:         plugins,
 					},
 				},
-				GatewayProxyName: translator.GatewayProxyName,
+				GatewayProxyName: defaults2.GatewayProxyName,
 			}
 		}
 

--- a/projects/gateway/pkg/translator/translator_test.go
+++ b/projects/gateway/pkg/translator/translator_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+
 	"github.com/solo-io/gloo/test/samples"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/transformation"
@@ -88,11 +90,11 @@ var _ = Describe("Translator", func() {
 		})
 
 		It("should translate proxy with default name", func() {
-			proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+			proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 			Expect(errs).To(HaveLen(4))
 			Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
-			Expect(proxy.Metadata.Name).To(Equal(GatewayProxyName))
+			Expect(proxy.Metadata.Name).To(Equal(defaults.GatewayProxyName))
 			Expect(proxy.Metadata.Namespace).To(Equal(ns))
 		})
 
@@ -113,11 +115,11 @@ var _ = Describe("Translator", func() {
 				Configs: extensions,
 			}}
 
-			proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+			proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 			Expect(errs).To(HaveLen(4))
 			Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
-			Expect(proxy.Metadata.Name).To(Equal(GatewayProxyName))
+			Expect(proxy.Metadata.Name).To(Equal(defaults.GatewayProxyName))
 			Expect(proxy.Metadata.Namespace).To(Equal(ns))
 			Expect(proxy.Listeners).To(HaveLen(1))
 			Expect(proxy.Listeners[0].Plugins.Extensions.Configs).To(HaveKey("plugin"))
@@ -139,10 +141,10 @@ var _ = Describe("Translator", func() {
 				},
 			)
 
-			proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+			proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 			Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
-			Expect(proxy.Metadata.Name).To(Equal(GatewayProxyName))
+			Expect(proxy.Metadata.Name).To(Equal(defaults.GatewayProxyName))
 			Expect(proxy.Metadata.Namespace).To(Equal(ns))
 			Expect(proxy.Listeners).To(HaveLen(2))
 		})
@@ -158,10 +160,10 @@ var _ = Describe("Translator", func() {
 				},
 			)
 
-			proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+			proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 			Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
-			Expect(proxy.Metadata.Name).To(Equal(GatewayProxyName))
+			Expect(proxy.Metadata.Name).To(Equal(defaults.GatewayProxyName))
 			Expect(proxy.Metadata.Namespace).To(Equal(ns))
 			Expect(proxy.Listeners).To(HaveLen(2))
 		})
@@ -173,7 +175,7 @@ var _ = Describe("Translator", func() {
 			}
 			snap.Gateways = append(snap.Gateways, &dupeGateway)
 
-			_, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+			_, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 			err := errs.ValidateStrict()
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("bind-address :2 is not unique in a proxy. gateways: gloo-system.name,gloo-system.name2"))
@@ -184,7 +186,7 @@ var _ = Describe("Translator", func() {
 			badRoute := &v1.Route{
 				Matcher: &gloov1.Matcher{PathSpecifier: &gloov1.Matcher_Prefix{Prefix: "/"}},
 				Action: &v1.Route_DelegateAction{
-					DelegateAction: &core.ResourceRef{"don't", "exist"},
+					DelegateAction: &core.ResourceRef{Name: "don't", Namespace: "exist"},
 				},
 			}
 
@@ -193,7 +195,7 @@ var _ = Describe("Translator", func() {
 			rt := snap.RouteTables[0]
 			rt.Routes = append(rt.Routes, badRoute)
 
-			_, reports := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+			_, reports := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 			err := reports.Validate()
 			Expect(err).NotTo(HaveOccurred())
 			err = reports.ValidateStrict()
@@ -267,7 +269,7 @@ var _ = Describe("Translator", func() {
 
 			It("should translate an empty gateway to have all vservices", func() {
 
-				proxy, _ := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+				proxy, _ := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 				Expect(proxy.Listeners).To(HaveLen(1))
 				listener := proxy.Listeners[0].ListenerType.(*gloov1.Listener_HttpListener).HttpListener
@@ -275,7 +277,7 @@ var _ = Describe("Translator", func() {
 			})
 
 			It("should have no ssl config", func() {
-				proxy, _ := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+				proxy, _ := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 				Expect(proxy.Listeners).To(HaveLen(1))
 				Expect(proxy.Listeners[0].SslConfigurations).To(BeEmpty())
@@ -289,7 +291,7 @@ var _ = Describe("Translator", func() {
 						},
 					}
 
-					proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 					Expect(proxy).NotTo(BeNil())
@@ -307,7 +309,7 @@ var _ = Describe("Translator", func() {
 						},
 					}
 
-					proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 					Expect(proxy).NotTo(BeNil())
@@ -320,7 +322,7 @@ var _ = Describe("Translator", func() {
 			It("should not have vhosts with ssl", func() {
 				snap.VirtualServices[0].SslConfig = new(gloov1.SslConfig)
 
-				proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+				proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 				Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 
@@ -334,7 +336,7 @@ var _ = Describe("Translator", func() {
 				snap.Gateways[0].Ssl = true
 				snap.VirtualServices[0].SslConfig = new(gloov1.SslConfig)
 
-				proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+				proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 				Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 
@@ -351,10 +353,10 @@ var _ = Describe("Translator", func() {
 
 				It("should translate 2 virtual services with the same domains to 1 virtual service", func() {
 
-					proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
-					Expect(proxy.Metadata.Name).To(Equal(GatewayProxyName))
+					Expect(proxy.Metadata.Name).To(Equal(defaults.GatewayProxyName))
 					Expect(proxy.Metadata.Namespace).To(Equal(ns))
 					Expect(proxy.Listeners).To(HaveLen(1))
 					listener := proxy.Listeners[0].ListenerType.(*gloov1.Listener_HttpListener).HttpListener
@@ -365,7 +367,7 @@ var _ = Describe("Translator", func() {
 					snap.VirtualServices[1].VirtualHost.Domains = nil
 					snap.VirtualServices[0].VirtualHost.Domains = nil
 
-					proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 					Expect(proxy.Listeners).To(HaveLen(1))
@@ -378,7 +380,7 @@ var _ = Describe("Translator", func() {
 				It("should not error with one contains plugins", func() {
 					snap.VirtualServices[0].VirtualHost.VirtualHostPlugins = new(gloov1.VirtualHostPlugins)
 
-					_, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					_, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 				})
@@ -387,7 +389,7 @@ var _ = Describe("Translator", func() {
 					snap.VirtualServices[0].VirtualHost.VirtualHostPlugins = new(gloov1.VirtualHostPlugins)
 					snap.VirtualServices[1].VirtualHost.VirtualHostPlugins = new(gloov1.VirtualHostPlugins)
 
-					_, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					_, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).To(HaveOccurred())
 				})
@@ -395,7 +397,7 @@ var _ = Describe("Translator", func() {
 				It("should not error with one contains ssl config", func() {
 					snap.VirtualServices[0].SslConfig = new(gloov1.SslConfig)
 
-					proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 					listener := proxy.Listeners[0].ListenerType.(*gloov1.Listener_HttpListener).HttpListener
@@ -406,7 +408,7 @@ var _ = Describe("Translator", func() {
 					snap.Gateways[0].Ssl = true
 					snap.VirtualServices[0].SslConfig = new(gloov1.SslConfig)
 
-					proxy, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					proxy, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 					listener := proxy.Listeners[0].ListenerType.(*gloov1.Listener_HttpListener).HttpListener
@@ -421,7 +423,7 @@ var _ = Describe("Translator", func() {
 					snap.VirtualServices[0].SslConfig.SniDomains = []string{"bar"}
 					snap.VirtualServices[1].SslConfig.SniDomains = []string{"foo"}
 
-					_, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					_, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).To(HaveOccurred())
 				})
@@ -433,7 +435,7 @@ var _ = Describe("Translator", func() {
 					snap.VirtualServices[0].SslConfig.SniDomains = []string{"bar"}
 					snap.VirtualServices[1].SslConfig.SniDomains = []string{"foo"}
 
-					_, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					_, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).To(HaveOccurred())
 				})
@@ -445,7 +447,7 @@ var _ = Describe("Translator", func() {
 					snap.VirtualServices[0].SslConfig.SniDomains = []string{"foo"}
 					snap.VirtualServices[1].SslConfig.SniDomains = []string{"foo"}
 
-					_, errs := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+					_, errs := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 					Expect(errs.ValidateStrict()).NotTo(HaveOccurred())
 				})
@@ -689,7 +691,7 @@ var _ = Describe("Translator", func() {
 					}
 
 					Expect(listener.VirtualHosts[0].Routes).To(Equal([]*gloov1.Route{
-						&gloov1.Route{
+						{
 							Matcher: &gloov1.Matcher{
 								PathSpecifier: &gloov1.Matcher_Prefix{
 									Prefix: "/a/1-upstream",
@@ -711,7 +713,7 @@ var _ = Describe("Translator", func() {
 							},
 							RoutePlugins: rootLevelRoutePlugins,
 						},
-						&gloov1.Route{
+						{
 							Matcher: &gloov1.Matcher{
 								PathSpecifier: &gloov1.Matcher_Prefix{
 									Prefix: "/a/3-delegate/upstream1",
@@ -733,7 +735,7 @@ var _ = Describe("Translator", func() {
 							},
 							RoutePlugins: mergedMidLevelRoutePlugins,
 						},
-						&gloov1.Route{
+						{
 							Matcher: &gloov1.Matcher{
 								PathSpecifier: &gloov1.Matcher_Prefix{
 									Prefix: "/a/3-delegate/upstream2",
@@ -945,7 +947,7 @@ var _ = Describe("Translator", func() {
 		})
 
 		It("can properly translate a tcp proxy", func() {
-			proxy, _ := translator.Translate(context.Background(), GatewayProxyName, ns, snap, snap.Gateways)
+			proxy, _ := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
 
 			Expect(proxy.Listeners).To(HaveLen(1))
 			listener := proxy.Listeners[0].ListenerType.(*gloov1.Listener_TcpListener).TcpListener

--- a/projects/gloo/pkg/syncer/translator_syncer_test.go
+++ b/projects/gloo/pkg/syncer/translator_syncer_test.go
@@ -1,7 +1,7 @@
 package syncer_test
 
 import (
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
+	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
@@ -37,7 +37,7 @@ var _ = Describe("Translate Proxy", func() {
 		proxy := &v1.Proxy{
 			Metadata: core.Metadata{
 				Namespace: "gloo-system",
-				Name:      translator.GatewayProxyName,
+				Name:      defaults.GatewayProxyName,
 			},
 		}
 

--- a/test/consulvaulte2e/consul_vault_test.go
+++ b/test/consulvaulte2e/consul_vault_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"time"
 
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+
 	fdssetup "github.com/solo-io/gloo/projects/discovery/pkg/fds/setup"
 	udssetup "github.com/solo-io/gloo/projects/discovery/pkg/uds/setup"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/rest"
@@ -27,7 +29,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/gloo/test/services"
@@ -135,7 +136,7 @@ var _ = Describe("Consul + Vault Configuration Happy Path e2e", func() {
 		// Start Envoy
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+translator.GatewayProxyName, glooPort)
+		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, glooPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run a simple web application locally

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"time"
 
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+
 	"github.com/solo-io/go-utils/errors"
 
 	"github.com/hashicorp/consul/api"
@@ -15,7 +17,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/gloo/projects/gloo/pkg/upstreams/consul"
@@ -93,7 +94,7 @@ var _ = Describe("Consul e2e", func() {
 		envoyPort = uint32(defaults.HttpPort)
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+translator.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run two simple web applications locally

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -6,8 +6,9 @@ import (
 	"net/http"
 	"time"
 
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+
 	"github.com/solo-io/gloo/pkg/utils"
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/common/kubernetes"
 	"github.com/solo-io/solo-kit/pkg/utils/kubeutils"
 	corev1 "k8s.io/api/core/v1"
@@ -94,7 +95,7 @@ var _ = Describe("Gateway", func() {
 			Eventually(
 				func() (int, error) {
 					numdisable := 0
-					proxy, err := testClients.ProxyClient.Read(writeNamespace, translator.GatewayProxyName, clients.ReadOpts{})
+					proxy, err := testClients.ProxyClient.Read(writeNamespace, gatewaydefaults.GatewayProxyName, clients.ReadOpts{})
 					if err != nil {
 						return 0, err
 					}
@@ -145,7 +146,7 @@ var _ = Describe("Gateway", func() {
 			// Wait for proxy to be accepted
 			var proxy *gloov1.Proxy
 			Eventually(func() bool {
-				proxy, err = testClients.ProxyClient.Read(writeNamespace, translator.GatewayProxyName, clients.ReadOpts{})
+				proxy, err = testClients.ProxyClient.Read(writeNamespace, gatewaydefaults.GatewayProxyName, clients.ReadOpts{})
 				if err != nil {
 					return false
 				}

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -10,10 +10,10 @@ import (
 	"strings"
 	"time"
 
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+
 	"github.com/pkg/errors"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/healthcheck"
-
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/stats"
 
@@ -482,7 +482,7 @@ func getTrivialProxyForService(ns string, bindPort uint32, service core.Resource
 func getTrivialProxy(ns string, bindPort uint32) *gloov1.Proxy {
 	return &gloov1.Proxy{
 		Metadata: core.Metadata{
-			Name:      translator.GatewayProxyName,
+			Name:      gatewaydefaults.GatewayProxyName,
 			Namespace: ns,
 		},
 		Listeners: []*gloov1.Listener{{

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -23,7 +23,6 @@ import (
 	kubecache "github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/cache"
 	skkube "github.com/solo-io/solo-kit/pkg/api/v1/resources/common/kubernetes"
 
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	"github.com/solo-io/go-utils/errors"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/linkerd"
@@ -57,7 +56,7 @@ import (
 var _ = Describe("Kube2e: gateway", func() {
 
 	const (
-		gatewayProxy = translator.GatewayProxyName
+		gatewayProxy = defaults.GatewayProxyName
 		gatewayPort  = int(80)
 	)
 
@@ -226,7 +225,7 @@ var _ = Describe("Kube2e: gateway", func() {
 
 				// wait for the expected proxy configuration to be accepted
 				Eventually(func() error {
-					proxy, err := proxyClient.Read(testHelper.InstallNamespace, translator.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+					proxy, err := proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 					if err != nil {
 						return err
 					}
@@ -331,8 +330,8 @@ var _ = Describe("Kube2e: gateway", func() {
 					Protocol:          "https",
 					Path:              "/",
 					Method:            "GET",
-					Host:              translator.GatewayProxyName,
-					Service:           translator.GatewayProxyName,
+					Host:              defaults.GatewayProxyName,
+					Service:           defaults.GatewayProxyName,
 					Port:              gatewayPort,
 					CaFile:            "/tmp/ca.crt",
 					ConnectionTimeout: 1,
@@ -647,7 +646,7 @@ var _ = Describe("Kube2e: gateway", func() {
 
 			// wait for the expected proxy configuration to be accepted
 			Eventually(func() error {
-				proxy, err := proxyClient.Read(testHelper.InstallNamespace, translator.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+				proxy, err := proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 				if err != nil {
 					return err
 				}

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -2,12 +2,12 @@ package gateway_test
 
 import (
 	"fmt"
+	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+	skerrors "github.com/solo-io/solo-kit/pkg/errors"
 	"sort"
 	"time"
 
 	"github.com/solo-io/gloo/projects/gateway/pkg/services/k8sadmisssion"
-
-	"github.com/solo-io/gloo/projects/gateway/pkg/translator"
 
 	"github.com/solo-io/go-utils/kubeutils"
 	"github.com/solo-io/go-utils/testutils/helper"
@@ -36,7 +36,7 @@ import (
 var _ = Describe("Robustness tests", func() {
 
 	const (
-		gatewayProxy = translator.GatewayProxyName
+		gatewayProxy = defaults.GatewayProxyName
 		gatewayPort  = int(80)
 	)
 
@@ -95,6 +95,18 @@ var _ = Describe("Robustness tests", func() {
 	})
 
 	AfterEach(func() {
+		if virtualService != nil {
+			_ = virtualServiceClient.Delete(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.DeleteOpts{Ctx: ctx, IgnoreNotExist: true})
+
+			Eventually(func() bool {
+				_, err := virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+				if err != nil && skerrors.IsNotExist(err) {
+					return true
+				}
+				return false
+			}, "15s", "0.5s").Should(BeTrue())
+		}
+
 		cancel()
 	})
 
@@ -144,7 +156,7 @@ var _ = Describe("Robustness tests", func() {
 
 		By("wait for proxy to be accepted")
 		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, translator.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 			if err != nil {
 				return err
 			}
@@ -204,7 +216,7 @@ var _ = Describe("Robustness tests", func() {
 
 		By("wait for proxy to enter warning state")
 		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, translator.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 			if err != nil {
 				return err
 			}

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -2,10 +2,11 @@ package gateway_test
 
 import (
 	"fmt"
-	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
-	skerrors "github.com/solo-io/solo-kit/pkg/errors"
 	"sort"
 	"time"
+
+	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+	skerrors "github.com/solo-io/solo-kit/pkg/errors"
 
 	"github.com/solo-io/gloo/projects/gateway/pkg/services/k8sadmisssion"
 


### PR DESCRIPTION
Bump `go-utils` to the latest release to get the fix for the race condition in the gateway kube2e tests. This seems to have fixed flakes in these tests:

![image](https://user-images.githubusercontent.com/16148461/67006772-f4e56f80-f0b3-11e9-87a8-3245d2f97dd9.png)

Also removed all references to the deprecated `translator.GatewayProxyName` constant.