### PR TITLE
Fix GlooE changelog generation during release

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -542,9 +542,12 @@
   revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
-  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
+  digest = "1:a507e8646bf3775af6f7e7b2a62a5e67d1c6a8f00754f87e66b96181b7f3d747"
   name = "github.com/golang/mock"
-  packages = ["gomock"]
+  packages = [
+    "gomock",
+    "mockgen/model",
+  ]
   pruneopts = "UT"
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
@@ -2777,6 +2780,7 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
+    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/ptypes/any",

--- a/Makefile
+++ b/Makefile
@@ -429,11 +429,9 @@ GLOOE_CHANGELOGS_BUCKET=gloo-ee-changelogs
 .PHONY: download-glooe-changelog
 download-glooe-changelog:
 ifeq ($(RELEASE),"true")
-	# ensure dir exists and that we don't overwrite !
 	mkdir -p '../solo-projects/changelog'
 	gsutil -m cp -r gs://$(GLOOE_CHANGELOGS_BUCKET)/$(VERSION)/* '../solo-projects/changelog'
 endif
-
 
 ASSETS_ONLY := true
 

--- a/Makefile
+++ b/Makefile
@@ -424,6 +424,17 @@ fetch-helm:
 #----------------------------------------------------------------------------------
 # Release
 #----------------------------------------------------------------------------------
+GLOOE_CHANGELOGS_BUCKET=gloo-ee-changelogs
+
+.PHONY: download-glooe-changelog
+download-glooe-changelog:
+ifeq ($(RELEASE),"true")
+	# ensure dir exists and that we don't overwrite !
+	mkdir -p '../solo-projects/changelog'
+	gsutil -m cp -r gs://$(GLOOE_CHANGELOGS_BUCKET)/$(VERSION)/* '../solo-projects/changelog'
+endif
+
+
 ASSETS_ONLY := true
 
 # The code does the proper checking for a TAGGED_VERSION

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ ifeq ($(TAGGED_VERSION),)
 	RELEASE := "false"
 endif
 VERSION ?= $(shell echo $(TAGGED_VERSION) | cut -c 2-)
+GLOOE_VERSION ?= 0.20.4
 
-LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
+LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION) -X github.com/solo-io/gloo/pkg/version.EnterpriseTag=$(GLOOE_VERSION)"
 GCFLAGS := all="-N -l"
 
 # Passed by cloudbuild
@@ -430,7 +431,7 @@ GLOOE_CHANGELOGS_BUCKET=gloo-ee-changelogs
 download-glooe-changelog:
 ifeq ($(RELEASE),"true")
 	mkdir -p '../solo-projects/changelog'
-	gsutil -m cp -r gs://$(GLOOE_CHANGELOGS_BUCKET)/$(VERSION)/* '../solo-projects/changelog'
+	gsutil -m cp -r gs://$(GLOOE_CHANGELOGS_BUCKET)/$(GLOOE_VERSION)/* '../solo-projects/changelog'
 endif
 
 ASSETS_ONLY := true

--- a/changelog/v0.21.0/download-glooe-changelog.yaml
+++ b/changelog/v0.21.0/download-glooe-changelog.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Download GlooE changelog from GCP bucket during release so Gloo can generate proper docs.
+    issueLink: https://github.com/solo-io/gloo/issues/1482

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -206,7 +206,7 @@ steps:
 # 2) Publish helm chart, compile manifests, produce release artifacts, deploy docs
 # isolating this portion of the release in order to force the manifest to be regenerated with the tagged version
 - name: 'gcr.io/$PROJECT_ID/go-make:0.1.12'
