### PR TITLE
Fix NPE on missing matchers in CLI

### DIFF
--- a/changelog/v0.20.13/cli-fix-missing-matcher-panic.yaml
+++ b/changelog/v0.20.13/cli-fix-missing-matcher-panic.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Avoid panicking on routes without matchers when running `glooctl get vs`.
+  issueLink: https://github.com/solo-io/gloo/issues/1563

--- a/projects/gloo/cli/pkg/printers/route.go
+++ b/projects/gloo/cli/pkg/printers/route.go
@@ -88,7 +88,7 @@ func routeDefaultTableRow(r *v1.Route, index int, customItems []string) []string
 func Matcher(r *v1.Route) (string, string, string, string) {
 	var path string
 	var rType string
-	switch p := r.Matcher.PathSpecifier.(type) {
+	switch p := r.GetMatcher().GetPathSpecifier().(type) {
 	case *gloov1.Matcher_Exact:
 		path = p.Exact
 		rType = "Exact Path"
@@ -103,13 +103,13 @@ func Matcher(r *v1.Route) (string, string, string, string) {
 		rType = "Unknown"
 	}
 	verb := "*"
-	if r.Matcher.Methods != nil {
-		verb = strings.Join(r.Matcher.Methods, " ")
+	if methods := r.GetMatcher().GetMethods(); methods != nil {
+		verb = strings.Join(methods, " ")
 	}
 	headers := ""
-	if r.Matcher.Headers != nil {
+	if headerMatchers := r.GetMatcher().GetHeaders(); headerMatchers != nil {
 		builder := bytes.Buffer{}
-		for _, v := range r.Matcher.Headers {
+		for _, v := range headerMatchers {
 			header := *v
 			builder.WriteString(string(header.Name))
 			builder.WriteString(":")

--- a/projects/gloo/cli/pkg/printers/virtualservice.go
+++ b/projects/gloo/cli/pkg/printers/virtualservice.go
@@ -195,7 +195,7 @@ func vhPlugins(v *v1.VirtualService) string {
 }
 
 func matcherString(matcher *gloov1.Matcher) string {
-	switch ps := matcher.PathSpecifier.(type) {
+	switch ps := matcher.GetPathSpecifier().(type) {
 	case *gloov1.Matcher_Exact:
 		return ps.Exact
 	case *gloov1.Matcher_Prefix:

--- a/projects/gloo/cli/pkg/surveyutils/route.go
+++ b/projects/gloo/cli/pkg/surveyutils/route.go
@@ -321,7 +321,7 @@ func SelectRouteFromVirtualServiceInteractive(vs *gatewayv1.VirtualService, rout
 
 	var routes []string
 	for i, r := range vs.VirtualHost.Routes {
-		routes = append(routes, fmt.Sprintf("%v: %+v", i, r.Matcher.PathSpecifier))
+		routes = append(routes, fmt.Sprintf("%v: %+v", i, r.GetMatcher().GetPathSpecifier()))
 	}
 
 	var chosenRoute string

--- a/projects/gloo/pkg/utils/sort_routes.go
+++ b/projects/gloo/pkg/utils/sort_routes.go
@@ -25,6 +25,15 @@ func SortGatewayRoutesByPath(routes []*gatewayv1.Route) {
 }
 
 func lessMatcher(m1, m2 *v1.Matcher) bool {
+
+	// Handle nil matchers by de-prioritizing them.
+	// This is just to handle panics, as Gloo will reject routes with nil matchers
+	if m1 == nil {
+		return false
+	} else if m2 == nil {
+		return true
+	}
+
 	if len(m1.Methods) != len(m2.Methods) {
 		return len(m1.Methods) > len(m2.Methods)
 	}
@@ -43,7 +52,7 @@ const (
 )
 
 func pathTypePriority(m *v1.Matcher) int {
-	switch m.PathSpecifier.(type) {
+	switch m.GetPathSpecifier().(type) {
 	case *v1.Matcher_Exact:
 		return pathPriorityExact
 	case *v1.Matcher_Regex:


### PR DESCRIPTION
Avoid panicking on routes without matchers when running `glooctl get vs`.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1563