### PR TITLE
Fix typo in transformation doc

### DIFF
--- a/changelog/v1.0.0-rc3/fix-transformation-docs-typo.yaml
+++ b/changelog/v1.0.0-rc3/fix-transformation-docs-typo.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Fix typo in transformation doc.
+  issueLink: https://github.com/solo-io/gloo/issues/1622

--- a/changelog/v1.0.0-rc3/fix-transformation-docs-typo.yaml
+++ b/changelog/v1.0.0-rc3/fix-transformation-docs-typo.yaml
@@ -1,4 +1,4 @@
 changelog:
-- type: FIX
+- type: NON_USER_FACING
   description: Fix typo in transformation doc.
   issueLink: https://github.com/solo-io/gloo/issues/1622

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/transformations/_index.md
@@ -120,7 +120,7 @@ An extraction must have one of two sources:
       myExtractor:
         header: 'foo'
     ```
-- `header`: extract information from the body. This attribute takes an empty value (as there is always only one body).
+- `body`: extract information from the body. This attribute takes an empty value (as there is always only one body).
     ```yaml
     extractors:
       myExtractor:


### PR DESCRIPTION
Fix typo in transformation documentation main page.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1622