### PR TITLE
Remove the GATEWAY_URL shell variable from the docs

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -542,9 +542,12 @@
   revision = "6f2cf27854a4a29e3811b0371547be335d411b8b"
 
 [[projects]]
-  digest = "1:b60efdeb75d3c0ceed88783ac2495256aba3491a537d0f31401202579fd62a94"
+  digest = "1:a507e8646bf3775af6f7e7b2a62a5e67d1c6a8f00754f87e66b96181b7f3d747"
   name = "github.com/golang/mock"
-  packages = ["gomock"]
+  packages = [
+    "gomock",
+    "mockgen/model",
+  ]
   pruneopts = "UT"
   revision = "51421b967af1f557f93a59e0057aaf15ca02e29c"
   version = "v1.2.0"
@@ -2788,6 +2791,7 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
+    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
     "github.com/golang/protobuf/ptypes/any",

--- a/changelog/v1.0.1/remove-gateway-url-shell-var.yaml
+++ b/changelog/v1.0.1/remove-gateway-url-shell-var.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: Remove the `GATEWAY_URL` shell variable from the docs and just use `$(glooctl proxy url)` when needed.
+  issueLink: https://github.com/solo-io/gloo/issues/1655
+  resolvesIssue: false

--- a/docs/content/gloo_integrations/knative/_index.md
+++ b/docs/content/gloo_integrations/knative/_index.md
@@ -72,7 +72,7 @@ run `glooctl proxy url --name knative-external-proxy`
   
      Gloo will use the `Host` header to route requests to the correct
      service. You can send a request to the `helloworld-go` service with curl
-     using the `Host` and `$GATEWAY_URL` from above:
+     using the `Host` and URL of the Gloo Gateway from above:
   
      ```
      $ curl -H "Host: helloworld-go.default.example.com" $(glooctl proxy url --name knative-external-proxy)

--- a/docs/content/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/matching_rules/header_matching/_index.md
@@ -64,7 +64,7 @@ We can now make a curl request to the new virtual service and set valid values f
 Let's send a request that satisfies all these criteria:
 
 ```shell
-curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v"  $GATEWAY_URL/posts
+curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v"  $(glooctl proxy url)/posts
 ```
 
 This returns a `json` list of posts. 
@@ -72,30 +72,30 @@ This returns a `json` list of posts.
 If we use an incorrect value for `header1`, we'll see a 404:
 
 ```shell
-curl -v -H "Host: foo" -H "header1: othervalue" -H "header2: value2" -H "header3: v"  $GATEWAY_URL/posts
+curl -v -H "Host: foo" -H "header1: othervalue" -H "header2: value2" -H "header3: v"  $(glooctl proxy url)/posts
 ```
 
 If we use a different value for `header2`, we'll see all the posts:
 ```shell
-curl -v -H "Host: foo" -H "header1: value1" -H "header2: othervalue" -H "header3: v"  $GATEWAY_URL/posts
+curl -v -H "Host: foo" -H "header1: value1" -H "header2: othervalue" -H "header3: v"  $(glooctl proxy url)/posts
 ```
 
 If we use an invalid value for `header3`, we'll get a 404: 
 ```shell
-curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: value3"  $GATEWAY_URL/posts
+curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: value3"  $(glooctl proxy url)/posts
 ```
 
 The `invertMatch` attribute in the last entry causes request to be matched only if it does **not** include a header named 
 `header4`. If we send a request with that header, we'll get a 404 response:
 ```shell
-curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v" -H "header4: value4"  $GATEWAY_URL/posts
+curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v" -H "header4: value4"  $(glooctl proxy url)/posts
 ```
 
 The `invertMatch` attribute can be combined with value match specifications. Where `header4` had no value spec, the inversion invalidated all possible values.
 The match constraints on `header5`, on the other hand, mean that if `header5` is present, the request will only match if the value is not equal to ``value5``.
 If we send a request with that value, we'll get a 404 response:
 ```shell
-curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v" -H "header5: value5"  $GATEWAY_URL/posts
+curl -v -H "Host: foo" -H "header1: value1" -H "header2: value2" -H "header3: v" -H "header5: value5"  $(glooctl proxy url)/posts
 ```
 
 ## Summary

--- a/docs/content/gloo_routing/virtual_services/routes/matching_rules/http_method_matching/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/matching_rules/http_method_matching/_index.md
@@ -42,7 +42,7 @@ glooctl add route --name test-post --method POST  --path-prefix / --dest-name js
 Let's POST to that route and make sure it works:
 
 ```shell
