### PR TITLE
Fix protobuf display links

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2843,7 +2843,6 @@
     "github.com/solo-io/go-utils/hashutils",
     "github.com/solo-io/go-utils/healthchecker",
     "github.com/solo-io/go-utils/installutils/helmchart",
-    "github.com/solo-io/go-utils/installutils/kuberesource",
     "github.com/solo-io/go-utils/kubeutils",
     "github.com/solo-io/go-utils/log",
     "github.com/solo-io/go-utils/manifesttestutils",

--- a/changelog/v1.0.0-rc3/fix-protobuf-display-links.yaml
+++ b/changelog/v1.0.0-rc3/fix-protobuf-display-links.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Fix protobuf display links.
+  issueLink: https://github.com/solo-io/solo-docs/issues/648

--- a/docs/content/advanced_configuration/consul_kv.md
+++ b/docs/content/advanced_configuration/consul_kv.md
@@ -156,7 +156,7 @@ The paths for Gloo's API objects are as follows:
 | Resource | Key |
 | ----- | ---- | 
 | {{< protobuf name="gloo.solo.io.Upstream">}} | `gloo/gloo.solo.io/v1/Upstream/<namespace>/<name>`  |
-| {{< protobuf name="gateway.solo.io.VirtualService">}}. | `gloo/gateway.solo.io/v1/VirtualService/<namespace>/<name>`  |
+| {{< protobuf name="gateway.solo.io.VirtualService">}} | `gloo/gateway.solo.io/v1/VirtualService/<namespace>/<name>`  |
 | {{< protobuf name="gateway.solo.io.v2.Gateway">}} | `gloo/gateway.solo.io.v2/v2/Gateway/<namespace>/<name>`  |
 | {{< protobuf name="gloo.solo.io.Proxy">}} | `gloo/gloo.solo.io/v1/Proxy/<namespace>/<name>`  |
 

--- a/docs/content/advanced_configuration/consul_kv.md
+++ b/docs/content/advanced_configuration/consul_kv.md
@@ -16,7 +16,7 @@ This document describes how to write configuration YAML to Consul's Key-Value st
 ## Configuring Gloo using custom Settings
 
 When Gloo boots, it attempts to read a 
-[`v1.Settings`]({{< protobuf name="gloo.solo.io.Settings">}}) resource from a 
+[{{< protobuf name="gloo.solo.io.Settings">}} resource from a 
 preconfigured location. By default, Gloo will attempt to connect to a Kubernetes cluster and look up the `gloo.solo.io/v1.Settings`
 Custom Resource in namespace `gloo-system`, named `default`. 
 
@@ -45,7 +45,7 @@ The default namespace for Gloo is `gloo-system`. This can be overridden with the
 ## Customizing the Gloo Settings file
 
 The full list of options for Gloo Settings, including the ability to set auth/TLS parameters for Consul can be found
-[`in the v1.Settings API reference`]({{< protobuf name="gloo.solo.io.Settings" >}}).
+{{< protobuf name="gloo.solo.io.Settings" display="in the v1.Settings API reference">}}.
 
 Here is provided an example Settings so Gloo will read config from Consul Key-Value store:
 
@@ -155,10 +155,10 @@ The paths for Gloo's API objects are as follows:
 
 | Resource | Key |
 | ----- | ---- | 
-| [Upstreams]({{< protobuf name="gloo.solo.io.Upstream">}}) | `gloo/gloo.solo.io/v1/Upstream/<namespace>/<name>`  |
-| [Virtual Services]({{< protobuf name="gateway.solo.io.VirtualService">}}).) | `gloo/gateway.solo.io/v1/VirtualService/<namespace>/<name>`  |
-| [Gateways]({{< protobuf name="gateway.solo.io.v2.Gateway">}}) | `gloo/gateway.solo.io.v2/v2/Gateway/<namespace>/<name>`  |
-| [Proxies]({{< protobuf name="gloo.solo.io.Proxy">}}) | `gloo/gloo.solo.io/v1/Proxy/<namespace>/<name>`  |
+| {{< protobuf name="gloo.solo.io.Upstream">}} | `gloo/gloo.solo.io/v1/Upstream/<namespace>/<name>`  |
+| {{< protobuf name="gateway.solo.io.VirtualService">}}. | `gloo/gateway.solo.io/v1/VirtualService/<namespace>/<name>`  |
+| {{< protobuf name="gateway.solo.io.v2.Gateway">}} | `gloo/gateway.solo.io.v2/v2/Gateway/<namespace>/<name>`  |
+| {{< protobuf name="gloo.solo.io.Proxy">}} | `gloo/gloo.solo.io/v1/Proxy/<namespace>/<name>`  |
 
 To store a Gloo resource in Consul, one can use `curl` or the `consul` CLI:
 

