### PR TITLE
Consolidate 0.20.x docs mgmt logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ docs/helm-values.md
 
 # ignore intermediate files that gomock sometimes generates
 **/gomock_reflect*
+
+## START Temporary exclusion while master/v0.20.x branch is supported
+old_docs_temp_dir/
+## END Temporary exclusion while master/v0.20.x branch is supported

--- a/Makefile
+++ b/Makefile
@@ -452,6 +452,27 @@ ifeq ($(RELEASE),"true")
 		RELEASE=$(RELEASE)
 endif
 
+## START Temporary targets while master/v0.20.x branch is supported
+## Run `GCLOUD_PROJECT_ID=solo-public TAGGED_VERSION=v0-20-11 make publish-v-20-docs -B` manually to produce a docs image with the following properties:
+# - api, cli, changelog content from master/v0.20.x
+# - docs content, hosting config from feature-rc1
+.PHONY: publish-v-20-docs
+publish-v-20-docs: gather-v-20-docs publish-docs
+
+OLD_DOCS_TEMP_DIR := "old_docs_temp_dir"
+.PHONY: gather-v-20-docs
+gather-v-20-docs:
+	# want the changelog files to reflect master
+	git checkout master -- changelog/
+	rm -rf $(OLD_DOCS_TEMP_DIR)
+	mkdir -p $(OLD_DOCS_TEMP_DIR)
+	cd $(OLD_DOCS_TEMP_DIR) && git clone git@github.com:solo-io/solo-docs.git
+	rm docs/content/cli/glooctl*
+	cp $(OLD_DOCS_TEMP_DIR)/solo-docs/gloo/docs/cli/glooctl* docs/content/cli/
+	rm -rf docs/content/api/
+	cp -r $(OLD_DOCS_TEMP_DIR)/solo-docs/gloo/docs/api/ docs/content/api/
+## END Temporary targets while master/v0.20.x branch is supported
+
 #----------------------------------------------------------------------------------
 # Docker
 #----------------------------------------------------------------------------------

--- a/Makefile
+++ b/Makefile
@@ -453,7 +453,9 @@ ifeq ($(RELEASE),"true")
 endif
 
 ## START Temporary targets while master/v0.20.x branch is supported
-## Run `GCLOUD_PROJECT_ID=solo-public TAGGED_VERSION=v0-20-11 make publish-v-20-docs -B` manually to produce a docs image with the following properties:
+# Whenever a new Gloo release is made from the master/v0.20.x branch,
+# run `GCLOUD_PROJECT_ID=solo-public TAGGED_VERSION=v0-20-<PARTICULAR_VERSION> make publish-v-20-docs -B`
+# to manually to produce a docs image with the following properties:
 # - api, cli, changelog content from master/v0.20.x
 # - docs content, hosting config from feature-rc1
 .PHONY: publish-v-20-docs

--- a/changelog/v1.0.0-rc2/consolidate-legacy-docs-mgmt.yaml
+++ b/changelog/v1.0.0-rc2/consolidate-legacy-docs-mgmt.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Include make targets for producing docs images from master/v0.20.x APIs
+      that can be hosted at docs.solo.io/gloo/latest/.


### PR DESCRIPTION
 Include make targets for producing docs images from master/v0.20.x APIs that can be hosted at docs.solo.io/gloo/latest/
