### PR TITLE
Avoid panicking on routes without matchers

### DIFF
--- a/changelog/v0.20.9/fix-missing-matcher-panic.yaml
+++ b/changelog/v0.20.9/fix-missing-matcher-panic.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Avoid panicking on routes without matchers.
+  issueLink: https://github.com/solo-io/gloo/issues/1438

--- a/projects/gateway/pkg/translator/translator_test.go
+++ b/projects/gateway/pkg/translator/translator_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Translator", func() {
 
 		It("should properly translate listener plugins to proxy listener", func() {
 			extensions := map[string]*types.Struct{
-				"plugin": &types.Struct{},
+				"plugin": {},
 			}
 
 			snap.Gateways[0].Plugins = &gloov1.ListenerPlugins{
@@ -203,6 +203,15 @@ var _ = Describe("Translator", func() {
 			Expect(err.Error()).To(ContainSubstring("route table exist.don't missing"))
 		})
 
+		It("should error on route with missing matcher", func() {
+			snap := samples.SimpleGatewaySnapshot(samples.SimpleUpstream().GetMetadata().Ref(), ns)
+			snap.VirtualServices[0].VirtualHost.Routes[0].Matcher = nil
+
+			_, reports := translator.Translate(context.Background(), defaults.GatewayProxyName, ns, snap, snap.Gateways)
+			err := reports.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid route: matcher cannot be missing"))
+		})
 	})
 
 	Context("http", func() {

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -147,12 +147,14 @@ func setMatch(in *v1.Route, routeReport *validationapi.RouteReport, out *envoyro
 			validationapi.RouteReport_Error_InvalidMatcherError,
 			"no matcher provided",
 		)
+		return
 	}
 	if in.Matcher.PathSpecifier == nil {
 		validation.AppendRouteError(routeReport,
 			validationapi.RouteReport_Error_InvalidMatcherError,
 			"no path specifier provided",
 		)
+		return
 	}
 	match := envoyroute.RouteMatch{
 		Headers:         envoyHeaderMatcher(in.Matcher.Headers),

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -331,6 +331,27 @@ var _ = Describe("Translator", func() {
 			Expect(report).To(Equal(expectedReport))
 		})
 	})
+
+	Context("route without a matcher", func() {
+		BeforeEach(func() {
+			routes[0].Matcher = nil
+		})
+		It("should error when a route is missing a matcher", func() {
+			_, errs, report, err := translator.Translate(params, proxy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(errs.Validate()).To(HaveOccurred())
+			Expect(errs.Validate().Error()).To(ContainSubstring("Route Error: InvalidMatcherError. Reason: no matcher provided"))
+			expectedReport := validationutils.MakeReport(proxy)
+			expectedReport.ListenerReports[0].GetHttpListenerReport().VirtualHostReports[0].RouteReports[0].Errors = []*validation.RouteReport_Error{
+				{
+					Type:   validation.RouteReport_Error_InvalidMatcherError,
+					Reason: "no matcher provided",
+				},
+			}
+			Expect(report).To(Equal(expectedReport))
+		})
+	})
+
 	Context("route header match", func() {
 		It("should translate header matcher with no value to a PresentMatch", func() {
 


### PR DESCRIPTION
Check for nil matchers on routes. Added test to cover this case.

This PR does not need to be ported to `feature-rc` as the issue has already been solved there.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1438