--- a/docs/content/advanced_configuration/multiple-gloo-installs.md
+++ b/docs/content/advanced_configuration/multiple-gloo-installs.md
@@ -17,7 +17,7 @@ In this document, we will review how to deploy multiple instances of Gloo to the
 
 When using the default installation, Gloo will watch all namespaces for Kubernetes services and Gloo CRDs. This means that any Kubernetes service can be a destination for any VirtualService in the cluster.
 
-Gloo can be configured to only watch specific namespaces, meaning Gloo will not see services and CRDs in any namespaces other than those provided in the [`watchNamespaces` setting]({{< protobuf name="gloo.solo.io.Settings">}}).
+Gloo can be configured to only watch specific namespaces, meaning Gloo will not see services and CRDs in any namespaces other than those provided in the {{< protobuf name="gloo.solo.io.Settings" display="watchNamespaces setting">}}.
 
 By leveraging this option, we can install Gloo to as many namespaces we need, ensuring that the `watchNamespaces` do not overlap.
 

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -20,8 +20,8 @@ Gloo's plugin based architecture makes it easy to extend functionality in a vari
 ## Gloo API Concepts
 
 
-* [v1.Proxies]({{< protobuf name="gloo.solo.io.Proxy">}}) provide the routing configuration which Gloo will translate and apply to Envoy.
-* [v1.Upstreams]({{< protobuf name="gloo.solo.io.Upstream">}}) describe routable destinations for Gloo.
+* {{< protobuf name="gloo.solo.io.Proxy"> display="v1.Proxies"}} provide the routing configuration which Gloo will translate and apply to Envoy.
+* {{< protobuf name="gloo.solo.io.Upstream" display="v1.Upstreams" >}} describe routable destinations for Gloo.
 
 * **Proxies** represent a unified configuration to be applied to one or more instances of a proxy. You can think of the proxy of as tree like such:
 

--- a/docs/content/dev/_index.md
+++ b/docs/content/dev/_index.md
@@ -20,7 +20,7 @@ Gloo's plugin based architecture makes it easy to extend functionality in a vari
 ## Gloo API Concepts
 
 
-* {{< protobuf name="gloo.solo.io.Proxy"> display="v1.Proxies"}} provide the routing configuration which Gloo will translate and apply to Envoy.
+* {{< protobuf name="gloo.solo.io.Proxy" display="v1.Proxies">}} provide the routing configuration which Gloo will translate and apply to Envoy.
 * {{< protobuf name="gloo.solo.io.Upstream" display="v1.Upstreams" >}} describe routable destinations for Gloo.
 
 * **Proxies** represent a unified configuration to be applied to one or more instances of a proxy. You can think of the proxy of as tree like such:

--- a/docs/content/dev/example-proxy-controller.md
+++ b/docs/content/dev/example-proxy-controller.md
@@ -891,6 +891,6 @@ kube-system-tiller-deploy-44134   54m
 
 Sweet! You're an official Gloo developer! You've just seen how easy it is to extend Gloo to service one of many 
 potential use cases. Take a look at our 
-[API Reference Documentation]({{< protobuf name="gloo.solo.io.Proxy">}}) to learn about the 
+{{< protobuf name="gloo.solo.io.Proxy" display="API Reference Documentation">}} to learn about the 
 wide range of configuration options Proxies expose such as request transformation, SSL termination, serverless computing, 
 and much more.

--- a/docs/content/dev/writing-upstream-plugins.md
+++ b/docs/content/dev/writing-upstream-plugins.md
@@ -39,9 +39,9 @@ Let's begin.
 
 ## Adding the new Upstream Type to Gloo's API
 
-The first step we'll take will be to add a new [**UpstreamType**]({{% protobuf name="gloo.solo.io.Upstream" %}}) to Gloo. 
+The first step we'll take will be to add a new {{% protobuf name="gloo.solo.io.Upstream" display="UpstreamType" %}} to Gloo. 
 
