### PR TITLE
ssl does not update when uds reconciles

### DIFF
--- a/changelog/v0.20.3/fix-uds-ssl.yaml
+++ b/changelog/v0.20.3/fix-uds-ssl.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Update ssl when uds reconciles
+    issueLink: https://github.com/solo-io/gloo/issues/1485

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
@@ -220,7 +220,7 @@ func UpdateUpstream(original, desired *v1.Upstream) (bool, error) {
 
 	utils.UpdateUpstreamSpec(original.UpstreamSpec, desired.UpstreamSpec)
 
-	if originalSpec.Equal(desiredSpec) {
+	if original.GetUpstreamSpec().Equal(desired.GetUpstreamSpec()) {
 		return false, nil
 	}
 

--- a/projects/gloo/pkg/plugins/kubernetes/uds_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_test.go
@@ -3,6 +3,7 @@ package kubernetes_test
 import (
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	gloov1kube "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/plugins/kubernetes"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,6 +35,36 @@ var _ = Describe("Uds", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(updated).To(BeTrue())
 		Expect(desired.UpstreamSpec.SslConfig).To(BeIdenticalTo(original.UpstreamSpec.SslConfig))
+	})
+
+	It("should update ssl config when one is desired", func() {
+		desiredSslConfig := &gloov1.UpstreamSslConfig{
+			SslSecrets: &gloov1.UpstreamSslConfig_SecretRef{
+				SecretRef: &core.ResourceRef{"hi", "there"},
+			},
+		}
+		desired := &gloov1.Upstream{
+			UpstreamSpec: &gloov1.UpstreamSpec{
+				UpstreamType: &gloov1.UpstreamSpec_Kube{
+					Kube: &gloov1kube.UpstreamSpec{
+						ServiceName: "test",
+					},
+				},
+				SslConfig: desiredSslConfig,
+			},
+		}
+		original := &gloov1.Upstream{
+			UpstreamSpec: &gloov1.UpstreamSpec{
+				UpstreamType: &gloov1.UpstreamSpec_Kube{
+					Kube: &gloov1kube.UpstreamSpec{},
+				},
+				SslConfig: &gloov1.UpstreamSslConfig{Sni: "testsni"},
+			},
+		}
+		updated, err := UpdateUpstream(original, desired)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeTrue())
+		Expect(desired.UpstreamSpec.SslConfig).To(BeIdenticalTo(desiredSslConfig))
 	})
 
 })


### PR DESCRIPTION
# the problem

the change in #1461 was not picked up because the transition function for UDS ignores SSL config when comparing original/desired hash

# the solution

do not ignore ssl config when comparing original/desired hash
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1485