### PR TITLE
Move installationId out of globals

### DIFF
--- a/changelog/v1.0.1/move-install-id.yaml
+++ b/changelog/v1.0.1/move-install-id.yaml
@@ -5,7 +5,7 @@ changelog:
       gets *copied* between a chart and its subchart, so the mutation that's necessary to guarantee uniqueness of
       the installationId isn't respected between the two charts.
     issueLink: https://github.com/solo-io/gloo/issues/1635
-  - type: Helm
+  - type: HELM
     description: >
       Move installationId Helm value out of `globals`. This is necessary because of the fact that the `globals` map
       gets *copied* between a chart and its subchart, so the mutation that's necessary to guarantee uniqueness of

--- a/changelog/v1.0.1/move-install-id.yaml
+++ b/changelog/v1.0.1/move-install-id.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: FIX
+    description: >
+      Move installationId Helm value out of `globals`. This is necessary because of the fact that the `globals` map
+      gets *copied* between a chart and its subchart, so the mutation that's necessary to guarantee uniqueness of
+      the installationId isn't respected between the two charts.
+    issueLink: https://github.com/solo-io/gloo/issues/1635
+  - type: Helm
+    description: >
+      Move installationId Helm value out of `globals`. This is necessary because of the fact that the `globals` map
+      gets *copied* between a chart and its subchart, so the mutation that's necessary to guarantee uniqueness of
+      the installationId isn't respected between the two charts.
+    issueLink: https://github.com/solo-io/gloo/issues/1635

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -25,6 +25,7 @@
 |settings.invalidConfigPolicy.replaceInvalidRoutes|bool|false|Rather than pausing configuration updates, in the event of an invalid Route defined on a virtual service or route table, Gloo will serve the route with a predefined direct response action. This allows valid routes to be updated when other routes are invalid.|
 |settings.invalidConfigPolicy.invalidRouteResponseCode|int64|404|the response code for the direct response|
 |settings.invalidConfigPolicy.invalidRouteResponseBody|string|Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.|the response body for the direct response|
+|settings.linkerd|bool|false|Enable automatic Linkerd integration in Gloo.|
 |gloo.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |gloo.deployment.image.repository|string|gloo|image name (repository) for the container.|
 |gloo.deployment.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|
@@ -229,6 +230,7 @@
 |accessLogger.resources.limits.cpu|string||amount of CPUs|
 |accessLogger.resources.requests.memory|string||amount of memory|
 |accessLogger.resources.requests.cpu|string||amount of CPUs|
+|installConfig.installationId|string||If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling|
 |global.image.tag|string||tag for the container|
 |global.image.repository|string||image name (repository) for the container.|
 |global.image.registry|string|quay.io/solo-io|image prefix/registry e.g. (quay.io/solo-io)|
@@ -238,4 +240,3 @@
 |global.glooRbac.create|bool|true|create rbac rules for the gloo-system service account|
 |global.glooRbac.namespaced|bool|false|use Roles instead of ClusterRoles|
 |global.glooRbac.nameSuffix|string||When nameSuffix is nonempty, append '-$nameSuffix' to the names of Gloo RBAC resources; e.g. when nameSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'|
-|global.glooInstallationId|string||If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -21,7 +21,7 @@ type Config struct {
 	IngressProxy   *IngressProxy           `json:"ingressProxy,omitempty"`
 	K8s            *K8s                    `json:"k8s,omitempty"`
 	AccessLogger   *AccessLogger           `json:"accessLogger,omitempty"`
-	InstallConfig  *InstallConfig          `json:"installConfig"`
+	InstallConfig  *InstallConfig          `json:"installConfig,omitempty"`
 }
 
 type InstallConfig struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -21,13 +21,17 @@ type Config struct {
 	IngressProxy   *IngressProxy           `json:"ingressProxy,omitempty"`
 	K8s            *K8s                    `json:"k8s,omitempty"`
 	AccessLogger   *AccessLogger           `json:"accessLogger,omitempty"`
+	InstallConfig  *InstallConfig          `json:"installConfig"`
+}
+
+type InstallConfig struct {
+	InstallationId string `json:"installationId" desc:"If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling"`
 }
 
 type Global struct {
-	Image              *Image      `json:"image,omitempty"`
-	Extensions         interface{} `json:"extensions,omitempty"`
-	GlooRbac           *Rbac       `json:"glooRbac,omitempty"`
-	GlooInstallationId string      `json:"glooInstallationId" desc:"If not user-defined, will default to a random string. Used to track all the resources created in one installation to assist with uninstalling"`
+	Image      *Image      `json:"image,omitempty"`
+	Extensions interface{} `json:"extensions,omitempty"`
+	GlooRbac   *Rbac       `json:"glooRbac,omitempty"`
 }
 
 type Namespace struct {

--- a/install/helm/gloo/templates/0-namespace.yaml
+++ b/install/helm/gloo/templates/0-namespace.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Release.Namespace }}
   labels:
     app: gloo
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "0"

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gloo
     gloo: gloo
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: gloo
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: gloo
     gloo: ingress
