### PR TITLE
Allow envoy to receive initContainers and extra volume definitions through Helm

### DIFF
--- a/changelog/v0.20.12/dual-extauth-deployment.yaml
+++ b/changelog/v0.20.12/dual-extauth-deployment.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >
+      Allow extauth to be deployed as both a standalone service and as a sidecar in
+      the envoy pod simultaneously. We have added the field global.extensions.extAuth.standaloneDeployment
+      to our helm chart and have deprecated (but not removed) the field global.extensions.extAuth.enabled.
+      Setting both extAuth.envoySidecar and extAuth.standaloneDeployment to false should be equivalent
+      to setting extAuth.enabled to false.
+    issueLink: https://github.com/solo-io/gloo/issues/1537

--- a/changelog/v0.20.12/dual-extauth-deployment.yaml
+++ b/changelog/v0.20.12/dual-extauth-deployment.yaml
@@ -1,9 +1,4 @@
 changelog:
   - type: NEW_FEATURE
-    description: >
-      Allow extauth to be deployed as both a standalone service and as a sidecar in
-      the envoy pod simultaneously. We have added the field global.extensions.extAuth.standaloneDeployment
-      to our helm chart and have deprecated (but not removed) the field global.extensions.extAuth.enabled.
-      Setting both extAuth.envoySidecar and extAuth.standaloneDeployment to false should be equivalent
-      to setting extAuth.enabled to false.
+    description: Allow the gateway-proxy pod to optionally receive both init containers to run and extra volumes to define through helm
     issueLink: https://github.com/solo-io/gloo/issues/1537

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -164,15 +164,17 @@ type Job struct {
 }
 
 type GatewayProxy struct {
-	Kind                  *GatewayProxyKind            `json:"kind,omitempty" desc:"value to determine how the gateway proxy is deployed"`
-	PodTemplate           *GatewayProxyPodTemplate     `json:"podTemplate,omitempty"`
-	ConfigMap             *GatewayProxyConfigMap       `json:"configMap,omitempty"`
-	Service               *GatewayProxyService         `json:"service,omitempty"`
-	Tracing               *Tracing                     `json:"tracing,omitempty"`
-	GatewaySettings       *GatewayProxyGatewaySettings `json:"gatewaySettings,omitempty" desc:"settings for the helm generated gateways, leave nil to not render"`
-	ExtraContainersHelper string                       `json:"extraContainersHelper,omitempty"`
-	Stats                 bool                         `json:"stats" desc:"enable prometheus stats"`
-	ReadConfig            bool                         `json:"readConfig" desc:"expose a read-only subset of the envoy admin api"`
+	Kind                      *GatewayProxyKind            `json:"kind,omitempty" desc:"value to determine how the gateway proxy is deployed"`
+	PodTemplate               *GatewayProxyPodTemplate     `json:"podTemplate,omitempty"`
+	ConfigMap                 *GatewayProxyConfigMap       `json:"configMap,omitempty"`
+	Service                   *GatewayProxyService         `json:"service,omitempty"`
+	Tracing                   *Tracing                     `json:"tracing,omitempty"`
+	GatewaySettings           *GatewayProxyGatewaySettings `json:"gatewaySettings,omitempty" desc:"settings for the helm generated gateways, leave nil to not render"`
+	ExtraContainersHelper     string                       `json:"extraContainersHelper,omitempty"`
+	ExtraInitContainersHelper string                       `json:"extraInitContainersHelper",omitempty`
+	ExtraVolumeHelper         string                       `json:"extraVolumeHelper",omitempty`
+	Stats                     bool                         `json:"stats" desc:"enable prometheus stats"`
+	ReadConfig                bool                         `json:"readConfig" desc:"expose a read-only subset of the envoy admin api"`
 }
 
 type GatewayProxyGatewaySettings struct {

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -2,7 +2,6 @@
 {{- include "gloo.updatevalues" . -}}
 {{- end -}}
 {{- if .Values.gateway.enabled }}
-{{- $topScope := . }}
 {{- $global := .Values.global }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
 {{- range $name, $spec := .Values.gatewayProxies }}
@@ -83,7 +82,7 @@ spec:
       serviceAccountName: gateway-proxy
       {{- if $spec.extraInitContainersHelper }}
       initContainers:
-      {{- include $spec.extraInitContainersHelper $topScope | nindent 6 }}
+      {{- include $spec.extraInitContainersHelper $ | nindent 6 }}
       {{- end }}
       containers:
       - args: ["--disable-hot-restart"]
@@ -166,7 +165,7 @@ spec:
 {{- if $spec.extraContainersHelper }}
         - mountPath: /usr/share/shared-data
           name: shared-data
-{{- include $spec.extraContainersHelper $topScope | nindent 6 }}
+{{- include $spec.extraContainersHelper $ | nindent 6 }}
 {{- end }}
       {{- if $spec.kind.daemonSet }}
       {{- if $spec.kind.daemonSet.hostPort}}
@@ -199,7 +198,7 @@ spec:
         emptyDir: {}
       {{- end }}
       {{- if $spec.extraVolumeHelper }}
-      {{- include $spec.extraVolumeHelper $topScope | nindent 6 }}
+      {{- include $spec.extraVolumeHelper $ | nindent 6 }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   {{- if $spec.kind.deployment}}
   replicas: {{ $spec.kind.deployment.replicas }}
-  {{- end}} # if deployment
+  {{- end}}
   selector:
     matchLabels:
       gloo: gateway-proxy
@@ -46,26 +46,26 @@ spec:
       annotations:
       {{- range $key, $value := $spec.podTemplate.extraAnnotations }}
         {{ $key }}: {{ $value | quote }}
-      {{- end }} # range extraAnnotations
-{{- end }} # if extraAnnotations
+      {{- end }}
+{{- end }}
 {{- if $spec.stats }}
 {{- if not $annotationExist }}
 {{- $annotationExist = true}}
       annotations:
-{{- end}} # if not $annotationExist
+{{- end}}
         prometheus.io/path: /metrics
         prometheus.io/port: "8081"
         prometheus.io/scrape: "true"
-{{- end}} # if stats
+{{- end}}
 {{- if $spec.readConfig }}
 {{- if not $annotationExist }}
       annotations:
-{{- end}} # if not annotationsExist
+{{- end}}
         readconfig-stats: /stats
         readconfig-ready: /ready
         readconfig-config_dump: /config_dump
         readconfig-port: "8082"
-{{- end}} # if readConfig
+{{- end}}
     spec:
 {{- if $spec.kind.deployment }}
 {{- if $spec.kind.deployment.antiAffinity }}
@@ -78,8 +78,8 @@ spec:
                 matchLabels:
                   gloo: gateway-proxy
               topologyKey: kubernetes.io/hostname
-{{- end}} # if deployment.antiAffinity
-{{- end}} # if deployment
+{{- end}}
+{{- end}}
       serviceAccountName: gateway-proxy
       {{- if $spec.extraInitContainersHelper }}
       initContainers:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 {{- else }}
 kind: DaemonSet
-{{- end}}
+{{- end}} # if deployment
 metadata:
   labels:
     app: gloo
@@ -27,7 +27,7 @@ metadata:
 spec:
   {{- if $spec.kind.deployment}}
   replicas: {{ $spec.kind.deployment.replicas }}
-  {{- end}}
+  {{- end}} # if deployment
   selector:
     matchLabels:
       gloo: gateway-proxy
@@ -46,26 +46,26 @@ spec:
       annotations:
       {{- range $key, $value := $spec.podTemplate.extraAnnotations }}
         {{ $key }}: {{ $value | quote }}
-      {{- end }}
-{{- end }}
+      {{- end }} # range extraAnnotations
+{{- end }} # if extraAnnotations
 {{- if $spec.stats }}
 {{- if not $annotationExist }}
 {{- $annotationExist = true}}
       annotations:
-{{- end}}
+{{- end}} # if not $annotationExist
         prometheus.io/path: /metrics
         prometheus.io/port: "8081"
         prometheus.io/scrape: "true"
-{{- end}}
+{{- end}} # if stats
 {{- if $spec.readConfig }}
 {{- if not $annotationExist }}
       annotations:
-{{- end}}
+{{- end}} # if not annotationsExist
         readconfig-stats: /stats
         readconfig-ready: /ready
         readconfig-config_dump: /config_dump
         readconfig-port: "8082"
-{{- end}}
+{{- end}} # if readConfig
     spec:
 {{- if $spec.kind.deployment }}
 {{- if $spec.kind.deployment.antiAffinity }}
@@ -78,9 +78,13 @@ spec:
                 matchLabels:
                   gloo: gateway-proxy
               topologyKey: kubernetes.io/hostname
-{{- end}}
-{{- end}}
+{{- end}} # if deployment.antiAffinity
+{{- end}} # if deployment
       serviceAccountName: gateway-proxy
+      {{- if $spec.extraInitContainersHelper }}
+      initContainers:
+      {{ include $spec.extraInitContainersHelper $topScope | nindent 6 }}
+      {{- end }}
       containers:
       - args: ["--disable-hot-restart"]
         env:
@@ -193,6 +197,9 @@ spec:
       {{- if $spec.extraContainersHelper }}
       - name: shared-data
         emptyDir: {}
+      {{- end }}
+      {{- if $spec.extraVolumeHelper }}
+      {{- include $spec.extraVolumeHelper $topScope | nindent 6 }}
       {{- end }}
 {{- end }}
 {{- end }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -16,7 +16,7 @@ apiVersion: apps/v1
 kind: Deployment
 {{- else }}
 kind: DaemonSet
-{{- end}} # if deployment
+{{- end}}
 metadata:
   labels:
     app: gloo

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -83,7 +83,7 @@ spec:
       serviceAccountName: gateway-proxy
       {{- if $spec.extraInitContainersHelper }}
       initContainers:
-      {{ include $spec.extraInitContainersHelper $topScope | nindent 6 }}
+      {{- include $spec.extraInitContainersHelper $topScope | nindent 6 }}
       {{- end }}
       containers:
       - args: ["--disable-hot-restart"]


### PR DESCRIPTION
Allow the gateway-proxy pod to optionally receive both init containers to run and extra volumes to define through helm
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1537