-curl -H "Host: foo" -XPOST $GATEWAY_URL/posts
+curl -H "Host: foo" -XPOST $(glooctl proxy url)/posts
 ```
 
 returns
@@ -79,13 +79,13 @@ glooctl add route --name test-get --method GET  --path-prefix / --dest-name json
 Now POST requests will return a 404:
 
 ```shell
-curl -v -H "Host: foo" -XPOST $GATEWAY_URL/posts
+curl -v -H "Host: foo" -XPOST $(glooctl proxy url)/posts
 ```
 
 But GET requests succeed:
 
 ```shell
-curl -H "Host: foo" $GATEWAY_URL/posts
+curl -H "Host: foo" $(glooctl proxy url)/posts
 ```
 
 ## Summary 

--- a/docs/content/gloo_routing/virtual_services/routes/matching_rules/path_matching/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/matching_rules/path_matching/_index.md
@@ -43,7 +43,7 @@ glooctl add route --name test-prefix --path-prefix / --dest-name json-upstream
 Since we are using the `foo` domain, if we make a curl request and don't provide the `Host` header, it will 404. 
 
 ```shell
-curl -v $GATEWAY_URL/posts
+curl -v $(glooctl proxy url)/posts
 ```
 
 This will print a 404 response containing:
@@ -57,7 +57,7 @@ This will print a 404 response containing:
 If we pass the `Host` header, we will successfully get results. 
 
 ```shell
-curl -H "Host: foo" $GATEWAY_URL/posts
+curl -H "Host: foo" $(glooctl proxy url)/posts
 ```
 
 ```json
@@ -198,7 +198,7 @@ glooctl add route --name test-regex --path-regex /[a-z]{5} --dest-name json-upst
 This request will return a 404 because the path `/comments` is more than 5 characters:
 
 ```shell
-curl -v -H "Host: foo" $GATEWAY_URL/comments
+curl -v -H "Host: foo" $(glooctl proxy url)/comments
 ```
 
 However, the following requests will both succeed:

--- a/docs/content/gloo_routing/virtual_services/routes/matching_rules/query_parameter_matching/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/matching_rules/query_parameter_matching/_index.md
@@ -47,24 +47,24 @@ The request must also have a query parameter `param2` with any value, and `param
 To test we can run the following command. Note that the URL must have quotes around it for curl to accept query parameters. 
 
 ```shell
-curl -v -H "Host: foo" "$GATEWAY_URL/posts?param1=value1&param2=value2&param3=v"
+curl -v -H "Host: foo" "$(glooctl proxy url)/posts?param1=value1&param2=value2&param3=v"
 ```
 
 This should return a large json response. We can set an incorrect value for query param 1, and see the curl command return a 404:
 
 ```shell
-curl -v -H "Host: foo" "$GATEWAY_URL/posts?param1=othervalue&param2=value2&param3=v"
+curl -v -H "Host: foo" "$(glooctl proxy url)/posts?param1=othervalue&param2=value2&param3=v"
 ```
 
 If we set a different value for query param 2, the command should work:
 ```shell
-curl -v -H "Host: foo" "$GATEWAY_URL/posts?param1=value1&param2=othervalue&param3=v"
+curl -v -H "Host: foo" "$(glooctl proxy url)/posts?param1=value1&param2=othervalue&param3=v"
 ```
 
 Finally, if we set an invalid value for query param 3, the command will return a 404:
 
 ```shell
-curl -v -H "Host: foo" "$GATEWAY_URL/posts?param1=value1&param2=value2&param3=vv"
+curl -v -H "Host: foo" "$(glooctl proxy url)/posts?param1=value1&param2=value2&param3=vv"
 ```
 
 ## Summary

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/direct_response_action/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/direct_response_action/_index.md
@@ -24,7 +24,7 @@ Let's create a virtual service with a direct response action instead of a route 
 Now if we curl the route, we should get the 200 response and see the message: 
 
 ```shell
-curl -H "Host: foo" $GATEWAY_URL/
+curl -H "Host: foo" $(glooctl proxy url)
 ```
 
 This will return the following message:

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/redirect_action/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/redirect_action/_index.md
@@ -23,7 +23,7 @@ Let's create a virtual service with a redirect action instead of a route action,
 Now if we curl the route, we should get a 301 Permanently Moved response. 
 
 ```shell
