### PR TITLE
fix handling of docs index files

### DIFF
--- a/docs/conf/conf.d/default.conf
+++ b/docs/conf/conf.d/default.conf
@@ -12,7 +12,7 @@ server {
   location / {
     root   /usr/share/nginx/html/no_auth;
     index  index.html index.htm;
-    try_files $uri $uri/ @docs_error;
+    try_files $uri $uri/index.html @docs_error;
   }
   location @docs_error {
     # this rewrite expects a "docerr" endpoint to be available with a service that logs the failed request path and returns a friendly response


### PR DESCRIPTION
Under the new hosting config, nginx is unable to interpolate the correct index filename.
This change uses the explicit filename generated by Hugo