### PR TITLE
fix links - use protobuf

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2940,6 +2940,7 @@
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/intstr",
     "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/util/sets",
     "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/discovery",
     "k8s.io/client-go/discovery/fake",

--- a/changelog/v1.0.0-rc3/fix-installation-links.yaml
+++ b/changelog/v1.0.0-rc3/fix-installation-links.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix broken installation table links in docs.

--- a/docs/content/gloo_routing/gateway_configuration/health_checks/_index.md
+++ b/docs/content/gloo_routing/gateway_configuration/health_checks/_index.md
@@ -4,7 +4,10 @@ weight: 4
 ---
 
 Gloo includes an HTTP health checking plugin that can be enabled in a 
-[Gateway]({{% ref "/api/github.com/solo-io/gloo/projects/gateway/api/v1/gateway.proto.sk" %}}) 
+{{< protobuf
+display="Gateway"
+name="gateway.solo.io.Gateway"
+>}}
 (which becomes an [Envoy Listener](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/listeners)). 
 This plugin will respond to health check requests directly with either a 200 OK or 503 Service Unavailable 
 depending on the current draining state of Envoy.

--- a/docs/content/gloo_routing/virtual_services/security/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/_index.md
@@ -95,7 +95,11 @@ spec:
 {{% extauth_version_info_note %}}
 {{% /notice %}}
 
-Authentication configuration is defined in [AuthConfig]({{< ref "/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/plugins/extauth/v1/extauth.proto.sk#authconfig" >}}) resources. 
+Authentication configuration is defined in 
+{{< protobuf
+name="enterprise.gloo.solo.io.AuthConfig"
+>}}
+resources. 
 `AuthConfig`s are top-level resources, which means that if you are running in Kubernetes, they will be stored in a dedicated CRD.
 Here is an example of a simple `AuthConfig` CRD:
 

--- a/docs/content/gloo_routing/virtual_services/security/apikey_auth/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/apikey_auth/_index.md
@@ -138,7 +138,8 @@ Now let's take the value of `data.extension`, which is base64-encoded, and decod
 echo Y29uZmlnOgogIGFwaV9rZXk6IE4yWXdNREl4WlRFdE5HVXpOUzFqTnpnekxUUmtZakF0WWpFMll6UmtaR1ZtTmpjeQogIGxhYmVsczoKICAtIHRlYW09aW5mcmFzdHJ1Y3R1cmUK | base64 -D
 ```
 
-You should get the following [API key secret configuration]({{< ref "/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/plugins/extauth/v1/extauth.proto.sk#apikeysecret" >}}):
+You should get the following 
+{{< protobuf display="API key secret configuration" name="enterprise.gloo.solo.io.ApiKeySecret" >}}:
 
 ```yaml
 config:

--- a/docs/content/gloo_routing/virtual_services/security/custom_auth/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/custom_auth/_index.md
@@ -73,7 +73,7 @@ When a request matches a route that defines an `extauth` configuration, Gloo wil
 auth service. If the HTTP service returns a `200 OK` response, the request will be considered authorized and sent to 
 its original destination. Otherwise the request will be denied.
 You can fine tune which headers are sent to the the auth service, and whether or not the body is forwarded as well, 
