### PR TITLE
Allow role/role-binding names to take on unique suffixes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1402,7 +1402,8 @@
     "vfsutils",
   ]
   pruneopts = "UT"
-  revision = "4a78c4940d03e0e6d1549b5e5fa2e400680408cb"
+  revision = "7a2d18c9ca395de2ebf7df015d5e1bdac18e122d"
+  version = "v0.10.25"
 
 [[projects]]
   digest = "1:a2922a665903e4336f9e8b13eb9134bdda25ed984b3966159d4aa2bf9c5b0e28"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -534,9 +534,12 @@
   revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
-  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
+  digest = "1:a507e8646bf3775af6f7e7b2a62a5e67d1c6a8f00754f87e66b96181b7f3d747"
   name = "github.com/golang/mock"
-  packages = ["gomock"]
+  packages = [
+    "gomock",
+    "mockgen/model",
+  ]
   pruneopts = "UT"
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
@@ -1357,7 +1360,7 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:ad4681c2ac6e9017882421da2b288ea198003ffbbf342b1bb140209ba1bcea7a"
+  digest = "1:cf8415990f3e539e6041842c11763f3fd3658202dde7785d6f96116377ed361d"
   name = "github.com/solo-io/go-utils"
   packages = [
     "certutils",
@@ -1399,8 +1402,7 @@
     "vfsutils",
   ]
   pruneopts = "UT"
-  revision = "68c84e0981898f92f0d7c7a846d8f0d82dd4fd9a"
-  version = "v0.10.20"
+  revision = "4a78c4940d03e0e6d1549b5e5fa2e400680408cb"
 
 [[projects]]
   digest = "1:a2922a665903e4336f9e8b13eb9134bdda25ed984b3966159d4aa2bf9c5b0e28"
@@ -1789,9 +1791,10 @@
   revision = "a985d3407aa71f30cf86696ee0a2f409709f22e1"
 
 [[projects]]
-  digest = "1:deedfa6fd63a3ab08bcdb6b84de7342a1dbcdb02150c5f6cdb50d2098ecb8e75"
+  digest = "1:bb533ccc3d271b79ca611125beaff2ec3f06c003174849531be262a64a58953e"
   name = "google.golang.org/api"
   packages = [
+    "compute/v1",
     "gensupport",
     "googleapi",
     "googleapi/internal/uritemplates",
@@ -2738,6 +2741,7 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
+    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/ptypes/any",
@@ -2846,7 +2850,10 @@
     "go.opencensus.io/trace",
     "go.uber.org/multierr",
     "go.uber.org/zap",
+    "golang.org/x/oauth2/google",
     "golang.org/x/sync/errgroup",
+    "google.golang.org/api/compute/v1",
+    "google.golang.org/api/option",
     "google.golang.org/genproto/googleapis/api/annotations",
     "google.golang.org/grpc",
     "google.golang.org/grpc/codes",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[override]]
   name = "github.com/solo-io/go-utils"
-  version = "0.10.20"
+  revision = "4a78c4940d03e0e6d1549b5e5fa2e400680408cb"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[override]]
   name = "github.com/solo-io/go-utils"
-  revision = "4a78c4940d03e0e6d1549b5e5fa2e400680408cb"
+  version = "0.10.25"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/changelog/v0.20.14/role-suffix.yaml
+++ b/changelog/v0.20.14/role-suffix.yaml
@@ -1,9 +1,12 @@
 changelog:
 - type: HELM
   description: >
-    Allow RBAC cluster-scoped role names to receive custom suffixes. This enables, for example,
-    blue/green deployments of Gloo to different namespaces within the same cluster. If you are
-    performing an upgrade of Gloo from a version prior to this change, then you may have
-    duplicate roles/role-bindings hanging around in your cluster. The ones created prior to this
-    version can be safely cleaned up.
+    Allow RBAC resource names to receive custom suffixes through the introduction of the new
+    Helm setting "global.glooRbac.nameSuffix". This enables, for example, blue/green
+    deployments of Gloo to different namespaces within the same cluster when using
+    cluster-scoped RBAC resources. This change is backwards compatible. However, if you are
+    performing an upgrade of Gloo from a version prior to this change and plan to use the new
+    Helm value, then you may end up with duplicate RBAC resources in your cluster (e.g.
+    Roles/RoleBindings with and without the suffix). If this is the case, the old resources
+    (without the suffix) can be safely cleaned up.
   issueLink: https://github.com/solo-io/gloo/issues/1459