-  args: ['manifest', 'upload-github-release-assets', 'publish-docs', '-B']
+  args: ['manifest', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', '-B']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
   - 'TAGGED_VERSION=$TAG_NAME'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -212,6 +212,7 @@ steps:
   - 'TAGGED_VERSION=$TAG_NAME'
   - 'PROJECT_ROOT=github.com/solo-io/gloo'
   - 'GOPATH=/workspace/gopath'
+  - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
   - 'HELM_HOME=/root/.helm' # tell helm where to find data
   dir: './gopath/src/github.com/solo-io/gloo'
   secretEnv: ['GITHUB_TOKEN']

--- a/docs/cmd/generate_changelog_doc.go
+++ b/docs/cmd/generate_changelog_doc.go
@@ -151,6 +151,7 @@ func generateChangelogMd(opts *options, args []string) error {
 		repo = "gloo"
 		changelogDirPath = "../changelog"
 	case glooEDocGen:
+		// files should already be there because we download them in CI, via `download-glooe-changelog` make target
 		repoRootPath = "../../solo-projects"
 		repo = "solo-projects"
 		changelogDirPath = "../../solo-projects/changelog"

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,5 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.20.4"
+// This will be set by the linker during build
+var EnterpriseTag = UndefinedVersion

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -37,6 +37,7 @@ var _ = BeforeSuite(func() {
 	err = testutils.Make(RootDir, "build-test-chart TEST_ASSET_DIR=\""+dir+"\" BUILD_ID=unit-testing")
 	Expect(err).NotTo(HaveOccurred())
 
+	// Some tests need the Gloo/GlooE version that gets linked into the glooctl binary at build time
 	err = testutils.Make(RootDir, "glooctl")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -1,11 +1,11 @@
 package install_test
 
 import (
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	gotestutils "github.com/solo-io/go-utils/testutils"
 
 	. "github.com/onsi/ginkgo"
@@ -34,6 +34,9 @@ var _ = BeforeSuite(func() {
 	os.Mkdir(dir, 0755)
 
 	err = testutils.Make(RootDir, "build-test-chart TEST_ASSET_DIR=\""+dir+"\" BUILD_ID=unit-testing")
+	Expect(err).NotTo(HaveOccurred())
+
+	err = testutils.Make(RootDir, "glooctl")
 	Expect(err).NotTo(HaveOccurred())
 
 	file = filepath.Join(dir, "gloo-test-unit-testing.tgz")

--- a/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_suite_test.go
@@ -1,10 +1,11 @@
 package install_test
 
 import (
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
 
 	gotestutils "github.com/solo-io/go-utils/testutils"
 

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -2,6 +2,7 @@ package install_test
 
 import (
 	"fmt"
+	"github.com/solo-io/go-utils/testutils/exec"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -61,7 +62,7 @@ var _ = Describe("Install", func() {
 	})
 
 	It("should not error when providing the admin console flag", func() {
-		out, err := testutils.GlooctlOut("install gateway --dry-run --with-admin-console")
+		out, err := exec.RunCommandInputOutput("glooctl", ".", true, "glooctl", "install", "gateway", "--dry-run", "--with-admin-console")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("kind: Namespace"))
 	})

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -2,6 +2,7 @@ package install_test
 
 import (
 	"fmt"
+
 	"github.com/solo-io/go-utils/testutils/exec"
 
 	. "github.com/onsi/ginkgo"

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -2,6 +2,7 @@ package install_test
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/solo-io/go-utils/testutils/exec"
 
@@ -65,7 +66,7 @@ var _ = Describe("Install", func() {
 	It("should not error when providing the admin console flag", func() {
 		// This test fetches the corresponding GlooE helm chart, thus it needs the version that gets linked
 		// into the glooctl binary at build time
-		out, err := exec.RunCommandInputOutput("glooctl", ".", true, "glooctl", "install", "gateway", "--dry-run", "--with-admin-console")
+		out, err := exec.RunCommandOutput(RootDir, true, filepath.Join("_output", "glooctl"), "install", "gateway", "--dry-run", "--with-admin-console")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("kind: Namespace"))
 	})

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -63,6 +63,8 @@ var _ = Describe("Install", func() {
 	})
 
 	It("should not error when providing the admin console flag", func() {
+		// This test fetches the corresponding GlooE helm chart, thus it needs the version that gets linked
+		// into the glooctl binary at build time
 		out, err := exec.RunCommandInputOutput("glooctl", ".", true, "glooctl", "install", "gateway", "--dry-run", "--with-admin-console")
 		Expect(err).NotTo(HaveOccurred())
 		Expect(out).To(ContainSubstring("kind: Namespace"))


### PR DESCRIPTION
cc @mitchdraft 

### Change
* Updates CI to download GlooE changelogs from publicly hosted bucket so Gloo docs generation can generate complete changelogs
* Fixes CI build step to set the expected and missing `GCLOUD_PROJECT_ID` env var

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1482