-All of Gloo's APIs are defined as protobuf files (`.proto`). The list of Upstream Types live in the [plugins.proto]({{% protobuf name="gloo.solo.io.UpstreamSpec" %}}) file, where Gloo's core API objects (Upstream, Virtual Service, Proxy, Gateway) are bound to plugin-specific configuration.
+All of Gloo's APIs are defined as protobuf files (`.proto`). The list of Upstream Types live in the {{% protobuf name="gloo.solo.io.UpstreamSpec" %}} file, where Gloo's core API objects (Upstream, Virtual Service, Proxy, Gateway) are bound to plugin-specific configuration.
 
 We'll write a simple `UpstreamSpec` proto for the new `gce` upstream type:
 
@@ -109,7 +109,7 @@ You can view the complete `gce.proto` here: [gce.proto](../gce.proto).
 
 
 Now we need to add the new GCE `UpstreamSpec` to Gloo's list of Upstream Types. This can be found in 
-the [plugins.proto]({{% protobuf name="gloo.solo.io.UpstreamSpec" %}}) file at the API root (projects/gloo/api/v1)/
+the {{% protobuf name="gloo.solo.io.UpstreamSpec" %}} file at the API root (projects/gloo/api/v1)/
 
 First, we'll add an import to the top of the file
 

--- a/docs/content/gloo_routing/gateway_configuration/access_logging/_index.md
+++ b/docs/content/gloo_routing/gateway_configuration/access_logging/_index.md
@@ -23,7 +23,7 @@ Possible use cases include:
 
 #### Configuration
 
-The following explanation assumes that the user has gloo `v0.18.1+` running, as well as some previous knowledge of Gloo resources, and how to use them. In order to install Gloo if it is not already please refer to the following [tutorial](../../../installation/gateway/kubernetes). The only Gloo resource involved in enabling Access Loggins is the `Gateway`. Further Documentation can be found [here]({{< protobuf name="gateway.solo.io.Gateway">}}).
+The following explanation assumes that the user has gloo `v0.18.1+` running, as well as some previous knowledge of Gloo resources, and how to use them. In order to install Gloo if it is not already please refer to the following [tutorial](../../../installation/gateway/kubernetes). The only Gloo resource involved in enabling Access Loggins is the `Gateway`. Further Documentation can be found {{< protobuf name="gateway.solo.io.Gateway" display="here">}}.
 
 Enabling access logs in Gloo is as simple as adding a [listener plugin](../../gateway_configuration/) to any one of the gateway resources. 
 The documentation for the `Access Logging Service` plugin API can be found {{< protobuf display="here" name="als.plugins.gloo.solo.io.AccessLog">}}.

--- a/docs/content/gloo_routing/tcp_proxy.md
+++ b/docs/content/gloo_routing/tcp_proxy.md
@@ -12,8 +12,8 @@ of the relative simplicity of TCP level routing. Current features include standa
 
 For reference on  the 
 
-- [Gateway]({{< protobuf name="gateway.solo.io.v2.Gateway">}})
-- [Proxy]({{< protobuf name="gloo.solo.io.Proxy">}})
+- {{< protobuf name="gateway.solo.io.v2.Gateway" display="Gateway">}}
+- {{< protobuf name="gloo.solo.io.Proxy" display="Proxy">}}
 
 ### What you'll need
 
@@ -59,9 +59,9 @@ EOF
 
 Once the `tcp-echo` pod is up and running we are ready to create our gateway resource and begin routing to it.
 
-As of vesion v2 of the [gateway]({{< protobuf name="gateway.solo.io.v2.Gateway">}}) 
+As of vesion v2 of the {{< protobuf name="gateway.solo.io.v2.Gateway" display="gateway">}} 
 resource, it now supports 2 different types, those being HTTP, and TCP. 
-The [proxy]({{< protobuf name="gloo.solo.io.Proxy">}}) resource has been extended as well with
+The {{< protobuf name="gloo.solo.io.Proxy" display="proxy">}} resource has been extended as well with
 the TCP listener type. This is not a breaking change and therefore does not require an API upgrade. 
 
 The gateway will contain the following: 

--- a/docs/content/gloo_routing/validation/_index.md
+++ b/docs/content/gloo_routing/validation/_index.md
@@ -27,7 +27,7 @@ not be updated until the errors are resolved.
 
 Each *Proxy* gets its own configuration; if config for an individual proxy is invalid, it does not affect the other proxies.
 The proxy that *Gateways* and their *Virtual Services* will be applied to can be configured via the `proxyNames` option on 