--- a/changelog/v0.20.14/role-suffix.yaml
+++ b/changelog/v0.20.14/role-suffix.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: HELM
+  description: >
+    Allow RBAC cluster-scoped role names to receive custom suffixes. This enables, for example,
+    blue/green deployments of Gloo to different namespaces within the same cluster.
+  issueLink: https://github.com/solo-io/gloo/issues/1459

--- a/changelog/v0.20.14/role-suffix.yaml
+++ b/changelog/v0.20.14/role-suffix.yaml
@@ -2,5 +2,8 @@ changelog:
 - type: HELM
   description: >
     Allow RBAC cluster-scoped role names to receive custom suffixes. This enables, for example,
-    blue/green deployments of Gloo to different namespaces within the same cluster.
+    blue/green deployments of Gloo to different namespaces within the same cluster. If you are
+    performing an upgrade of Gloo from a version prior to this change, then you may have
+    duplicate roles/role-bindings hanging around in your cluster. The ones created prior to this
+    version can be safely cleaned up.
   issueLink: https://github.com/solo-io/gloo/issues/1459

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -36,7 +36,7 @@ type Namespace struct {
 type Rbac struct {
 	Create     bool   `json:"create" desc:"create rbac rules for the gloo-system service account"`
 	Namespaced bool   `json:"Namespaced" desc:"use Roles instead of ClusterRoles"`
-	RoleSuffix string `json:"roleSuffix" desc:"When roleSuffix is nonempty, append '-$roleSuffix' to the names of Gloo RBAC resources; eg when roleSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'"`
+	NameSuffix string `json:"nameSuffix" desc:"When nameSuffix is nonempty, append '-$nameSuffix' to the names of Gloo RBAC resources; e.g. when nameSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'"`
 }
 
 type Crds struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -34,8 +34,9 @@ type Namespace struct {
 }
 
 type Rbac struct {
-	Create     bool `json:"create" desc:"create rbac rules for the gloo-system service account"`
-	Namespaced bool `json:"Namespaced" desc:"use Roles instead of ClusterRoles"`
+	Create     bool   `json:"create" desc:"create rbac rules for the gloo-system service account"`
+	Namespaced bool   `json:"Namespaced" desc:"use Roles instead of ClusterRoles"`
+	RoleSuffix string `json:"roleSuffix" desc:"When roleSuffix is nonempty, append '-$roleSuffix' to the names of Gloo RBAC resources; eg when roleSuffix is 'foo', the role 'gloo-resource-reader-foo' will be installed"`
 }
 
 type Crds struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -36,7 +36,7 @@ type Namespace struct {
 type Rbac struct {
 	Create     bool   `json:"create" desc:"create rbac rules for the gloo-system service account"`
 	Namespaced bool   `json:"Namespaced" desc:"use Roles instead of ClusterRoles"`
-	RoleSuffix string `json:"roleSuffix" desc:"When roleSuffix is nonempty, append '-$roleSuffix' to the names of Gloo RBAC resources; eg when roleSuffix is 'foo', the role 'gloo-resource-reader-foo' will be installed"`
+	RoleSuffix string `json:"roleSuffix" desc:"When roleSuffix is nonempty, append '-$roleSuffix' to the names of Gloo RBAC resources; eg when roleSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'"`
 }
 
 type Crds struct {

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -4,7 +4,7 @@
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: kube-resource-watcher
+    name: kube-resource-watcher{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -22,7 +22,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-upstream-mutator
+    name: gloo-upstream-mutator{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -41,7 +41,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-resource-reader
+    name: gloo-resource-reader{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -63,7 +63,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: settings-user
+    name: settings-user{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -82,7 +82,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-resource-mutator
+    name: gloo-resource-mutator{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -100,7 +100,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gateway-resource-reader
+    name: gateway-resource-reader{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -131,7 +131,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolebindingsuffix" . }}
+    name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolesuffix" . }}
     labels:
         app: gloo
         gloo: rbac

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -4,7 +4,7 @@
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: kube-resource-watcher{{ include "gloo.rolesuffix" . }}
+    name: kube-resource-watcher{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -22,7 +22,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-upstream-mutator{{ include "gloo.rolesuffix" . }}
+    name: gloo-upstream-mutator{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -41,7 +41,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-resource-reader{{ include "gloo.rolesuffix" . }}
+    name: gloo-resource-reader{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -63,7 +63,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: settings-user{{ include "gloo.rolesuffix" . }}
+    name: settings-user{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -82,7 +82,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-resource-mutator{{ include "gloo.rolesuffix" . }}
+    name: gloo-resource-mutator{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -100,7 +100,7 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gateway-resource-reader{{ include "gloo.rolesuffix" . }}
+    name: gateway-resource-reader{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -131,7 +131,7 @@ rules:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolesuffix" . }}
+    name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rbacNameSuffix" . }}
     labels:
         app: gloo
         gloo: rbac

--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -4,7 +4,7 @@
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kube-resource-watcher-binding{{ include "gloo.rolesuffix" . }}
+  name: kube-resource-watcher-binding{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -23,13 +23,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: kube-resource-watcher{{ include "gloo.rolesuffix" . }}
+  name: kube-resource-watcher{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-upstream-mutator-binding{{ include "gloo.rolesuffix" . }}
+  name: gloo-upstream-mutator-binding{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -45,13 +45,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gloo-upstream-mutator{{ include "gloo.rolesuffix" . }}
+  name: gloo-upstream-mutator{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-resource-reader-binding{{ include "gloo.rolesuffix" . }}
+  name: gloo-resource-reader-binding{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -67,13 +67,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gloo-resource-reader{{ include "gloo.rolesuffix" . }}
+  name: gloo-resource-reader{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: settings-user-binding{{ include "gloo.rolesuffix" . }}
+  name: settings-user-binding{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -95,13 +95,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: settings-user{{ include "gloo.rolesuffix" . }}
+  name: settings-user{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-resource-mutator-binding{{ include "gloo.rolesuffix" . }}
+  name: gloo-resource-mutator-binding{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -117,13 +117,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gloo-resource-mutator{{ include "gloo.rolesuffix" . }}
+  name: gloo-resource-mutator{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gateway-resource-reader-binding{{ include "gloo.rolesuffix" . }}
+  name: gateway-resource-reader-binding{{ include "gloo.rbacNameSuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -139,7 +139,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gateway-resource-reader{{ include "gloo.rolesuffix" . }}
+  name: gateway-resource-reader{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 
 
@@ -149,7 +149,7 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolesuffix" . }}
+  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rbacNameSuffix" . }}
   labels:
     app: gloo
     gloo: rbac
@@ -162,7 +162,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolesuffix" . }}
+  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- end -}}

--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -4,7 +4,7 @@
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: kube-resource-watcher-binding{{ include "gloo.rolebindingsuffix" . }}
+  name: kube-resource-watcher-binding{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -23,13 +23,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: kube-resource-watcher
+  name: kube-resource-watcher{{ include "gloo.rolesuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-upstream-mutator-binding{{ include "gloo.rolebindingsuffix" . }}
+  name: gloo-upstream-mutator-binding{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -45,13 +45,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gloo-upstream-mutator
+  name: gloo-upstream-mutator{{ include "gloo.rolesuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-resource-reader-binding{{ include "gloo.rolebindingsuffix" . }}
+  name: gloo-resource-reader-binding{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -67,13 +67,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gloo-resource-reader
+  name: gloo-resource-reader{{ include "gloo.rolesuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: settings-user-binding{{ include "gloo.rolebindingsuffix" . }}
+  name: settings-user-binding{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -95,13 +95,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: settings-user
+  name: settings-user{{ include "gloo.rolesuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-resource-mutator-binding{{ include "gloo.rolebindingsuffix" . }}
+  name: gloo-resource-mutator-binding{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -117,13 +117,13 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gloo-resource-mutator
+  name: gloo-resource-mutator{{ include "gloo.rolesuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: {{ include "gloo.roleKind" . }}Binding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gateway-resource-reader-binding{{ include "gloo.rolebindingsuffix" . }}
+  name: gateway-resource-reader-binding{{ include "gloo.rolesuffix" . }}
 {{- if .Values.global.glooRbac.namespaced }}
   namespace: {{ .Release.Namespace }}
 {{- end }}
@@ -139,7 +139,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
-  name: gateway-resource-reader
+  name: gateway-resource-reader{{ include "gloo.rolesuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 
 
@@ -149,7 +149,7 @@ roleRef:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolebindingsuffix" . }}
+  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolesuffix" . }}
   labels:
     app: gloo
     gloo: rbac
@@ -162,7 +162,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolebindingsuffix" . }}
+  name: gloo-gateway-secret-create-vwc-update{{ include "gloo.rolesuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- end -}}

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -12,9 +12,9 @@ ClusterRole
 {{- end -}}
 {{- end -}}
 
-{{- define "gloo.rolesuffix" -}}
-{{- if .Values.global.glooRbac.roleSuffix -}}
--{{ .Values.global.glooRbac.roleSuffix }}
+{{- define "gloo.rbacNameSuffix" -}}
+{{- if .Values.global.glooRbac.nameSuffix -}}
+-{{ .Values.global.glooRbac.nameSuffix }}
 {{- else if not .Values.global.glooRbac.namespaced -}}
 -{{ .Release.Namespace }}
 {{- end -}}

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -12,11 +12,14 @@ ClusterRole
 {{- end -}}
 {{- end -}}
 
-{{- define "gloo.rolebindingsuffix" -}}
-{{- if not .Values.global.glooRbac.namespaced -}}
+{{- define "gloo.rolesuffix" -}}
+{{- if .Values.global.glooRbac.roleSuffix -}}
+-{{ .Values.global.glooRbac.roleSuffix }}
+{{- else if not .Values.global.glooRbac.namespaced -}}
 -{{ .Release.Namespace }}
 {{- end -}}
 {{- end -}}
+
 {{/*
 Expand the name of a container image
 */}}

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -61,7 +61,7 @@ var _ = Describe("RBAC Test", func() {
 			checkSuffix(suffix)
 		})
 
-		It("is named appropriately in a non-namespaced install", func() {
+		It("is all named appropriately in a non-namespaced install", func() {
 			prepareMakefile("--namespace " + namespace)
 			checkSuffix(namespace)
 		})

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -34,12 +34,6 @@ var _ = Describe("RBAC Test", func() {
 	})
 
 	Context("all cluster-scoped RBAC resources", func() {
-		allShouldHaveSuffix := func(manifest TestManifest, suffix string) {
-			manifest.ExpectAll(func(resource *unstructured.Unstructured) {
-				Expect(resource.GetName()).To(HaveSuffix("-" + suffix))
-			})
-		}
-
 		checkSuffix := func(suffix string) {
 			rbacResources := testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
 				return resource.GetKind() == "ClusterRole" || resource.GetKind() == "ClusterRoleBinding"
@@ -47,12 +41,14 @@ var _ = Describe("RBAC Test", func() {
 
 			Expect(rbacResources.NumResources()).NotTo(BeZero())
 
-			allShouldHaveSuffix(rbacResources, suffix)
+			rbacResources.ExpectAll(func(resource *unstructured.Unstructured) {
+				Expect(resource.GetName()).To(HaveSuffix("-" + suffix))
+			})
 		}
 
 		It("is all named appropriately when a custom suffix is specified", func() {
 			suffix := "test-suffix"
-			prepareMakefile("--namespace " + namespace + " --set global.glooRbac.roleSuffix=" + suffix)
+			prepareMakefile("--namespace " + namespace + " --set global.glooRbac.nameSuffix=" + suffix)
 			checkSuffix(suffix)
 		})
 

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -2,7 +2,9 @@ package test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	. "github.com/solo-io/go-utils/manifesttestutils"
 )
@@ -28,6 +30,40 @@ var _ = Describe("RBAC Test", func() {
 			prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 			permissions := GetServiceAccountPermissions("")
 			testManifest.ExpectPermissions(permissions)
+		})
+	})
+
+	Context("all cluster-scoped RBAC resources", func() {
+		allShouldHaveSuffix := func(manifest TestManifest, suffix string) {
+			manifest.ExpectAll(func(role *unstructured.Unstructured) {
+				Expect(role.GetName()).To(HaveSuffix("-" + suffix))
+			})
+		}
+
+		checkSuffix := func(suffix string) {
+			rolesManifest := testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+				return resource.GetKind() == "ClusterRole"
+			})
+			roleBindingsManifest := testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+				return resource.GetKind() == "ClusterRoleBinding"
+			})
+
+			Expect(rolesManifest.NumResources()).NotTo(BeZero())
+			Expect(roleBindingsManifest.NumResources()).NotTo(BeZero())
+
+			allShouldHaveSuffix(rolesManifest, suffix)
+			allShouldHaveSuffix(roleBindingsManifest, suffix)
+		}
+
+		It("is all named appropriately when a custom suffix is specified", func() {
+			suffix := "test-suffix"
+			prepareMakefile("--namespace " + namespace + " --set global.glooRbac.roleSuffix=" + suffix)
+			checkSuffix(suffix)
+		})
+
+		It("is named appropriately in a non-namespaced install", func() {
+			prepareMakefile("--namespace " + namespace)
+			checkSuffix(namespace)
 		})
 	})
 
@@ -65,6 +101,7 @@ var _ = Describe("RBAC Test", func() {
 		})
 		Context("cluster scope", func() {
 			It("role", func() {
+				resourceBuilder.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRole(resourceBuilder.GetClusterRole())
 			})
@@ -72,6 +109,7 @@ var _ = Describe("RBAC Test", func() {
 			It("role binding", func() {
 				resourceBuilder.Name += "-binding-" + namespace
 				resourceBuilder.Annotations["helm.sh/hook-weight"] = "15"
+				resourceBuilder.RoleRef.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRoleBinding(resourceBuilder.GetClusterRoleBinding())
 			})
@@ -126,6 +164,7 @@ var _ = Describe("RBAC Test", func() {
 		})
 		Context("cluster scope", func() {
 			It("role", func() {
+				resourceBuilder.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRole(resourceBuilder.GetClusterRole())
 			})
@@ -133,6 +172,7 @@ var _ = Describe("RBAC Test", func() {
 			It("role binding", func() {
 				resourceBuilder.Name += "-binding-" + namespace
 				resourceBuilder.Annotations["helm.sh/hook-weight"] = "15"
+				resourceBuilder.RoleRef.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRoleBinding(resourceBuilder.GetClusterRoleBinding())
 			})
@@ -192,6 +232,7 @@ var _ = Describe("RBAC Test", func() {
 		})
 		Context("cluster scope", func() {
 			It("role", func() {
+				resourceBuilder.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRole(resourceBuilder.GetClusterRole())
 			})
@@ -199,6 +240,7 @@ var _ = Describe("RBAC Test", func() {
 			It("role binding", func() {
 				resourceBuilder.Name += "-binding-" + namespace
 				resourceBuilder.Annotations["helm.sh/hook-weight"] = "15"
+				resourceBuilder.RoleRef.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRoleBinding(resourceBuilder.GetClusterRoleBinding())
 			})
@@ -261,6 +303,7 @@ var _ = Describe("RBAC Test", func() {
 		})
 		Context("cluster scope", func() {
 			It("role", func() {
+				resourceBuilder.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRole(resourceBuilder.GetClusterRole())
 			})
@@ -268,6 +311,7 @@ var _ = Describe("RBAC Test", func() {
 			It("role binding", func() {
 				resourceBuilder.Name += "-binding-" + namespace
 				resourceBuilder.Annotations["helm.sh/hook-weight"] = "15"
+				resourceBuilder.RoleRef.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRoleBinding(resourceBuilder.GetClusterRoleBinding())
 			})
@@ -322,6 +366,7 @@ var _ = Describe("RBAC Test", func() {
 		})
 		Context("cluster scope", func() {
 			It("role", func() {
+				resourceBuilder.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRole(resourceBuilder.GetClusterRole())
 			})
@@ -329,6 +374,7 @@ var _ = Describe("RBAC Test", func() {
 			It("role binding", func() {
 				resourceBuilder.Name += "-binding-" + namespace
 				resourceBuilder.Annotations["helm.sh/hook-weight"] = "15"
+				resourceBuilder.RoleRef.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRoleBinding(resourceBuilder.GetClusterRoleBinding())
 			})
@@ -391,6 +437,7 @@ var _ = Describe("RBAC Test", func() {
 		})
 		Context("cluster scope", func() {
 			It("role", func() {
+				resourceBuilder.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRole(resourceBuilder.GetClusterRole())
 			})
@@ -398,6 +445,7 @@ var _ = Describe("RBAC Test", func() {
 			It("role binding", func() {
 				resourceBuilder.Name += "-binding-" + namespace
 				resourceBuilder.Annotations["helm.sh/hook-weight"] = "15"
+				resourceBuilder.RoleRef.Name += "-" + namespace
 				prepareMakefile("--namespace " + namespace + " --set namespace.create=true --set global.glooRbac.namespaced=false")
 				testManifest.ExpectClusterRoleBinding(resourceBuilder.GetClusterRoleBinding())
 			})

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -35,24 +35,19 @@ var _ = Describe("RBAC Test", func() {
 
 	Context("all cluster-scoped RBAC resources", func() {
 		allShouldHaveSuffix := func(manifest TestManifest, suffix string) {
-			manifest.ExpectAll(func(role *unstructured.Unstructured) {
-				Expect(role.GetName()).To(HaveSuffix("-" + suffix))
+			manifest.ExpectAll(func(resource *unstructured.Unstructured) {
+				Expect(resource.GetName()).To(HaveSuffix("-" + suffix))
 			})
 		}
 
 		checkSuffix := func(suffix string) {
-			rolesManifest := testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
-				return resource.GetKind() == "ClusterRole"
-			})
-			roleBindingsManifest := testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
-				return resource.GetKind() == "ClusterRoleBinding"
+			rbacResources := testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+				return resource.GetKind() == "ClusterRole" || resource.GetKind() == "ClusterRoleBinding"
 			})
 
-			Expect(rolesManifest.NumResources()).NotTo(BeZero())
-			Expect(roleBindingsManifest.NumResources()).NotTo(BeZero())
+			Expect(rbacResources.NumResources()).NotTo(BeZero())
 
-			allShouldHaveSuffix(rolesManifest, suffix)
-			allShouldHaveSuffix(roleBindingsManifest, suffix)
+			allShouldHaveSuffix(rbacResources, suffix)
 		}
 
 		It("is all named appropriately when a custom suffix is specified", func() {

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -120,6 +120,7 @@ func getHelmValuesOverrideFile() (filename string, cleanup func()) {
 global:
   glooRbac:
     namespaced: true
+    nameSuffix: e2e-test-rbac-suffix
 settings:
   singleNamespace: true
   create: true


### PR DESCRIPTION
Allow RBAC cluster-scoped role names to receive custom suffixes. This enables, for example, blue/green deployments of Gloo to different namespaces within the same cluster. If you are performing an upgrade of Gloo from a version prior to this change, then you may have duplicate roles/role-bindings hanging around in your cluster. The ones created prior to this version can be safely cleaned up.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1459