### PR TITLE
CLI installs GlooE version 0.20.8 by default

### DIFF
--- a/changelog/v0.20.14/bump-glooe-tag.yaml
+++ b/changelog/v0.20.14/bump-glooe-tag.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  description: The default version of GlooE installed by the CLI is now 0.20.8.
+  issueLink: https://github.com/solo-io/gloo/issues/1596

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,4 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.20.6"
+const EnterpriseTag = "0.20.8"


### PR DESCRIPTION
The default version of GlooE installed by the CLI is now 0.20.8.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1596