### PR TITLE
Ensure glooctl deletes resources only for the appropriate installation

### DIFF
--- a/changelog/v0.20.14/glooctl-uninstall-id.yaml
+++ b/changelog/v0.20.14/glooctl-uninstall-id.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: FIX
+    description: >
+      Use the installation ID set by Helm to ensure that glooctl uninstalls only resources created for
+      the instance of Gloo being uninstalled. It does this by attempting to read the "installationId"
+      label from the gloo pod. If the label is not found, the uninstall will fail. You can choose to
+      proceed by passing the new --force flag to "glooctl uninstall", which will attempt to perform an
+      uninstall that may inadvertently delete cluster-scoped resources belonging to some other
+      installation of Gloo.
+    issueLink: https://github.com/solo-io/gloo/issues/1593

--- a/docs/cli/glooctl_uninstall.md
+++ b/docs/cli/glooctl_uninstall.md
@@ -20,6 +20,7 @@ glooctl uninstall [flags]
       --all                Deletes all gloo resources, including the namespace, crds, and cluster role
       --delete-crds        Delete all gloo crds (all custom gloo objects will be deleted)
       --delete-namespace   Delete the namespace (all objects written to this namespace will be deleted)
+      --force              Uninstalls Gloo even if the installation ID cannot be determined from the gloo pod labels (using this may delete cluster-scoped resources belonging to other Gloo installations)
   -h, --help               help for uninstall
   -n, --namespace string   namespace in which Gloo is installed (default "gloo-system")
   -v, --verbose            If true, output from kubectl commands will print to stdout/stderr

