### PR TITLE
fix potential plugin race

### DIFF
--- a/changelog/v1.0.0-rc2/fix-plugin-race.yaml
+++ b/changelog/v1.0.0-rc2/fix-plugin-race.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix potential race where plugins may be called across translates invoked by the Validation server at the same time as the Translation sync.
+    issueLink: https://github.com/solo-io/gloo/issues/1616

--- a/changelog/v1.0.0-rc2/fix-plugin-race.yaml
+++ b/changelog/v1.0.0-rc2/fix-plugin-race.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: FIX
-    description: Fix potential race where plugins may be called across translates invoked by the Validation server at the same time as the Translation sync.
-    issueLink: https://github.com/solo-io/gloo/issues/1616

--- a/changelog/v1.0.0-rc3/fix-plugin-race.yaml
+++ b/changelog/v1.0.0-rc3/fix-plugin-race.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix potential race where plugins may be called across translates invoked by the Validation server at the same time as the Translation sync.
+    issueLink: https://github.com/solo-io/gloo/issues/1616

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -386,10 +386,12 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 	xds.SetupEnvoyXds(opts.ControlPlane.GrpcServer, opts.ControlPlane.XDSServer, opts.ControlPlane.SnapshotCache)
 	xdsHasher := xds.NewNodeHasher()
 
-	allPlugins := registry.Plugins(opts, extensions.PluginExtensions...)
+	getPlugins := func() []plugins.Plugin {
+		return registry.Plugins(opts, extensions.PluginExtensions...)
+	}
 
 	var discoveryPlugins []discovery.DiscoveryPlugin
