### PR TITLE
Update install script

### DIFF
--- a/changelog/v0.21.2/update-install-script.yaml
+++ b/changelog/v0.21.2/update-install-script.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/1266
+    description: >
+      Update install script to honor `GLOO_VERSION` env var for desired version, if set. Also update to sort located
+      releases in semver order so that if desired version is omitted, we try to download the largest release rather
+      than the most recent release. (for example, we backport a fix and release a 0.x.x after 1.0.0 is already out).
+    resolvesIssue: false

--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -2,8 +2,11 @@
 
 set -eu
 
-
-GLOO_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | python -c "import sys; from json import loads as l; releases = l(sys.stdin.read()); print('\n'.join(release['tag_name'] for release in releases))")
+if [ -z "${GLOO_VERSION}" ]; then
+  GLOO_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | python -c "import sys; from distutils.version import LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  releases.sort(key=LooseVersion, reverse=True); print('\n'.join(releases))")
+else
+  GLOO_VERSIONS="${GLOO_VERSION}"
+fi
 
 if [ "$(uname -s)" = "Darwin" ]; then
   OS=darwin
@@ -11,14 +14,14 @@ else
   OS=linux
 fi
 
-for GLOO_VERSION in $GLOO_VERSIONS; do
+for gloo_version in $GLOO_VERSIONS; do
 
 tmp=$(mktemp -d /tmp/gloo.XXXXXX)
 filename="glooctl-${OS}-amd64"
-url="https://github.com/solo-io/gloo/releases/download/${GLOO_VERSION}/${filename}"
+url="https://github.com/solo-io/gloo/releases/download/${gloo_version}/${filename}"
 
 if curl -f ${url} >/dev/null 2>&1; then
-  echo "Attempting to download glooctl version ${GLOO_VERSION}"
+  echo "Attempting to download glooctl version ${gloo_version}"
 else
   continue
 fi


### PR DESCRIPTION
Update install script to honor `GLOO_VERSION` env var for desired version, if set. Also update to sort located releases in semver order so that if desired version is omitted, we try to download the largest release rather than the most recent release. (for example, we backport a fix and release a 0.x.x after 1.0.0 is already out).
  