--- a/pkg/cliutil/install/kubernetes.go
+++ b/pkg/cliutil/install/kubernetes.go
@@ -24,12 +24,19 @@ func KubectlDelete(manifest []byte, extraArgs ...string) error {
 
 type KubeCli interface {
 	Kubectl(stdin io.Reader, args ...string) error
+	KubectlOut(stdin io.Reader, args ...string) ([]byte, error)
 }
 
 type CmdKubectl struct{}
 
+var _ KubeCli = &CmdKubectl{}
+
 func (k *CmdKubectl) Kubectl(stdin io.Reader, args ...string) error {
 	return Kubectl(stdin, args...)
+}
+
+func (k *CmdKubectl) KubectlOut(stdin io.Reader, args ...string) ([]byte, error) {
+	return KubectlOut(stdin, args...)
 }
 
 var verbose bool

--- a/projects/gloo/cli/pkg/cmd/install/errors.go
+++ b/projects/gloo/cli/pkg/cmd/install/errors.go
@@ -1,0 +1,17 @@
+package install
+
+import "github.com/solo-io/go-utils/errors"
+
+var (
+	FailedToFindLabel = func(err error) error {
+		return errors.Wrapf(err, "kubectl failed to pull %s label from gloo pod", installationIdLabel)
+	}
+	LabelNotSet                   = errors.Errorf("%s label has no value on gloo pod", installationIdLabel)
+	CantUninstallWithoutInstallId = func(err error) error {
+		return errors.Wrapf(err, `Could not find installation ID in 'gloo' pod labels. Use --force to uninstall anyway.
+Note that using --force may delete cluster-scoped resources belonging to some other installation of Gloo...
+This error may mean that you are trying to use glooctl >=0.20.14 to uninstall a version of Gloo <0.20.13 (or Enterprise Gloo <0.20.9).
+Make sure you are on open source Gloo >=0.20.14 or Enterprise Gloo >=0.20.9.
+`)
+	}
+)

--- a/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
@@ -1,6 +1,7 @@
 package install_test
 
 import (
+	"fmt"
 	"io"
 	"strings"
 
@@ -13,14 +14,17 @@ import (
 )
 
 type MockKubectl struct {
-	expected []string
-	next     int
+	expected        []string
+	next            int
+	stdoutLines     []string
+	stdoutLineIndex int
 }
 
-func NewMockKubectl(cmds ...string) *MockKubectl {
+func NewMockKubectl(cmds []string, stdoutLines []string) *MockKubectl {
 	return &MockKubectl{
-		expected: cmds,
-		next:     0,
+		expected:    cmds,
+		next:        0,
+		stdoutLines: stdoutLines,
 	}
 }
 
@@ -34,10 +38,26 @@ func (k *MockKubectl) Kubectl(stdin io.Reader, args ...string) error {
 	return nil
 }
 
+func (k *MockKubectl) KubectlOut(stdin io.Reader, args ...string) ([]byte, error) {
+	Expect(k.next < len(k.expected)).To(BeTrue())
+	Expect(stdin).To(BeNil())
+	cmd := strings.Join(args, " ")
+	Expect(cmd).To(BeEquivalentTo(k.expected[k.next]))
+	k.next = k.next + 1
+	Expect(k.stdoutLineIndex < len(k.stdoutLines)).To(BeTrue(), "Mock kubectl has run out of stdout lines on command "+cmd)
+	stdOutLine := k.stdoutLines[k.stdoutLineIndex]
+	k.stdoutLineIndex = k.stdoutLineIndex + 1
+	return []byte(stdOutLine), nil
+}
+
 var _ = Describe("Uninstall", func() {
 
 	const (
-		deleteCrds = `delete crd gateways.gateway.solo.io.v2 proxies.gloo.solo.io settings.gloo.solo.io upstreams.gloo.solo.io upstreamgroups.gloo.solo.io virtualservices.gateway.solo.io routetables.gateway.solo.io authconfigs.enterprise.gloo.solo.io`
+		deleteCrds    = `delete crd gateways.gateway.solo.io.v2 proxies.gloo.solo.io settings.gloo.solo.io upstreams.gloo.solo.io upstreamgroups.gloo.solo.io virtualservices.gateway.solo.io routetables.gateway.solo.io authconfigs.enterprise.gloo.solo.io`
+		testInstallId = "test-install-id"
+
+		// expects to be formatted with the namespace
+		findInstallIdCmd = "-n %s get pod -l gloo=gloo -ojsonpath='{.items[0].metadata.labels.installationId}'"
 	)
 
 	var flagSet *pflag.FlagSet
@@ -49,147 +69,175 @@ var _ = Describe("Uninstall", func() {
 		flagutils.AddUninstallFlags(flagSet, &opts.Uninstall)
 	})
 
-	uninstall := func(cli *MockKubectl) {
-		install.UninstallGloo(&opts, cli)
+	uninstall := func(cli *MockKubectl) error {
+		err := install.UninstallGloo(&opts, cli)
 		// If this fails, then the mock CLI had extra commands that were expected to run but weren't
 		Expect(cli.next).To(BeEquivalentTo(len(cli.expected)))
+
+		return err
 	}
 
 	It("works with no args", func() {
 		flagSet.Parse([]string{})
-		cli := NewMockKubectl(
-			"delete Deployment -l app=gloo -n gloo-system",
-			"delete Deployment -l app=glooe-grafana -n gloo-system",
-			"delete Deployment -l app=glooe-prometheus -n gloo-system",
-			"delete Service -l app=gloo -n gloo-system",
-			"delete Service -l app=glooe-grafana -n gloo-system",
-			"delete Service -l app=glooe-prometheus -n gloo-system",
-			"delete ServiceAccount -l app=gloo -n gloo-system",
-			"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
-			"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
-			"delete ConfigMap -l app=gloo -n gloo-system",
-			"delete ConfigMap -l app=glooe-grafana -n gloo-system",
-			"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
-			"delete Job -l app=gloo -n gloo-system",
-			"delete Job -l app=glooe-grafana -n gloo-system",
-			"delete Job -l app=glooe-prometheus -n gloo-system",
-		)
-		uninstall(cli)
+		commands := []string{
+			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
+			"delete Deployment -l installationId=test-install-id -n gloo-system",
+			"delete Service -l installationId=test-install-id -n gloo-system",
+			"delete ServiceAccount -l installationId=test-install-id -n gloo-system",
+			"delete ConfigMap -l installationId=test-install-id -n gloo-system",
+			"delete Job -l installationId=test-install-id -n gloo-system",
+		}
+		stdoutLines := []string{testInstallId}
+		cli := NewMockKubectl(commands, stdoutLines)
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with namespace", func() {
 		flagSet.Parse([]string{"-n", "foo"})
-		cli := NewMockKubectl(
-			"delete Deployment -l app=gloo -n foo",
-			"delete Deployment -l app=glooe-grafana -n foo",
-			"delete Deployment -l app=glooe-prometheus -n foo",
-			"delete Service -l app=gloo -n foo",
-			"delete Service -l app=glooe-grafana -n foo",
-			"delete Service -l app=glooe-prometheus -n foo",
-			"delete ServiceAccount -l app=gloo -n foo",
-			"delete ServiceAccount -l app=glooe-grafana -n foo",
-			"delete ServiceAccount -l app=glooe-prometheus -n foo",
-			"delete ConfigMap -l app=gloo -n foo",
-			"delete ConfigMap -l app=glooe-grafana -n foo",
-			"delete ConfigMap -l app=glooe-prometheus -n foo",
-			"delete Job -l app=gloo -n foo",
-			"delete Job -l app=glooe-grafana -n foo",
-			"delete Job -l app=glooe-prometheus -n foo",
-		)
-		uninstall(cli)
+		cmds := []string{
+			fmt.Sprintf(findInstallIdCmd, "foo"),
+			"delete Deployment -l installationId=test-install-id -n foo",
+			"delete Service -l installationId=test-install-id -n foo",
+			"delete ServiceAccount -l installationId=test-install-id -n foo",
+			"delete ConfigMap -l installationId=test-install-id -n foo",
+			"delete Job -l installationId=test-install-id -n foo",
+		}
+		stdoutLines := []string{testInstallId}
+		cli := NewMockKubectl(cmds, stdoutLines)
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete crds", func() {
 		flagSet.Parse([]string{"--delete-crds"})
-		cli := NewMockKubectl(
-			"delete Deployment -l app=gloo -n gloo-system",
-			"delete Deployment -l app=glooe-grafana -n gloo-system",
-			"delete Deployment -l app=glooe-prometheus -n gloo-system",
-			"delete Service -l app=gloo -n gloo-system",
-			"delete Service -l app=glooe-grafana -n gloo-system",
-			"delete Service -l app=glooe-prometheus -n gloo-system",
-			"delete ServiceAccount -l app=gloo -n gloo-system",
-			"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
-			"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
-			"delete ConfigMap -l app=gloo -n gloo-system",
-			"delete ConfigMap -l app=glooe-grafana -n gloo-system",
-			"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
-			"delete Job -l app=gloo -n gloo-system",
-			"delete Job -l app=glooe-grafana -n gloo-system",
-			"delete Job -l app=glooe-prometheus -n gloo-system",
-			deleteCrds)
-		uninstall(cli)
+		cmds := []string{
+			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
+			"delete Deployment -l installationId=test-install-id -n gloo-system",
+			"delete Service -l installationId=test-install-id -n gloo-system",
+			"delete ServiceAccount -l installationId=test-install-id -n gloo-system",
+			"delete ConfigMap -l installationId=test-install-id -n gloo-system",
+			"delete Job -l installationId=test-install-id -n gloo-system",
+			deleteCrds,
+		}
+		stdoutLines := []string{testInstallId}
+		cli := NewMockKubectl(cmds, stdoutLines)
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete crds and namespace", func() {
 		flagSet.Parse([]string{"-n", "foo", "--delete-crds"})
-		cli := NewMockKubectl(
-			"delete Deployment -l app=gloo -n foo",
-			"delete Deployment -l app=glooe-grafana -n foo",
-			"delete Deployment -l app=glooe-prometheus -n foo",
-			"delete Service -l app=gloo -n foo",
-			"delete Service -l app=glooe-grafana -n foo",
-			"delete Service -l app=glooe-prometheus -n foo",
-			"delete ServiceAccount -l app=gloo -n foo",
-			"delete ServiceAccount -l app=glooe-grafana -n foo",
-			"delete ServiceAccount -l app=glooe-prometheus -n foo",
-			"delete ConfigMap -l app=gloo -n foo",
-			"delete ConfigMap -l app=glooe-grafana -n foo",
-			"delete ConfigMap -l app=glooe-prometheus -n foo",
-			"delete Job -l app=gloo -n foo",
-			"delete Job -l app=glooe-grafana -n foo",
-			"delete Job -l app=glooe-prometheus -n foo",
-			deleteCrds)
-		uninstall(cli)
+		cmds := []string{
+			fmt.Sprintf(findInstallIdCmd, "foo"),
+			"delete Deployment -l installationId=test-install-id -n foo",
+			"delete Service -l installationId=test-install-id -n foo",
+			"delete ServiceAccount -l installationId=test-install-id -n foo",
+			"delete ConfigMap -l installationId=test-install-id -n foo",
+			"delete Job -l installationId=test-install-id -n foo",
+			deleteCrds,
+		}
+		stdoutLines := []string{testInstallId}
+		cli := NewMockKubectl(cmds, stdoutLines)
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete namespace", func() {
 		flagSet.Parse([]string{"--delete-namespace"})
-		cli := NewMockKubectl(
-			"delete namespace gloo-system")
-		uninstall(cli)
+		cli := NewMockKubectl([]string{fmt.Sprintf(findInstallIdCmd, "gloo-system"), "delete namespace gloo-system"}, []string{testInstallId})
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete namespace with custom namespace", func() {
 		flagSet.Parse([]string{"--delete-namespace", "-n", "foo"})
-		cli := NewMockKubectl(
-			"delete namespace foo")
-		uninstall(cli)
+		cli := NewMockKubectl([]string{fmt.Sprintf(findInstallIdCmd, "foo"), "delete namespace foo"}, []string{testInstallId})
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete namespace and crds", func() {
 		flagSet.Parse([]string{"--delete-namespace", "--delete-crds"})
-		cli := NewMockKubectl(
-			"delete namespace gloo-system",
-			deleteCrds)
-		uninstall(cli)
+		cli := NewMockKubectl([]string{fmt.Sprintf(findInstallIdCmd, "gloo-system"), "delete namespace gloo-system", deleteCrds}, []string{testInstallId})
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete crds and namespace with custom namespace", func() {
 		flagSet.Parse([]string{"--delete-namespace", "--delete-crds", "-n", "foo"})
-		cli := NewMockKubectl(
-			"delete namespace foo",
-			deleteCrds)
-		uninstall(cli)
+		cli := NewMockKubectl([]string{fmt.Sprintf(findInstallIdCmd, "foo"), "delete namespace foo", deleteCrds}, []string{testInstallId})
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete all", func() {
 		flagSet.Parse([]string{"--all"})
-		cli := NewMockKubectl(
+		cmds := []string{
+			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
 			"delete namespace gloo-system",
 			deleteCrds,
-			"delete ClusterRole -l app=gloo",
-			"delete ClusterRoleBinding -l app=gloo")
-		uninstall(cli)
+			"delete ClusterRole -l installationId=test-install-id",
+			"delete ClusterRoleBinding -l installationId=test-install-id",
+		}
+		stdoutLines := []string{testInstallId}
+		cli := NewMockKubectl(cmds, stdoutLines)
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
 	})
 
 	It("works with delete all custom namespace", func() {
 		flagSet.Parse([]string{"--all", "-n", "foo"})
-		cli := NewMockKubectl(
+		cmds := []string{
+			fmt.Sprintf(findInstallIdCmd, "foo"),
 			"delete namespace foo",
 			deleteCrds,
-			"delete ClusterRole -l app=gloo",
-			"delete ClusterRoleBinding -l app=gloo")
-		uninstall(cli)
+			"delete ClusterRole -l installationId=test-install-id",
+			"delete ClusterRoleBinding -l installationId=test-install-id",
+		}
+		stdoutLines := []string{testInstallId}
+		cli := NewMockKubectl(cmds, stdoutLines)
+		err := uninstall(cli)
+		Expect(err).NotTo(HaveOccurred(), "The uninstall should be successful")
+	})
+
+	When("the install ID is not discoverable", func() {
+		It("errors by default", func() {
+			flagSet.Parse([]string{})
+			commands := []string{
+				fmt.Sprintf(findInstallIdCmd, "gloo-system"),
+			}
+			installId := ""
+			cli := NewMockKubectl(commands, []string{installId})
+			err := uninstall(cli)
+			Expect(err).To(HaveOccurred(), "An error should occur if the install ID is not discoverable")
+		})
+
+		It("proceeds and uses the old logic when forced", func() {
+			flagSet.Parse([]string{"--force"})
+			commands := []string{
+				fmt.Sprintf(findInstallIdCmd, "gloo-system"),
+				"delete Deployment -l app=gloo -n gloo-system",
+				"delete Deployment -l app=glooe-grafana -n gloo-system",
+				"delete Deployment -l app=glooe-prometheus -n gloo-system",
+				"delete Service -l app=gloo -n gloo-system",
+				"delete Service -l app=glooe-grafana -n gloo-system",
+				"delete Service -l app=glooe-prometheus -n gloo-system",
+				"delete ServiceAccount -l app=gloo -n gloo-system",
+				"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
+				"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
+				"delete ConfigMap -l app=gloo -n gloo-system",
+				"delete ConfigMap -l app=glooe-grafana -n gloo-system",
+				"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
+				"delete Job -l app=gloo -n gloo-system",
+				"delete Job -l app=glooe-grafana -n gloo-system",
+				"delete Job -l app=glooe-prometheus -n gloo-system",
+			}
+			installId := ""
+			stdoutLines := []string{installId}
+			cli := NewMockKubectl(commands, stdoutLines)
+			err := uninstall(cli)
+			Expect(err).NotTo(HaveOccurred(), "An error should not occur if the installation ID is not discoverable but it was forced")
+		})
 	})
 })

--- a/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
@@ -81,21 +81,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{})
 		commands := []string{
 			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
-			"delete Deployment -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete Deployment -l app=glooe-grafana -n gloo-system",
 			"delete Deployment -l app=glooe-prometheus -n gloo-system",
-			"delete Service -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete Service -l app=glooe-grafana -n gloo-system",
 			"delete Service -l app=glooe-prometheus -n gloo-system",
-			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Service -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
 			"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
-			"delete ConfigMap -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete ConfigMap -l app=glooe-grafana -n gloo-system",
 			"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
-			"delete Job -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete Job -l app=glooe-grafana -n gloo-system",
 			"delete Job -l app=glooe-prometheus -n gloo-system",
+			"delete Job -l app=gloo,installationId=test-install-id -n gloo-system",
 		}
 		stdoutLines := []string{testInstallId}
 		cli := NewMockKubectl(commands, stdoutLines)
@@ -107,21 +107,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{"-n", "foo"})
 		cmds := []string{
 			fmt.Sprintf(findInstallIdCmd, "foo"),
-			"delete Deployment -l app=gloo,installationId=test-install-id -n foo",
 			"delete Deployment -l app=glooe-grafana -n foo",
 			"delete Deployment -l app=glooe-prometheus -n foo",
-			"delete Service -l app=gloo,installationId=test-install-id -n foo",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n foo",
 			"delete Service -l app=glooe-grafana -n foo",
 			"delete Service -l app=glooe-prometheus -n foo",
-			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n foo",
+			"delete Service -l app=gloo,installationId=test-install-id -n foo",
 			"delete ServiceAccount -l app=glooe-grafana -n foo",
 			"delete ServiceAccount -l app=glooe-prometheus -n foo",
-			"delete ConfigMap -l app=gloo,installationId=test-install-id -n foo",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n foo",
 			"delete ConfigMap -l app=glooe-grafana -n foo",
 			"delete ConfigMap -l app=glooe-prometheus -n foo",
-			"delete Job -l app=gloo,installationId=test-install-id -n foo",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n foo",
 			"delete Job -l app=glooe-grafana -n foo",
 			"delete Job -l app=glooe-prometheus -n foo",
+			"delete Job -l app=gloo,installationId=test-install-id -n foo",
 		}
 		stdoutLines := []string{testInstallId}
 		cli := NewMockKubectl(cmds, stdoutLines)
@@ -133,21 +133,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{"--delete-crds"})
 		cmds := []string{
 			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
-			"delete Deployment -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete Deployment -l app=glooe-grafana -n gloo-system",
 			"delete Deployment -l app=glooe-prometheus -n gloo-system",
-			"delete Service -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete Service -l app=glooe-grafana -n gloo-system",
 			"delete Service -l app=glooe-prometheus -n gloo-system",
-			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Service -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
 			"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
-			"delete ConfigMap -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete ConfigMap -l app=glooe-grafana -n gloo-system",
 			"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
-			"delete Job -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n gloo-system",
 			"delete Job -l app=glooe-grafana -n gloo-system",
 			"delete Job -l app=glooe-prometheus -n gloo-system",
+			"delete Job -l app=gloo,installationId=test-install-id -n gloo-system",
 			deleteCrds,
 		}
 		stdoutLines := []string{testInstallId}
@@ -160,21 +160,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{"-n", "foo", "--delete-crds"})
 		cmds := []string{
 			fmt.Sprintf(findInstallIdCmd, "foo"),
-			"delete Deployment -l app=gloo,installationId=test-install-id -n foo",
 			"delete Deployment -l app=glooe-grafana -n foo",
 			"delete Deployment -l app=glooe-prometheus -n foo",
-			"delete Service -l app=gloo,installationId=test-install-id -n foo",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n foo",
 			"delete Service -l app=glooe-grafana -n foo",
 			"delete Service -l app=glooe-prometheus -n foo",
-			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n foo",
+			"delete Service -l app=gloo,installationId=test-install-id -n foo",
 			"delete ServiceAccount -l app=glooe-grafana -n foo",
 			"delete ServiceAccount -l app=glooe-prometheus -n foo",
-			"delete ConfigMap -l app=gloo,installationId=test-install-id -n foo",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n foo",
 			"delete ConfigMap -l app=glooe-grafana -n foo",
 			"delete ConfigMap -l app=glooe-prometheus -n foo",
-			"delete Job -l app=gloo,installationId=test-install-id -n foo",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n foo",
 			"delete Job -l app=glooe-grafana -n foo",
 			"delete Job -l app=glooe-prometheus -n foo",
+			"delete Job -l app=gloo,installationId=test-install-id -n foo",
 			deleteCrds,
 		}
 		stdoutLines := []string{testInstallId}

