### PR TITLE
Move the installationId Helm field to globals to make Gloo Helm chart easier to consume

### DIFF
--- a/changelog/v1.0.0-rc3/global-install-id.yaml
+++ b/changelog/v1.0.0-rc3/global-install-id.yaml
@@ -1,0 +1,11 @@
+changelog:
+- type: HELM
+  description: >
+    Move the Helm values field "installConfig.installationId" to "global.glooInstallationId" in order to better
+    facilitate usage of the Gloo sub-chart in Gloo Enterprise
+  issueLink: https://github.com/solo-io/gloo/issues/1635
+- type: BREAKING_CHANGE
+  description: >
+    Move the Helm values field "installConfig.installationId" to "global.glooInstallationId" in order to better
+    facilitate usage of the Gloo sub-chart in Gloo Enterprise
+  issueLink: https://github.com/solo-io/gloo/issues/1635

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -1,6 +1,5 @@
 |Option|Type|Default Value|Description|
 |------|----|-----------|-------------|
-|installConfig.installationId|string||If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling|
 |namespace.create|bool|false|create the installation namespace|
 |crds.create|bool|true|create CRDs for Gloo (turn off if installing with Helm to a cluster that already has Gloo CRDs)|
 |settings.watchNamespaces[]|string||whitelist of namespaces for gloo to watch for services and CRDs. Empty list means all namespaces|
@@ -88,6 +87,8 @@
 |gateway.certGenJob.image.pullPolicy|string||image pull policy for the container|
 |gateway.certGenJob.image.pullSecret|string||image pull policy for the container |
 |gateway.certGenJob.restartPolicy|string|OnFailure|restart policy to use when the pod exits|
+|gateway.certGenJob.setTtlAfterFinished|bool|true|Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true|
+|gateway.certGenJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.updateValues|bool|false|if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions|
 |gateway.proxyServiceAccount.disableAutomount|bool|false|disable automunting the service account to the gateway proxy. not mounting the token hardens the proxy container, but may interfere with service mesh integrations|
 |gatewayProxies.NAME.kind.deployment.antiAffinity|bool||configure anti affinity such that pods are prefferably not co-located|
@@ -241,3 +242,4 @@
 |global.glooRbac.create|bool|true|create rbac rules for the gloo-system service account|
 |global.glooRbac.namespaced|bool|false|use Roles instead of ClusterRoles|
 |global.glooRbac.nameSuffix|string||When nameSuffix is nonempty, append '-$nameSuffix' to the names of Gloo RBAC resources; e.g. when nameSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'|
+|global.glooInstallationId|string||If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -10,7 +10,6 @@ type HelmConfig struct {
 }
 
 type Config struct {
-	InstallConfig  *InstallConfig          `json:"installConfig,omitempty"`
 	Namespace      *Namespace              `json:"namespace,omitempty"`
 	Crds           *Crds                   `json:"crds,omitempty"`
 	Settings       *Settings               `json:"settings,omitempty"`
@@ -24,14 +23,11 @@ type Config struct {
 	AccessLogger   *AccessLogger           `json:"accessLogger,omitempty"`
 }
 
-type InstallConfig struct {
-	InstallationId string `json:"installationId" desc:"If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling"`
-}
-
 type Global struct {
-	Image      *Image      `json:"image,omitempty"`
-	Extensions interface{} `json:"extensions,omitempty"`
-	GlooRbac   *Rbac       `json:"glooRbac,omitempty"`
+	Image              *Image      `json:"image,omitempty"`
+	Extensions         interface{} `json:"extensions,omitempty"`
+	GlooRbac           *Rbac       `json:"glooRbac,omitempty"`
+	GlooInstallationId string      `json:"glooInstallationId" desc:"If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling"`
 }
 
 type Namespace struct {

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -30,8 +30,8 @@ Expand the name of a container image
 {{/* This value makes its way into k8s labels, so if the implementation changes,
      make sure it's compatible with label values */}}
 {{- define "gloo.installationId" -}}
-{{- if not .Values.installConfig.installationId -}}
-{{- $_ := set .Values.installConfig "installationId" (randAlphaNum 20) -}}
+{{- if not .Values.global.glooInstallationId -}}
+{{- $_ := set .Values.global "glooInstallationId" (randAlphaNum 20) -}}
 {{- end -}}
-{{ .Values.installConfig.installationId }}
+{{ .Values.global.glooInstallationId }}
 {{- end -}}

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -1,6 +1,5 @@
 namespace:
   create: false
-installConfig: {}
 crds:
   create: true
 k8s:

--- a/install/helm/gloo/values-ingress-template.yaml
+++ b/install/helm/gloo/values-ingress-template.yaml
@@ -1,6 +1,5 @@
 namespace:
   create: false
-installConfig: {}
 crds:
   create: true
 k8s:

--- a/install/helm/gloo/values-knative-template.yaml
+++ b/install/helm/gloo/values-knative-template.yaml
@@ -1,6 +1,5 @@
 namespace:
   create: false
-installConfig: {}
 crds:
   create: true
 k8s:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -95,7 +95,7 @@ var _ = Describe("Helm Test", func() {
 
 		// adds the install ID into the provided helm flags- no need to provide it yourself
 		prepareMakefile := func(helmFlags string) {
-			testManifest = renderManifest(helmFlags + " --set installConfig.installationId=" + helmTestInstallId)
+			testManifest = renderManifest(helmFlags + " --set global.glooInstallationId=" + helmTestInstallId)
 		}
 
 		// helper for passing a values file
@@ -146,7 +146,7 @@ var _ = Describe("Helm Test", func() {
 
 			It("can assign a custom installation ID", func() {
 				installId := "custom-install-id"
-				testManifest = renderManifest("--namespace " + namespace + " --set installConfig.installationId=" + installId)
+				testManifest = renderManifest("--namespace " + namespace + " --set global.glooInstallationId=" + installId)
 
 				Expect(testManifest.NumResources()).NotTo(BeZero())
 				testManifest.ExpectAll(func(resource *unstructured.Unstructured) {

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -18,7 +18,7 @@ var _ = Describe("RBAC Test", func() {
 	)
 
 	prepareMakefile := func(helmFlags string) {
-		testManifest = renderManifest(helmFlags + " --set installConfig.installationId=" + installationId)
+		testManifest = renderManifest(helmFlags + " --set global.glooInstallationId=" + installationId)
 	}
 
 	Context("implementation-agnostic permissions", func() {

--- a/install/test/svc_accnt_test.go
+++ b/install/test/svc_accnt_test.go
@@ -18,7 +18,7 @@ var _ = Describe("SVC Accnt Test", func() {
 		resourceBuilder.Labels["gloo"] = name
 		resourceBuilder.Labels["installationId"] = installationId
 
-		testManifest = renderManifest(helmFlags + " --set installConfig.installationId=" + installationId)
+		testManifest = renderManifest(helmFlags + " --set global.glooInstallationId=" + installationId)
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
Move the Helm values field "installConfig.installationId" to "global.glooInstallationId" in order to better facilitate usage of the Gloo sub-chart in Gloo Enterprise
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1635