### PR TITLE
Handle rate_limit_before_auth setting in its deprecated location

### DIFF
--- a/changelog/v0.20.13/fix-handling-deprecated-ratelimit-settings.yaml
+++ b/changelog/v0.20.13/fix-handling-deprecated-ratelimit-settings.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  description: >
+    Handle the `rate_limit_before_auth` setting in its deprecated location. We currently correctly handle the flag in its
+    new location (`spec.extensions.configs.rate-limit.rate_limit_before_auth`) but ignore it in the
+    deprecated one (`spec.ratelimit_server.rate_limit_before_auth`).
+  issueLink: https://github.com/solo-io/gloo/issues/1572

--- a/projects/gloo/pkg/plugins/ratelimit/plugin.go
+++ b/projects/gloo/pkg/plugins/ratelimit/plugin.go
@@ -61,6 +61,7 @@ func (p *Plugin) handleDeprecatedPluginConfig(params plugins.InitParams) error {
 	p.upstreamRef = settings.RatelimitServerRef
 	p.timeout = settings.RequestTimeout
 	p.denyOnFail = settings.DenyOnFail
+	p.rateLimitBeforeAuth = settings.RateLimitBeforeAuth
 	return nil
 }
 

--- a/projects/gloo/pkg/plugins/ratelimit/plugin.go
+++ b/projects/gloo/pkg/plugins/ratelimit/plugin.go
@@ -46,10 +46,6 @@ func NewPlugin() *Plugin {
 	return &Plugin{}
 }
 
-func (p *Plugin) ShouldRateLimitBeforeAuth() bool {
-	return p.rateLimitBeforeAuth
-}
-
 //TODO(kdorosh) delete once support for old config is dropped
 func (p *Plugin) handleDeprecatedPluginConfig(params plugins.InitParams) error {
 	var settings ratelimit.Settings

--- a/projects/gloo/pkg/plugins/ratelimit/plugin.go
+++ b/projects/gloo/pkg/plugins/ratelimit/plugin.go
@@ -46,6 +46,10 @@ func NewPlugin() *Plugin {
 	return &Plugin{}
 }
 
+func (p *Plugin) ShouldRateLimitBeforeAuth() bool {
+	return p.rateLimitBeforeAuth
+}
+
 //TODO(kdorosh) delete once support for old config is dropped
 func (p *Plugin) handleDeprecatedPluginConfig(params plugins.InitParams) error {
 	var settings ratelimit.Settings

--- a/projects/gloo/pkg/plugins/ratelimit/plugin_test.go
+++ b/projects/gloo/pkg/plugins/ratelimit/plugin_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Plugin", func() {
 		allTests()
 	})
 
-	// TODO(kdorosh) clean this up and remove this higher level context whssen we stop supporting opaque rate-limiting config
+	// TODO(kdorosh) clean this up and remove this higher level context when we stop supporting opaque rate-limiting config
 	Context("strongly-typed config", func() {
 		BeforeEach(beforeEach)
 

--- a/projects/gloo/pkg/plugins/ratelimit/plugin_test.go
+++ b/projects/gloo/pkg/plugins/ratelimit/plugin_test.go
@@ -1,7 +1,9 @@
-package ratelimit
+package ratelimit_test
 
 import (
 	"time"
+
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/ratelimit"
 
 	extauthapi "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/plugins/extauth/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/extauth"
@@ -28,13 +30,13 @@ var _ = Describe("Plugin", func() {
 		rlSettings *ratelimitpb.Settings
 		initParams plugins.InitParams
 		params     plugins.Params
-		rlPlugin   *Plugin
+		rlPlugin   *ratelimit.Plugin
 		extensions *gloov1.Extensions
 		ref        core.ResourceRef
 	)
 
 	beforeEach := func() {
-		rlPlugin = NewPlugin()
+		rlPlugin = ratelimit.NewPlugin()
 		ref = core.ResourceRef{
 			Name:      "test",
 			Namespace: "test",
@@ -61,7 +63,7 @@ var _ = Describe("Plugin", func() {
 				Expect(cfg.FailureModeDeny).To(BeFalse())
 			}
 
-			hundredms := DefaultTimeout
+			hundredms := ratelimit.DefaultTimeout
 			expectedConfig := &envoyratelimit.RateLimit{
 				Domain:          "custom",
 				FailureModeDeny: false,
@@ -84,7 +86,7 @@ var _ = Describe("Plugin", func() {
 		It("default timeout is 100ms", func() {
 			filters, err := rlPlugin.HttpFilters(params, nil)
 			Expect(err).NotTo(HaveOccurred())
-			timeout := DefaultTimeout
+			timeout := ratelimit.DefaultTimeout
 			Expect(filters).To(HaveLen(1))
 			for _, f := range filters {
 				cfg := getConfig(f.HttpFilter)
@@ -132,7 +134,7 @@ var _ = Describe("Plugin", func() {
 			})
 
 			It("should be ordered before ext auth", func() {
-				Expect(rlPlugin.rateLimitBeforeAuth).To(BeTrue())
+				Expect(rlPlugin.ShouldRateLimitBeforeAuth()).To(BeTrue())
 
 				filters, err := rlPlugin.HttpFilters(params, nil)
 				Expect(err).NotTo(HaveOccurred(), "Should be able to build rate limit filters")
@@ -181,7 +183,7 @@ var _ = Describe("Plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			glooExtensions := map[string]*types.Struct{
-				ExtensionName: settingsStruct,
+				ratelimit.ExtensionName: settingsStruct,
 			}
 			extensions = &gloov1.Extensions{
 				Configs: glooExtensions,

--- a/projects/gloo/pkg/plugins/ratelimit/plugin_test.go
+++ b/projects/gloo/pkg/plugins/ratelimit/plugin_test.go
@@ -134,8 +134,6 @@ var _ = Describe("Plugin", func() {
 			})
 
 			It("should be ordered before ext auth", func() {
-				Expect(rlPlugin.ShouldRateLimitBeforeAuth()).To(BeTrue())
-
 				filters, err := rlPlugin.HttpFilters(params, nil)
 				Expect(err).NotTo(HaveOccurred(), "Should be able to build rate limit filters")
 				Expect(filters).To(HaveLen(1), "Should only have created one custom filter")


### PR DESCRIPTION
Handle the `rate_limit_before_auth` setting in its deprecated location. We currently correctly handle the flag in its new location (`spec.extensions.configs.rate-limit.rate_limit_before_auth`) but ignore it in the deprecated one (`spec.ratelimit_server.rate_limit_before_auth`).
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1572