-curl -v -H "Host: foo" $GATEWAY_URL/
+curl -v -H "Host: foo" $(glooctl proxy url)
 ```
 
 This will contain the following message:

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/discovered_upstream/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/discovered_upstream/_index.md
@@ -159,7 +159,7 @@ glooctl add route --name test-petstore --path-prefix /api/pets --dest-name defau
 We can now query this route using curl. 
 
 ```shell
-curl -H "Host: foo" $GATEWAY_URL/api/pets
+curl -H "Host: foo" $(glooctl proxy url)/api/pets
 ```
 
 This should return: 

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/function_routing/rest_endpoint/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/function_routing/rest_endpoint/_index.md
@@ -107,8 +107,7 @@ Let's see how this plugin works by creating some routes to these functions in th
     Let's go ahead and test the route using `curl`:
 
     ```shell
-    export GATEWAY_URL=$(glooctl proxy url)
-    curl ${GATEWAY_URL}/petstore/findPet
+    curl $(glooctl proxy url)/petstore/findPet
     ```
 
     ```json
@@ -129,7 +128,7 @@ Let's see how this plugin works by creating some routes to these functions in th
 1. Try the request again, but now add a JSON body which includes the `id` parameter:
 
     ```shell
-    curl ${GATEWAY_URL}/petstore/findPet -d '{"id": 1}'
+    curl $(glooctl proxy url)/petstore/findPet -d '{"id": 1}'
     ```
 
     ```json
@@ -137,7 +136,7 @@ Let's see how this plugin works by creating some routes to these functions in th
     ```
 
     ```shell
-    curl ${GATEWAY_URL}/petstore/findPet -d '{"id": 2}'
+    curl $(glooctl proxy url)/petstore/findPet -d '{"id": 2}'
     ```
 
     ```json
@@ -197,7 +196,7 @@ virtualHost:
     Try `curl` again, this time with the new header:
 
     ```shell
-    curl ${GATEWAY_URL}/petstore/findWithId/1
+    curl $(glooctl proxy url)/petstore/findWithId/1
     ```
 
     ```json

--- a/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/static_upstream/_index.md
+++ b/docs/content/gloo_routing/virtual_services/routes/route_destinations/single_upstreams/static_upstream/_index.md
@@ -41,7 +41,7 @@ glooctl add route --name test-static --path-prefix / --dest-name json-upstream
 Now we can verify that the proxy was updated to support routing to this upstream using curl:
 
 ```shell
-curl -H "Host: foo" $GATEWAY_URL/posts
+curl -H "Host: foo" $(glooctl proxy url)/posts
 ```
 
 ```json

--- a/docs/content/gloo_routing/virtual_services/security/apikey_auth/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/apikey_auth/_index.md
@@ -69,7 +69,7 @@ glooctl add route --name test-no-auth --path-prefix / --dest-name json-upstream
 Let's send a request that matches the above route to the Gloo Gateway and make sure it works:
 
 ```shell
-curl -H "Host: foo" $GATEWAY_URL/posts/1
+curl -H "Host: foo" $(glooctl proxy url)/posts/1
 ```
 
 The above command should return:
@@ -204,7 +204,7 @@ inherit its `AuthConfig`, unless it [overwrites or disables]({{< versioned_link_
 Let's try and resend the same request we sent earlier:
 
 ```shell
-curl -v -H "Host: foo" $GATEWAY_URL/posts/1
+curl -v -H "Host: foo" $(glooctl proxy url)/posts/1
 ```
 
 You will see that the response now contains a **401 Unauthorized** code, indicating that Gloo denied the request.
@@ -227,7 +227,7 @@ For a request to be allowed, it must include a header named `api-key` with the v
 stored in our secret. Now let's add the authorization headers:
 
 ```shell
-curl -H "api-key: N2YwMDIxZTEtNGUzNS1jNzgzLTRkYjAtYjE2YzRkZGVmNjcy" -H "Host: foo" $GATEWAY_URL/posts/1
+curl -H "api-key: N2YwMDIxZTEtNGUzNS1jNzgzLTRkYjAtYjE2YzRkZGVmNjcy" -H "Host: foo" $(glooctl proxy url)/posts/1
 ```
 
 We are now able to reach the upstream again!

--- a/docs/content/gloo_routing/virtual_services/security/basic_auth/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/basic_auth/_index.md
@@ -56,7 +56,7 @@ glooctl add route --name test-no-auth --path-prefix / --dest-name json-upstream
 Let's send a request that matches the above route to the Gloo Gateway and make sure it works:
 
 ```shell
