### PR TITLE
Dedicated dep cache for feature branch

### DIFF
--- a/changelog/v0.21.0/dedicated-dep-cache.yaml
+++ b/changelog/v0.21.0/dedicated-dep-cache.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Build a dedicated dep cache for the feature-rc1 branch.

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -13,3 +13,5 @@ steps:
 
 - name: gcr.io/cloud-builders/gsutil
   args: ['cp', 'gloo-dep-${BRANCH_NAME}.tar.gz', 'gs://solo-public-cache/gloo']
+
+timeout: 1800s

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -6,10 +6,10 @@ steps:
 
 - name: 'gcr.io/$PROJECT_ID/go-make'
   entrypoint: 'bash'
-  args: ['-c', 'tar -zvcf gloo-dep.tar.gz ./gopath/pkg/dep']
+  args: ['-c', 'tar -zvcf gloo-dep-${BRANCH_NAME}.tar.gz ./gopath/pkg/dep']
   env:
   - 'PROJECT_ROOT=github.com/solo-io/gloo'
   - 'GOPATH=/workspace/gopath'
 
 - name: gcr.io/cloud-builders/gsutil
-  args: ['cp', 'gloo-dep.tar.gz', 'gs://solo-public-cache/gloo']
+  args: ['cp', 'gloo-dep-${BRANCH_NAME}.tar.gz', 'gs://solo-public-cache/gloo']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,8 @@ steps:
 # These two steps should populate the cache
 - name: gcr.io/cloud-builders/gsutil
   entrypoint: 'bash'
-  args: ['-c', 'mkdir -p ./gopath/pkg/dep && gsutil cat gs://solo-public-cache/gloo/gloo-dep.tar.gz | tar -xzf -']
+  # TODO: This is currently hardcoded to get the dep cache for the feature-rc1 branch
+  args: ['-c', 'mkdir -p ./gopath/pkg/dep && gsutil cat gs://solo-public-cache/gloo/gloo-dep-feature-rc1.tar.gz | tar -xzf -']
   id: 'download-untar-dep-cache'
   waitFor: ['-']
 


### PR DESCRIPTION
Build a dedicated dep cache for the `feature-rc1` branch.

- [Cache](https://console.cloud.google.com/storage/browser/solo-public-cache/gloo/?project=solo-public) has been pre-populated
- [New trigger](https://console.cloud.google.com/cloud-build/triggers/50bc36aa-30fe-46e4-ae55-e46f6952d3fe?project=solo-public) has been defined