### PR TITLE
Make note of breaking change and remove installation ID from pod labels

### DIFF
--- a/changelog/v1.0.0-rc2/role-suffix.yaml
+++ b/changelog/v1.0.0-rc2/role-suffix.yaml
@@ -10,3 +10,15 @@ changelog:
     Roles/RoleBindings with and without the suffix). If this is the case, the old resources
     (without the suffix) can be safely cleaned up.
   issueLink: https://github.com/solo-io/gloo/issues/1459
+- type: BREAKING_CHANGE
+  description: >
+    This release changes the names of Gloo's ClusterRoles. By default, cluster-scoped roles
+    will have the namespace of the associated Gloo installation appended to their name
+    (i.e., the cluster-scoped role "gloo-resource-reader" created along with a Gloo installation
+    to the gloo-system namespace will now become "gloo-resource-reader-gloo-system"). This
+    may cause a problem during upgrades from Gloo <0.21.0 to Gloo >=0.21.0 for both
+    open-source and enterprise Gloo, as the role ref in a ClusterRoleBinding is immutable.
+    To resolve this, you can delete the existing ClusterRoleBindings with
+    "kubectl delete clusterrolebinding -l app=gloo" and they will be recreated correctly by
+    the rest of the upgrade process.
+  issueLink: https://github.com/solo-io/gloo/issues/1459

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -16,12 +16,10 @@ spec:
   selector:
     matchLabels:
       gloo: gloo
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: gloo
-        installationId: {{ include "gloo.installationId" . }}
       {{- if .Values.gloo.deployment.stats }}
       annotations:
         prometheus.io/path: /metrics

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -17,12 +17,10 @@ spec:
   selector:
     matchLabels:
       gloo: ingress
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: ingress
-        installationId: {{ include "gloo.installationId" . }}
     spec:
       containers:
       - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
@@ -17,12 +17,10 @@ spec:
   selector:
     matchLabels:
       gloo: ingress-proxy
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: ingress-proxy
-        installationId: {{ include "gloo.installationId" . }}
 {{- if .Values.ingressProxy.deployment.extraAnnotations }}
       annotations:
       {{- range $key, $value := .Values.ingressProxy.deployment.extraAnnotations }}

--- a/install/helm/gloo/templates/13-ingress-proxy-service.yaml
+++ b/install/helm/gloo/templates/13-ingress-proxy-service.yaml
@@ -18,7 +18,6 @@ spec:
     name: https
   selector:
     gloo: ingress-proxy
-    installationId: {{ include "gloo.installationId" . }}
   type: LoadBalancer
 
 

--- a/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
@@ -18,12 +18,10 @@ spec:
   selector:
     matchLabels:
       gloo: clusteringress-proxy
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: clusteringress-proxy
-        installationId: {{ include "gloo.installationId" . }}
     spec:
       containers:
       - args: ["--disable-hot-restart"]

--- a/install/helm/gloo/templates/16-clusteringress-proxy-service.yaml
+++ b/install/helm/gloo/templates/16-clusteringress-proxy-service.yaml
@@ -19,7 +19,6 @@ spec:
     name: https
   selector:
     gloo: clusteringress-proxy
-    installationId: {{ include "gloo.installationId" . }}
   type: LoadBalancer
 {{- end }}
 {{- end }}

--- a/install/helm/gloo/templates/2-gloo-service.yaml
+++ b/install/helm/gloo/templates/2-gloo-service.yaml
@@ -23,4 +23,3 @@ spec:
     protocol: TCP
   selector:
     gloo: gloo
-    installationId: {{ include "gloo.installationId" . }}

--- a/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
@@ -18,12 +18,10 @@ spec:
   selector:
     matchLabels:
       gloo: knative-external-proxy
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: knative-external-proxy
-        installationId: {{ include "gloo.installationId" . }}
     spec:
       containers:
       - args: ["--disable-hot-restart"]

--- a/install/helm/gloo/templates/28-knative-external-proxy-service.yaml
+++ b/install/helm/gloo/templates/28-knative-external-proxy-service.yaml
@@ -19,7 +19,6 @@ spec:
     name: https
   selector:
     gloo: knative-external-proxy
-    installationId: {{ include "gloo.installationId" . }}
   type: LoadBalancer
 {{- end }}
 {{- end }}

--- a/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
@@ -18,12 +18,10 @@ spec:
   selector:
     matchLabels:
       gloo: knative-internal-proxy
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: knative-internal-proxy
-        installationId: {{ include "gloo.installationId" . }}
     spec:
       containers:
       - args: ["--disable-hot-restart"]

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -17,12 +17,10 @@ spec:
   selector:
     matchLabels:
       gloo: discovery
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: discovery
-        installationId: {{ include "gloo.installationId" . }}
       {{- if .Values.discovery.deployment.stats }}
       annotations:
         prometheus.io/path: /metrics