-curl -H "Host: foo" $GATEWAY_URL/posts/1
+curl -H "Host: foo" $(glooctl proxy url)/posts/1
 ```
 
 The above command should produce the following output:
@@ -151,7 +151,7 @@ inherit its `AuthConfig`, unless it [overwrites or disables]({{< versioned_link_
 Let's try and resend the same request we sent earlier:
 
 ```shell
-curl -v -H "Host: foo" $GATEWAY_URL/posts/1
+curl -v -H "Host: foo" $(glooctl proxy url)/posts/1
 ```
 
 You will see that the response now contains a **401 Unauthorized** code, indicating that Gloo denied the request.
@@ -186,7 +186,7 @@ echo -n "user:password" | base64
 This outputs `dXNlcjpwYXNzd29yZA==`. Let's include the header with this value in our request:
 
 ```shell
-curl -H "Authorization: basic dXNlcjpwYXNzd29yZA==" -H "Host: foo" $GATEWAY_URL/posts/1
+curl -H "Authorization: basic dXNlcjpwYXNzd29yZA==" -H "Host: foo" $(glooctl proxy url)/posts/1
 ```
 
 We are now able to reach the upstream again!

--- a/docs/content/gloo_routing/virtual_services/security/custom_auth/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/custom_auth/_index.md
@@ -58,7 +58,7 @@ glooctl add route --name default --namespace gloo-system --path-prefix / --dest-
 Let's verify that everything so far works by querying the virtual service.
 
 ```shell script
-curl $GATEWAY_URL/api/pets/
+curl $(glooctl proxy url)/api/pets/
 ```
 
 You should see the following output:
@@ -250,7 +250,7 @@ both the `Settings` and the `Virtual Service`.
 Let's verify that our configuration has been accepted by Gloo. Requests to `/api/pets/1` should be allowed:
 
 ```shell
-curl --write-out "%{http_code}\n" $GATEWAY_URL/api/pets/1
+curl --write-out "%{http_code}\n" $(glooctl proxy url)/api/pets/1
 ```
 
 ```noop
@@ -261,7 +261,7 @@ curl --write-out "%{http_code}\n" $GATEWAY_URL/api/pets/1
 Any request with a path that is not `/api/pets/1` should be denied.
 
 ```shell
-curl --write-out "%{http_code}\n" $GATEWAY_URL/api/pets/2
+curl --write-out "%{http_code}\n" $(glooctl proxy url)/api/pets/2
 ```
 
 ```noop

--- a/docs/content/gloo_routing/virtual_services/security/jwt/access_control.md
+++ b/docs/content/gloo_routing/virtual_services/security/jwt/access_control.md
@@ -70,7 +70,7 @@ spec:
 To verify that the Virtual Service works, let's send a request to `/api/pets`:
 
 ```shell
-curl $GATEWAY_URL/api/pets
+curl $(glooctl proxy url)/api/pets
 ```
 
 You should see the following output:

--- a/docs/content/gloo_routing/virtual_services/security/jwt/claim_routing.md
+++ b/docs/content/gloo_routing/virtual_services/security/jwt/claim_routing.md
@@ -176,13 +176,13 @@ For convenience, we added the `tokenSource` settings so we can pass the token as
 ### Testing our configuration
 Send a request as a solo.io team member:
 ```
-curl "$GATEWAY_URL?token=$SOLO_TOKEN"
+curl "$(glooctl proxy url)?token=$SOLO_TOKEN"
 ```
 The output should be `canary`.
 
 Send a request as a othercompany.com team member:
 ```
-curl "$GATEWAY_URL?token=$OTHER_TOKEN"
+curl "$(glooctl proxy url)?token=$OTHER_TOKEN"
 ```
 The output should be `primary`.
 

--- a/docs/content/gloo_routing/virtual_services/security/ldap/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/ldap/_index.md
@@ -82,7 +82,7 @@ Now we can create a Virtual Service that routes any requests with the `/echo` pr
 To verify that the Virtual Service works, let's send a request to `/echo`:
 
 ```bash
