### PR TITLE
Revamp transformation docs

### DIFF
--- a/changelog/v1.0.0-rc2/revamp-transformation-docs.yaml
+++ b/changelog/v1.0.0-rc2/revamp-transformation-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Improve the existing documentation of Gloo's transformation features.
+  issueLink: https://github.com/solo-io/gloo/issues/1565

--- a/docs/content/gloo_routing/gateway_configuration/access_logging/_index.md
+++ b/docs/content/gloo_routing/gateway_configuration/access_logging/_index.md
@@ -9,7 +9,8 @@ HTTP (L7) connections as well at TCP (L4).
 
 # Access Logging
 
-The envoy documentation on Access Logging can be found [here](https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/access_log#config-access-log-default-format)
+The envoy documentation on Access Logging can be found 
+[here](https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/access_log#config-access-log-default-format).
 
 #### Usage
 
@@ -24,7 +25,8 @@ Possible use cases include:
 
 The following explanation assumes that the user has gloo `v0.18.1+` running, as well as some previous knowledge of Gloo resources, and how to use them. In order to install Gloo if it is not already please refer to the following [tutorial](../../../installation/gateway/kubernetes). The only Gloo resource involved in enabling Access Loggins is the `Gateway`. Further Documentation can be found [here]({{< protobuf name="gateway.solo.io.Gateway">}}).
 
-Enabling access logs in Gloo is as simple as adding a [listener plugin](../../gateway_configuration/) to any one of the gateway resources. The documentation for the `Access Logging Service` plugin API can be found [here]({{< protobuf name="als.plugins.gloo.solo.io.AccessLog">}}).
+Enabling access logs in Gloo is as simple as adding a [listener plugin](../../gateway_configuration/) to any one of the gateway resources. 
+The documentation for the `Access Logging Service` plugin API can be found {{< protobuf display="here" name="als.plugins.gloo.solo.io.AccessLog">}}.
 
 Gloo supports two types of Access Logging. `File Sink` and `GRPC`.
 
@@ -38,6 +40,12 @@ Within the `File Sink` category of Access Logs there are 2 options for output, t
 These are mutually exclusive for a given Access Logging configuration, but any number of access logging configurations can be applied to any place in the API which supports Access Logging. All `File Sink` configurations also accept a file path which envoy logs to. If the desired behavior is for these logs to output to `stdout` along with the other envoy logs then use the value `/dev/stdout` as the path.
 
 The documentation on envoy formatting directives can be found [here](https://www.envoyproxy.io/docs/envoy/v1.10.0/configuration/access_log#format-dictionaries)
+
+{{% notice note %}}
+See [**this guide**]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs" >}}) 
+to see how to include custom attributes in your access logs by leveraging Gloo's 
+[**transformation API**]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations" >}}).
+{{% /notice %}}
 
 ##### String formatted
 

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
@@ -1,52 +1,291 @@
 ---
 title: Transformations
 weight: 10
-description: Transform requests and responses by using the Gloo transformation filter
+description: Use the Gloo Transformation API to transform requests and responses
 ---
 
-[Inja Templates](https://github.com/pantor/inja/tree/74ad4281edd4ceca658888602af74bf2050107f0) give you a powerful way
-to process JSON formatted data. For example, if you had a message body that contained the JSON `{ "name": "world" }`
-then the Inja template `Hello {{ name }}` would become `Hello world`. The template variables, e.g., `{{ name }}`, is
-used as the key into a JSON object and is replaced with the key's associated value.
+One of the core features of any API Gateway is the ability to transform the traffic that it manages. To really enable the 
+decoupling of your services, the API Gateway should be able to mutate requests before forwarding them to your 
+upstream services and do the same with the resulting responses before they reach the downstream clients. 
+Gloo delivers on this promise by providing you with a powerful transformation API.
+
+## Defining a transformation
+Transformations are defined by adding the `transformations` attribute to your Virtual Services.
+You can define this attribute on three different Virtual Service sub-resources:
+ 
+- on **VirtualHosts**,
+- on **Routes**, and
+- on **WeightedDestinations**.
+
+The configuration format is the same in all three cases and must be specified under the relevant `plugins` attribute 
+(`VirtualHostPlugins`, `RoutePlugins`, or `WeightedDestinationPlugins`). For example, to configure transformations for 
+all traffic matching a Virtual Host, you need to add the following attribute to your Virtual Host definition:
+
+{{< highlight yaml "hl_lines=3-11" >}}
+# This snippet has been abridged for brevity
+virtualHost:
+  virtualHostPlugins:
+    transformations:
+      requestTransformation: 
+        transformationTemplate:
+          headers:
+            foo:
+              text: 'bar'
+{{< /highlight >}}
+
+In case of a Route or Weighted Destination the top attribute would be named `routePlugins` and `weightedDestinationPlugins` respectively.
+
+#### Inheritance rules
+
+By default, a transformation defined on a Virtual Service attribute is **inherited** by all the child attributes:
+
+- transformations defined on `VirtualHosts` are inherited by `Route`s and `WeightedDestination`s.
+- transformations defined on `Route`s are inherited by `WeightedDestination`s.
+
+If however a child attribute defines its own transformation, it will override the configuration on its parent.
+
+### Configuration format
+In this section we will detail all the properties of the `transformations` [object]({{< protobuf name="envoy.api.v2.filter.http.RouteTransformations" >}}),
+which has the following structure:
+
+```yaml
+transformations:
+  clearRouteCache: bool
+  requestTransformation: {}
+  responseTransformation: {}
+```
+
+The `clearRouteCache` attribute is a boolean value that determines whether the route cache should be cleared if the 
+request transformation was applied. If the transformation modifies the headers in a way that affects routing, this 
+attribute must be set to `true`.
+
+The `requestTransformation` and `responseTransformation` attributes have the 
+[same format]({{< protobuf name="envoy.api.v2.filter.http.Transformation" >}}) and specify transformations that 
+will be applied to requests and responses respectively. The format can take one of two forms:
+
+- `headerBodyTransform`: this type of transformation will make all the headers available in the body. The result will be 
+a JSON body that consists of two attributes: `headers`, containing the headers, and `body`, containing the original body.
+- `transformationTemplate`: this type of transformation allows you to define transformation templates. This is the more 
+powerful and flexible type of transformation. We will spend the rest of this guide to describe its properties.
+
+#### Transformation templates
+[Templates]({{< protobuf name="envoy.api.v2.filter.http.TransformationTemplate" >}}) are the core of Gloo's 
+transformation API. They allow you to mutate the headers and bodies of requests and responses based on the properties of 
+the headers and bodies themselves. The following snippet illustrates the structure of the `transformationTemplate` object:
+
+```yaml
+transformationTemplate:
+  parseBodyBehavior: {}
+  ignoreErrorOnParse: bool
+  extractors:  {}
+  headers: {}
+  # Only one of body, passthrough, and mergeExtractorsToBody can be specified
+  body: {} 
+  passthrough: {}
+  mergeExtractorsToBody: {}
+  dynamicMetadataValues: []
+  advancedTemplates: bool
+```
 
 {{% notice note %}}
-Inja Templates default to using `.` notation for JSON keys, i.e., `address.street` => `{ "address": { "street": "value" } }`.
-If `advancedTemplates` is `true`, Inja Templates use `/` notation, i.e., `address/street` => `{ "address": { "street": "value" } }`
+The `body`, `passthrough`, and `mergeExtractorsToBody` attributes define three different ways of handling the body of 
+the request/response. Please note that **only one of them may be set**, otherwise Gloo will reject the `transformationTemplate`.
 {{% /notice %}}
 
-Gloo adds two additional functions that can be used within templates.
+Let's go ahead and describe each one of these attribute in detail.
 
-* `header` - returns the value of the specified header name, e.g., `{{ header("date") }}`
-* `extraction` - returns the value of the specified extractor name, e.g. `{{ extraction("date") }}`. Only needed when
-`advancedTemplates` is set to `true`, otherwise extractor values are available in the templates using their name as key
+##### parseBodyBehavior
+This attribute determines how the request/response body will be parsed and can have one of two values:
 
-{{< highlight yaml "hl_lines=20-30" >}}
-apiVersion: gateway.solo.io/v1
-kind: VirtualService
-metadata:
-  name: 'default'
-  namespace: 'gloo-system'
-spec:
-  virtualHost:
-    domains:
-    - '*'
-    routes:
-    - matcher:
-        prefix: '/'
-      routeAction:
-        single:
-          upstream:
-            name: 'jsonplaceholder-80'
-            namespace: 'gloo-system'
-      routePlugins:
-        transformations:
-          responseTransformation:
-            transformation_template:
-              body:
-                text: 'extractor ({{ foo }}) header ({{ header("date")}}) json ({{ phone }})'
-              extractors:
-                foo:
-                  header: 'date'
-                  regex: '\w*, (.+):(.+):(.+) GMT'
-                  subgroup: 2
-{{< /highlight >}}
+- `ParseAsJson`: Gloo will attempt to parse the body as a JSON structure. This is the default behavior.
+- `DontParse`: the body will be treated as plain text.
+
+As we will [see later](#templating-language), some of the templating features won't be available when treating the body as plain text.
+
+##### ignoreErrorOnParse
+If set to true, Envoy will not throw an exception in case the body parsing fails.
+
+##### extractors
+Use this attribute to extract information from a request or response. It consists of a set of mappings from a string 
+to an `extraction`: 
+
+- the `extraction` defines which information will be extracted
+- the string key will provide the extractor with a name it can be referred by.
+
+An extraction must have one of two sources:
+
+- `header`: extract information from a header with the given name.
+    ```yaml
+    extractors:
+      myExtractor:
+        header: 'foo'
+    ```
+- `header`: extract information from the body. This attribute takes an empty value (as there is always only one body).
+    ```yaml
+    extractors:
+      myExtractor:
+        body: {}
+    ```
+
+{{% notice note %}}
+The `body` extraction source has been introduced with **Gloo**, release 0.20.12, and **Gloo Enterprise**, release 0.20.7. 
+If you are using an earlier version, it will not work.
+{{% /notice %}}
+
+An extraction must also define which information is to be extracted from the source. This can be done by providing a 
+regular expression via the `regex` attribute. The regular expression will be applied to the body or to the value of 
+relevant header. If your regular expression uses _capturing groups_, you can select the group match you want to use via 
+the `subgroup` attribute.
+
+As an example, to define an extraction named `foo` which will contain the value of the `foo` query parameter 
+you can apply the following configuration:
+
+```yaml
+extractors:
+  # This is the name of the extraction
+  foo:
+    # The :path pseudo-header contains the URI
+    header: ':path'
+    # Use a nested capturing group to extract the query param
+    regex: '(.*foo=([^&]*).*)'
+    # Select the second group match
+    subgroup: 2
+```
+
+Extracted values can be used in two ways:
+- You can reference extractors by their name in template strings, e.g. `{{ my-extractor }}` will render to the value of 
+  the `my-extractor` extractor.
+- You can use them in conjunction with the `mergeExtractorsToBody` body transformation type to merge them into the body.
+
+##### headers
+Use this attribute to apply templates to request/response headers. It consists of a map where each key determines the name of 
+the resulting header, while the corresponding value is a [template]({{< protobuf name="envoy.api.v2.filter.http.InjaTemplate" >}}) 
+which will determine the value.
+
+For example, to set the header `foo` to the value of the header `bar`, you could use the following configuration:
+
+```yaml
+transformationTemplate:
+  headers:
+    foo:
+      text: '{{ header("bar") }}'
+```
+
+See the [template language section](#templating-language) for more details about template strings.
+
+##### body
+Use this attribute to apply templates to the request/response body. It consists of a template string that will determine 
+the content of the resulting body.
+
+As an example, the following configuration snippet could be used to transform a response body only if the HTTP 
+response code is `404` and preserve the original response body in other cases.
+
+```yaml
+transformationTemplate:
+  # [...]
+  body: 
+    text: '{% if header(":status") == "404" %}{ "error": "Not found!" }{% else %}{{ body() }}{% endif %}'
+  # [...]
+```
+
+See the [template language section](#templating-language) for more details about template strings.
+
+##### passthrough
+In some cases your do not need to transform the request/response body nor extract information from it. In these cases, 
+particularly if the payload is large, you should use the `passthrough` attribute to instruct Gloo to ignore the body 
+(i.e. to not buffer it). The attribute always takes just the empty value:
+
+```yaml
+transformationTemplate:
+  # [...]
+  passthrough: {}
+  # [...]
+```
+
+##### mergeExtractorsToBody
+Use this type of body transformation to merge all the `extractions` defined in the `transformationTemplate` to the body.
+The values of the extractions will be merged to a location in the body JSON determined by their names. You can use separators 
+in the extractor names to nest elements inside the body.
+
+For an example, see the following configuration:
+
+```yaml
+transformationTemplate:
+  mergeExtractorsToBody: {}
+  extractors:
+  path:
+    header: ':path'
+    regex: '.*'
+  # The name of this attribute determines where the value will be nested in the body
+  host.name:
+    header: 'host'
+    regex: '.*'
+```
+
+This will cause the resulting body to include the following extra attributes (in additional to the original ones):
+
+```json
+{
+  "path": "/the/request/path",
+  "host": {
+    "name": "value of the 'host' header"
+  }
+}
+```
+
+##### dynamicMetadataValues
+This attribute can be used to define an [Envoy Dynamic Metadata](https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata) 
+entry. This metadata can be used by other filters in the filter chain to implement custom behavior.
+
+As an example, the following configuration creates a dynamic metadata entry in the `com.example` namespace with key  `foo` and 
+value equal to that of the `foo` header . 
+
+```yaml
+dynamicMetadataValues:
+- metadataNamespace: "com.example"
+  key: 'foo'
+  value:
+    text: '{{ header("foo") }}'
+
+```
+
+The `metadataNamespace` is optional. It defaults to the namespace of the Gloo transformation filter name, i.e. `io.solo.transformation`.
+
+A common use case for this attribute is to define custom data to be included in your access logs. See the 
+[dedicated tutorial]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs" >}}) 
+for an example of how this can be achieved.
+
+##### advancedTemplates
+This attribute determines which notation to use when accessing elements in JSON structures. If set to `true`, Gloo will 
+expect JSON pointer notation (e.g. "time/start") instead of dot notation (e.g. "time.start"). Defaults to `false`.
+
+Please note that, if set to `true`, you will need to use the `extraction` function to access extractors in template 
+strings (e.g. `{{ extraction("myExtractor") }}`); if the default value of `false` is used, extractors will
+simply be available by their name (e.g. `{{ myExtractor }}`).
+
+#### Templating language
+{{% notice note %}}
+Templates can be used only if the request/response payload is a JSON string.
+{{% /notice %}}
+
+Gloo templates are powered by the [Inja](https://github.com/pantor/inja) template engine, which is inspired by 
+the popular [Jinja](https://palletsprojects.com/p/jinja/) templating language in Python. 
+When writing you templates, you can take advantage of all the core _Inja_ features, i.a. loops, conditional logic, 
+and functions.
+
+In addition to the standard functions available in the core _Inja_ library, you can use additional custom functions that 
+we have added:
+
+- `header(header_name)`: returns the value of the header with the given name.
+- `extraction(extractor_name)`: returns the value of the extractor with the given name.
+- `env(env_var_name)`: returns the value of the environment variable with the given name.
+- `body()`: returns the request/response body.
+- `context()`: returns the base JSON context (allowing for example to range on a JSON body that is an array).
+You can use templates to mutate [headers](#headers), the [body](#body), and [dynamic metadata](#dynamicmetadatavalues).
+
+### Common use cases
+On this page we have seen all the properties of the Gloo Transformation API as well as some simple example snippets. 
+If are looking for complete examples, please check out the following tutorials, which will guide you through 
+some of the most common transformation use cases.
+
+{{% children description="true" %}}

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
@@ -281,6 +281,7 @@ we have added:
 - `env(env_var_name)`: returns the value of the environment variable with the given name.
 - `body()`: returns the request/response body.
 - `context()`: returns the base JSON context (allowing for example to range on a JSON body that is an array).
+
 You can use templates to mutate [headers](#headers), the [body](#body), and [dynamic metadata](#dynamicmetadatavalues).
 
 ### Common use cases

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
@@ -92,7 +92,7 @@ The `body`, `passthrough`, and `mergeExtractorsToBody` attributes define three d
 the request/response. Please note that **only one of them may be set**, otherwise Gloo will reject the `transformationTemplate`.
 {{% /notice %}}
 
-Let's go ahead and describe each one of these attribute in detail.
+Let's go ahead and describe each one of these attributes in detail.
 
 ##### parseBodyBehavior
 This attribute determines how the request/response body will be parsed and can have one of two values:

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
@@ -153,7 +153,9 @@ extractors:
 ```
 
 Extracted values can be used in two ways:
-- You can reference extractors by their name in template strings, e.g. `{{ my-extractor }}` will render to the value of 
+
+- You can reference extractors by their name in template strings, e.g. `{{ my-extractor }}` 
+(or `{{ extraction(my-extractor) }}`, if you are setting `advancedTemplates` to `true`) will render to the value of 
   the `my-extractor` extractor.
 - You can use them in conjunction with the `mergeExtractorsToBody` body transformation type to merge them into the body.
 

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
@@ -45,7 +45,7 @@ By default, a transformation defined on a Virtual Service attribute is **inherit
 If however a child attribute defines its own transformation, it will override the configuration on its parent.
 
 ### Configuration format
-In this section we will detail all the properties of the `transformations` [object]({{< protobuf name="envoy.api.v2.filter.http.RouteTransformations" >}}),
+In this section we will detail all the properties of the `transformations` {{< protobuf display="object" name="envoy.api.v2.filter.http.RouteTransformations" >}},
 which has the following structure:
 
 ```yaml
@@ -57,10 +57,10 @@ transformations:
 
 The `clearRouteCache` attribute is a boolean value that determines whether the route cache should be cleared if the 
 request transformation was applied. If the transformation modifies the headers in a way that affects routing, this 
-attribute must be set to `true`.
+attribute must be set to `true`. The default value is `false`.
 
 The `requestTransformation` and `responseTransformation` attributes have the 
-[same format]({{< protobuf name="envoy.api.v2.filter.http.Transformation" >}}) and specify transformations that 
+{{< protobuf display="same format" name="envoy.api.v2.filter.http.Transformation" >}} and specify transformations that 
 will be applied to requests and responses respectively. The format can take one of two forms:
 
 - `headerBodyTransform`: this type of transformation will make all the headers available in the body. The result will be 
@@ -69,7 +69,7 @@ a JSON body that consists of two attributes: `headers`, containing the headers, 
 powerful and flexible type of transformation. We will spend the rest of this guide to describe its properties.
 
 #### Transformation templates
-[Templates]({{< protobuf name="envoy.api.v2.filter.http.TransformationTemplate" >}}) are the core of Gloo's 
+{{< protobuf display="Templates" name="envoy.api.v2.filter.http.TransformationTemplate" >}} are the core of Gloo's 
 transformation API. They allow you to mutate the headers and bodies of requests and responses based on the properties of 
 the headers and bodies themselves. The following snippet illustrates the structure of the `transformationTemplate` object:
 
@@ -103,7 +103,7 @@ This attribute determines how the request/response body will be parsed and can h
 As we will [see later](#templating-language), some of the templating features won't be available when treating the body as plain text.
 
 ##### ignoreErrorOnParse
-If set to true, Envoy will not throw an exception in case the body parsing fails.
+If set to `true`, Envoy will not throw an exception in case the body parsing fails. Defaults to `false`.
 
 ##### extractors
 Use this attribute to extract information from a request or response. It consists of a set of mappings from a string 
@@ -161,7 +161,7 @@ Extracted values can be used in two ways:
 
 ##### headers
 Use this attribute to apply templates to request/response headers. It consists of a map where each key determines the name of 
-the resulting header, while the corresponding value is a [template]({{< protobuf name="envoy.api.v2.filter.http.InjaTemplate" >}}) 
+the resulting header, while the corresponding value is a {{< protobuf display="template" name="envoy.api.v2.filter.http.InjaTemplate" >}} 
 which will determine the value.
 
 For example, to set the header `foo` to the value of the header `bar`, you could use the following configuration:

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/add_headers_to_body/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/add_headers_to_body/_index.md
@@ -40,12 +40,14 @@ glooctl add route --name update-request-path --path-prefix / --dest-name postman
 We will be sending POST requests to the upstream, so let's create a simple JSON file that will constitute our request 
 body. Create a file named `data.json` with the following content in your current working directory:
 
-```json
+```shell
+cat << EOF > data.json
 {
   "payload": {
     "foo": "bar"
   }
 }
+EOF
 ```
 
 Let's test that the configuration was correctly picked up by Gloo by executing the following command:

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/add_headers_to_body/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/add_headers_to_body/_index.md
@@ -1,0 +1,200 @@
+---
+title: Add headers to the body
+weight: 40
+description: Adding request/response headers to the body
+---
+
+In this tutorial we will see how to extract headers and add them to the JSON body of a request (or a response).
+
+### Setup
+{{< readfile file="/static/content/setup_postman_echo.md" markdown="true">}}
+
+Let's also create a simple Virtual Service that matches any path and routes all traffic to our Upstream:
+
+{{< tabs >}}
+{{< tab name="kubectl" codelang="yaml">}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: headers-to-body
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+{{< /tab >}}
+{{< tab name="glooctl" codelang="shell">}}
+glooctl create vs --name update-request-path --namespace gloo-system 
+glooctl add route --name update-request-path --path-prefix / --dest-name postman-echo
+{{< /tab >}}
+{{< /tabs >}}
+
+We will be sending POST requests to the upstream, so let's create a simple JSON file that will constitute our request 
+body. Create a file named `data.json` with the following content in your current working directory:
+
+```json
+{
+  "payload": {
+    "foo": "bar"
+  }
+}
+```
+
+Let's test that the configuration was correctly picked up by Gloo by executing the following command:
+
+```shell
+curl -H "Content-Type: application/json" $(glooctl proxy url)/post -d @data.json | jq
+```
+
+You should get a response with status `200` and a JSON body similar to this:
+
+```json
+{
+  "args": {},
+  "data": {
+    "payload": {
+      "foo": "bar"
+    }
+  },
+  "files": {},
+  "form": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "content-length": "35",
+    "accept": "*/*",
+    "content-type": "application/json",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "2ae7b930-bf4f-476e-9c56-d3cec1c564d1",
+    "x-forwarded-port": "80"
+  },
+  "json": {
+    "payload": {
+      "foo": "bar"
+    }
+  },
+  "url": "https://postman-echo.com/post"
+}
+```
+
+### Updating the response code
+As you can see from the response above, the upstream service echoes the JSON payload we included in our request inside 
+the `data` response body attribute. We will now configure Gloo to add the values of two headers to the body:
+
+- the value of the `root` header will be added to a new `root` attribute at the top level of the JSON body,
+- the value of the `nested` header will be added to a new `nested` attribute inside the `payload` attribute.
+
+#### Update Virtual Service
+To implement this behavior, we need to add the following to our Virtual Service definition:
+
+{{< highlight yaml "hl_lines=18-36" >}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: headers-to-body
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+    virtualHostPlugins:
+      transformations:
+        requestTransformation:
+          transformation_template:
+            # Merge the specified extractors to the request body
+            merge_extractors_to_body: {}
+            extractors:
+              # The name of this attribute determines where the value will be nested in the body (using dots)
+              root:
+                # Name of the header to extract
+                header: 'root'
+                # Regex to apply to it, this is needed
+                regex: '.*'
+              # The name of this attribute determines where the value will be nested in the body (using dots)
+              payload.nested:
+                # Name of the header to extract
+                header: 'nested'
+                # Regex to apply to it, this is needed
+                regex: '.*'
+{{< /highlight >}}
+
+The above `virtualHostPlugins` configuration is to be interpreted as following:
+
+1. Add a transformation to all traffic handled by this Virtual Host.
+1. Apply the transformation only to responses.
+1. Use a [template transformation]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#transformation-templates" >}}).
+1. Define two [extractions]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#extractors" >}}) 
+to extract the required headers from the request. You can control where the values will be nested in the body by using 
+separators in their names (dots if `advancedTemplates` is `false`, forward slashes otherwise).
+1. Merge the defined extractions to the request body.
+
+#### Test our configuration
+To test that our configuration has been correctly applied, let's execute `curl` command again, adding the two headers:
+
+```shell
+curl -H "Content-Type: application/json" -H "root: root-val" -H "nested: nested-val" $(glooctl proxy url)/post -d @data.json | jq
+```
+
+You should get the following output, indicating that the headers have been merged into the request body at the expected 
+locations:
+
+{{< highlight json "hl_lines=6 8" >}}
+{
+  "args": {},
+  "data": {
+    "payload": {
+      "foo": "bar",
+      "nested": "nested-val"
+    },
+    "root": "root-val"
+  },
+  "files": {},
+  "form": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "content-length": "65",
+    "accept": "*/*",
+    "content-type": "application/json",
+    "nested": "nested-val",
+    "root": "root-val",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "57c255fc-9412-4bf8-97cb-e7f495240703",
+    "x-forwarded-port": "80"
+  },
+  "json": {
+    "payload": {
+      "foo": "bar",
+      "nested": "nested-val"
+    },
+    "root": "root-val"
+  },
+  "url": "https://postman-echo.com/post"
+}
+{{< /highlight >}}
+
+### Cleanup
+To cleanup the resources created in this tutorial you can run the following commands:
+
+```shell
+kubectl delete virtualservice -n gloo-system headers-to-body
+kubectl delete upstream -n gloo-system postman-echo
+```

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/change_response_status/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/change_response_status/_index.md
@@ -128,9 +128,9 @@ spec:
 The above `virtualHostPlugins` configuration is to be interpreted as following:
 
 1. Add a transformation to all traffic handled by this Virtual Host.
-2. Apply the transformation only to responses.
-3. Use a [template transformation]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#transformation-templates" >}}).
-4. Transform the ":status" pseudo-header according to the template string.
+1. Apply the transformation only to responses.
+1. Use a [template transformation]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#transformation-templates" >}}).
+1. Transform the ":status" pseudo-header according to the template string.
 
 The template uses the [Inja templating language]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#templating-language" >}}) 
 to define the conditional logic that will be applied to the ":status" header.

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/change_response_status/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/change_response_status/_index.md
@@ -43,12 +43,14 @@ glooctl add route --name update-response-code --path-prefix / --dest-name postma
 We will be sending POST requests to the upstream, so let's create a simple JSON file that will constitute our request 
 body. Create a file named `data.json` with the following content in your current working directory:
 
-```json
+```shell
+cat << EOF > data.json
 {
   "error": {
     "message": "This is an error"
   }
 }
+EOF
 ```
 
 Let's test that the configuration was correctly picked up by Gloo by executing the following command:
@@ -151,10 +153,13 @@ You should get the following output, representing the response code:
 
 Now let's update the `data.json` file to turn `error` into an empty object:
 
-```json
+
+```shell
+cat << EOF > data.json
 {
   "error": {}
 }
+EOF
 ```
 
 If you execute the same `curl` command again, you should now get a `200` response:

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/change_response_status/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/change_response_status/_index.md
@@ -1,0 +1,173 @@
+---
+title: Change response status
+weight: 10
+description: Conditionally update the status of an HTTP response
+---
+
+Sometimes an upstream service does not communicate a failure via HTTP response status codes, but rather includes the 
+failure information within the response body. But what if some of your downstream clients expect the status code to be set?
+In this tutorial we will see how to use transformations to change the HTTP status code based on the contents of the 
+response payload.
+
+### Setup
+{{< readfile file="/static/content/setup_postman_echo.md" markdown="true">}}
+
+Let's also create a simple Virtual Service that matches any path and routes all traffic to our Upstream:
+
+{{< tabs >}}
+{{< tab name="kubectl" codelang="yaml">}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: update-response-code
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+{{< /tab >}}
+{{< tab name="glooctl" codelang="shell">}}
+glooctl create vs --name update-response-code --namespace gloo-system 
+glooctl add route --name update-response-code --path-prefix / --dest-name postman-echo
+{{< /tab >}}
+{{< /tabs >}}
+
+We will be sending POST requests to the upstream, so let's create a simple JSON file that will constitute our request 
+body. Create a file named `data.json` with the following content in your current working directory:
+
+```json
+{
+  "error": {
+    "message": "This is an error"
+  }
+}
+```
+
+Let's test that the configuration was correctly picked up by Gloo by executing the following command:
+
+```shell
+curl -v -H "Content-Type: application/json" $(glooctl proxy url)/post -d @data.json | jq
+```
+
+You should get a response with status `200` and a JSON body similar to this:
+
+```json
+{
+  "args": {},
+  "data": {
+    "error": {
+      "message": "This is an error"
+    }
+  },
+  "files": {},
+  "form": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "content-length": "50",
+    "accept": "*/*",
+    "content-type": "application/json",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "65c4cf68-0a92-4650-a1a0-3d6104d24e51",
+    "x-forwarded-port": "80"
+  },
+  "json": {
+    "error": {
+      "message": "This is an error"
+    }
+  },
+  "url": "https://postman-echo.com/post"
+}
+```
+
+### Updating the response code
+As you can see from the response above, the upstream service echoes the JSON payload we included in our request inside 
+the `data` response body attribute. We will now configure Gloo to change the response status to 400 if the `data.error` 
+attribute is present; otherwise, the original status code should be preserved.
+
+#### Update Virtual Service
+To implement this behavior, we need to add the following to our Virtual Service definition:
+
+{{< highlight yaml "hl_lines=18-33" >}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: update-response-code
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+    virtualHostPlugins:
+      transformations:
+        responseTransformation:
+          transformationTemplate:
+            headers:
+              # We set the response status via the :status pseudo-header based on the response code
+              ":status":
+                text: '{% if default(data.error.message, "") != "" %}400{% else %}{{ header(":status") }}{% endif %}'
+{{< /highlight >}}
+
+The above `virtualHostPlugins` configuration is to be interpreted as following:
+
+1. Add a transformation to all traffic handled by this Virtual Host.
+2. Apply the transformation only to responses.
+3. Use a [template transformation]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#transformation-templates" >}}).
+4. Transform the ":status" pseudo-header according to the template string.
+
+The template uses the [Inja templating language]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#templating-language" >}}) 
+to define the conditional logic that will be applied to the ":status" header.
+
+#### Test our configuration
+To test that our configuration has been correctly applied, let's execute `curl` command again, with a slight 
+modification so that it will only output the status code:
+
+```shell
+curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" $(glooctl proxy url)/post -d @data.json
+```
+
+You should get the following output, representing the response code:
+
+```
+400%
+```
+
+Now let's update the `data.json` file to turn `error` into an empty object:
+
+```json
+{
+  "error": {}
+}
+```
+
+If you execute the same `curl` command again, you should now get a `200` response:
+
+```shell
+curl -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" $(glooctl proxy url)/post -d @data.json
+200%
+```
+
+### Cleanup
+To cleanup the resources created in this tutorial you can run the following commands:
+
+```shell
+kubectl delete virtualservice -n gloo-system update-response-code
+kubectl delete upstream -n gloo-system postman-echo
+```

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs/_index.md
@@ -1,0 +1,282 @@
+---
+title: Enrich Gloo access logs
+weight: 10
+description: Use transformations to craft custom attributes in access logs.
+---
+
+In this tutorial we will see how to use transformations to add custom attributes to your 
+[Access Logs]({{< ref "gloo_routing/gateway_configuration/access_logging" >}}).
+
+### Setup
+{{< readfile file="/static/content/setup_postman_echo.md" markdown="true">}}
+
+Let's also update the default `Gateway` resource to enable access logging:
+
+{{< highlight yaml "hl_lines=14-38" >}}
+apiVersion: gateway.solo.io.v2/v2
+kind: Gateway
+metadata:
+  labels:
+    app: gloo
+  name: gateway-proxy-v2
+  namespace: gloo-system
+proxyNames:
+- gateway-proxy-v2
+spec:
+  bindAddress: '::'
+  bindPort: 8080
+  httpGateway: {}
+  plugins:
+    accessLoggingService:
+      accessLog:
+      - fileSink:
+          jsonFormat:
+            # HTTP method name
+            httpMethod: '%REQ(:METHOD)%'
+            # Protocol. Currently either HTTP/1.1 or HTTP/2.
+            protocol: '%PROTOCOL%'
+            # HTTP response code. Note that a response code of ‘0’ means that the server never sent the
+            # beginning of a response. This generally means that the (downstream) client disconnected.
+            responseCode: '%RESPONSE_CODE%'
+            # Total duration in milliseconds of the request from the start time to the last byte out
+            clientDuration: '%DURATION%'
+            # Total duration in milliseconds of the request from the start time to the first byte read from the upstream host
+            targetDuration: '%RESPONSE_DURATION%'
+            # Value of the "x-envoy-original-path" header (falls back to "path" header if not present)
+            path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+            # Upstream cluster to which the upstream host belongs to
+            upstreamName: '%UPSTREAM_CLUSTER%'
+            # Request start time including milliseconds.
+            systemTime: '%START_TIME%'
+            # Unique tracking ID
+            requestId: '%REQ(X-REQUEST-ID)%'
+          path: /dev/stdout
+{{< /highlight >}}
+
+This configures the Gateway to create a log entry in JSON format for all incoming requests and write it to the standard 
+output stream. For more information about access logging, see the 
+[correspondent section]({{< ref "gloo_routing/gateway_configuration/access_logging" >}}) of the docs.
+
+Finally, let's create a simple Virtual Service that matches any path and routes all traffic to our Upstream:
+
+{{< tabs >}}
+{{< tab name="kubectl" codelang="yaml">}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: test-access-logs
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+{{< /tab >}}
+{{< tab name="glooctl" codelang="shell">}}
+glooctl create vs --name test-access-logs --namespace gloo-system 
+glooctl add route --name test-access-logs --path-prefix / --dest-name postman-echo
+{{< /tab >}}
+{{< /tabs >}}
+
+Let's test that the configuration was correctly picked up by Gloo by executing the following command:
+
+```shell
+curl -v $(glooctl proxy url)/get | jq
+```
+
+You should see an output similar like this:
+
+```json
+{
+  "args": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "accept": "*/*",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "bd20e4be-3c8a-405f-80a4-027204f732cb",
+    "x-forwarded-port": "80"
+  },
+  "url": "https://postman-echo.com/get"
+}
+```
+
+Now let's take a look at the Gateway logs to verify whether the request has been logged:
+
+```shell
+# Print only log lines starting with {" (our access logs are formatted as JSON)
+kubectl logs -n gloo-system deployment/gateway-proxy-v2 | grep '^{' | jq
+```
+
+You should see the following output, indicating that an access log entry has been created for the request we just sent:
+
+```json
+{
+  "httpMethod": "GET",
+  "clientDuration": "88",
+  "upstreamName": "postman-echo_gloo-system",
+  "responseCode": "200",
+  "systemTime": "2019-11-01T16:58:57.576Z",
+  "targetDuration": "88",
+  "path": "/get",
+  "requestId": "ebed1bcf-6fa0-4e56-84ee-134d6712a473",
+  "protocol": "HTTP/1.1"
+}
+```
+
+### Adding custom access log attributes
+Envoy's access log [command operators](https://www.envoyproxy.io/docs/envoy/latest/configuration/observability/access_log#command-operators) 
+provide a powerful way of extracting information from HTTP streams. The `REQ` and `RESP` operators allow you to log headers, 
+but there is no way of including custom information that is not included in the headers, e.g. attributes included in the 
+request/response payloads, or environment variables. There is a `DYNAMIC_METADATA` operator, but it relies on the custom 
+information having been written to the [Dynamic Metadata](https://www.envoyproxy.io/docs/envoy/latest/configuration/advanced/well_known_dynamic_metadata) 
+by an Envoy filter. Fortunately, as we saw in the [main page]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#dynamicmetadatavalues" >}}) 
+of the transformation docs, Gloo's Transformation API provides you with the means of adding information the dynamic metadata.
+Let's see how this can be done.
+
+We will add two custom access logging attributes:
+
+- `pod_name`: the name of the Gateway pod that handled the request
+- `endpoint_url`: the URL of the upstream endpoint; note that this attribute is included in the JSON response payload 
+returned by the Postman Echo service (see our earlier `curl` command output).
+
+#### Update access logging configuration
+We will start by updating the access logging configuration in our Gateway:
+
+{{< highlight yaml "hl_lines=38-41" >}}
+apiVersion: gateway.solo.io.v2/v2
+kind: Gateway
+metadata:
+  labels:
+    app: gloo
+  name: gateway-proxy-v2
+  namespace: gloo-system
+proxyNames:
+- gateway-proxy-v2
+spec:
+  bindAddress: '::'
+  bindPort: 8080
+  httpGateway: {}
+  plugins:
+    accessLoggingService:
+      accessLog:
+      - fileSink:
+          jsonFormat:
+            # HTTP method name
+            httpMethod: '%REQ(:METHOD)%'
+            # Protocol. Currently either HTTP/1.1 or HTTP/2.
+            protocol: '%PROTOCOL%'
+            # HTTP response code. Note that a response code of ‘0’ means that the server never sent the
+            # beginning of a response. This generally means that the (downstream) client disconnected.
+            responseCode: '%RESPONSE_CODE%'
+            # Total duration in milliseconds of the request from the start time to the last byte out
+            clientDuration: '%DURATION%'
+            # Total duration in milliseconds of the request from the start time to the first byte read from the upstream host
+            targetDuration: '%RESPONSE_DURATION%'
+            # Value of the "x-envoy-original-path" header (falls back to "path" header if not present)
+            path: '%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%'
+            # Upstream cluster to which the upstream host belongs to
+            upstreamName: '%UPSTREAM_CLUSTER%'
+            # Request start time including milliseconds.
+            systemTime: '%START_TIME%'
+            # Unique tracking ID
+            requestId: '%REQ(X-REQUEST-ID)%'
+            # The 'pod' dynamic metadata entry that is set by the Gloo transformation filter
+            pod_name: '%DYNAMIC_METADATA(io.solo.transformation:pod_name)%'
+            # The 'error' dynamic metadata entry that is set by the Gloo transformation filter
+            endpoint_url: '%DYNAMIC_METADATA(io.solo.transformation:endpoint_url)%'
+          path: /dev/stdout
+{{< /highlight >}}
+
+This relies on the `pod_name` and `endpoint_url` dynamic metadata entries having being added to the HTTP stream by Gloo's 
+transformation filter.
+
+#### Update Virtual Service
+For the above dynamic metadata to be available, we need to update our Virtual Service definition. Specifically, we need 
+to add a transformation that extracts the value of the `POD_NAME` environment variable and the value of the `url` 
+response attribute and uses them to populate the corresponding metadata attributes.
+
+{{< highlight yaml "hl_lines=18-33" >}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: test-access-logs
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+    virtualHostPlugins:
+      transformations:
+        # Apply a transformation to the response
+        responseTransformation:
+          transformationTemplate:
+            dynamicMetadataValues:
+            # Set a dynamic metadata entry named "pod"
+            - key: 'pod_name'
+              value:
+                # The POD_NAME env is set by default on the gateway-proxy-v2 pods
+                text: '{{ env("POD_NAME") }}'
+            # Set a dynamic metadata entry using an request body attribute
+            - key: 'endpoint_url'
+              value:
+                # The "url" attribute in the JSON response body
+                text: '{{ url }}'
+{{< /highlight >}}
+
+#### Test our configuration
+To test that our configuration has been correctly picked up by Gloo, let's execute our `curl` command again:
+
+```shell
+curl -v $(glooctl proxy url)/get | jq
+```
+
+Now let's inspect the access logs again:
+
+```shell
+kubectl logs -n gloo-system deployment/gateway-proxy-v2 | grep '^{' | jq
+```
+
+You should see an entry like the following:
+
+{{< highlight json "hl_lines=6-7" >}}
+{
+  "path": "/get",
+  "targetDuration": "85",
+  "protocol": "HTTP/1.1",
+  "requestId": "57c71e10-5a03-407a-9a57-cd63dd50fd39",
+  "endpoint_url": "\"https://postman-echo.com/get\"",
+  "pod_name": "\"gateway-proxy-v2-f46b58f89-5fkmd\"",
+  "clientDuration": "85",
+  "httpMethod": "GET",
+  "upstreamName": "postman-echo_gloo-system",
+  "responseCode": "200",
+  "systemTime": "2019-11-01T17:30:36.178Z"
+}
+{{< /highlight >}}
+
+As you can see, the access log entries now include the gateway pod name and the `url` attribute in the response body.
+
+### Cleanup
+To cleanup the resources created in this tutorial you can run the following commands:
+
+```shell
+kubectl delete virtualservice -n gloo-system test-access-logs
+kubectl delete upstream -n gloo-system postman-echo
+```

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Enrich Gloo access logs
+title: Enriching access logs
 weight: 50
 description: Use transformations to craft custom attributes in access logs.
 ---

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/enrich_access_logs/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Enrich Gloo access logs
-weight: 10
+weight: 50
 description: Use transformations to craft custom attributes in access logs.
 ---
 
@@ -88,7 +88,7 @@ glooctl add route --name test-access-logs --path-prefix / --dest-name postman-ec
 Let's test that the configuration was correctly picked up by Gloo by executing the following command:
 
 ```shell
-curl -v $(glooctl proxy url)/get | jq
+curl $(glooctl proxy url)/get | jq
 ```
 
 You should see an output similar like this:
@@ -244,7 +244,7 @@ spec:
 To test that our configuration has been correctly picked up by Gloo, let's execute our `curl` command again:
 
 ```shell
-curl -v $(glooctl proxy url)/get | jq
+curl $(glooctl proxy url)/get | jq
 ```
 
 Now let's inspect the access logs again:

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/extract_query_params/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/extract_query_params/_index.md
@@ -62,7 +62,7 @@ You should get a response with status `200` and a JSON body similar to this:
 ```
 
 #### Update Virtual Service
-As you can see from the response above, the upstream service returns the request headers is the JSON payload. 
+As you can see from the response above, the upstream service returns the request headers as part of the JSON payload. 
 We will now configure Gloo to extract the values of the `foo` and `bar` query parameters and use them to create two new 
 headers named - you guessed it - `foo` and `bar`.
 
@@ -116,11 +116,11 @@ spec:
 The above `virtualHostPlugins` configuration is to be interpreted as following:
 
 1. Add a transformation to all traffic handled by this Virtual Host.
-2. Apply the transformation only to requests.
-3. Define two [extractions]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#extractors" >}}) 
+1. Apply the transformation only to requests.
+1. Define two [extractions]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#extractors" >}}) 
 to extract the values of the query parameters. We achieve this by using regex capturing groups and selecting the nested group 
 which matches only the value of the relevant query parameter.
-4. Add two headers and set their values of the values of the extractions.
+1. Add two headers and set their values of the values of the extractions.
 
 #### Test our configuration
 To test that our configuration has been correctly applied, let's add the two expected query parameters to the previously 

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/extract_query_params/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/extract_query_params/_index.md
@@ -1,0 +1,168 @@
+---
+title: Extract query parameters
+weight: 20
+description: Extract query parameters from a request
+---
+
+In this tutorial we will see how to extract query parameters from a request and use them in a transformation.
+
+### Setup
+{{< readfile file="/static/content/setup_postman_echo.md" markdown="true">}}
+
+Let's also create a simple Virtual Service that matches any path and routes all traffic to our Upstream:
+
+{{< tabs >}}
+{{< tab name="kubectl" codelang="yaml">}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: extract-query-params
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+{{< /tab >}}
+{{< tab name="glooctl" codelang="shell">}}
+glooctl create vs --name extract-query-params --namespace gloo-system 
+glooctl add route --name extract-query-params --path-prefix / --dest-name postman-echo
+{{< /tab >}}
+{{< /tabs >}}
+
+Let's test that the configuration was correctly picked up by Gloo by executing the following command:
+
+```shell
+curl $(glooctl proxy url)/get | jq
+```
+
+You should get a response with status `200` and a JSON body similar to this:
+
+```json
+{
+  "args": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "accept": "*/*",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "db7eca70-630a-4aab-8e42-7ac3cfa064e8",
+    "x-forwarded-port": "80"
+  },
+  "url": "https://postman-echo.com/get"
+}
+```
+
+#### Update Virtual Service
+As you can see from the response above, the upstream service returns the request headers is the JSON payload. 
+We will now configure Gloo to extract the values of the `foo` and `bar` query parameters and use them to create two new 
+headers named - you guessed it - `foo` and `bar`.
+
+To implement this behavior, we need to add the following to our Virtual Service definition:
+
+{{< highlight yaml "hl_lines=18-42" >}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: extract-query-params
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+    virtualHostPlugins:
+      transformations:
+        requestTransformation:
+          transformationTemplate:
+            extractors:
+              # This extracts the 'foo' query param to an extractor named 'foo'
+              foo:
+                # The :path pseudo-header contains the URI
+                header: ':path'
+                # Use a nested capturing group to extract the query param
+                regex: '(.*foo=([^&]*).*)'
+                subgroup: 2
+              # This extracts the 'bar' query param to an extractor named 'bar'
+              bar:
+                # The :path pseudo-header contains the URI
+                header: ':path'
+                # Use a nested capturing group to extract the query param
+                regex: '(.*bar=([^&]*).*)'
+                subgroup: 2
+            # Add two new headers with the values of the 'foo' and 'bar' extractions
+            headers:
+              foo:
+                text: '{{ foo }}'
+              bar:
+                text: '{{ bar }}'
+{{< /highlight >}}  
+
+The above `virtualHostPlugins` configuration is to be interpreted as following:
+
+1. Add a transformation to all traffic handled by this Virtual Host.
+2. Apply the transformation only to requests.
+3. Define two [extractions]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#extractors" >}}) 
+to extract the values of the query parameters. We achieve this by using regex capturing groups and selecting the nested group 
+which matches only the value of the relevant query parameter.
+4. Add two headers and set their values of the values of the extractions.
+
+#### Test our configuration
+To test that our configuration has been correctly applied, let's add the two expected query parameters to the previously 
+used `curl` command:
+
+```shell
+curl "$(glooctl proxy url)/get?foo=foo-value&bar=bar-value" | jq
+```
+
+You should get the following output:
+
+```json
+{
+  "args": {
+    "foo": "foo-value",
+    "bar": "bar-value"
+  },
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "accept": "*/*",
+    "bar": "bar-value",
+    "foo": "foo-value",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "9dbe87fe-7ee8-4d47-b3e4-76c545515d33",
+    "x-forwarded-port": "80"
+  },
+  "url": "https://postman-echo.com/get?foo=foo-value&bar=bar-value"
+}
+```
+
+Notice that the `headers` section now contains two new attributes with the expected values.
+
+{{% notice note %}}
+In this guide we used **extractions** to add new headers, but you can use the extractions you define in any template.
+{{% /notice %}}
+
+### Cleanup
+To cleanup the resources created in this tutorial you can run the following commands:
+
+```shell
+kubectl delete virtualservice -n gloo-system extract-query-params
+kubectl delete upstream -n gloo-system postman-echo
+```

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/update_request_uri/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/update_request_uri/_index.md
@@ -1,0 +1,176 @@
+---
+title: Update request path
+weight: 30
+description: Conditionally update the request path
+---
+
+In this tutorial we will see how to conditionally update the request path by using a transformation.
+
+### Setup
+{{< readfile file="/static/content/setup_postman_echo.md" markdown="true">}}
+
+Let's also create a simple Virtual Service that matches any path and routes all traffic to our Upstream:
+
+{{< tabs >}}
+{{< tab name="kubectl" codelang="yaml">}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: update-request-path
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+{{< /tab >}}
+{{< tab name="glooctl" codelang="shell">}}
+glooctl create vs --name update-request-path --namespace gloo-system 
+glooctl add route --name update-request-path --path-prefix / --dest-name postman-echo
+{{< /tab >}}
+{{< /tabs >}}
+
+Let's test that the configuration was correctly picked up by Gloo by executing the following command:
+
+```shell
+curl $(glooctl proxy url)/get | jq
+```
+
+You should get a response with status `200` and a JSON body similar to this:
+
+```json
+{
+  "args": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "accept": "*/*",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "3ed578a1-b33a-40db-b18a-e8d11e24c22c",
+    "x-forwarded-port": "80"
+  },
+  "url": "https://postman-echo.com/get"
+}
+```
+
+#### Update Virtual Service
+We will now configure Gloo to update the request path from `/get` to `/post` if a header named `foo` is present and has 
+the value `bar`. Since the `/post` endpoint on the Postman Echo service expected `POST` requests, we will need to update 
+the HTTP method of the request as well.
+
+To do this, we need to add the following to our Virtual Service definition:
+
+{{< highlight yaml "hl_lines=18-42" >}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: update-request-path
+  namespace: gloo-system
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matcher:
+        prefix: /
+      routeAction:
+        single:
+          upstream:
+            name: postman-echo
+            namespace: gloo-system
+    virtualHostPlugins:
+      transformations:
+        requestTransformation:
+          transformationTemplate:
+            headers:
+              # By updating the :path pseudo-header, we update the request URI
+              ":path":
+                text: '{% if header("foo") == "bar" %}/post{% else %}{{ header(":path") }}{% endif %}'
+              # By updating the :method pseudo-header, we update the request HTTP method
+              ":method":
+                text: '{% if header("foo") == "bar" %}POST{% else %}{{ header(":method") }}{% endif %}'
+{{< /highlight >}}  
+
+The above `virtualHostPlugins` configuration is to be interpreted as following:
+
+1. Add a transformation to all traffic handled by this Virtual Host.
+1. Apply the transformation only to requests.
+1. Use a [template transformation]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#transformation-templates" >}}).
+1. Update the `:path` and `:method` pseudo-headers if the `foo` header is present and has value `bar`; otherwise keep the original values.
+
+The template uses the [Inja templating language]({{< ref "gloo_routing/virtual_services/routes/routing_features/transformations#templating-language" >}}) 
+to define the conditional logic that will be applied to the `:path` and `:method` pseudo-headers.
+
+#### Test our configuration
+To test that our configuration has been correctly applied, let's add the `foo` header with the expected `bar` value to 
+the previously used `curl` command:
+
+```shell
+curl -H "foo: bar" $(glooctl proxy url)/get | jq
+```
+
+You should get the following output:
+
+{{< highlight yaml "hl_lines=18" >}}
+{
+  "args": {},
+  "data": {},
+  "files": {},
+  "form": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "content-length": "0",
+    "accept": "*/*",
+    "foo": "bar",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "193637cb-d551-4c0e-80a6-866218c25c3b",
+    "x-forwarded-port": "80"
+  },
+  "json": null,
+  "url": "https://postman-echo.com/post"
+}
+{{< /highlight >}} 
+
+Notice that the `url` attribute now displays a `/post` path where it previously displayed `/get`.
+
+Now let's try omitting the header from the request:
+
+```shell
+curl $(glooctl proxy url)/get | jq
+```
+
+We will hit the same endpoint as we did at the beginning of this tutorial:
+
+{{< highlight yaml "hl_lines=12" >}}
+{
+  "args": {},
+  "headers": {
+    "x-forwarded-proto": "https",
+    "host": "postman-echo.com",
+    "accept": "*/*",
+    "user-agent": "curl/7.54.0",
+    "x-envoy-expected-rq-timeout-ms": "15000",
+    "x-request-id": "f8844eba-85cd-4253-81a2-12f143d9db41",
+    "x-forwarded-port": "80"
+  },
+  "url": "https://postman-echo.com/get"
+}
+{{< /highlight >}} 
+
+### Cleanup
+To cleanup the resources created in this tutorial you can run the following commands:
+
+```shell
+kubectl delete virtualservice -n gloo-system update-request-path
+kubectl delete upstream -n gloo-system postman-echo
+```

--- a/docs/content/static/content/setup_postman_echo.md
+++ b/docs/content/static/content/setup_postman_echo.md
@@ -1,0 +1,23 @@
+This guide assumes that you have installed Gloo into the `gloo-system` namespace and that `glooctl` is installed on your
+machine. We will also use the [jq](https://stedolan.github.io/jq/) command line utility to pretty print JSON strings.
+
+We will need an upstream service to serve as the target for the requests that we will send to test the Gloo configurations 
+in this tutorial. To this end, we will use the publicly available [Postman Echo](https://postman-echo.com/) service. 
+It exposes a set of endpoints that are very useful for inspecting both the requests sent upstream and the resulting responses; 
+please refer to the [official documentation](https://docs.postman-echo.com/?version=latest) for more information about the service.
+
+Let's create a static upstream to represent the _postman-echo.com_ remote service.
+
+```yaml
+apiVersion: gloo.solo.io/v1
+kind: Upstream
+metadata:
+  name: postman-echo
+  namespace: gloo-system
+spec:
+  upstreamSpec:
+    static:
+      hosts:
+      - addr: postman-echo.com
+        port: 80
+```


### PR DESCRIPTION
Improve the existing documentation of Gloo's transformation features.

The new docs will be structured as a main page (describing the API and providing some simple example snippets) plus a series of tutorial pages, each exemplifying a use case for transformations:
- [x] Enriching access logs
- [x] Adding headers to the body
- [x] Extracting query parameters
- [x] Transforming response status code based on payload
- [x] Updating request URI based on request properties

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1565