--- a/install/helm/gloo/templates/31-knative-internal-proxy-service.yaml
+++ b/install/helm/gloo/templates/31-knative-internal-proxy-service.yaml
@@ -19,7 +19,6 @@ spec:
     name: https
   selector:
     gloo: knative-internal-proxy
-    installationId: {{ include "gloo.installationId" . }}
   type: ClusterIP
 {{- end }}
 {{- end }}

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -17,12 +17,10 @@ spec:
   selector:
     matchLabels:
       gloo: gateway
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         gloo: gateway
-        installationId: {{ include "gloo.installationId" . }}
       {{- if .Values.gateway.deployment.stats }}
       annotations:
         prometheus.io/path: /metrics

--- a/install/helm/gloo/templates/5-gateway-service.yaml
+++ b/install/helm/gloo/templates/5-gateway-service.yaml
@@ -18,5 +18,4 @@ spec:
     targetPort: 8443
   selector:
     gloo: gateway
-    installationId: {{ include "gloo.installationId" . }}
 {{- end}}

--- a/install/helm/gloo/templates/6-access-logger-deployment.yaml
+++ b/install/helm/gloo/templates/6-access-logger-deployment.yaml
@@ -19,13 +19,11 @@ spec:
     matchLabels:
       app: gloo
       gloo: gateway-proxy-v2-access-logger
-      installationId: {{ include "gloo.installationId" . }}
   template:
     metadata:
       labels:
         app: gloo
         gloo: gateway-proxy-v2-access-logger
-        installationId: {{ include "gloo.installationId" . }}
     spec:
       serviceAccountName: gateway-proxy
       containers:

--- a/install/helm/gloo/templates/6-access-logger-service.yaml
+++ b/install/helm/gloo/templates/6-access-logger-service.yaml
@@ -18,5 +18,4 @@ spec:
   selector:
     app: gloo
     gloo: gateway-proxy-v2-access-logger