--- a/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
@@ -81,11 +81,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{})
 		commands := []string{
 			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
-			"delete Deployment -l installationId=test-install-id -n gloo-system",
-			"delete Service -l installationId=test-install-id -n gloo-system",
-			"delete ServiceAccount -l installationId=test-install-id -n gloo-system",
-			"delete ConfigMap -l installationId=test-install-id -n gloo-system",
-			"delete Job -l installationId=test-install-id -n gloo-system",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Deployment -l app=glooe-grafana -n gloo-system",
+			"delete Deployment -l app=glooe-prometheus -n gloo-system",
+			"delete Service -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Service -l app=glooe-grafana -n gloo-system",
+			"delete Service -l app=glooe-prometheus -n gloo-system",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
+			"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ConfigMap -l app=glooe-grafana -n gloo-system",
+			"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
+			"delete Job -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Job -l app=glooe-grafana -n gloo-system",
+			"delete Job -l app=glooe-prometheus -n gloo-system",
 		}
 		stdoutLines := []string{testInstallId}
 		cli := NewMockKubectl(commands, stdoutLines)
@@ -97,11 +107,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{"-n", "foo"})
 		cmds := []string{
 			fmt.Sprintf(findInstallIdCmd, "foo"),
-			"delete Deployment -l installationId=test-install-id -n foo",
-			"delete Service -l installationId=test-install-id -n foo",
-			"delete ServiceAccount -l installationId=test-install-id -n foo",
-			"delete ConfigMap -l installationId=test-install-id -n foo",
-			"delete Job -l installationId=test-install-id -n foo",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n foo",
+			"delete Deployment -l app=glooe-grafana -n foo",
+			"delete Deployment -l app=glooe-prometheus -n foo",
+			"delete Service -l app=gloo,installationId=test-install-id -n foo",
+			"delete Service -l app=glooe-grafana -n foo",
+			"delete Service -l app=glooe-prometheus -n foo",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n foo",
+			"delete ServiceAccount -l app=glooe-grafana -n foo",
+			"delete ServiceAccount -l app=glooe-prometheus -n foo",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n foo",
+			"delete ConfigMap -l app=glooe-grafana -n foo",
+			"delete ConfigMap -l app=glooe-prometheus -n foo",
+			"delete Job -l app=gloo,installationId=test-install-id -n foo",
+			"delete Job -l app=glooe-grafana -n foo",
+			"delete Job -l app=glooe-prometheus -n foo",
 		}
 		stdoutLines := []string{testInstallId}
 		cli := NewMockKubectl(cmds, stdoutLines)
