### PR TITLE
knative helm charts compare semver

### DIFF
--- a/changelog/v1.0.0-rc3/knative-helm-uses-semver-compare.yml
+++ b/changelog/v1.0.0-rc3/knative-helm-uses-semver-compare.yml
@@ -1,0 +1,4 @@
+changelog:
+  - type: HELM
+    description: knative helm charts use compareSemver
+    issueLink: https://github.com/solo-io/gloo/pull/1623

--- a/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][0-7]+[.][0-9]" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare "< 0.8.0" .Values.settings.integrations.knative.version ) }}
 {{- $image := .Values.settings.integrations.knative.proxy.image }}
 {{- if .Values.global  }}
 {{- $image = merge .Values.settings.integrations.knative.proxy.image .Values.global.image }}

--- a/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][8-9]+[.][0-9]+" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare ">= 0.8.0" .Values.settings.integrations.knative.version ) }}
 {{- $image := .Values.settings.integrations.knative.proxy.image }}
 {{- if .Values.global  }}
 {{- $image = merge .Values.settings.integrations.knative.proxy.image .Values.global.image  }}

--- a/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][8-9]+[.][0-9]" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare ">= 0.8.0" .Values.settings.integrations.knative.version ) }}
 
 # configmap
 apiVersion: v1

--- a/install/helm/gloo/templates/28-knative-external-proxy-service.yaml
+++ b/install/helm/gloo/templates/28-knative-external-proxy-service.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][8-9]+[.][0-9]" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare ">= 0.8.0" .Values.settings.integrations.knative.version ) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][8-9]+[.][0-9]+" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare ">= 0.8.0" .Values.settings.integrations.knative.version ) }}
 {{- $image := .Values.settings.integrations.knative.proxy.image }}
 {{- if .Values.global  }}
 {{- $image = merge .Values.settings.integrations.knative.proxy.image .Values.global.image }}

--- a/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][8-9]+[.][0-9]" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare ">= 0.8.0" .Values.settings.integrations.knative.version ) }}
 
 # configmap
 apiVersion: v1

--- a/install/helm/gloo/templates/31-knative-internal-proxy-service.yaml
+++ b/install/helm/gloo/templates/31-knative-internal-proxy-service.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][8-9]+[.][0-9]" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare ">= 0.8.0" .Values.settings.integrations.knative.version ) }}
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
### Solution
Improve the knative helm charts by swapping `semverCompare` in for `regexMatch`.

### Context
Before this PR, if you ran `glooctl install knative --install-knative-version 0.10.0`, you got knative 0.10.0 but a gloo system targeted at knative 0.7.0.

**Caveat:** Unfortunately, AFAICT this doesn't actually yield a working knative 0.10.0 system.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/pull/1623