### PR TITLE
Minor cleanup including downgrading a log line from error to warn and DRYing out some logic

### DIFF
--- a/changelog/v0.21.1/minor-cleanup.yaml
+++ b/changelog/v0.21.1/minor-cleanup.yaml
@@ -5,3 +5,4 @@ changelog:
 - type: NON_USER_FACING
   description: DRY out the logic that determines what stage the rate limit plugin runs in
   issueLink: https://github.com/solo-io/gloo/issues/1521
+  resolvesIssue: false

--- a/changelog/v0.21.1/minor-cleanup.yaml
+++ b/changelog/v0.21.1/minor-cleanup.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: FIX
+  description: Downgrade the log level from Error to Warn when gloo fails to report statistics
+  issueLink: https://github.com/solo-io/gloo/issues/1633
+- type: NON_USER_FACING
+  description: DRY out the logic that determines what stage the rate limit plugin runs in
+  issueLink: https://github.com/solo-io/gloo/issues/1521

--- a/pkg/utils/setuputils/main_setup.go
+++ b/pkg/utils/setuputils/main_setup.go
@@ -60,7 +60,7 @@ func Main(opts SetupOpts) error {
 		go func() {
 			errs := StartReportingUsage(opts.CustomCtx, opts.UsageReporter, opts.LoggingPrefix)
 			for err := range errs {
-				contextutils.LoggerFrom(ctx).Errorw("Error while reporting usage", zap.Error(err))
+				contextutils.LoggerFrom(ctx).Warnw("Error while reporting usage", zap.Error(err))
 			}
 		}()
 	}

--- a/projects/gloo/pkg/plugins/ratelimit/plugin.go
+++ b/projects/gloo/pkg/plugins/ratelimit/plugin.go
@@ -28,11 +28,11 @@ const (
 
 var (
 	// rate limiting should happen after auth
-	DefaultFilterStage = plugins.DuringStage(plugins.RateLimitStage)
+	defaultFilterStage = plugins.DuringStage(plugins.RateLimitStage)
 
 	// we may want to rate limit before executing the AuthN and AuthZ stages
 	// notably, AuthZ still needs to occur after AuthN
-	BeforeAuthStage = plugins.BeforeStage(plugins.AuthNStage)
+	beforeAuthStage = plugins.BeforeStage(plugins.AuthNStage)
 )
 
 type Plugin struct {
@@ -160,12 +160,7 @@ func (p *Plugin) HttpFilters(params plugins.Params, listener *v1.HttpListener) (
 
 	customConf := generateEnvoyConfigForCustomFilter(*p.upstreamRef, p.timeout, p.denyOnFail)
 
-	filterStage := DefaultFilterStage
-	if p.rateLimitBeforeAuth {
-		filterStage = BeforeAuthStage
-	}
-
-	customStagedFilter, err := plugins.NewStagedFilterWithConfig(FilterName, customConf, filterStage)
+	customStagedFilter, err := plugins.NewStagedFilterWithConfig(FilterName, customConf, DetermineFilterStage(p.rateLimitBeforeAuth))
 	if err != nil {
 		return nil, err
 	}
@@ -173,4 +168,14 @@ func (p *Plugin) HttpFilters(params plugins.Params, listener *v1.HttpListener) (
 	return []plugins.StagedHttpFilter{
 		customStagedFilter,
 	}, nil
+}
+
+// figure out what stage the rate limit plugin should run in given some configuration
+func DetermineFilterStage(rateLimitBeforeAuth bool) plugins.FilterStage {
+	stage := defaultFilterStage
+	if rateLimitBeforeAuth {
+		stage = beforeAuthStage
+	}
+
+	return stage
 }


### PR DESCRIPTION
Downgrade the log level from Error to Warn when gloo fails to report statistics, and DRY out the logic that determines what stage the rate limit plugin runs in
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1633