### PR TITLE
Remove orphaned RBAC role from chart

### DIFF
--- a/changelog/v0.20.9/remove-orphaned-rbac-role.yaml
+++ b/changelog/v0.20.9/remove-orphaned-rbac-role.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  description: >
+    The Helm chart contained a `Role`/`ClusterRole` named `kube-crd-creator` which was unused. This role caused
+    problems to users with limited privileges and effectively prevented them from installing Gloo in namespace-scoped mode.
+    This fix removes the `kube-crd-creator` resource from the Helm chart.
+  issueLink: https://github.com/solo-io/gloo/issues/1491

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -41,24 +41,6 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: kube-crd-creator
-{{- if .Values.global.glooRbac.namespaced }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-    labels:
-        app: gloo
-        gloo: rbac
-    annotations:
-      "helm.sh/hook": "pre-install"
-      "helm.sh/hook-weight": "10"
-rules:
-- apiGroups: ["apiextensions.k8s.io"]
-  resources: ["customresourcedefinitions"]
-  verbs: ["get", "create", "update"]
----
-kind: {{ include "gloo.roleKind" . }}
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
     name: gloo-resource-reader
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
The Helm chart contained a `Role`/`ClusterRole` named `kube-crd-creator` which was unused. This role caused problems to users with limited privileges and effectively prevented them from installing Gloo in namespace-scoped mode.

This fix removes the `kube-crd-creator` resource from the Helm chart.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1491