-	for _, plug := range allPlugins {
+	for _, plug := range getPlugins() {
 		disc, ok := plug.(discovery.DiscoveryPlugin)
 		if ok {
 			discoveryPlugins = append(discoveryPlugins, disc)
@@ -445,7 +447,7 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 	apiCache := v1.NewApiEmitter(artifactClient, endpointClient, proxyClient, upstreamGroupClient, secretClient, hybridUsClient, authConfigClient)
 	rpt := reporter.NewReporter("gloo", hybridUsClient.BaseClient(), proxyClient.BaseClient(), upstreamGroupClient.BaseClient())
 
-	t := translator.NewTranslator(sslutils.NewSslConfigTranslator(), opts.Settings, allPlugins...)
+	t := translator.NewTranslator(sslutils.NewSslConfigTranslator(), opts.Settings, getPlugins)
 
 	validator := validation.NewValidator(t)
 	if opts.ValidationServer.Server != nil {

--- a/projects/gloo/pkg/translator/clusters.go
+++ b/projects/gloo/pkg/translator/clusters.go
@@ -17,7 +17,7 @@ import (
 	"go.opencensus.io/trace"
 )
 
-func (t *translator) computeClusters(params plugins.Params, reports reporter.ResourceReports) []*envoyapi.Cluster {
+func (t *translatorInstance) computeClusters(params plugins.Params, reports reporter.ResourceReports) []*envoyapi.Cluster {
 
 	ctx, span := trace.StartSpan(params.Ctx, "gloo.translator.computeClusters")
 	params.Ctx = ctx
@@ -36,7 +36,7 @@ func (t *translator) computeClusters(params plugins.Params, reports reporter.Res
 	return clusters
 }
 
-func (t *translator) computeCluster(params plugins.Params, upstream *v1.Upstream, reports reporter.ResourceReports) *envoyapi.Cluster {
+func (t *translatorInstance) computeCluster(params plugins.Params, upstream *v1.Upstream, reports reporter.ResourceReports) *envoyapi.Cluster {
 	params.Ctx = contextutils.WithLogger(params.Ctx, upstream.Metadata.Name)
 	out := t.initializeCluster(upstream, params.Snapshot.Endpoints, reports)
 
@@ -57,7 +57,7 @@ func (t *translator) computeCluster(params plugins.Params, upstream *v1.Upstream
 	return out
 }
 
-func (t *translator) initializeCluster(upstream *v1.Upstream, endpoints []*v1.Endpoint, reports reporter.ResourceReports) *envoyapi.Cluster {
+func (t *translatorInstance) initializeCluster(upstream *v1.Upstream, endpoints []*v1.Endpoint, reports reporter.ResourceReports) *envoyapi.Cluster {
 	hcConfig, err := createHealthCheckConfig(upstream)
 	if err != nil {
 		reports.AddError(upstream, err)

--- a/projects/gloo/pkg/translator/http_filters.go
+++ b/projects/gloo/pkg/translator/http_filters.go
@@ -52,7 +52,7 @@ func NewHttpConnectionManager(listener *v1.HttpListener, httpFilters []*envoyhtt
 	}
 }
 
-func (t *translator) computeHttpConnectionManagerFilter(params plugins.Params, listener *v1.HttpListener, rdsName string, httpListenerReport *validationapi.HttpListenerReport) envoylistener.Filter {
+func (t *translatorInstance) computeHttpConnectionManagerFilter(params plugins.Params, listener *v1.HttpListener, rdsName string, httpListenerReport *validationapi.HttpListenerReport) envoylistener.Filter {
 	httpFilters := t.computeHttpFilters(params, listener, httpListenerReport)
 	params.Ctx = contextutils.WithLogger(params.Ctx, "compute_http_connection_manager")
 
@@ -65,7 +65,7 @@ func (t *translator) computeHttpConnectionManagerFilter(params plugins.Params, l
 	return hcmFilter
 }
 
-func (t *translator) computeHttpFilters(params plugins.Params, listener *v1.HttpListener, httpListenerReport *validationapi.HttpListenerReport) []*envoyhttp.HttpFilter {
+func (t *translatorInstance) computeHttpFilters(params plugins.Params, listener *v1.HttpListener, httpListenerReport *validationapi.HttpListenerReport) []*envoyhttp.HttpFilter {
 	var httpFilters []plugins.StagedHttpFilter
 	// run the Http Filter Plugins
 	for _, plug := range t.plugins {

--- a/projects/gloo/pkg/translator/listener.go
+++ b/projects/gloo/pkg/translator/listener.go
@@ -17,7 +17,7 @@ import (
 	"github.com/solo-io/go-utils/contextutils"
 )
 
-func (t *translator) computeListener(params plugins.Params, proxy *v1.Proxy, listener *v1.Listener, listenerReport *validationapi.ListenerReport) *envoyapi.Listener {
+func (t *translatorInstance) computeListener(params plugins.Params, proxy *v1.Proxy, listener *v1.Listener, listenerReport *validationapi.ListenerReport) *envoyapi.Listener {
 	params.Ctx = contextutils.WithLogger(params.Ctx, "compute_listener."+listener.Name)
 
 	validateListenerPorts(proxy, listenerReport)
@@ -81,7 +81,7 @@ func (t *translator) computeListener(params plugins.Params, proxy *v1.Proxy, lis
 	return out
 }
 
-func (t *translator) computeListenerFilters(params plugins.Params, listener *v1.Listener, listenerReport *validationapi.ListenerReport) []envoylistener.Filter {
+func (t *translatorInstance) computeListenerFilters(params plugins.Params, listener *v1.Listener, listenerReport *validationapi.ListenerReport) []envoylistener.Filter {
 	var listenerFilters []plugins.StagedListenerFilter
 	// run the Listener Filter Plugins
 	for _, plug := range t.plugins {
@@ -124,7 +124,7 @@ func (t *translator) computeListenerFilters(params plugins.Params, listener *v1.
 
 // create a duplicate of the listener filter chain for each ssl cert we want to serve
 // if there is no SSL config on the listener, the envoy listener will have one insecure filter chain
-func (t *translator) computeFilterChainsFromSslConfig(snap *v1.ApiSnapshot, listener *v1.Listener, listenerFilters []envoylistener.Filter, listenerReport *validationapi.ListenerReport) []envoylistener.FilterChain {
+func (t *translatorInstance) computeFilterChainsFromSslConfig(snap *v1.ApiSnapshot, listener *v1.Listener, listenerFilters []envoylistener.Filter, listenerReport *validationapi.ListenerReport) []envoylistener.FilterChain {
 
 	// if no ssl config is provided, return a single insecure filter chain
 	if len(listener.SslConfigurations) == 0 {

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -32,7 +32,7 @@ var (
 	SubsetsMisconfiguredErr = errors.New("route has a subset config, but the upstream does not.")
 )
 
-func (t *translator) computeRouteConfig(params plugins.Params, proxy *v1.Proxy, listener *v1.Listener, routeCfgName string, listenerReport *validationapi.ListenerReport) *envoyapi.RouteConfiguration {
+func (t *translatorInstance) computeRouteConfig(params plugins.Params, proxy *v1.Proxy, listener *v1.Listener, routeCfgName string, listenerReport *validationapi.ListenerReport) *envoyapi.RouteConfiguration {
 	if listener.GetHttpListener() == nil {
 		return nil
 	}
@@ -60,7 +60,7 @@ func (t *translator) computeRouteConfig(params plugins.Params, proxy *v1.Proxy, 
 	}
 }
 
-func (t *translator) computeVirtualHosts(params plugins.Params, proxy *v1.Proxy, listener *v1.Listener, httpListenerReport *validationapi.HttpListenerReport) []envoyroute.VirtualHost {
+func (t *translatorInstance) computeVirtualHosts(params plugins.Params, proxy *v1.Proxy, listener *v1.Listener, httpListenerReport *validationapi.HttpListenerReport) []envoyroute.VirtualHost {
 	httpListener, ok := listener.ListenerType.(*v1.Listener_HttpListener)
 	if !ok {
 		return nil
@@ -81,7 +81,7 @@ func (t *translator) computeVirtualHosts(params plugins.Params, proxy *v1.Proxy,
 	return envoyVirtualHosts
 }
 
-func (t *translator) computeVirtualHost(params plugins.VirtualHostParams, virtualHost *v1.VirtualHost, requireTls bool, vhostReport *validationapi.VirtualHostReport) envoyroute.VirtualHost {
+func (t *translatorInstance) computeVirtualHost(params plugins.VirtualHostParams, virtualHost *v1.VirtualHost, requireTls bool, vhostReport *validationapi.VirtualHostReport) envoyroute.VirtualHost {
 
 	// Make copy to avoid modifying the snapshot
 	virtualHost = proto.Clone(virtualHost).(*v1.VirtualHost)
@@ -131,7 +131,7 @@ func (t *translator) computeVirtualHost(params plugins.VirtualHostParams, virtua
 	return out
 }
 
-func (t *translator) envoyRoutes(params plugins.RouteParams, routeReport *validationapi.RouteReport, in *v1.Route) []envoyroute.Route {
+func (t *translatorInstance) envoyRoutes(params plugins.RouteParams, routeReport *validationapi.RouteReport, in *v1.Route) []envoyroute.Route {
 
 	out := initRoutes(in, routeReport)
 
@@ -190,7 +190,7 @@ func GlooMatcherToEnvoyMatcher(matcher *matchers.Matcher) envoyroute.RouteMatch 
 	return match
 }
 
-func (t *translator) setAction(params plugins.RouteParams, routeReport *validationapi.RouteReport, in *v1.Route, out *envoyroute.Route) {
+func (t *translatorInstance) setAction(params plugins.RouteParams, routeReport *validationapi.RouteReport, in *v1.Route, out *envoyroute.Route) {
 	switch action := in.Action.(type) {
 	case *v1.Route_RouteAction:
 		if err := ValidateRouteDestinations(params.Snapshot, action.RouteAction); err != nil {
@@ -290,7 +290,7 @@ func (t *translator) setAction(params plugins.RouteParams, routeReport *validati
 	}
 }
 
-func (t *translator) setRouteAction(params plugins.RouteParams, in *v1.RouteAction, out *envoyroute.RouteAction, routeReport *validationapi.RouteReport) error {
+func (t *translatorInstance) setRouteAction(params plugins.RouteParams, in *v1.RouteAction, out *envoyroute.RouteAction, routeReport *validationapi.RouteReport) error {
 	switch dest := in.Destination.(type) {
 	case *v1.RouteAction_Single:
 		usRef, err := usconversion.DestinationToUpstreamRef(dest.Single)
@@ -320,7 +320,7 @@ func (t *translator) setRouteAction(params plugins.RouteParams, in *v1.RouteActi
 	return errors.Errorf("unknown upstream destination type")
 }
 
-func (t *translator) setWeightedClusters(params plugins.RouteParams, multiDest *v1.MultiDestination, out *envoyroute.RouteAction, routeReport *validationapi.RouteReport) error {
+func (t *translatorInstance) setWeightedClusters(params plugins.RouteParams, multiDest *v1.MultiDestination, out *envoyroute.RouteAction, routeReport *validationapi.RouteReport) error {
 	if len(multiDest.Destinations) == 0 {
 		return NoDestinationSpecifiedError
 	}

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -150,7 +150,10 @@ var _ = Describe("Translator", func() {
 	})
 
 	JustBeforeEach(func() {
-		translator = NewTranslator(sslutils.NewSslConfigTranslator(), settings, registeredPlugins...)
+		getPlugins := func() []plugins.Plugin {
+			return registeredPlugins
+		}
+		translator = NewTranslator(sslutils.NewSslConfigTranslator(), settings, getPlugins)
 		httpListener := &v1.Listener{
 			Name:        "http-listener",
 			BindAddress: "127.0.0.1",

--- a/projects/gloo/pkg/translator/upstream_groups.go
+++ b/projects/gloo/pkg/translator/upstream_groups.go
@@ -7,7 +7,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
 )
 
-func (t *translator) verifyUpstreamGroups(params plugins.Params, reports reporter.ResourceReports) {
+func (t *translatorInstance) verifyUpstreamGroups(params plugins.Params, reports reporter.ResourceReports) {
 
 	upstreams := params.Snapshot.Upstreams
 	upstreamGroups := params.Snapshot.UpstreamGroups

--- a/projects/gloo/pkg/validation/server_test.go
+++ b/projects/gloo/pkg/validation/server_test.go
@@ -60,7 +60,11 @@ var _ = Describe("Validation Server", func() {
 	})
 
 	JustBeforeEach(func() {
-		translator = NewTranslator(sslutils.NewSslConfigTranslator(), settings, registeredPlugins...)
+
+		getPlugins := func() []plugins.Plugin {
+			return registeredPlugins
+		}
+		translator = NewTranslator(sslutils.NewSslConfigTranslator(), settings, getPlugins)
 	})
 
 	It("validates the requested proxy", func() {


### PR DESCRIPTION
# problem

Gloo plugins are shared across calls to `Translate`. some plugins generate temporary state that is flushed at the start of the next translation loop.

Translation loops can now be called concurrently as a result of the proxy validation server.

# solution

initialize new plugins every translation by creating a "translationInstance" with a freshly constructed set of plugins whenever Translate is called
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1616