### PR TITLE
Assets only release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -424,11 +424,12 @@ fetch-helm:
 #----------------------------------------------------------------------------------
 # Release
 #----------------------------------------------------------------------------------
+ASSETS_ONLY := true
 
 # The code does the proper checking for a TAGGED_VERSION
 .PHONY: upload-github-release-assets
 upload-github-release-assets: build-cli render-yaml
-	go run ci/upload_github_release_assets.go
+	go run ci/upload_github_release_assets.go $(ASSETS_ONLY)
 
 .PHONY: publish-docs
 publish-docs:

--- a/changelog/v0.21.0/assets-only-release.yaml
+++ b/changelog/v0.21.0/assets-only-release.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Support "asset-only" releases, which don't update homebrew formulas or fish food. Also updates release script
+      to use the new `glooctl version` command now that `glooctl --version` has been removed.

--- a/changelog/v0.21.0/assets-only-release.yaml
+++ b/changelog/v0.21.0/assets-only-release.yaml
@@ -3,3 +3,4 @@ changelog:
     description: >
       Support "asset-only" releases, which don't update homebrew formulas or fish food. Also updates release script
       to use the new `glooctl version` command now that `glooctl --version` has been removed.
+    resolvesIssue: https://github.com/solo-io/gloo/issues/1476

--- a/changelog/v0.21.0/assets-only-release.yaml
+++ b/changelog/v0.21.0/assets-only-release.yaml
@@ -3,4 +3,4 @@ changelog:
     description: >
       Support "asset-only" releases, which don't update homebrew formulas or fish food. Also updates release script
       to use the new `glooctl version` command now that `glooctl --version` has been removed.
-    resolvesIssue: https://github.com/solo-io/gloo/issues/1476
+    issueLink: https://github.com/solo-io/gloo/issues/1476


### PR DESCRIPTION
Support "asset-only" releases, which don't update homebrew formulas or fish food. Also updates release script to use the new `glooctl version` command now that `glooctl --version` has been removed.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1476