-    installationId: {{ include "gloo.installationId" $ }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: ingress
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/100-gloo-crds.yaml
+++ b/install/helm/gloo/templates/100-gloo-crds.yaml
@@ -7,7 +7,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     gloo: settings
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: gloo.solo.io
   names:
@@ -30,7 +30,7 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
   labels:
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: gateway.solo.io
   names:
@@ -54,7 +54,7 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
   labels:
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: gateway.solo.io
   names:
@@ -78,7 +78,7 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
   labels:
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: gateway.solo.io
   names:
@@ -102,7 +102,7 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
   labels:
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: gloo.solo.io
   names:
@@ -126,7 +126,7 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
   labels:
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: gloo.solo.io
   names:
@@ -150,7 +150,7 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
   labels:
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: gloo.solo.io
   names:
@@ -174,7 +174,7 @@ metadata:
   annotations:
     "helm.sh/hook": crd-install
   labels:
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 spec:
   group: enterprise.gloo.solo.io
   names:

--- a/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: gloo
     gloo: ingress-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: ingress-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gloo
     gloo: ingress-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 data:
 {{ if (empty .Values.ingressProxy.configMap.data) }}
   envoy.yaml: |

--- a/install/helm/gloo/templates/13-ingress-proxy-service.yaml
+++ b/install/helm/gloo/templates/13-ingress-proxy-service.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: gloo
     gloo: ingress-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: ingress-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: gloo
     gloo: clusteringress-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: clusteringress-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: gloo
     gloo: clusteringress-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 data:
   envoy.yaml: |
     node:

--- a/install/helm/gloo/templates/16-clusteringress-proxy-service.yaml
+++ b/install/helm/gloo/templates/16-clusteringress-proxy-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gloo
     gloo: clusteringress-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: clusteringress-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -5,7 +5,7 @@ kind: Settings
 metadata:
   labels:
     app: gloo
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: default
   namespace: {{ .Release.Namespace }}
   annotations:

--- a/install/helm/gloo/templates/2-gloo-service-account.yaml
+++ b/install/helm/gloo/templates/2-gloo-service-account.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: gloo
     gloo: gloo
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/2-gloo-service.yaml
+++ b/install/helm/gloo/templates/2-gloo-service.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: gloo
     gloo: gloo
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: gloo
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/2-gloo-usage-configmap.yaml
+++ b/install/helm/gloo/templates/2-gloo-usage-configmap.yaml
@@ -7,5 +7,5 @@ metadata:
   labels:
     app: gloo
     gloo: gloo-usage
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 data:

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -11,7 +11,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"
@@ -30,7 +30,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"
@@ -50,7 +50,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"
@@ -73,7 +73,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"
@@ -93,7 +93,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"
@@ -112,7 +112,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"
@@ -136,7 +136,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/21-namespace-clusterrole-ingress.yaml
+++ b/install/helm/gloo/templates/21-namespace-clusterrole-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"

--- a/install/helm/gloo/templates/22-namespace-clusterrole-knative.yaml
+++ b/install/helm/gloo/templates/22-namespace-clusterrole-knative.yaml
@@ -8,7 +8,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
-        installationId: {{ include "gloo.installationId" . }}
+        installationId: {{ include "gloo.installationId" .Values.installConfig }}
     annotations:
       "helm.sh/hook": "pre-install"
       "helm.sh/hook-weight": "10"

--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"
@@ -37,7 +37,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"
@@ -60,7 +60,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"
@@ -83,7 +83,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"
@@ -112,7 +112,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"
@@ -135,7 +135,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"
@@ -159,7 +159,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/24-namespace-clusterrolebinding-ingress.yaml
+++ b/install/helm/gloo/templates/24-namespace-clusterrolebinding-ingress.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"

--- a/install/helm/gloo/templates/25-namespace-clusterrolebinding-knative.yaml
+++ b/install/helm/gloo/templates/25-namespace-clusterrolebinding-knative.yaml
@@ -8,7 +8,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "15"

--- a/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: gloo
     gloo: knative-external-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: knative-external-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: gloo
     gloo: knative-external-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 data:
   envoy.yaml: |
     node:

--- a/install/helm/gloo/templates/28-knative-external-proxy-service.yaml
+++ b/install/helm/gloo/templates/28-knative-external-proxy-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gloo
     gloo: knative-external-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: knative-external-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: gloo
     gloo: knative-internal-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: knative-internal-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: gloo
     gloo: discovery
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: discovery
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/3-discovery-service-account.yaml
+++ b/install/helm/gloo/templates/3-discovery-service-account.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: gloo
     gloo: discovery
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: gloo
     gloo: knative-internal-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
 data:
   envoy.yaml: |
     node:

--- a/install/helm/gloo/templates/31-knative-internal-proxy-service.yaml
+++ b/install/helm/gloo/templates/31-knative-internal-proxy-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gloo
     gloo: knative-internal-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: knative-internal-proxy
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: gateway
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/5-gateway-service-account.yaml
+++ b/install/helm/gloo/templates/5-gateway-service-account.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"
@@ -22,7 +22,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/5-gateway-service.yaml
+++ b/install/helm/gloo/templates/5-gateway-service.yaml
@@ -6,7 +6,7 @@ metadata:
     discovery.solo.io/function_discovery: disabled
     app: gloo
     gloo: gateway
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: gateway
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
+++ b/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "5" # should come before cert-gen job

--- a/install/helm/gloo/templates/6-access-logger-deployment.yaml
+++ b/install/helm/gloo/templates/6-access-logger-deployment.yaml
@@ -10,7 +10,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway-proxy-access-logger
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: gateway-proxy-access-logger
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/6-access-logger-service.yaml
+++ b/install/helm/gloo/templates/6-access-logger-service.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway-proxy-access-logger
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: gateway-proxy-access-logger
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -11,7 +11,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway-certgen
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   name: gateway-certgen
   namespace: {{ .Release.Namespace }}
   annotations:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -4,7 +4,6 @@
 {{- if .Values.gateway.enabled }}
 {{- $global := .Values.global }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
-{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 {{- $image := $spec.podTemplate.image }}
 {{- if $global }}
@@ -22,7 +21,7 @@ metadata:
     app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
-    installationId: {{ include "gloo.installationId" $installConfig }}
+    installationId: {{ include "gloo.installationId" $.Values.installConfig }}
   name: {{ $name | kebabcase }}
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -4,6 +4,7 @@
 {{- if .Values.gateway.enabled }}
 {{- $global := .Values.global }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
+{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 {{- $image := $spec.podTemplate.image }}
 {{- if $global }}
@@ -21,7 +22,7 @@ metadata:
     app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
-    installationId: {{ include "gloo.installationId" $ }}
+    installationId: {{ include "gloo.installationId" $installConfig }}
   name: {{ $name | kebabcase }}
   namespace: {{ $.Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -1,3 +1,4 @@
+{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 {{- if $spec.gatewaySettings}}
 {{$gatewaySettings := $spec.gatewaySettings}}
@@ -11,7 +12,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     app: gloo
-    installationId: {{ include "gloo.installationId" $ }}
+    installationId: {{ include "gloo.installationId" $installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"
@@ -38,7 +39,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     app: gloo
-    installationId: {{ include "gloo.installationId" $ }}
+    installationId: {{ include "gloo.installationId" $installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -1,4 +1,3 @@
-{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 {{- if $spec.gatewaySettings}}
 {{$gatewaySettings := $spec.gatewaySettings}}
@@ -12,7 +11,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     app: gloo
-    installationId: {{ include "gloo.installationId" $installConfig }}
+    installationId: {{ include "gloo.installationId" $.Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"
@@ -39,7 +38,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     app: gloo
-    installationId: {{ include "gloo.installationId" $installConfig }}
+    installationId: {{ include "gloo.installationId" $.Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/8-gateway-proxy-service-account.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service-account.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway-proxy
-    installationId: {{ include "gloo.installationId" . }}
+    installationId: {{ include "gloo.installationId" .Values.installConfig }}
   annotations:
     "helm.sh/hook": "pre-install"
     "helm.sh/hook-weight": "5"

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.gateway.enabled }}
-{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 ---
 apiVersion: v1
@@ -9,7 +8,7 @@ metadata:
     app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
-    installationId: {{ include "gloo.installationId" $installConfig }}
+    installationId: {{ include "gloo.installationId" $.Values.installConfig }}
   name: {{ $name | kebabcase }}
   namespace: {{ $.Release.Namespace }}
 {{- if $spec.service.extraAnnotations }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.gateway.enabled }}
+{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 ---
 apiVersion: v1
@@ -8,7 +9,7 @@ metadata:
     app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
-    installationId: {{ include "gloo.installationId" $ }}
+    installationId: {{ include "gloo.installationId" $installConfig }}
   name: {{ $name | kebabcase }}
   namespace: {{ $.Release.Namespace }}
 {{- if $spec.service.extraAnnotations }}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -1,5 +1,4 @@
 {{- if .Values.gateway.enabled }}
-{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 ---
 # config_map
@@ -12,7 +11,7 @@ metadata:
     app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
-    installationId: {{ include "gloo.installationId" $installConfig }}
+    installationId: {{ include "gloo.installationId" $.Values.installConfig }}
 data:
 {{ if (empty $spec.configMap.data) }}
   envoy.yaml: |

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.gateway.enabled }}
+{{- $installConfig := .Values.installConfig }}
 {{- range $name, $spec := .Values.gatewayProxies }}
 ---
 # config_map
@@ -11,7 +12,7 @@ metadata:
     app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
-    installationId: {{ include "gloo.installationId" $ }}
+    installationId: {{ include "gloo.installationId" $installConfig }}
 data:
 {{ if (empty $spec.configMap.data) }}
   envoy.yaml: |

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -28,10 +28,11 @@ Expand the name of a container image
 {{- end -}}
 
 {{/* This value makes its way into k8s labels, so if the implementation changes,
-     make sure it's compatible with label values */}}
+     make sure it's compatible with label values. Expects its root context to
+     have an "installationId" key that will be unique through the installation. */}}
 {{- define "gloo.installationId" -}}
-{{- if not .Values.global.glooInstallationId -}}
-{{- $_ := set .Values.global "glooInstallationId" (randAlphaNum 20) -}}
+{{- if not .installationId -}}
+{{- $_ := set . "installationId" (randAlphaNum 20) -}}
 {{- end -}}
-{{ .Values.global.glooInstallationId }}
+{{ .installationId }}
 {{- end -}}

--- a/install/helm/gloo/values-gateway-template.yaml
+++ b/install/helm/gloo/values-gateway-template.yaml
@@ -104,3 +104,5 @@ global:
     pullPolicy: IfNotPresent
   glooRbac:
     create: true
+
+installConfig: {}

--- a/install/helm/gloo/values-ingress-template.yaml
+++ b/install/helm/gloo/values-ingress-template.yaml
@@ -38,3 +38,4 @@ global:
   glooRbac:
     create: true
 
+installConfig: {}

--- a/install/helm/gloo/values-knative-template.yaml
+++ b/install/helm/gloo/values-knative-template.yaml
@@ -43,3 +43,5 @@ global:
     pullPolicy: IfNotPresent
   glooRbac:
     create: true
+
+installConfig: {}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Helm Test", func() {
 
 		// adds the install ID into the provided helm flags- no need to provide it yourself
 		prepareMakefile := func(helmFlags string) {
-			testManifest = renderManifest(helmFlags + " --set global.glooInstallationId=" + helmTestInstallId)
+			testManifest = renderManifest(helmFlags + " --set installConfig.installationId=" + helmTestInstallId)
 		}
 
 		// helper for passing a values file
@@ -145,7 +145,7 @@ var _ = Describe("Helm Test", func() {
 
 			It("can assign a custom installation ID", func() {
 				installId := "custom-install-id"
-				testManifest = renderManifest("--namespace " + namespace + " --set global.glooInstallationId=" + installId)
+				testManifest = renderManifest("--namespace " + namespace + " --set installConfig.installationId=" + installId)
 
 				Expect(testManifest.NumResources()).NotTo(BeZero())
 				testManifest.ExpectAll(func(resource *unstructured.Unstructured) {

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -18,7 +18,7 @@ var _ = Describe("RBAC Test", func() {
 	)
 
 	prepareMakefile := func(helmFlags string) {
-		testManifest = renderManifest(helmFlags + " --set global.glooInstallationId=" + installationId)
+		testManifest = renderManifest(helmFlags + " --set installConfig.installationId=" + installationId)
 	}
 
 	Context("implementation-agnostic permissions", func() {

--- a/install/test/svc_accnt_test.go
+++ b/install/test/svc_accnt_test.go
@@ -18,7 +18,7 @@ var _ = Describe("SVC Accnt Test", func() {
 		resourceBuilder.Labels["gloo"] = name
 		resourceBuilder.Labels["installationId"] = installationId
 
-		testManifest = renderManifest(helmFlags + " --set global.glooInstallationId=" + installationId)
+		testManifest = renderManifest(helmFlags + " --set installConfig.installationId=" + installationId)
 	}
 
 	BeforeEach(func() {


### PR DESCRIPTION
Move installationId Helm value out of `globals`. This is necessary because of the fact that the `globals` map gets *copied* between a chart and its subchart, so the mutation that's necessary to guarantee uniqueness of the installationId isn't respected between the two charts.

### Testing

```bash
# in gloo:
helm package --destination _output/helm/charts install/helm/gloo
cp _output/helm/charts/gloo-dev.tgz ../solo-projects/install/helm/gloo-ee/charts/gloo-dev.tgz

# in solo-projects:
helm template install/helm/gloo-ee --namespace gloo-system --name=glooe "" | grep -o 'installationId.*$' | sort | uniq -c
  64 installationId: zoeH1QqX25l0te9tYlYJ
```

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1635