### PR TITLE
Simpler disable of validation/certgenjob

### DIFF
--- a/changelog/v1.0.0-rc3/add-enabled-flag-validation-certgenjob.yaml
+++ b/changelog/v1.0.0-rc3/add-enabled-flag-validation-certgenjob.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    description: Add `enabled` to `.Values.gateway.validation` and `.Values.gateway.certGenJob` so users can disable
+      the features without setting the root resource to nil.
+    issueLink: https://github.com/solo-io/gloo/issues/1561

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -58,6 +58,7 @@
 |discovery.fdsMode|string||mode for function discovery (blacklist or whitelist). See more info in the settings docs|
 |discovery.enabled|bool|true|enable Discovery features|
 |gateway.enabled|bool|true|enable Gloo API Gateway features|
+|gateway.validation.enabled|bool|true|enable Gloo API Gateway validation hook (default true)|
 |gateway.validation.alwaysAcceptResources|bool|true|unless this is set this to false in order to ensure validation webhook rejects invalid resources. by default, validation webhook will only log and report metrics for invalid resource admission without rejecting them outright.|
 |gateway.validation.secretName|string|gateway-validation-certs|Name of the Kubernetes Secret containing TLS certificates used by the validation webhook server. This secret will be created by the certGen Job if the certGen Job is enabled.|
 |gateway.validation.failurePolicy|string|Ignore|failurePolicy defines how unrecognized errors from the Gateway validation endpoint are handled - allowed values are 'Ignore' or 'Fail'. Defaults to Ignore |
@@ -80,6 +81,7 @@
 |gateway.certGenJob.image.pullPolicy|string||image pull policy for the container|
 |gateway.certGenJob.image.pullSecret|string||image pull policy for the container |
 |gateway.certGenJob.restartPolicy|string|OnFailure|restart policy to use when the pod exits|
+|gateway.certGenJob.enabled|bool|true|enable Gloo API certgen job (default true)|
 |gateway.certGenJob.setTtlAfterFinished|bool|true|Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true|
 |gateway.certGenJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.updateValues|bool|false|if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions|
@@ -228,8 +230,8 @@
 |accessLogger.resources.requests.cpu|string||amount of CPUs|
 |global.image.tag|string||tag for the container|
 |global.image.repository|string||image name (repository) for the container.|
