### PR TITLE
Bump go-utils to get new changelog entry types

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -542,12 +542,9 @@
   revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
-  digest = "1:a507e8646bf3775af6f7e7b2a62a5e67d1c6a8f00754f87e66b96181b7f3d747"
+  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
   name = "github.com/golang/mock"
-  packages = [
-    "gomock",
-    "mockgen/model",
-  ]
+  packages = ["gomock"]
   pruneopts = "UT"
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
@@ -1387,7 +1384,7 @@
   revision = "171e4740d00f71bdc66de3aea93a1b8606f1c1a0"
 
 [[projects]]
-  digest = "1:3c22eb15e732e1bc71a679cca21d33f1f074f7cd94cc3dbd69efa74f4c0c5181"
+  digest = "1:953b61fc106fcd8629859c78630015425fa87b29488608b57ac0f01ce9896bf3"
   name = "github.com/solo-io/go-utils"
   packages = [
     "certutils",
@@ -1427,8 +1424,8 @@
     "vfsutils",
   ]
   pruneopts = "UT"
-  revision = "c94685d96e67457ff488e7aba68e9965b40c3fa9"
-  version = "v0.10.21"
+  revision = "fbde466dfa3dd055301e48fa1d7b20c23efceb90"
+  version = "v0.10.24"
 
 [[projects]]
   digest = "1:3f4ac0fb4306bc49eb2111c4898bfb6e98e1ca7805a0b8c7692ebc41ad5dadc3"
@@ -2792,12 +2789,10 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
-    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/ptypes/any",
     "github.com/google/go-github/github",
-    "github.com/google/uuid",
     "github.com/gorilla/mux",
     "github.com/grpc-ecosystem/go-grpc-middleware",
     "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[override]]
   name = "github.com/solo-io/go-utils"
-  version = "0.10.20"
+  version = "0.10.22"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/changelog/v1.0.0-rc2/bump-go-utils.yaml
+++ b/changelog/v1.0.0-rc2/bump-go-utils.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyTag: v0.10.22
+  dependencyRepo: go-utils
+  description: Update go-utils to version v0.10.22 to get the new `HELM` and `UPGRADE` changelog entry types.


### PR DESCRIPTION
Update go-utils to version v0.10.22 to get the new `HELM` and `UPGRADE` changelog entry types.