-  the [`Gateway` resource]({{< protobuf name="gateway.solo.io.v2.Gateway">}}).
+  the {{< protobuf name="gateway.solo.io.v2.Gateway" display="Gateway resource">}}.
 
 {{% notice note %}}
 
@@ -53,15 +53,15 @@ API Server before it is written to persistent storage.
 
 Gloo runs a [Kubernetes Validating Admission Webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/)
 which is invoked whenever a `gateway.solo.io` custom resource is created or modified. This includes 
-[Gateways]({{< protobuf name="gateway.solo.io.v2.Gateway">}}), 
-[Virtual Services]({{< protobuf name="gateway.solo.io.VirtualService">}}).),
-and [Route Tables]({{< protobuf name="gateway.solo.io.RouteTable">}}).
+{{< protobuf name="gateway.solo.io.v2.Gateway" display="Gateways">}}, 
+{{< protobuf name="gateway.solo.io.VirtualService" display="Virtual Services">}}.),
+and {{< protobuf name="gateway.solo.io.RouteTable" display="Route Tables">}}.
 
 The [validating webhook configuration](https://github.com/solo-io/gloo/blob/master/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml) is enabled by default by Gloo's Helm chart and `glooctl install gateway`. This admission webhook can be disabled 
 by removing the `ValidatingWebhookConfiguration`.
 
 The webhook can be configured to perform strict or permissive validation, depending on the `gateay.validation.alwaysAccept` setting in the 
-[Settings]({{< protobuf name="gloo.solo.io.Settings">}}) resource.
+{{< protobuf name="gloo.solo.io.Settings" display="Settings">}} resource.
 
 When `alwaysAccept` is `true` (currently the default is `true`), resources will only be rejected when Gloo fails to 
 deserialize them (due to invalid JSON/YAML).
@@ -78,7 +78,7 @@ By default, the Validation Webhook only logs the validation result, but always a
 configuration options are inconsistent/invalid).
 
 The webhook can be configured to reject invalid resources via the 
-[Settings]({{< protobuf name="gloo.solo.io.Settings">}}) resource.
+{{< protobuf name="gloo.solo.io.Settings" display="Settings">}} resource.
 
 If using Helm to manage settings, set the following value:
 

--- a/docs/content/gloo_routing/virtual_services/delegation/_index.md
+++ b/docs/content/gloo_routing/virtual_services/delegation/_index.md
@@ -306,9 +306,9 @@ graph LR;
 
 Explore Gloo's Routing API in the API documentation:
 
-- [Virtual Services]({{< protobuf name="gateway.solo.io.VirtualService">}}).)
+- {{< protobuf name="gateway.solo.io.VirtualService" display="Virtual Services">}}.
 