-    installationId: {{ include "gloo.installationId" . }}
 {{- end }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -32,13 +32,11 @@ spec:
     matchLabels:
       gloo: gateway-proxy
       gateway-proxy-id: {{ $name | kebabcase }}
-      installationId: {{ include "gloo.installationId" $ }}
   template:
     metadata:
       labels:
         gloo: gateway-proxy
         gateway-proxy-id: {{ $name | kebabcase }}
-        installationId: {{ include "gloo.installationId" $ }}
         {{- if not $isUpgrade }}
         gateway-proxy: live
         {{- end }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -33,7 +33,6 @@ spec:
   selector:
     gateway-proxy-id: {{ $name | kebabcase }}
     gateway-proxy: live
-    installationId: {{ include "gloo.installationId" $ }}
   type: {{ $spec.service.type }}
   {{- if and (eq $spec.service.type "ClusterIP") $spec.service.clusterIP }}
   clusterIP: {{ $spec.service.clusterIP }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/solo-io/go-utils/installutils/kuberesource"
 	"github.com/solo-io/reporting-client/pkg/client"
 
 	"k8s.io/apimachinery/pkg/runtime"

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -143,26 +143,6 @@ var _ = Describe("Helm Test", func() {
 				})
 
 				Expect(uniqueInstallationId).NotTo(Equal(helmTestInstallId), "Make sure we didn't accidentally set our install ID to the helm test ID")
-
-				haveNonzeroDeployments := false
-				testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
-					return resource.GetKind() == "Deployment"
-				}).ExpectAll(func(unstructuredDeployment *unstructured.Unstructured) {
-					haveNonzeroDeployments = true
-
-					converted, err := kuberesource.ConvertUnstructured(unstructuredDeployment)
-					Expect(err).NotTo(HaveOccurred(), "Should be able to convert from unstructured")
-					deployment, ok := converted.(*appsv1.Deployment)
-					Expect(ok).To(BeTrue(), "Should be castable to a deployment")
-
-					Expect(len(deployment.Spec.Template.Labels)).NotTo(BeZero(), "The deployment's pod spec had no labels")
-
-					podInstallId, ok := deployment.Spec.Template.Labels[installIdLabel]
-					Expect(ok).To(BeTrue(), "Should have the install id label set")
-					Expect(podInstallId).To(Equal(uniqueInstallationId), "Pods from deployments should have the same install IDs as everything else")
-				})
-
-				Expect(haveNonzeroDeployments).To(BeTrue())
 			})
 
 			It("can assign a custom installation ID", func() {
@@ -200,7 +180,6 @@ var _ = Describe("Helm Test", func() {
 					"gateway-proxy":    "live",
 					"gateway-proxy-id": "gateway-proxy-v2",
 				}
-				setGlobalLabels(selector)
 			})
 
 			It("has a namespace", func() {
@@ -242,7 +221,6 @@ var _ = Describe("Helm Test", func() {
 						"app":  "gloo",
 						"gloo": "gateway-proxy-v2-access-logger",
 					}
-					setGlobalLabels(labels)
 				})
 
 				It("can create an access logging deployment/service", func() {
@@ -258,10 +236,10 @@ var _ = Describe("Helm Test", func() {
 						},
 					)
 					container.PullPolicy = "Always"
-					rb := &ResourceBuilder{
+					svcBuilder := &ResourceBuilder{
 						Namespace:  namespace,
 						Name:       accessLoggerName,
-						Labels:     labels,
+						Labels:     cloneMap(labels),
 						Containers: []ContainerSpec{container},
 						Service: ServiceSpec{
 							Ports: []PortSpec{
@@ -272,11 +250,34 @@ var _ = Describe("Helm Test", func() {
 							},
 						},
 					}
-					svc := rb.GetService()
-					svc.Spec.Selector = labels
+					svc := svcBuilder.GetService()
+					svc.Spec.Selector = map[string]string{
+						"app":  "gloo",
+						"gloo": "gateway-proxy-v2-access-logger",
+					}
 					svc.Spec.Type = ""
 					svc.Spec.Ports[0].TargetPort = intstr.FromInt(8083)
-					dep := rb.GetDeploymentAppsv1()
+					svc.Spec.Selector = cloneMap(labels)
+					setGlobalLabels(svc.ObjectMeta.Labels)
+
+					deploymentBuilder := &ResourceBuilder{
+						Namespace:  namespace,
+						Name:       accessLoggerName,
+						Labels:     cloneMap(labels),
+						Containers: []ContainerSpec{container},
+						Service: ServiceSpec{
+							Ports: []PortSpec{
+								{
+									Name: "http",
+									Port: 8083,
+								},
+							},
+						},
+					}
+					dep := deploymentBuilder.GetDeploymentAppsv1()
+					dep.Spec.Template.ObjectMeta.Labels = cloneMap(labels)
+					dep.Spec.Selector.MatchLabels = cloneMap(labels)
+					setGlobalLabels(dep.ObjectMeta.Labels)
 					dep.Spec.Template.Spec.Containers[0].Ports = []v1.ContainerPort{
 						{Name: "http", ContainerPort: 8083, Protocol: "TCP"},
 					}
@@ -446,7 +447,6 @@ var _ = Describe("Helm Test", func() {
 						"gateway-proxy-id": "gateway-proxy-v2",
 						"gateway-proxy":    "live",
 					}
-					setGlobalLabels(selectorLabels)
 					gatewayProxyService.Spec.Selector = selectorLabels
 					gatewayProxyService.Spec.Ports = []v1.ServicePort{
 						{
@@ -509,13 +509,11 @@ var _ = Describe("Helm Test", func() {
 						"gloo":             "gateway-proxy",
 						"gateway-proxy-id": "gateway-proxy-v2",
 					}
-					setGlobalLabels(selector)
 					podLabels := map[string]string{
 						"gloo":             "gateway-proxy",
 						"gateway-proxy":    "live",
 						"gateway-proxy-id": "gateway-proxy-v2",
 					}
-					setGlobalLabels(podLabels)
 					podname := v1.EnvVar{
 						Name: "POD_NAME",
 						ValueFrom: &v1.EnvVarSource{
@@ -774,7 +772,6 @@ spec:
     targetPort: 8443
   selector:
     gloo: gateway
-    installationId: ` + helmTestInstallId + `
 `)
 
 					prepareMakefile("--namespace " + namespace)
@@ -871,12 +868,10 @@ spec:
   selector:
     matchLabels:
       gloo: gateway
-      installationId: ` + helmTestInstallId + `
   template:
     metadata:
       labels:
         gloo: gateway
-        installationId: ` + helmTestInstallId + `
       annotations:
         prometheus.io/path: /metrics
         prometheus.io/port: "9091"
@@ -1043,7 +1038,6 @@ metadata:
 					MatchLabels: selector,
 				}
 				deploy.Spec.Template.ObjectMeta.Labels = map[string]string{}
-				deploy.Spec.Template.ObjectMeta.Labels["installationId"] = helmTestInstallId
 				for k, v := range selector {
 					deploy.Spec.Template.ObjectMeta.Labels[k] = v
 				}
@@ -1076,7 +1070,6 @@ metadata:
 					selector = map[string]string{
 						"gloo": "gloo",
 					}
-					setGlobalLabels(selector)
 					container := GetQuayContainerSpec("gloo", version, GetPodNamespaceEnvVar(), GetPodNamespaceStats())
 
 					rb := ResourceBuilder{
@@ -1199,7 +1192,6 @@ metadata:
 					selector = map[string]string{
 						"gloo": "gateway",
 					}
-					setGlobalLabels(selector)
 					container := GetQuayContainerSpec("gateway", version, GetPodNamespaceEnvVar(), GetPodNamespaceStats())
 
 					rb := ResourceBuilder{
@@ -1308,7 +1300,6 @@ metadata:
 					selector = map[string]string{
 						"gloo": "discovery",
 					}
-					setGlobalLabels(selector)
 					container := GetQuayContainerSpec("discovery", version, GetPodNamespaceEnvVar(), GetPodNamespaceStats())
 
 					rb := ResourceBuilder{
@@ -1475,11 +1466,9 @@ metadata:
 				selectors := map[string]string{
 					"gloo": "gloo",
 				}
-				setGlobalLabels(selectors)
 				podLabels := map[string]string{
 					"gloo": "gloo",
 				}
-				setGlobalLabels(podLabels)
 				var glooDeploymentPostMerge = &appsv1.Deployment{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Deployment",
@@ -1574,11 +1563,9 @@ metadata:
 				ingressSelector := map[string]string{
 					"gloo": "ingress",
 				}
-				setGlobalLabels(ingressSelector)
 				ingressPodLabels := map[string]string{
 					"gloo": "ingress",
 				}
-				setGlobalLabels(ingressPodLabels)
 				var ingressDeploymentPostMerge = &appsv1.Deployment{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "Deployment",
@@ -1648,4 +1635,13 @@ func makeUnstructured(yam string) *unstructured.Unstructured {
 	runtimeObj, err := runtime.Decode(unstructured.UnstructuredJSONScheme, jsn)
 	Expect(err).NotTo(HaveOccurred())
 	return runtimeObj.(*unstructured.Unstructured)
+}
+
+func cloneMap(input map[string]string) map[string]string {
+	ret := map[string]string{}
+	for k, v := range input {
+		ret[k] = v
+	}
+
+	return ret
 }

--- a/projects/gloo/cli/pkg/cmd/install/uninstall.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall.go
@@ -57,7 +57,7 @@ func uninstallGloo(opts *options.Options, cli install.KubeCli) error {
 // attempt to read the installation id off of the gloo pod labels
 func findInstallationId(opts *options.Options, cli install.KubeCli) (string, error) {
 	jsonPath := fmt.Sprintf("-ojsonpath='{.items[0].metadata.labels.%s}'", installationIdLabel)
-	kubeOutput, err := cli.KubectlOut(nil, "-n", opts.Uninstall.Namespace, "get", "pod", "-l", "gloo=gloo", jsonPath)
+	kubeOutput, err := cli.KubectlOut(nil, "-n", opts.Uninstall.Namespace, "get", "deployment", "-l", "gloo=gloo", jsonPath)
 	if err != nil {
 		return "", FailedToFindLabel(err)
 	}

--- a/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/uninstall_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Uninstall", func() {
 		testInstallId = "test-install-id"
 
 		// expects to be formatted with the namespace
-		findInstallIdCmd = "-n %s get pod -l gloo=gloo -ojsonpath='{.items[0].metadata.labels.installationId}'"
+		findInstallIdCmd = "-n %s get deployment -l gloo=gloo -ojsonpath='{.items[0].metadata.labels.installationId}'"
 	)
 
 	var flagSet *pflag.FlagSet


### PR DESCRIPTION
Amended changelog for 1.0-rc2: 

This release changes the names of Gloo's ClusterRoles. By default, cluster-scoped roles will have the namespace of the associated Gloo installation appended to their name (i.e., the cluster-scoped role gloo-resource-reader created along with a Gloo installation to the gloo-system namespace will now become gloo-resource-reader-gloo-system). This may cause a problem during upgrades from Gloo <0.21.0 to Gloo >=0.21.0 for both open-source and enterprise Gloo, as the role ref in a ClusterRoleBinding is immutable. To resolve this, you can delete the existing ClusterRoleBindings with kubectl