-|global.image.registry|string|gcr.io/|image prefix/registry e.g. (quay.io/solo-io)|
-|global.image.pullPolicy|string|Always|image pull policy for the container|
+|global.image.registry|string|quay.io/solo-io|image prefix/registry e.g. (quay.io/solo-io)|
+|global.image.pullPolicy|string|IfNotPresent|image pull policy for the container|
 |global.image.pullSecret|string||image pull policy for the container |
 |global.extensions|interface|||
 |global.glooRbac.create|bool|true|create rbac rules for the gloo-system service account|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -174,7 +174,7 @@ type Job struct {
 
 type CertGenJob struct {
 	Job
-	Enabled                 bool `json:"enabled" desc:"enable Gloo API certgen job (default true)"`
+	Enabled                 bool `json:"enabled" desc:"enable the job that generates the certificates for the validating webhook at install time (default true)"`
 	SetTtlAfterFinished     bool `json:"setTtlAfterFinished" desc:"Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true"`
 	TtlSecondsAfterFinished int  `json:"ttlSecondsAfterFinished" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
 }

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -174,7 +174,7 @@ type Job struct {
 
 type CertGenJob struct {
 	Job
-	Enabled                 bool  `json:"enabled" desc:"enable Gloo API certgen job (default true)"`
+	Enabled                 bool `json:"enabled" desc:"enable Gloo API certgen job (default true)"`
 	SetTtlAfterFinished     bool `json:"setTtlAfterFinished" desc:"Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true"`
 	TtlSecondsAfterFinished int  `json:"ttlSecondsAfterFinished" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
 }

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -153,6 +153,7 @@ type ServiceAccount struct {
 }
 
 type GatewayValidation struct {
+	Enabled               bool   `json:"enabled" desc:"enable Gloo API Gateway validation hook (default true)"`
 	AlwaysAcceptResources *bool  `json:"alwaysAcceptResources" desc:"unless this is set this to false in order to ensure validation webhook rejects invalid resources. by default, validation webhook will only log and report metrics for invalid resource admission without rejecting them outright."`
 	SecretName            string `json:"secretName" desc:"Name of the Kubernetes Secret containing TLS certificates used by the validation webhook server. This secret will be created by the certGen Job if the certGen Job is enabled."`
 	FailurePolicy         string `json:"failurePolicy" desc:"failurePolicy defines how unrecognized errors from the Gateway validation endpoint are handled - allowed values are 'Ignore' or 'Fail'. Defaults to Ignore "`
@@ -173,6 +174,7 @@ type Job struct {
 
 type CertGenJob struct {
 	Job
+	Enabled                 bool  `json:"enabled" desc:"enable Gloo API certgen job (default true)"`
 	SetTtlAfterFinished     bool `json:"setTtlAfterFinished" desc:"Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true"`
 	TtlSecondsAfterFinished int  `json:"ttlSecondsAfterFinished" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
 }

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -38,7 +38,7 @@ spec:
 {{- end }}
 {{- end }}
 
-{{- if .Values.gateway.validation }}
+{{- if .Values.gateway.validation.enabled }}
   gateway:
     validation:
       proxyValidationServerAddr: gloo:{{ .Values.gloo.deployment.validationPort }}

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -126,7 +126,7 @@ rules:
   # update is needed for status updates, create for creating the default ones.
   verbs: ["get", "list", "watch", "create", "update"]
 
-{{- if and .Values.gateway.validation .Values.gateway.certGenJob }}
+{{- if and .Values.gateway.validation.enabled .Values.gateway.certGenJob.enabled }}
 ---
 # this role requires access to cluster-scoped resources
 kind: ClusterRole

--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -149,7 +149,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 
 
-{{- if and .Values.gateway.validation .Values.gateway.certGenJob }}
+{{- if and .Values.gateway.validation.enabled .Values.gateway.certGenJob.enabled }}
 ---
 # this role requires access to cluster-scoped resources
 kind: ClusterRoleBinding

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -38,7 +38,7 @@ spec:
 {{ toYaml .Values.gateway.deployment.resources | indent 10}}
 {{- end}}
 
-{{- if .Values.gateway.validation }}
+{{- if .Values.gateway.validation.enabled }}
         ports:
           - containerPort: 8443
             name: https
@@ -64,12 +64,12 @@ spec:
           - name: START_STATS_SERVER
             value: "true"
         {{- end}}
-        {{- if .Values.gateway.validation }}
+        {{- if .Values.gateway.validation.enabled }}
           - name: VALIDATION_MUST_START
             value: "true"
         {{- end}}
 
-{{- if .Values.gateway.validation }}
+{{- if .Values.gateway.validation.enabled }}
         volumeMounts:
           - mountPath: /etc/gateway/validation-certs
             name: validation-certs

--- a/install/helm/gloo/templates/5-gateway-service-account.yaml
+++ b/install/helm/gloo/templates/5-gateway-service-account.yaml
@@ -13,7 +13,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
 
 
-{{- if and .Values.gateway.validation .Values.gateway.certGenJob }}
+{{- if and .Values.gateway.validation.enabled .Values.gateway.certGenJob.enabled }}
 ---
 
 apiVersion: v1

--- a/install/helm/gloo/templates/5-gateway-service.yaml
+++ b/install/helm/gloo/templates/5-gateway-service.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enabled .Values.gateway.validation }}
+{{- if and .Values.gateway.enabled .Values.gateway.validation.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
+++ b/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.gateway.enabled .Values.gateway.validation }}
+{{- if and .Values.gateway.enabled .Values.gateway.validation.enabled }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/install/helm/gloo/templates/6-access-logger-deployment.yaml
+++ b/install/helm/gloo/templates/6-access-logger-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if and  .Values.gateway.enabled .Values.accessLogger.enabled }}
+{{- if and .Values.gateway.enabled .Values.accessLogger.enabled }}
 {{- $image := .Values.accessLogger.image }}
 {{- if .Values.global  }}
 {{- $image = merge .Values.accessLogger.image .Values.global.image }}

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.gateway.enabled }}
-{{- if .Values.gateway.validation }}
-{{- if .Values.gateway.certGenJob }}
+{{- if .Values.gateway.validation.enabled }}
+{{- if .Values.gateway.certGenJob.enabled }}
 {{- $image := .Values.gateway.certGenJob.image }}
 {{- if .Values.global  }}
 {{- $image = merge .Values.gateway.certGenJob.image .Values.global.image }}

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -40,6 +40,7 @@ discovery:
 gateway:
   enabled: true
   validation:
+    enabled: true
     failurePolicy: "Ignore"
     secretName: gateway-validation-certs
     alwaysAcceptResources: true
@@ -50,6 +51,7 @@ gateway:
     stats: true
     runAsUser: 10101
   certGenJob:
+    enabled: true
     image:
       repository: certgen
     restartPolicy: OnFailure


### PR DESCRIPTION
Add `enabled` to `.Values.gateway.validation` and `.Values.gateway.certGenJob` so users can disable the features without setting the root resource to nil.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1561