-- [Route Tables]({{< protobuf name="gateway.solo.io.RouteTable">}})
+- {{< protobuf name="gateway.solo.io.RouteTable" display="Route Tables">}}
 
 Please submit questions and feedback to [the solo.io slack channel](https://slack.solo.io/), or [open an issue on GitHub](https://github.com/solo-io/gloo).
 

--- a/docs/content/gloo_routing/virtual_services/delegation/_index.md
+++ b/docs/content/gloo_routing/virtual_services/delegation/_index.md
@@ -306,7 +306,7 @@ graph LR;
 
 Explore Gloo's Routing API in the API documentation:
 
-- {{< protobuf name="gateway.solo.io.VirtualService" display="Virtual Services">}}.
+- {{< protobuf name="gateway.solo.io.VirtualService" display="Virtual Services">}}
 
 - {{< protobuf name="gateway.solo.io.RouteTable" display="Route Tables">}}
 

--- a/docs/content/gloo_routing/virtual_services/routes/matching_rules/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/matching_rules/_index.md
@@ -7,7 +7,7 @@ description: Various ways to enable routes based on  matching predicates
 In the basic example, we saw how Gloo uses a **VirtualService** CRD to allow users to specify routes to a particular destination, or **Upstream**.
 Each route on a **VirtualService** includes a matcher, specifying the rules to determine if a request should be passed along the route. 
 In the basic example, we used an exact match for a particular path. 
-We'll now look at how to configure a route on a **VirtualService** with different kinds of matching logic using the [Route Matcher]({{< protobuf name="gloo.solo.io.Matcher">}}).
+We'll now look at how to configure a route on a **VirtualService** with different kinds of matching logic using the {{< protobuf name="gloo.solo.io.Matcher">}}.
 
 The following are the different aspects of the request that you can match against a route rule. Each aspect is `AND`
 with others, i.e., all aspects must test `true` for the route to match and the specified route action to be taken.

--- a/docs/content/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
@@ -10,7 +10,7 @@ attribute will not be available.
 {{% /notice %}}
 
 When configuring the matcher on a route, you may want to specify one or more 
-[Header Matchers]({{< protobuf name="gloo.solo.io.HeaderMatcher">}}) to require headers 
+{{< protobuf name="gloo.solo.io.HeaderMatcher" display="Header Matchers">}} to require headers 
 with matching values be present on the request. Each header matcher has three attributes:
 
 * `name` - the name of the request header. Note: Gloo/Envoy use HTTP/2 so if you want to match against HTTP/1 `Host`,

--- a/docs/content/gloo_routing/virtual_services/routes/matching_rules/query_parameter_matching/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/matching_rules/query_parameter_matching/_index.md
@@ -5,7 +5,7 @@ description: Request to route matching based on query parameters
 ---
 
 When configuring the matcher on a route, you may want to specify one or more 
-[Query Parameter Matcher]({{< protobuf name="gloo.solo.io.QueryParameterMatcher">}})
+{{< protobuf name="gloo.solo.io.QueryParameterMatcher">}}
 to require query parameters with matching values be present on the request. Each query parameter matcher has three attributes:
 
 * `name` - the name of the query parameter

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/multiple_upstreams/multi_destination/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/multiple_upstreams/multi_destination/_index.md
@@ -4,8 +4,8 @@ weight: 10
 description: This is where multiple upstreams are configured on a route, with weights associated with them. 
 ---
 
-The [MultiDestination]({{% protobuf name="gloo.solo.io.MultiDestination" %}})
-has an array of one or more [WeightedDestination]({{% protobuf name="gloo.solo.io.WeightedDestination" %}})
+The {{% protobuf name="gloo.solo.io.MultiDestination" display="MultiDestination" %}}
+has an array of one or more {{% protobuf name="gloo.solo.io.WeightedDestination" display="WeightedDestination" %}}
 specs that are a single destination plus a `weight`. The weight is the percentage of request traffic forwarded to that
 destination where the percentage is: `weight` divided by sum of all weights in `MultiDestination`.
 

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/multiple_upstreams/subsets/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/multiple_upstreams/subsets/_index.md
@@ -6,13 +6,13 @@ description: Routing to subsets of an upstream
 
 ## Subset
 
-[Subset]({{< protobuf name="gloo.solo.io.Subset">}}) currently lets you
+{{< protobuf name="gloo.solo.io.Subset">}} currently lets you
 provide a Kubernetes selector to allow request forwarding to a subset of Kubernetes Pods within the upstream associated
 Kubernetes Service. There are currently two steps required to get subsetting to work for Kubernetes upstreams, which are
 the only upstream type currently supported. 
 
-**First**, you need to edit the [Spec]({{< protobuf name="kubernetes.plugins.gloo.solo.io.UpstreamSpec">}})
-of the Kubernetes Upstream that you want to define subsets for by adding a [`subsetSpec`]({{< protobuf name="plugins.gloo.solo.io.SubsetSpec">}}). 
+**First**, you need to edit the {{< protobuf name="kubernetes.plugins.gloo.solo.io.UpstreamSpec">}}
+of the Kubernetes Upstream that you want to define subsets for by adding a {{< protobuf name="plugins.gloo.solo.io.SubsetSpec">}}. 
 The `subsetSpec` contains a list of `selectors`, each of which consist of a set of `keys`. Each key represents a Kubernetes 
 label key. These selectors determine how the subsets for the upstream are to be calculated. For example, the following 
 `subsetSpec`:
@@ -32,8 +32,8 @@ labels, and on the value of the `size` label alone. Envoy requires this informat
 that it needs to compute. The [Envoy documentation](https://github.com/envoyproxy/envoy/blob/master/source/docs/subset_load_balancer.md) 
 contains a great explanation of how on subset load balancing works and we strongly recommend that you read it if you plan to use this feature.
 
-**Second**, you need to add a [`subset`]({{< protobuf name="gloo.solo.io.Subset">}})
-within the [`Destination` spec]({{< protobuf name="gloo.solo.io.Destination">}})
+**Second**, you need to add a {{< protobuf name="gloo.solo.io.Subset">}}
+within the {{< protobuf name="gloo.solo.io.Destination">}}
 of the Route Action. This will determine which of the upstream subsets should be selected as destination for this route.
 
 Following is an example of using a label, e.g. `color: blue`, to subset pods handling requests.

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/multiple_upstreams/upstream_groups/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/multiple_upstreams/upstream_groups/_index.md
@@ -4,7 +4,7 @@ weight: 20
 description: This is an abstraction where the upstreams and weights are stored in a separate UpstreamGroup CRD. This makes it easier to reuse the same set of upstreams across multiple routes, and modify the membership of the group without changing the VirtualService definition. 
 ---
 
-An [UpstreamGroup]({{< protobuf name="gloo.solo.io.UpstreamGroup">}}) addresses
+An {{< protobuf name="gloo.solo.io.UpstreamGroup" display="UpstreamGroup">}} addresses
 an issue of how do you have multiple routes or virtual services referencing the same multiple weighted destinations where
 you want to change the weighting consistently for all calling routes. This is a common need for Canary deployments
 where you want all calling routes to forward traffic consistently across the two service versions.

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/function_routing/grpc_to_rest/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/function_routing/grpc_to_rest/_index.md
@@ -176,10 +176,10 @@ EOF
 
 An explanation for the VirtalService above:
 We have defined four routes. Each route uses
-a [gRPC destinationSpec]({{< protobuf name="grpc.plugins.gloo.solo.io.DestinationSpec">}}) to define REST routes to a gRPC service.
+a {{< protobuf name="grpc.plugins.gloo.solo.io.DestinationSpec" display="gRPC destinationSpec" >}} to define REST routes to a gRPC service.
 When translating a REST API to a gRPC API the JSON body is automatically used to fill in the proto
 message fields. If you have some parameters in the path or in headers, your can specify them using 
-the [parameters]({{< protobuf name="transformation.plugins.gloo.solo.io.Parameters">}})  block in the [gRPC destinationSpec]({{< protobuf name="grpc.plugins.gloo.solo.io.DestinationSpec">}}) (as done in the route to `GetItem` and `DeleteItem`). We use HTTP method matching to make sure that our API adheres to the REST semantics. Note that the routes for `CreateItem` and `ListItems` are defined for the exact path `/items` (i.e. no trailing slash).
+the {{< protobuf name="transformation.plugins.gloo.solo.io.Parameters" display="parameters">}}  block in the {{< protobuf name="grpc.plugins.gloo.solo.io.DestinationSpec" display="gRPC destinationSpec">}} (as done in the route to `GetItem` and `DeleteItem`). We use HTTP method matching to make sure that our API adheres to the REST semantics. Note that the routes for `CreateItem` and `ListItems` are defined for the exact path `/items` (i.e. no trailing slash).
 
 ## Test
 

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/function_routing/rest_endpoint/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/function_routing/rest_endpoint/_index.md
@@ -79,7 +79,7 @@ glooctl get upstream default-petstore-8080 --output yaml
 We can see there are functions on our `default-petstore-8080` upstream. These functions were populated automatically by
 the `discovery` pod. You can see the function discovery service in action by running `kubectl logs -l gloo=discovery`.
 
-The [function spec]({{< protobuf name="gloo.solo.io.Upstream" >}}) you see on the functions
+The {{< protobuf name="gloo.solo.io.Upstream" display="function spec" >}} you see on the functions
 listed above belongs to the transformation plugin. <!--(TODO)-->
 
 This powerful plugin configures Gloo's [request/response transformation Envoy filter](https://github.com/solo-io/envoy-transformation)

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/append_remove_headers/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/append_remove_headers/_index.md
@@ -8,9 +8,9 @@ description: Append and Remove Headers from Requests and Responses using Route c
 Gloo can add and remove headers to/from requests and responses. We refer to this feature as "Header Manipulation".
 
 Header Manipulation is configured via the 
-[`headerManipulation`]({{< protobuf name="headers.plugins.gloo.solo.io.HeaderManipulation">}}) struct.
+{{< protobuf name="headers.plugins.gloo.solo.io.HeaderManipulation" display="headerManipulation">}} struct.
 
-This struct can be added to [Route Plugins]({{< protobuf name="gloo.solo.io.RoutePlugins">}}), [Virtual Host Plugins]({{< protobuf name="gloo.solo.io.VirtualHostPlugins">}}), and [Weighted Destination Plugins]({{< protobuf name="gloo.solo.io.WeightedDestinationPlugins">}}).
+This struct can be added to {{< protobuf name="gloo.solo.io.RoutePlugins" display="Route Plugins">}}, {{< protobuf name="gloo.solo.io.VirtualHostPlugins" display="Virtual Host Plugins">}}, and {{< protobuf name="gloo.solo.io.WeightedDestinationPlugins" display="Weighted Destination Plugins" >}}.
 
 The `headerManipulation` struct contains four optional fields `requestHeadersToAdd`, `requestHeadersToRemove`,  `responseHeadersToAdd`, and `responseHeadersToRemove` :
 

--- a/docs/content/gloo_routing/virtual_services/routes/routing_features/prefix_rewrite/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/routing_features/prefix_rewrite/_index.md
@@ -4,7 +4,7 @@ weight: 30
 description: Prefix-rewriting when routing to upstreams
 ---
 
-[PrefixRewrite]({{< protobuf name="gloo.solo.io.RoutePlugins" >}})
+{{< protobuf name="gloo.solo.io.RoutePlugins" display="PrefixRewrite" >}}
 is a route feature that allows you to replace (rewrite) the matched request path with a specified value before sending it upstream.
 
 Routes are processed in order, so the first matching request path is the only one that will be processed.

--- a/docs/content/gloo_routing/virtual_services/security/jwt/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/jwt/_index.md
@@ -54,7 +54,7 @@ and cannot be used to sign new JWTs. The JWT can be independently verified by an
 ## JWTs in Gloo
 Gloo supports JWT verification using the JWT extension. You can define multiple JWT providers.
 In each provider you can specify where to find the keys required for JWT verification, the 
-values for the issuer and audience claims to verify, as well as [other settings]({{< protobuf name="jwt.plugins.gloo.solo.io.Provider">}}).
+values for the issuer and audience claims to verify, as well as {{< protobuf name="jwt.plugins.gloo.solo.io.Provider" display="other settings">}}.
 
 We have a few guides that go into more detail:
 

--- a/docs/content/installation/gateway/docker-compose-consul/_index.md
+++ b/docs/content/installation/gateway/docker-compose-consul/_index.md
@@ -88,7 +88,7 @@ virtualHost:
 {{% notice note %}}
 All `glooctl add` and `glooctl create` commands can be run with a `--yaml` flag
 which will output Gloo YAML to stdout. These outputs can be stored as Consul Values
-and `.yaml` files for configuring Gloo. See the [API reference]({{< protobuf name="gateway.solo.io.VirtualService">}}).)
+and `.yaml` files for configuring Gloo. See the {{< protobuf name="gateway.solo.io.VirtualService" display="API reference" >}}.)
 for details on writing Gloo configuration YAML.
 {{% /notice %}}
 

