### PR TITLE
Fix docs highlight

### DIFF
--- a/changelog/v1.0.0-rc2/fix-docker-snippet-in-docs.yaml
+++ b/changelog/v1.0.0-rc2/fix-docker-snippet-in-docs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      A Dockerfile snippet had been interpreted as an invalid Hugo shortcode, causing site generation to fail.
+      Also fixes some `refs`, changing them to `versioned_link_path` shortcodes to handle product/version scope hosting.

--- a/docs/content/dev/writing_auth_plugins/_index.md
+++ b/docs/content/dev/writing_auth_plugins/_index.md
@@ -300,6 +300,12 @@ plugins:
 
 Here is the sample output of a successful run of the script:
 
+```text	
+{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins.header_value_plugin","caller":"pkg/impl.go:39","msg":"Parsed RequiredHeaderAuthService config","requiredHeader":"my-auth-header","allowedHeaderValues":["foo","bar","baz"]}	
+{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"plugins/loader.go:85","msg":"Successfully loaded plugin. Adding it to the plugin chain.","pluginName":"RequiredHeader"}	
+{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"scripts/verify_plugins.go:62","msg":"Successfully verified that plugins can be loaded by Gloo!"}	
+```
+
 {{% notice note %}}
 The script is compiled to run on `linux` with `amd64` architectures. We will explain how it is supposed to be used in the next section.
 {{% /notice %}}

--- a/docs/content/dev/writing_auth_plugins/_index.md
+++ b/docs/content/dev/writing_auth_plugins/_index.md
@@ -300,10 +300,10 @@ plugins:
 
 Here is the sample output of a successful run of the script:
 
-```text	
-{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins.header_value_plugin","caller":"pkg/impl.go:39","msg":"Parsed RequiredHeaderAuthService config","requiredHeader":"my-auth-header","allowedHeaderValues":["foo","bar","baz"]}	
-{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"plugins/loader.go:85","msg":"Successfully loaded plugin. Adding it to the plugin chain.","pluginName":"RequiredHeader"}	
-{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"scripts/verify_plugins.go:62","msg":"Successfully verified that plugins can be loaded by Gloo!"}	
+```text
+{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins.header_value_plugin","caller":"pkg/impl.go:39","msg":"Parsed RequiredHeaderAuthService config","requiredHeader":"my-auth-header","allowedHeaderValues":["foo","bar","baz"]}
+{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"plugins/loader.go:85","msg":"Successfully loaded plugin. Adding it to the plugin chain.","pluginName":"RequiredHeader"}
+{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"scripts/verify_plugins.go:62","msg":"Successfully verified that plugins can be loaded by Gloo!"}
 ```
 
 {{% notice note %}}

--- a/docs/content/dev/writing_auth_plugins/_index.md
+++ b/docs/content/dev/writing_auth_plugins/_index.md
@@ -300,12 +300,6 @@ plugins:
 
 Here is the sample output of a successful run of the script:
 
-```text
-{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins.header_value_plugin","caller":"pkg/impl.go:39","msg":"Parsed RequiredHeaderAuthService config","requiredHeader":"my-auth-header","allowedHeaderValues":["foo","bar","baz"]}
-{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"plugins/loader.go:85","msg":"Successfully loaded plugin. Adding it to the plugin chain.","pluginName":"RequiredHeader"}
-{"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"scripts/verify_plugins.go:62","msg":"Successfully verified that plugins can be loaded by Gloo!"}
-```
-
 {{% notice note %}}
 The script is compiled to run on `linux` with `amd64` architectures. We will explain how it is supposed to be used in the next section.
 {{% /notice %}}
@@ -320,7 +314,7 @@ which we include here since all of it is relevant. You can use it as a starting 
 you use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/) to keep the size of 
 your final image to a minimum. See the comments for an explanation of each build layer:
 
-```Dockerfile
+{{< highlight yaml >}}
 # This stage is parametrized to replicate the same environment GlooE was built in.
 # All ARGs need to be set via the docker `--build-arg` flags.
 ARG GO_BUILD_IMAGE
@@ -374,7 +368,7 @@ COPY --from=build-env /go/src/github.com/solo-io/ext-auth-plugin-examples/plugin
 # This is the command that will be executed when the container is run. 
 # It has to copy the compiled plugin file(s) to a directory.
 CMD cp /compiled-auth-plugins/* /auth-plugins/
-```
+{{< /highlight >}}
 
 The two `GO_BUILD_IMAGE`, `VERIFY_SCRIPT`, and `GC_FLAGS` arguments have to be passed to docker via the `--build-arg` flag(s):
 

--- a/docs/content/gloo_routing/tls/client_tls.md
+++ b/docs/content/gloo_routing/tls/client_tls.md
@@ -195,7 +195,7 @@ kubectl annotate service -n default example-tls-server gloo.solo.io/sslService.s
 {{< /tabs >}}
 
 {{% notice note %}}
-See the [guide on using Service annotations to configure SSL]({{< ref "/gloo_routing/tls/client_tls_service_annotations.md">}}) for 
+See the [guide on using Service annotations to configure SSL]({{< versioned_link_path fromRoot="/gloo_routing/tls/client_tls_service_annotations.md">}}) for
 the full set of options when using Service annotations to configure upstream SSL.
 {{% /notice %}}
 

--- a/docs/content/gloo_routing/tls/client_tls_service_annotations.md
+++ b/docs/content/gloo_routing/tls/client_tls_service_annotations.md
@@ -7,11 +7,11 @@ description: Set up Gloo to route to TLS-encrypted services by using annotations
 
 # Motivation
 
-Gloo can auto-discover SSL configuration for [upstream TLS connections]({{< ref "/gloo_routing/tls/client_tls.md">}}) using annotations on the Kubernetes Service. 
+Gloo can auto-discover SSL configuration for [upstream TLS connections]({{< versioned_link_path fromRoot="/gloo_routing/tls/client_tls.md">}}) using annotations on the Kubernetes Service.
 
 This can be used as a convenient alternative to the [Upstream]({{% protobuf name="gloo.solo.io.Upstream" %}}) to configure Upstream or Client SSL.
 
-This document explains the options for configuring SSL using service annotations. For a step-by-step guide illustrating Upstream SSL in Gloo, see [the Upstream SSL Guide]({{< ref "/gloo_routing/tls/client_tls.md">}})
+This document explains the options for configuring SSL using service annotations. For a step-by-step guide illustrating Upstream SSL in Gloo, see [the Upstream SSL Guide]({{< versioned_link_path fromRoot="/gloo_routing/tls/client_tls.md">}})
 
 # Configuring Upstream SSL Using Kubernetes Secrets
 


### PR DESCRIPTION
- docs could not build because dockerfile snippet was interpreted as a hugo shortcode
- also fixes links that did not support product/version scoping