### PR TITLE
Linkerd Helm Chart Value

### DIFF
--- a/changelog/v1.0.0-rc3/add-linkerd-helm-option.yaml
+++ b/changelog/v1.0.0-rc3/add-linkerd-helm-option.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Added Helm `settings.linkerd` chart value
+    issueLink: https://github.com/solo-io/gloo/issues/1651

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -101,6 +101,7 @@ type Settings struct {
 	Extensions          interface{}          `json:"extensions,omitempty"`
 	SingleNamespace     bool                 `json:"singleNamespace" desc:"Enable to use install namespace as WatchNamespace and WriteNamespace"`
 	InvalidConfigPolicy *InvalidConfigPolicy `json:"invalidConfigPolicy" desc:"Define policies for Gloo to handle invalid configuration"`
+	Linkerd             bool                 `json:"linkerd" desc:"Enable automatic Linkerd integration in Gloo."`
 }
 
 type InvalidConfigPolicy struct {

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -28,6 +28,9 @@ spec:
   kubernetesConfigSource: {}
   kubernetesSecretSource: {}
   refreshRate: 60s
+{{- if .Values.settings.linkerd }}
+  linkerd: true
+{{- end }}
 {{- if .Values.settings.integrations.knative.enabled }}
   knative:
 {{- if (regexMatch "[0-9]+[.][0-7]+[.][0-9]+" .Values.settings.integrations.knative.version ) }}

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -8,6 +8,7 @@ k8s:
 settings:
   # if this is set to false, default settings will be created by pods upon boot
   create: true
+  linkerd: false
   invalidConfigPolicy:
     replaceInvalidRoutes: false
     invalidRouteResponseCode: 404

--- a/install/helm/gloo/values-knative-template.yaml
+++ b/install/helm/gloo/values-knative-template.yaml
@@ -7,6 +7,7 @@ k8s:
 
 settings:
   create: true
+  linkerd: false
   integrations:
     knative:
       enabled: true


### PR DESCRIPTION
Adds a convenience option for Linkerd when deploying via. helm chart.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1651