--- a/docs/content/introduction/architecture.md
+++ b/docs/content/introduction/architecture.md
@@ -37,9 +37,9 @@ providing advanced configuration for Envoy (including Gloo's custom Envoy filter
 ![Component Architecture](../component_architecture.png "Component Architecture")
 
 * The **Config Watcher** watches the storage layer for updates to user configuration objects ([Upstreams](../concepts#upstreams) and [Virtual Services](../concepts#virtual-services)).
-* The **Secret Watcher** watches a secret store for updates to secrets (which are required for certain plugins such as the [AWS Lambda Plugin]({{% protobuf name="aws.plugins.gloo.solo.io.DestinationSpec" %}}).
+* The **Secret Watcher** watches a secret store for updates to secrets (which are required for certain plugins such as the {{% protobuf name="aws.plugins.gloo.solo.io.DestinationSpec" display="AWS Lambda Plugin"%}}.
 * **Endpoint Discovery** watches service registries such as Kubernetes, Cloud Foundry, and Consul for IPs associated with services.
-Endpoint Discovery is plugin-specific. For example, the [Kubernetes Plugin]({{< protobuf name="kubernetes.plugins.gloo.solo.io.UpstreamSpec">}}) runs its own Endpoint Discovery goroutine.
+Endpoint Discovery is plugin-specific. For example, the {{< protobuf name="kubernetes.plugins.gloo.solo.io.UpstreamSpec" display="Kubernetes Plugin">}} runs its own Endpoint Discovery goroutine.
 * The **Translator** receives snapshots of the entire state, composed of user configuration, secrets, and discovery information
 and initiates a new *translation loop*, creating a new Envoy xDS Snapshot.
   1. The translation cycle starts by creating **[Envoy clusters](https://www.envoyproxy.io/docs/envoy/v1.8.0/api-v1/cluster_manager/cluster)** from all configured upstreams. Each upstream has a **type**, indicating which upstream plugin is responsible for
@@ -49,7 +49,7 @@ and initiates a new *translation loop*, creating a new Envoy xDS Snapshot.
   the functions on upstream, setting function-specifc cluster metadata, which will be later processed by
   function-specific Envoy filters.
   1. The next step generates all of the **[Envoy routes](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto.html?highlight=route)**
-  via the route plugins . Routes are generated for each route rule defined on the [virtual service objects]({{< protobuf name="gateway.solo.io.VirtualService">}}). When all of the routes are created, the translator aggregates them into
+  via the route plugins . Routes are generated for each route rule defined on the {{< protobuf name="gateway.solo.io.VirtualService" display="virtual service objects">}}. When all of the routes are created, the translator aggregates them into
   [Envoy virtual hosts](https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#route-virtualhost)
   and adds them to a new [Envoy HTTP Connection Manager](https://www.envoyproxy.io/docs/envoy/v1.11.2/intro/arch_overview/http/http_connection_management.html#http-connection-management)
   configuration.

--- a/docs/content/introduction/concepts.md
+++ b/docs/content/introduction/concepts.md
@@ -24,8 +24,8 @@ of a *matcher*, which specifies the kind of function calls to match (requests an
 and the name of the destination (or destinations) to route them to.
 
 - **Upstreams** define destinations for routes. Upstreams tell Gloo what to route to. Upstreams may also define
-[functions]({{< protobuf name="aws.plugins.gloo.solo.io.LambdaFunctionSpec">}}).)
-and [service specs]({{< protobuf name="plugins.gloo.solo.io.ServiceSpec">}}) for *function-level routing*.
+{{< protobuf name="aws.plugins.gloo.solo.io.LambdaFunctionSpec" display="functions" >}}.)
+and {{< protobuf name="plugins.gloo.solo.io.ServiceSpec" display="service specs">}} for *function-level routing*.
 
 ## Gateways
 
@@ -143,9 +143,9 @@ types as well as new function types through our plugin interface.
 how to handle routing for the upstream based on its `spec` field. Upstreams have a type-specific `spec` field which must
 be used to provide routing information to Gloo.
 
-The most basic upstream type is the [`static` upstream type]({{< protobuf name="static.plugins.gloo.solo.io.UpstreamSpec">}}), which tells Gloo
+The most basic upstream type is the {{< protobuf name="static.plugins.gloo.solo.io.UpstreamSpec" display="static upstream type" >}}, which tells Gloo
 a list of static hosts or dns names logically grouped together for an upstream. More sophisticated upstream types
-include the kubernetes upstream and the [AWS Lambda upstream]({{< protobuf name="aws.plugins.gloo.solo.io.UpstreamSpec">}}).
+include the kubernetes upstream and the {{< protobuf name="aws.plugins.gloo.solo.io.UpstreamSpec" display="AWS Lambda upstream">}}.
 
 Let's walk through an example of a kubernetes upstream in order to understand how this works.
 
@@ -214,7 +214,7 @@ section.
 
 ## Secrets
 
-Certain plugins such as the [AWS Lambda Plugin]({{< protobuf name="aws.plugins.gloo.solo.io.UpstreamSpec">}})
+Certain plugins such as the {{< protobuf name="aws.plugins.gloo.solo.io.UpstreamSpec" display="AWS Lambda Plugin">}}
 require the use of secrets for authentication, configuration of SSL Certificates, and other data that should not be
 stored in plaintext configuration.
 


### PR DESCRIPTION
when docs were updated, some former markdown link syntax lingered, which produced broken links

here are some examples of how to use the protobuf shortcode to generate links: https://github.com/solo-io/hugo-theme-soloio#examples
BOT NOTES: 
resolves https://github.com/solo-io/solo-docs/issues/648