### PR TITLE
Fix controller pod crash when settings is missing refreshRate

### DIFF
--- a/docs/changelog/v0.20.9/fix-nil-duration-err.yaml
+++ b/docs/changelog/v0.20.9/fix-nil-duration-err.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix controller pod crash when settings is missing 
+    issueLink: https://github.com/solo-io/gloo/issues/1498

--- a/projects/gloo/pkg/defaults/port.go
+++ b/projects/gloo/pkg/defaults/port.go
@@ -1,10 +1,13 @@
 package defaults
 
+import "time"
+
 var HttpPort uint32 = 8080
 var HttpsPort uint32 = 8443
 var EnvoyAdminPort uint32 = 19000
 var GlooXdsPort = 9977
 var GlooValidationPort = 9988
+var DefaultRefreshRate = time.Minute
 
 // Used for testing
 var TcpPort uint32 = 8000

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v2/enterprise/plugins/ratelimit"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
@@ -190,9 +191,12 @@ func (s *setupSyncer) Setup(ctx context.Context, kubeCache kube.SharedCache, mem
 		return errors.Wrapf(err, "parsing validation addr")
 	}
 
-	refreshRate, err := types.DurationFromProto(settings.RefreshRate)
-	if err != nil {
-		return err
+	refreshRate := time.Minute
+	if settings.GetRefreshRate() != nil {
+		refreshRate, err = types.DurationFromProto(settings.GetRefreshRate())
+		if err != nil {
+			return err
+		}
 	}
 
 	writeNamespace := settings.DiscoveryNamespace


### PR DESCRIPTION
# problem

controller pods crash when `refreshRate` is nil

# solution

check for nil `refreshRate`, default to 1m