-curl $GATEWAY_URL/echo
+curl $(glooctl proxy url)/echo
 'Hello World!'
 ```
 
@@ -333,7 +333,7 @@ so here are the `base64`-encoded credentials for some test users:
 To start with, let's send a request without any header:
 
 {{< highlight bash "hl_lines=11" >}}
-curl -v "$GATEWAY_URL"/echo 
+curl -v "$(glooctl proxy url)"/echo 
 
 *   Trying 192.168.99.100...
 * TCP_NODELAY set
@@ -357,7 +357,7 @@ We can see that Gloo returned a `401` response.
 Now let's try the unknown user, which will produce the same result:
 
 {{< highlight bash "hl_lines=12" >}}
-curl -v -H "Authorization: Basic am9objpkb2U=" "$GATEWAY_URL"/echo
+curl -v -H "Authorization: Basic am9objpkb2U=" "$(glooctl proxy url)"/echo
 
 *   Trying 192.168.99.100...
 * TCP_NODELAY set
@@ -381,7 +381,7 @@ If we try to authenticate as a user that belongs to the "developers" group, Gloo
 indicating that the user was successfully authenticated, but lacks the permissions to access the resource.
 
 {{< highlight bash "hl_lines=12" >}}
-curl -v -H "Authorization: Basic bWFyY286bWFyY29wd2Q=" "$GATEWAY_URL"/echo
+curl -v -H "Authorization: Basic bWFyY286bWFyY29wd2Q=" "$(glooctl proxy url)"/echo
 
 *   Trying 192.168.99.100...
 * TCP_NODELAY set
@@ -404,7 +404,7 @@ curl -v -H "Authorization: Basic bWFyY286bWFyY29wd2Q=" "$GATEWAY_URL"/echo
 Finally, if we provide a user that belongs to the "managers" group, we will be able to access the upstream.
 
 {{< highlight bash "hl_lines=12 21" >}}
-curl -v -H "Authorization: Basic cmljazpyaWNrcHdk" "$GATEWAY_URL"/echo
+curl -v -H "Authorization: Basic cmljazpyaWNrcHdk" "$(glooctl proxy url)"/echo
 
 *   Trying 192.168.99.100...
 * TCP_NODELAY set

--- a/docs/content/gloo_routing/virtual_services/security/opa/_index.md
+++ b/docs/content/gloo_routing/virtual_services/security/opa/_index.md
@@ -78,7 +78,7 @@ spec:
 To verify that the Virtual Service works, let's send a request to `/api/pets`:
 
 ```shell
-curl $GATEWAY_URL/api/pets
+curl $(glooctl proxy url)/api/pets
 ```
 
 You should see the following output:
@@ -194,21 +194,21 @@ inherit its `AuthConfig`, unless it [overwrites or disables]({{< ref "gloo_routi
 ### Testing the configuration
 Paths that don't start with `/api/pets` are not authorized (should return 403):
 ```
-curl -s -w "%{http_code}\n" $GATEWAY_URL/api/
+curl -s -w "%{http_code}\n" $(glooctl proxy url)/api/
 
 403
 ```
 
 Not allowed to delete `pets/1` (should return 403):
 ```
-curl -s -w "%{http_code}\n" $GATEWAY_URL/api/pets/1 -X DELETE
+curl -s -w "%{http_code}\n" $(glooctl proxy url)/api/pets/1 -X DELETE
 
 403
 ```
 
 Allowed to delete `pets/2` (should return 204):
 ```
-curl -s -w "%{http_code}\n" $GATEWAY_URL/api/pets/2 -X DELETE
+curl -s -w "%{http_code}\n" $(glooctl proxy url)/api/pets/2 -X DELETE
 
 204
 ```

--- a/docs/content/static/content/setup_notes
+++ b/docs/content/static/content/setup_notes
@@ -1,6 +1,8 @@
-This guide assumes that you have installed Gloo into the `gloo-system` namespace and that `glooctl` is installed on your
-machine. For convenience, let's also store the URL of the Gloo Gateway in a variable in your terminal:
+This guide assumes that you have deployed Gloo to the `gloo-system` namespace and that the `glooctl` command line utility
+is installed on your machine. `glooctl` provides several convenient functions to view, manipulate, and debug Gloo resources;
+in particular, it is worth mentioning the following command, which we will use each time we need to retrieve the URL of
+the Gloo Gateway that is running inside your cluster:
 
 ```shell
-export GATEWAY_URL=$(glooctl proxy url)
+glooctl proxy url
 ```


### PR DESCRIPTION
Remove the `GATEWAY_URL` shell variable from the docs and just use `$(glooctl proxy url)` where needed.