### PR TITLE
Bump the default version of GlooE installed by the CLI to 0.21.0

### DIFF
--- a/changelog/v0.21.3/bump-glooe-tag.yaml
+++ b/changelog/v0.21.3/bump-glooe-tag.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  description: The default version of GlooE installed by the CLI is now 0.21.0.
+  issueLink: https://github.com/solo-io/gloo/issues/1725

--- a/pkg/version/enterprise.go
+++ b/pkg/version/enterprise.go
@@ -1,4 +1,4 @@
 package version
 
 // The version of GlooE installed by the CLI
-const EnterpriseTag = "0.20.8"
+const EnterpriseTag = "0.21.0"


### PR DESCRIPTION
Bump the default version of GlooE installed by the CLI to 0.21.0.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1725