@@ -113,11 +133,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{"--delete-crds"})
 		cmds := []string{
 			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
-			"delete Deployment -l installationId=test-install-id -n gloo-system",
-			"delete Service -l installationId=test-install-id -n gloo-system",
-			"delete ServiceAccount -l installationId=test-install-id -n gloo-system",
-			"delete ConfigMap -l installationId=test-install-id -n gloo-system",
-			"delete Job -l installationId=test-install-id -n gloo-system",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Deployment -l app=glooe-grafana -n gloo-system",
+			"delete Deployment -l app=glooe-prometheus -n gloo-system",
+			"delete Service -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Service -l app=glooe-grafana -n gloo-system",
+			"delete Service -l app=glooe-prometheus -n gloo-system",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
+			"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete ConfigMap -l app=glooe-grafana -n gloo-system",
+			"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
+			"delete Job -l app=gloo,installationId=test-install-id -n gloo-system",
+			"delete Job -l app=glooe-grafana -n gloo-system",
+			"delete Job -l app=glooe-prometheus -n gloo-system",
 			deleteCrds,
 		}
 		stdoutLines := []string{testInstallId}
@@ -130,11 +160,21 @@ var _ = Describe("Uninstall", func() {
 		flagSet.Parse([]string{"-n", "foo", "--delete-crds"})
 		cmds := []string{
 			fmt.Sprintf(findInstallIdCmd, "foo"),
-			"delete Deployment -l installationId=test-install-id -n foo",
-			"delete Service -l installationId=test-install-id -n foo",
-			"delete ServiceAccount -l installationId=test-install-id -n foo",
-			"delete ConfigMap -l installationId=test-install-id -n foo",
-			"delete Job -l installationId=test-install-id -n foo",
+			"delete Deployment -l app=gloo,installationId=test-install-id -n foo",
+			"delete Deployment -l app=glooe-grafana -n foo",
+			"delete Deployment -l app=glooe-prometheus -n foo",
+			"delete Service -l app=gloo,installationId=test-install-id -n foo",
+			"delete Service -l app=glooe-grafana -n foo",
+			"delete Service -l app=glooe-prometheus -n foo",
+			"delete ServiceAccount -l app=gloo,installationId=test-install-id -n foo",
+			"delete ServiceAccount -l app=glooe-grafana -n foo",
+			"delete ServiceAccount -l app=glooe-prometheus -n foo",
+			"delete ConfigMap -l app=gloo,installationId=test-install-id -n foo",
+			"delete ConfigMap -l app=glooe-grafana -n foo",
+			"delete ConfigMap -l app=glooe-prometheus -n foo",
+			"delete Job -l app=gloo,installationId=test-install-id -n foo",
+			"delete Job -l app=glooe-grafana -n foo",
+			"delete Job -l app=glooe-prometheus -n foo",
 			deleteCrds,
 		}
 		stdoutLines := []string{testInstallId}
@@ -217,21 +257,21 @@ var _ = Describe("Uninstall", func() {
 			flagSet.Parse([]string{"--force"})
 			commands := []string{
 				fmt.Sprintf(findInstallIdCmd, "gloo-system"),
-				"delete Deployment -l app=gloo -n gloo-system",
 				"delete Deployment -l app=glooe-grafana -n gloo-system",
 				"delete Deployment -l app=glooe-prometheus -n gloo-system",
-				"delete Service -l app=gloo -n gloo-system",
+				"delete Deployment -l app=gloo -n gloo-system",
 				"delete Service -l app=glooe-grafana -n gloo-system",
 				"delete Service -l app=glooe-prometheus -n gloo-system",
-				"delete ServiceAccount -l app=gloo -n gloo-system",
+				"delete Service -l app=gloo -n gloo-system",
 				"delete ServiceAccount -l app=glooe-grafana -n gloo-system",
 				"delete ServiceAccount -l app=glooe-prometheus -n gloo-system",
-				"delete ConfigMap -l app=gloo -n gloo-system",
+				"delete ServiceAccount -l app=gloo -n gloo-system",
 				"delete ConfigMap -l app=glooe-grafana -n gloo-system",
 				"delete ConfigMap -l app=glooe-prometheus -n gloo-system",
-				"delete Job -l app=gloo -n gloo-system",
+				"delete ConfigMap -l app=gloo -n gloo-system",
 				"delete Job -l app=glooe-grafana -n gloo-system",
 				"delete Job -l app=glooe-prometheus -n gloo-system",
+				"delete Job -l app=gloo -n gloo-system",
 			}
 			installId := ""
 			stdoutLines := []string{installId}

--- a/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
@@ -217,8 +217,8 @@ var _ = Describe("Uninstall", func() {
 			fmt.Sprintf(findInstallIdCmd, "gloo-system"),
 			"delete namespace gloo-system",
 			deleteCrds,
-			"delete ClusterRole -l installationId=test-install-id",
-			"delete ClusterRoleBinding -l installationId=test-install-id",
+			"delete ClusterRole -l app=gloo,installationId=test-install-id",
+			"delete ClusterRoleBinding -l app=gloo,installationId=test-install-id",
 		}
 		stdoutLines := []string{testInstallId}
 		cli := NewMockKubectl(cmds, stdoutLines)
@@ -232,8 +232,8 @@ var _ = Describe("Uninstall", func() {
 			fmt.Sprintf(findInstallIdCmd, "foo"),
 			"delete namespace foo",
 			deleteCrds,
-			"delete ClusterRole -l installationId=test-install-id",
-			"delete ClusterRoleBinding -l installationId=test-install-id",
+			"delete ClusterRole -l app=gloo,installationId=test-install-id",
+			"delete ClusterRoleBinding -l app=gloo,installationId=test-install-id",
 		}
 		stdoutLines := []string{testInstallId}
 		cli := NewMockKubectl(cmds, stdoutLines)

--- a/projects/gloo/cli/pkg/cmd/options/options.go
+++ b/projects/gloo/cli/pkg/cmd/options/options.go
@@ -67,6 +67,7 @@ type Uninstall struct {
 	DeleteCrds      bool
 	DeleteNamespace bool
 	DeleteAll       bool
+	Force           bool
 }
 
 type Proxy struct {

--- a/projects/gloo/cli/pkg/flagutils/uninstall.go
+++ b/projects/gloo/cli/pkg/flagutils/uninstall.go
@@ -11,4 +11,5 @@ func AddUninstallFlags(set *pflag.FlagSet, opts *options.Uninstall) {
 	set.BoolVar(&opts.DeleteNamespace, "delete-namespace", false, "Delete the namespace (all objects written to this namespace will be deleted)")
 	set.BoolVar(&opts.DeleteCrds, "delete-crds", false, "Delete all gloo crds (all custom gloo objects will be deleted)")
 	set.BoolVar(&opts.DeleteAll, "all", false, "Deletes all gloo resources, including the namespace, crds, and cluster role")
+	set.BoolVar(&opts.Force, "force", false, "Uninstalls Gloo even if the installation ID cannot be determined from the gloo pod labels (using this may delete cluster-scoped resources belonging to other Gloo installations)")
 }


### PR DESCRIPTION
Use the installation ID set by Helm to ensure that glooctl uninstalls only resources created for the instance of Gloo being uninstalled. It does this by attempting to read the "installationId" label from the gloo pod. If the label is not found, the uninstall will fail. You can choose to proceed by passing the new --force flag to "glooctl uninstall", which will attempt to perform an uninstall that may inadvertently delete cluster-scoped resources belonging to some other installation of Gloo.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1593