-by editing the [extauth settings]({{< ref "/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/plugins/extauth/v1/extauth.proto.sk#settings" >}}) 
+by editing the {{< protobuf name="enterprise.gloo.solo.io.Settings" display="extauth settings" >}} 
 in the Gloo settings (see the example [below](#configure-gloo-settings)).
 
 For reference, here's the code for the authorization server used in this tutorial:
@@ -164,7 +164,7 @@ spec:
 {{< /highlight >}}
 
 More details about the `httpService` object are available 
-[here]({{< ref "/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/plugins/extauth/v1/extauth.proto.sk#httpservice" >}}).
+{{< protobuf display="here" name="https://docs.solo.io/gloo/latest/installation/cluster_setup/" >}}.
 For example, if you want to copy some of the original request headers to the request that gets sent to the custom auth 
 server, you would need to configure the `extauth` attribute in the following way:
 

--- a/docs/content/gloo_routing/virtual_services/security/custom_auth/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/custom_auth/_index.md
@@ -164,7 +164,10 @@ spec:
 {{< /highlight >}}
 
 More details about the `httpService` object are available 
-{{< protobuf display="here" name="https://docs.solo.io/gloo/latest/installation/cluster_setup/" >}}.
+{{<
+protobuf display="here"
+name="enterprise.gloo.solo.io.HttpService"
+>}}.
 For example, if you want to copy some of the original request headers to the request that gets sent to the custom auth 
 server, you would need to configure the `extauth` attribute in the following way:
 

--- a/docs/content/gloo_routing/virtual_services/security/ldap/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/ldap/_index.md
@@ -252,7 +252,10 @@ earlier .
 
 #### LDAP auth flow
 Before updating our Virtual Service, it is important to understand how Gloo interacts with the LDAP server. Let's first 
-look at the [LDAP auth configuration]({{< ref "/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/plugins/extauth/v1/extauth.proto.sk#ldap" >}}):
+look at the {{< protobuf
+display="LDAP auth configuration"
+name="enterprise.gloo.solo.io.Ldap"
+>}}:
 
 - `address`: this is the address of the LDAP server that Gloo will query when a request matches the Virtual Service.
 - `userDnTemplate`: this is a template string that Gloo uses to build the DNs of the user entry that 

--- a/docs/content/installation/gateway/_index.md
+++ b/docs/content/installation/gateway/_index.md
@@ -10,7 +10,7 @@ weight: 2
 <table>
   <tr height="100">
     <td width="10%">
-      <a href="kubernetes"><img src='{{% versioned_link_path fromRoot="/img/kube.png" %}}' width="60"/></a>
+      <a href='{{% versioned_link_path fromRoot="/installation/gateway/kubernetes" %}}'><img src='{{% versioned_link_path fromRoot="/img/kube.png" %}}' width="60"/></a>
     </td>
     <td>
      Install the Gloo Gateway on Kubernetes, using Kubernetes Custom Resources to configure routing.
@@ -18,7 +18,7 @@ weight: 2
   </tr>
   <tr height="100">
     <td width="10%">
-      <a href="docker-compose-file"><img src='{{% versioned_link_path fromRoot="/img/docker.png" %}}' width="60"/></a>
+      <a href='{{% versioned_link_path fromRoot="/installation/gateway/docker-compose-file" %}}'><img src='{{% versioned_link_path fromRoot="/img/docker.png" %}}' width="60"/></a>
     </td>
     <td>
      Run Gloo locally with Docker Compose, using `yaml` files which are mounted to the Gloo container for configuration and secret storage.
@@ -26,7 +26,7 @@ weight: 2
   </tr>
   <tr height="100">
     <td width="10%">
-      <a href="docker-compose-consul"><img src='{{% versioned_link_path fromRoot="/img/consul.png" %}}' width="60"/></a>
+      <a href='{{% versioned_link_path fromRoot="/installation/gateway/docker-compose-consul" %}}'><img src='{{% versioned_link_path fromRoot="/img/consul.png" %}}' width="60"/></a>
     </td>
     <td>
      Run Gloo locally with Docker Compose, using [HashiCorp Consul](https://www.consul.io/) for configuration and [HashiCorp Vault](https://www.vaultproject.io/) for secret storage.
@@ -34,7 +34,7 @@ weight: 2
   </tr>
   <tr height="100">
     <td width="10%">
-      <a href="nomad"><img src='{{% versioned_link_path fromRoot="/img/nomad.png" %}}' width="60"/></a>
+      <a href='{{% versioned_link_path fromRoot="/installation/gateway/nomad" %}}'><img src='{{% versioned_link_path fromRoot="/img/nomad.png" %}}' width="60"/></a>
     </td>
     <td>
      Run Gloo on a [HashiCorp Nomad Cluster](https://www.nomadproject.io/), using [Consul](https://www.consul.io/) for configuration and [Vault](https://www.vaultproject.io/) for secret storage.


### PR DESCRIPTION
api rename unearthed some old-format links that are now broken
fix links and update to use `protobuf` shortcode