### PR TITLE
Fix docker permissions to push docs images during release

### DIFF
--- a/changelog/v1.0.0-rc1/fix-docker-release-perms.yaml
+++ b/changelog/v1.0.0-rc1/fix-docker-release-perms.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix docker permissions to push docs images during release.
+    issueLink: https://github.com/solo-io/gloo/issues/1516

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -208,7 +208,6 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/go-make:0.1.12'
   args: ['manifest', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', '-B']
   env:
-  - 'DOCKER_CONFIG=/workspace/docker-config'
   - 'TAGGED_VERSION=$TAG_NAME'
   - 'PROJECT_ROOT=github.com/solo-io/gloo'
   - 'GOPATH=/workspace/gopath'


### PR DESCRIPTION
tested with success here: https://console.cloud.google.com/cloud-build/builds/2000da81-c50b-40a6-a039-a6b7d7e3bd55?project=solo-public
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1516