### PR TITLE
Re-order the messages in the security-related proto files

### DIFF
--- a/changelog/v1.0.1/reorder-messages-in-proto-files.yaml
+++ b/changelog/v1.0.1/reorder-messages-in-proto-files.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+    Re-order the messages in the security-related proto files so that higher-level messages appear at the top of the file.
+    this will improve the experience of navigating to the protos. We currently link mostly to the messages that represent
+    VirtualHost/Route options, which often are at the bottom of the proto files. This causes the browser to seemingly focus
+    on unrelated messages when navigating to such messages.
+  issueLink: https://github.com/solo-io/gloo/issues/1655
+  resolvesIssue: false

--- a/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto
+++ b/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto
@@ -59,6 +59,7 @@ message ExtAuthExtension {
   }
 }
 
+// Global external auth settings
 message Settings {
   // The upstream to ask about auth decisions
   core.solo.io.ResourceRef extauthz_server_ref = 1;

--- a/projects/gloo/api/v1/enterprise/options/jwt/jwt.proto
+++ b/projects/gloo/api/v1/enterprise/options/jwt/jwt.proto
@@ -10,6 +10,44 @@ option (gogoproto.equal_all) = true;
 
 import "google/protobuf/duration.proto";
 
+message VhostExtension {
+    // Auth providers can be used instead of the fields above where more than one is required.
+    // if this list is provided the fields above are ignored.
+    map<string, Provider> providers = 4;
+}
+
+message RouteExtension {
+    // Disable JWT checks on this route.
+    bool disable = 1;
+}
+
+message Provider {
+    // The source for the keys to validate JWTs.
+    Jwks jwks = 1;
+    // An incoming JWT must have an 'aud' claim and it must be in this list.
+    repeated string audiences = 2;
+    // Issuer of the JWT. the 'iss' claim of the JWT must match this.
+    string issuer = 3;
+
+    // Where to find the JWT of the current provider.
+    TokenSource token_source = 4;
+
+    // Should the token forwarded upstream. if false, the header containing the token will be removed.
+    bool keep_token = 5;
+
+    // What claims should be copied to upstream headers.
+    repeated ClaimToHeader claims_to_headers = 6;
+}
+
+message Jwks {
+    oneof jwks {
+        // Use a remote JWKS server
+        RemoteJwks remote = 1;
+        // Use an inline JWKS
+        LocalJwks local   = 2;
+    }
+}
+
 message RemoteJwks {
     // The url used when accessing the upstream for Json Web Key Set.
     // This is used to set the host and path in the request
@@ -24,15 +62,6 @@ message RemoteJwks {
 message LocalJwks {
     // Inline key. this can be json web key, key-set or PEM format.
     string key = 1;
-}
-
-message Jwks {
-    oneof jwks {
-        // Use a remote JWKS server
-        RemoteJwks remote = 1;
-        // Use an inline JWKS
-        LocalJwks local   = 2;
-    }
 }
 
 // Describes the location of a JWT token
@@ -59,33 +88,4 @@ message ClaimToHeader {
     string header = 2;
     // If the header exists, append to it (true), or overwrite it (false).
     bool append = 4;
-}
-
-message Provider {
-    // The source for the keys to validate JWTs.
-    Jwks jwks = 1;
-    // An incoming JWT must have an 'aud' claim and it must be in this list.
-    repeated string audiences = 2;
-    // Issuer of the JWT. the 'iss' claim of the JWT must match this.
-    string issuer = 3;
-
-    // Where to find the JWT of the current provider.
-    TokenSource token_source = 4;
-
-    // Should the token forwarded upstream. if false, the header containing the token will be removed.
-    bool keep_token = 5;
-
-    // What claims should be copied to upstream headers.
-    repeated ClaimToHeader claims_to_headers = 6;
-}
-
-message VhostExtension {
-    // Auth providers can be used instead of the fields above where more than one is required.
-    // if this list is provided the fields above are ignored.
-    map<string, Provider> providers = 4;
-}
-
-message RouteExtension {
-    // Disable JWT checks on this route.
-    bool disable = 1;
 }

--- a/projects/gloo/api/v1/enterprise/options/rbac/rbac.proto
+++ b/projects/gloo/api/v1/enterprise/options/rbac/rbac.proto
@@ -7,6 +7,33 @@ import "gogoproto/gogo.proto";
 option (gogoproto.equal_all) = true;
 // TODO: should we add standard claims to the jwt principal?
 
+// Global RBAC settings
+message Settings {
+    // Require RBAC for all virtual hosts. A vhost without an RBAC policy set will fallback to a deny-all policy.
+    bool require_rbac = 1;
+}
+
+// RBAC settings for Virtual Hosts and Routes.s
+message ExtensionSettings {
+    // Disable RBAC checks on this resource (default false). This is useful to allow access to static resources/login page without RBAC checks.
+    // If provided on a route, all route settings override any vhost settings
+    bool disable = 1;
+    // Named policies to apply.
+    map<string, Policy> policies = 2;
+}
+
+message Policy {
+    // Principals in this policy.
+    repeated Principal principals = 1;
+    // Permissions granted to the principals.
+    Permissions permissions = 2;
+}
+
+// An RBAC principal - the identity entity (usually a user or a service account).
+message Principal {
+    JWTPrincipal jwt_principal = 1;
+}
+
 // A JWT principal. To use this, JWT option MUST be enabled.
 message JWTPrincipal {
     // Set of claims that make up this principal. Commonly, the 'iss' and 'sub' or 'email' claims are used.
@@ -17,11 +44,6 @@ message JWTPrincipal {
     string provider = 2;
 }
 
-// An RBAC principal - the identity entity (usually a user or a service account).
-message Principal {
-    JWTPrincipal jwt_principal = 1;
-}
-
 // What permissions should be granted. An empty field means allow-all.
 // If more than one field is added, all of them need to match.
 message Permissions {
@@ -29,24 +51,4 @@ message Permissions {
     string path_prefix = 1;
     // What http methods (GET, POST, ...) are allowed.
     repeated string methods = 2;
-}
-
-message Policy {
-    // Principals in this policy.
-    repeated Principal principals = 1;
-    // Permissions granted to the principals.
-    Permissions permissions = 2;
-}
-
-message Settings {
-    // Require RBAC for all virtual hosts. A vhost without an RBAC policy set will fallback to a deny-all policy.
-    bool require_rbac = 1;
-}
-
-message ExtensionSettings {
-    // Disable RBAC checks on this resource (default false). This is useful to allow access to static resources/login page without RBAC checks.
-    // If provided on a route, all route settings override any vhost settings
-    bool disable = 1;
-    // Named policies to apply.
-    map<string, Policy> policies = 2;
 }

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
@@ -315,6 +315,7 @@ func (*ExtAuthExtension) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+// Global external auth settings
 type Settings struct {
 	// The upstream to ask about auth decisions
 	ExtauthzServerRef *core.ResourceRef `protobuf:"bytes,1,opt,name=extauthz_server_ref,json=extauthzServerRef,proto3" json:"extauthz_server_ref,omitempty"`

--- a/projects/gloo/pkg/api/v1/enterprise/options/jwt/jwt.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/jwt/jwt.pb.go
@@ -25,102 +25,167 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-type RemoteJwks struct {
-	// The url used when accessing the upstream for Json Web Key Set.
-	// This is used to set the host and path in the request
-	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
-	// The Upstream representing the Json Web Key Set server
-	UpstreamRef *core.ResourceRef `protobuf:"bytes,2,opt,name=upstream_ref,json=upstreamRef,proto3" json:"upstream_ref,omitempty"`
-	// Duration after which the cached JWKS should be expired.
-	// If not specified, default cache duration is 5 minutes.
-	CacheDuration        *types.Duration `protobuf:"bytes,4,opt,name=cache_duration,json=cacheDuration,proto3" json:"cache_duration,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
-	XXX_unrecognized     []byte          `json:"-"`
-	XXX_sizecache        int32           `json:"-"`
+type VhostExtension struct {
+	// Auth providers can be used instead of the fields above where more than one is required.
+	// if this list is provided the fields above are ignored.
+	Providers            map[string]*Provider `protobuf:"bytes,4,rep,name=providers,proto3" json:"providers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
+	XXX_unrecognized     []byte               `json:"-"`
+	XXX_sizecache        int32                `json:"-"`
 }
 
-func (m *RemoteJwks) Reset()         { *m = RemoteJwks{} }
-func (m *RemoteJwks) String() string { return proto.CompactTextString(m) }
-func (*RemoteJwks) ProtoMessage()    {}
-func (*RemoteJwks) Descriptor() ([]byte, []int) {
+func (m *VhostExtension) Reset()         { *m = VhostExtension{} }
+func (m *VhostExtension) String() string { return proto.CompactTextString(m) }
+func (*VhostExtension) ProtoMessage()    {}
+func (*VhostExtension) Descriptor() ([]byte, []int) {
 	return fileDescriptor_3d83f6c4a43394a0, []int{0}
 }
-func (m *RemoteJwks) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_RemoteJwks.Unmarshal(m, b)
+func (m *VhostExtension) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_VhostExtension.Unmarshal(m, b)
 }
-func (m *RemoteJwks) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_RemoteJwks.Marshal(b, m, deterministic)
+func (m *VhostExtension) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_VhostExtension.Marshal(b, m, deterministic)
 }
-func (m *RemoteJwks) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RemoteJwks.Merge(m, src)
+func (m *VhostExtension) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_VhostExtension.Merge(m, src)
 }
-func (m *RemoteJwks) XXX_Size() int {
-	return xxx_messageInfo_RemoteJwks.Size(m)
+func (m *VhostExtension) XXX_Size() int {
+	return xxx_messageInfo_VhostExtension.Size(m)
 }
-func (m *RemoteJwks) XXX_DiscardUnknown() {
-	xxx_messageInfo_RemoteJwks.DiscardUnknown(m)
+func (m *VhostExtension) XXX_DiscardUnknown() {
+	xxx_messageInfo_VhostExtension.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_RemoteJwks proto.InternalMessageInfo
+var xxx_messageInfo_VhostExtension proto.InternalMessageInfo
 
-func (m *RemoteJwks) GetUrl() string {
+func (m *VhostExtension) GetProviders() map[string]*Provider {
 	if m != nil {
-		return m.Url
-	}
-	return ""
-}
-
-func (m *RemoteJwks) GetUpstreamRef() *core.ResourceRef {
-	if m != nil {
-		return m.UpstreamRef
+		return m.Providers
 	}
 	return nil
 }
 
-func (m *RemoteJwks) GetCacheDuration() *types.Duration {
-	if m != nil {
-		return m.CacheDuration
-	}
-	return nil
-}
-
-type LocalJwks struct {
-	// Inline key. this can be json web key, key-set or PEM format.
-	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+type RouteExtension struct {
+	// Disable JWT checks on this route.
+	Disable              bool     `protobuf:"varint,1,opt,name=disable,proto3" json:"disable,omitempty"`
 	XXX_NoUnkeyedLiteral struct{} `json:"-"`
 	XXX_unrecognized     []byte   `json:"-"`
 	XXX_sizecache        int32    `json:"-"`
 }
 
-func (m *LocalJwks) Reset()         { *m = LocalJwks{} }
-func (m *LocalJwks) String() string { return proto.CompactTextString(m) }
-func (*LocalJwks) ProtoMessage()    {}
-func (*LocalJwks) Descriptor() ([]byte, []int) {
+func (m *RouteExtension) Reset()         { *m = RouteExtension{} }
+func (m *RouteExtension) String() string { return proto.CompactTextString(m) }
+func (*RouteExtension) ProtoMessage()    {}
+func (*RouteExtension) Descriptor() ([]byte, []int) {
 	return fileDescriptor_3d83f6c4a43394a0, []int{1}
 }
-func (m *LocalJwks) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_LocalJwks.Unmarshal(m, b)
+func (m *RouteExtension) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RouteExtension.Unmarshal(m, b)
 }
-func (m *LocalJwks) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_LocalJwks.Marshal(b, m, deterministic)
+func (m *RouteExtension) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RouteExtension.Marshal(b, m, deterministic)
 }
-func (m *LocalJwks) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_LocalJwks.Merge(m, src)
+func (m *RouteExtension) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RouteExtension.Merge(m, src)
 }
-func (m *LocalJwks) XXX_Size() int {
-	return xxx_messageInfo_LocalJwks.Size(m)
+func (m *RouteExtension) XXX_Size() int {
+	return xxx_messageInfo_RouteExtension.Size(m)
 }
-func (m *LocalJwks) XXX_DiscardUnknown() {
-	xxx_messageInfo_LocalJwks.DiscardUnknown(m)
+func (m *RouteExtension) XXX_DiscardUnknown() {
+	xxx_messageInfo_RouteExtension.DiscardUnknown(m)
 }
 
-var xxx_messageInfo_LocalJwks proto.InternalMessageInfo
+var xxx_messageInfo_RouteExtension proto.InternalMessageInfo
 
-func (m *LocalJwks) GetKey() string {
+func (m *RouteExtension) GetDisable() bool {
 	if m != nil {
-		return m.Key
+		return m.Disable
+	}
+	return false
+}
+
+type Provider struct {
+	// The source for the keys to validate JWTs.
+	Jwks *Jwks `protobuf:"bytes,1,opt,name=jwks,proto3" json:"jwks,omitempty"`
+	// An incoming JWT must have an 'aud' claim and it must be in this list.
+	Audiences []string `protobuf:"bytes,2,rep,name=audiences,proto3" json:"audiences,omitempty"`
+	// Issuer of the JWT. the 'iss' claim of the JWT must match this.
+	Issuer string `protobuf:"bytes,3,opt,name=issuer,proto3" json:"issuer,omitempty"`
+	// Where to find the JWT of the current provider.
+	TokenSource *TokenSource `protobuf:"bytes,4,opt,name=token_source,json=tokenSource,proto3" json:"token_source,omitempty"`
+	// Should the token forwarded upstream. if false, the header containing the token will be removed.
+	KeepToken bool `protobuf:"varint,5,opt,name=keep_token,json=keepToken,proto3" json:"keep_token,omitempty"`
+	// What claims should be copied to upstream headers.
+	ClaimsToHeaders      []*ClaimToHeader `protobuf:"bytes,6,rep,name=claims_to_headers,json=claimsToHeaders,proto3" json:"claims_to_headers,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
+	XXX_unrecognized     []byte           `json:"-"`
+	XXX_sizecache        int32            `json:"-"`
+}
+
+func (m *Provider) Reset()         { *m = Provider{} }
+func (m *Provider) String() string { return proto.CompactTextString(m) }
+func (*Provider) ProtoMessage()    {}
+func (*Provider) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3d83f6c4a43394a0, []int{2}
+}
+func (m *Provider) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Provider.Unmarshal(m, b)
+}
+func (m *Provider) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Provider.Marshal(b, m, deterministic)
+}
+func (m *Provider) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Provider.Merge(m, src)
+}
+func (m *Provider) XXX_Size() int {
+	return xxx_messageInfo_Provider.Size(m)
+}
+func (m *Provider) XXX_DiscardUnknown() {
+	xxx_messageInfo_Provider.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Provider proto.InternalMessageInfo
+
+func (m *Provider) GetJwks() *Jwks {
+	if m != nil {
+		return m.Jwks
+	}
+	return nil
+}
+
+func (m *Provider) GetAudiences() []string {
+	if m != nil {
+		return m.Audiences
+	}
+	return nil
+}
+
+func (m *Provider) GetIssuer() string {
+	if m != nil {
+		return m.Issuer
 	}
 	return ""
+}
+
+func (m *Provider) GetTokenSource() *TokenSource {
+	if m != nil {
+		return m.TokenSource
+	}
+	return nil
+}
+
+func (m *Provider) GetKeepToken() bool {
+	if m != nil {
+		return m.KeepToken
+	}
+	return false
+}
+
+func (m *Provider) GetClaimsToHeaders() []*ClaimToHeader {
+	if m != nil {
+		return m.ClaimsToHeaders
+	}
+	return nil
 }
 
 type Jwks struct {
@@ -137,7 +202,7 @@ func (m *Jwks) Reset()         { *m = Jwks{} }
 func (m *Jwks) String() string { return proto.CompactTextString(m) }
 func (*Jwks) ProtoMessage()    {}
 func (*Jwks) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3d83f6c4a43394a0, []int{2}
+	return fileDescriptor_3d83f6c4a43394a0, []int{3}
 }
 func (m *Jwks) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Jwks.Unmarshal(m, b)
@@ -201,6 +266,104 @@ func (*Jwks) XXX_OneofWrappers() []interface{} {
 	}
 }
 
+type RemoteJwks struct {
+	// The url used when accessing the upstream for Json Web Key Set.
+	// This is used to set the host and path in the request
+	Url string `protobuf:"bytes,1,opt,name=url,proto3" json:"url,omitempty"`
+	// The Upstream representing the Json Web Key Set server
+	UpstreamRef *core.ResourceRef `protobuf:"bytes,2,opt,name=upstream_ref,json=upstreamRef,proto3" json:"upstream_ref,omitempty"`
+	// Duration after which the cached JWKS should be expired.
+	// If not specified, default cache duration is 5 minutes.
+	CacheDuration        *types.Duration `protobuf:"bytes,4,opt,name=cache_duration,json=cacheDuration,proto3" json:"cache_duration,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}        `json:"-"`
+	XXX_unrecognized     []byte          `json:"-"`
+	XXX_sizecache        int32           `json:"-"`
+}
+
+func (m *RemoteJwks) Reset()         { *m = RemoteJwks{} }
+func (m *RemoteJwks) String() string { return proto.CompactTextString(m) }
+func (*RemoteJwks) ProtoMessage()    {}
+func (*RemoteJwks) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3d83f6c4a43394a0, []int{4}
+}
+func (m *RemoteJwks) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_RemoteJwks.Unmarshal(m, b)
+}
+func (m *RemoteJwks) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_RemoteJwks.Marshal(b, m, deterministic)
+}
+func (m *RemoteJwks) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_RemoteJwks.Merge(m, src)
+}
+func (m *RemoteJwks) XXX_Size() int {
+	return xxx_messageInfo_RemoteJwks.Size(m)
+}
+func (m *RemoteJwks) XXX_DiscardUnknown() {
+	xxx_messageInfo_RemoteJwks.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_RemoteJwks proto.InternalMessageInfo
+
+func (m *RemoteJwks) GetUrl() string {
+	if m != nil {
+		return m.Url
+	}
+	return ""
+}
+
+func (m *RemoteJwks) GetUpstreamRef() *core.ResourceRef {
+	if m != nil {
+		return m.UpstreamRef
+	}
+	return nil
+}
+
+func (m *RemoteJwks) GetCacheDuration() *types.Duration {
+	if m != nil {
+		return m.CacheDuration
+	}
+	return nil
+}
+
+type LocalJwks struct {
+	// Inline key. this can be json web key, key-set or PEM format.
+	Key                  string   `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *LocalJwks) Reset()         { *m = LocalJwks{} }
+func (m *LocalJwks) String() string { return proto.CompactTextString(m) }
+func (*LocalJwks) ProtoMessage()    {}
+func (*LocalJwks) Descriptor() ([]byte, []int) {
+	return fileDescriptor_3d83f6c4a43394a0, []int{5}
+}
+func (m *LocalJwks) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_LocalJwks.Unmarshal(m, b)
+}
+func (m *LocalJwks) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_LocalJwks.Marshal(b, m, deterministic)
+}
+func (m *LocalJwks) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LocalJwks.Merge(m, src)
+}
+func (m *LocalJwks) XXX_Size() int {
+	return xxx_messageInfo_LocalJwks.Size(m)
+}
+func (m *LocalJwks) XXX_DiscardUnknown() {
+	xxx_messageInfo_LocalJwks.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LocalJwks proto.InternalMessageInfo
+
+func (m *LocalJwks) GetKey() string {
+	if m != nil {
+		return m.Key
+	}
+	return ""
+}
+
 // Describes the location of a JWT token
 type TokenSource struct {
 	// Try to retrieve token from these headers
@@ -216,7 +379,7 @@ func (m *TokenSource) Reset()         { *m = TokenSource{} }
 func (m *TokenSource) String() string { return proto.CompactTextString(m) }
 func (*TokenSource) ProtoMessage()    {}
 func (*TokenSource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3d83f6c4a43394a0, []int{3}
+	return fileDescriptor_3d83f6c4a43394a0, []int{6}
 }
 func (m *TokenSource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TokenSource.Unmarshal(m, b)
@@ -265,7 +428,7 @@ func (m *TokenSource_HeaderSource) Reset()         { *m = TokenSource_HeaderSour
 func (m *TokenSource_HeaderSource) String() string { return proto.CompactTextString(m) }
 func (*TokenSource_HeaderSource) ProtoMessage()    {}
 func (*TokenSource_HeaderSource) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3d83f6c4a43394a0, []int{3, 0}
+	return fileDescriptor_3d83f6c4a43394a0, []int{6, 0}
 }
 func (m *TokenSource_HeaderSource) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_TokenSource_HeaderSource.Unmarshal(m, b)
@@ -316,7 +479,7 @@ func (m *ClaimToHeader) Reset()         { *m = ClaimToHeader{} }
 func (m *ClaimToHeader) String() string { return proto.CompactTextString(m) }
 func (*ClaimToHeader) ProtoMessage()    {}
 func (*ClaimToHeader) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3d83f6c4a43394a0, []int{4}
+	return fileDescriptor_3d83f6c4a43394a0, []int{7}
 }
 func (m *ClaimToHeader) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ClaimToHeader.Unmarshal(m, b)
@@ -357,180 +520,17 @@ func (m *ClaimToHeader) GetAppend() bool {
 	return false
 }
 
-type Provider struct {
-	// The source for the keys to validate JWTs.
-	Jwks *Jwks `protobuf:"bytes,1,opt,name=jwks,proto3" json:"jwks,omitempty"`
-	// An incoming JWT must have an 'aud' claim and it must be in this list.
-	Audiences []string `protobuf:"bytes,2,rep,name=audiences,proto3" json:"audiences,omitempty"`
-	// Issuer of the JWT. the 'iss' claim of the JWT must match this.
-	Issuer string `protobuf:"bytes,3,opt,name=issuer,proto3" json:"issuer,omitempty"`
-	// Where to find the JWT of the current provider.
-	TokenSource *TokenSource `protobuf:"bytes,4,opt,name=token_source,json=tokenSource,proto3" json:"token_source,omitempty"`
-	// Should the token forwarded upstream. if false, the header containing the token will be removed.
-	KeepToken bool `protobuf:"varint,5,opt,name=keep_token,json=keepToken,proto3" json:"keep_token,omitempty"`
-	// What claims should be copied to upstream headers.
-	ClaimsToHeaders      []*ClaimToHeader `protobuf:"bytes,6,rep,name=claims_to_headers,json=claimsToHeaders,proto3" json:"claims_to_headers,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}         `json:"-"`
-	XXX_unrecognized     []byte           `json:"-"`
-	XXX_sizecache        int32            `json:"-"`
-}
-
-func (m *Provider) Reset()         { *m = Provider{} }
-func (m *Provider) String() string { return proto.CompactTextString(m) }
-func (*Provider) ProtoMessage()    {}
-func (*Provider) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3d83f6c4a43394a0, []int{5}
-}
-func (m *Provider) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Provider.Unmarshal(m, b)
-}
-func (m *Provider) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Provider.Marshal(b, m, deterministic)
-}
-func (m *Provider) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Provider.Merge(m, src)
-}
-func (m *Provider) XXX_Size() int {
-	return xxx_messageInfo_Provider.Size(m)
-}
-func (m *Provider) XXX_DiscardUnknown() {
-	xxx_messageInfo_Provider.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Provider proto.InternalMessageInfo
-
-func (m *Provider) GetJwks() *Jwks {
-	if m != nil {
-		return m.Jwks
-	}
-	return nil
-}
-
-func (m *Provider) GetAudiences() []string {
-	if m != nil {
-		return m.Audiences
-	}
-	return nil
-}
-
-func (m *Provider) GetIssuer() string {
-	if m != nil {
-		return m.Issuer
-	}
-	return ""
-}
-
-func (m *Provider) GetTokenSource() *TokenSource {
-	if m != nil {
-		return m.TokenSource
-	}
-	return nil
-}
-
-func (m *Provider) GetKeepToken() bool {
-	if m != nil {
-		return m.KeepToken
-	}
-	return false
-}
-
-func (m *Provider) GetClaimsToHeaders() []*ClaimToHeader {
-	if m != nil {
-		return m.ClaimsToHeaders
-	}
-	return nil
-}
-
-type VhostExtension struct {
-	// Auth providers can be used instead of the fields above where more than one is required.
-	// if this list is provided the fields above are ignored.
-	Providers            map[string]*Provider `protobuf:"bytes,4,rep,name=providers,proto3" json:"providers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	XXX_NoUnkeyedLiteral struct{}             `json:"-"`
-	XXX_unrecognized     []byte               `json:"-"`
-	XXX_sizecache        int32                `json:"-"`
-}
-
-func (m *VhostExtension) Reset()         { *m = VhostExtension{} }
-func (m *VhostExtension) String() string { return proto.CompactTextString(m) }
-func (*VhostExtension) ProtoMessage()    {}
-func (*VhostExtension) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3d83f6c4a43394a0, []int{6}
-}
-func (m *VhostExtension) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_VhostExtension.Unmarshal(m, b)
-}
-func (m *VhostExtension) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_VhostExtension.Marshal(b, m, deterministic)
-}
-func (m *VhostExtension) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_VhostExtension.Merge(m, src)
-}
-func (m *VhostExtension) XXX_Size() int {
-	return xxx_messageInfo_VhostExtension.Size(m)
-}
-func (m *VhostExtension) XXX_DiscardUnknown() {
-	xxx_messageInfo_VhostExtension.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_VhostExtension proto.InternalMessageInfo
-
-func (m *VhostExtension) GetProviders() map[string]*Provider {
-	if m != nil {
-		return m.Providers
-	}
-	return nil
-}
-
-type RouteExtension struct {
-	// Disable JWT checks on this route.
-	Disable              bool     `protobuf:"varint,1,opt,name=disable,proto3" json:"disable,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *RouteExtension) Reset()         { *m = RouteExtension{} }
-func (m *RouteExtension) String() string { return proto.CompactTextString(m) }
-func (*RouteExtension) ProtoMessage()    {}
-func (*RouteExtension) Descriptor() ([]byte, []int) {
-	return fileDescriptor_3d83f6c4a43394a0, []int{7}
-}
-func (m *RouteExtension) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_RouteExtension.Unmarshal(m, b)
-}
-func (m *RouteExtension) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_RouteExtension.Marshal(b, m, deterministic)
-}
-func (m *RouteExtension) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_RouteExtension.Merge(m, src)
-}
-func (m *RouteExtension) XXX_Size() int {
-	return xxx_messageInfo_RouteExtension.Size(m)
-}
-func (m *RouteExtension) XXX_DiscardUnknown() {
-	xxx_messageInfo_RouteExtension.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_RouteExtension proto.InternalMessageInfo
-
-func (m *RouteExtension) GetDisable() bool {
-	if m != nil {
-		return m.Disable
-	}
-	return false
-}
-
 func init() {
-	proto.RegisterType((*RemoteJwks)(nil), "jwt.options.gloo.solo.io.RemoteJwks")
-	proto.RegisterType((*LocalJwks)(nil), "jwt.options.gloo.solo.io.LocalJwks")
-	proto.RegisterType((*Jwks)(nil), "jwt.options.gloo.solo.io.Jwks")
-	proto.RegisterType((*TokenSource)(nil), "jwt.options.gloo.solo.io.TokenSource")
-	proto.RegisterType((*TokenSource_HeaderSource)(nil), "jwt.options.gloo.solo.io.TokenSource.HeaderSource")
-	proto.RegisterType((*ClaimToHeader)(nil), "jwt.options.gloo.solo.io.ClaimToHeader")
-	proto.RegisterType((*Provider)(nil), "jwt.options.gloo.solo.io.Provider")
 	proto.RegisterType((*VhostExtension)(nil), "jwt.options.gloo.solo.io.VhostExtension")
 	proto.RegisterMapType((map[string]*Provider)(nil), "jwt.options.gloo.solo.io.VhostExtension.ProvidersEntry")
 	proto.RegisterType((*RouteExtension)(nil), "jwt.options.gloo.solo.io.RouteExtension")
+	proto.RegisterType((*Provider)(nil), "jwt.options.gloo.solo.io.Provider")
+	proto.RegisterType((*Jwks)(nil), "jwt.options.gloo.solo.io.Jwks")
+	proto.RegisterType((*RemoteJwks)(nil), "jwt.options.gloo.solo.io.RemoteJwks")
+	proto.RegisterType((*LocalJwks)(nil), "jwt.options.gloo.solo.io.LocalJwks")
+	proto.RegisterType((*TokenSource)(nil), "jwt.options.gloo.solo.io.TokenSource")
+	proto.RegisterType((*TokenSource_HeaderSource)(nil), "jwt.options.gloo.solo.io.TokenSource.HeaderSource")
+	proto.RegisterType((*ClaimToHeader)(nil), "jwt.options.gloo.solo.io.ClaimToHeader")
 }
 
 func init() {
@@ -538,61 +538,60 @@ func init() {
 }
 
 var fileDescriptor_3d83f6c4a43394a0 = []byte{
-	// 690 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x54, 0xdd, 0x6e, 0xd3, 0x48,
-	0x14, 0xae, 0xf3, 0xd7, 0xe6, 0x24, 0xcd, 0xee, 0x5a, 0xd5, 0xca, 0x1b, 0x6d, 0xab, 0xac, 0x17,
-	0x44, 0x84, 0xc0, 0x16, 0xe1, 0x82, 0x0a, 0x50, 0x85, 0x0a, 0x15, 0x11, 0x6a, 0xa5, 0x6a, 0xda,
-	0x72, 0xc1, 0x4d, 0x70, 0x9c, 0x93, 0xc4, 0xb5, 0xe3, 0x31, 0x33, 0xe3, 0xb6, 0x79, 0x06, 0xde,
-	0x81, 0x6b, 0xae, 0x79, 0x00, 0xee, 0x79, 0x0d, 0x9e, 0x04, 0x79, 0x7e, 0x48, 0x0a, 0x04, 0xf5,
-	0x22, 0xca, 0x7c, 0x67, 0xe6, 0xfb, 0xce, 0x39, 0xdf, 0xf1, 0x0c, 0x1c, 0x4d, 0x22, 0x31, 0xcd,
-	0x87, 0x5e, 0x48, 0x67, 0x3e, 0xa7, 0x09, 0xbd, 0x1f, 0x51, 0x7f, 0x92, 0x50, 0xea, 0x67, 0x8c,
-	0x9e, 0x63, 0x28, 0xb8, 0x42, 0x41, 0x16, 0xf9, 0x17, 0x0f, 0x7c, 0x4c, 0x05, 0xb2, 0x8c, 0x45,
-	0x1c, 0x7d, 0x9a, 0x89, 0x88, 0xa6, 0xdc, 0x3f, 0xbf, 0x14, 0xc5, 0xcf, 0xcb, 0x18, 0x15, 0xd4,
-	0x76, 0x8a, 0xa5, 0xde, 0xf2, 0x0a, 0xa6, 0x57, 0x88, 0x7a, 0x11, 0x6d, 0xdf, 0xfb, 0x45, 0x22,
-	0xf9, 0x1f, 0x47, 0xc2, 0xc8, 0x33, 0x1c, 0x2b, 0x9d, 0xf6, 0xd6, 0x84, 0x4e, 0xa8, 0x5c, 0xfa,
-	0xc5, 0x4a, 0x47, 0x77, 0x26, 0x94, 0x4e, 0x12, 0xf4, 0x25, 0x1a, 0xe6, 0x63, 0x7f, 0x94, 0xb3,
-	0xa0, 0xc8, 0xa5, 0xf6, 0xdd, 0x0f, 0x16, 0x00, 0xc1, 0x19, 0x15, 0xf8, 0xea, 0x32, 0xe6, 0xf6,
-	0x9f, 0x50, 0xce, 0x59, 0xe2, 0x58, 0x1d, 0xab, 0x5b, 0x27, 0xc5, 0xd2, 0x7e, 0x0a, 0xcd, 0x3c,
-	0xe3, 0x82, 0x61, 0x30, 0x1b, 0x30, 0x1c, 0x3b, 0xa5, 0x8e, 0xd5, 0x6d, 0xf4, 0xfe, 0xf1, 0x42,
-	0xca, 0xd0, 0x54, 0xea, 0x11, 0xe4, 0x34, 0x67, 0x21, 0x12, 0x1c, 0x93, 0x86, 0x39, 0x4e, 0x70,
-	0x6c, 0x3f, 0x83, 0x56, 0x18, 0x84, 0x53, 0x1c, 0x98, 0xb4, 0x4e, 0x45, 0xf3, 0x55, 0x5d, 0x9e,
-	0xa9, 0xcb, 0x7b, 0xa1, 0x0f, 0x90, 0x4d, 0x49, 0x30, 0xd0, 0xdd, 0x86, 0xfa, 0x21, 0x0d, 0x83,
-	0xc4, 0x94, 0x17, 0xe3, 0xdc, 0x94, 0x17, 0xe3, 0xdc, 0x7d, 0x6f, 0x41, 0x45, 0x6e, 0xed, 0x41,
-	0x8d, 0xc9, 0x3e, 0xe4, 0x6e, 0xa3, 0x77, 0xcb, 0x5b, 0xe5, 0xab, 0xb7, 0xe8, 0xb7, 0xbf, 0x46,
-	0x34, 0xcb, 0x7e, 0x02, 0xd5, 0xa4, 0xc8, 0xa3, 0x1b, 0xfc, 0x7f, 0x35, 0xfd, 0x7b, 0x39, 0xfd,
-	0x35, 0xa2, 0x38, 0xfb, 0x35, 0xa8, 0x9c, 0x5f, 0xc6, 0xdc, 0xfd, 0x6c, 0x41, 0xe3, 0x94, 0xc6,
-	0x98, 0x9e, 0x48, 0x3b, 0xec, 0x43, 0x58, 0x9f, 0x62, 0x30, 0x42, 0xc6, 0x1d, 0xab, 0x53, 0xee,
-	0x36, 0x7a, 0xbd, 0xd5, 0xb2, 0x4b, 0x3c, 0xaf, 0x2f, 0x49, 0x0a, 0x10, 0x23, 0x61, 0xff, 0x07,
-	0xcd, 0x77, 0x39, 0xb2, 0xf9, 0x20, 0x0b, 0x58, 0x30, 0xe3, 0x4e, 0xa9, 0x53, 0xee, 0xd6, 0x49,
-	0x43, 0xc6, 0x8e, 0x65, 0xa8, 0xbd, 0x07, 0xcd, 0x65, 0xae, 0xfd, 0x37, 0xd4, 0x14, 0x5b, 0x7b,
-	0xa6, 0x51, 0x11, 0xcf, 0x18, 0x8e, 0xa3, 0x2b, 0xd9, 0x6e, 0x9d, 0x68, 0xe4, 0x9e, 0xc1, 0xe6,
-	0xf3, 0x24, 0x88, 0x66, 0xa7, 0x54, 0xc9, 0xd8, 0x5b, 0x50, 0x0d, 0x8b, 0x80, 0xe6, 0x2b, 0xb0,
-	0x24, 0x5b, 0xfa, 0x51, 0x36, 0xc8, 0x32, 0x4c, 0x47, 0x72, 0xcc, 0x1b, 0x44, 0x23, 0xf7, 0x53,
-	0x09, 0x36, 0x8e, 0x19, 0xbd, 0x88, 0x8a, 0x43, 0x3d, 0x65, 0x96, 0x9e, 0xd3, 0xce, 0x6a, 0x47,
-	0x0a, 0x8f, 0x89, 0x3c, 0x6b, 0xff, 0x0b, 0xf5, 0x20, 0x1f, 0x45, 0x98, 0x86, 0x68, 0xfa, 0x5e,
-	0x04, 0x8a, 0xb4, 0x11, 0xe7, 0x39, 0x32, 0xa7, 0xac, 0xca, 0x51, 0xc8, 0xee, 0x43, 0x53, 0x14,
-	0xae, 0x0e, 0xd4, 0xd7, 0xa9, 0xbf, 0xbd, 0xdb, 0x37, 0x9a, 0x01, 0x69, 0x88, 0xa5, 0x41, 0x6e,
-	0x03, 0xc4, 0x88, 0xd9, 0x40, 0xc6, 0x9c, 0xaa, 0x6c, 0xae, 0x5e, 0x44, 0x24, 0xc3, 0x3e, 0x81,
-	0xbf, 0xa4, 0x31, 0x7c, 0x20, 0xe8, 0xc0, 0x4c, 0xbc, 0x26, 0x27, 0x7e, 0x67, 0x75, 0xb6, 0x6b,
-	0x4e, 0x93, 0x3f, 0x94, 0x82, 0xc1, 0xdc, 0xfd, 0x62, 0x41, 0xeb, 0xf5, 0x94, 0x72, 0x71, 0x70,
-	0x25, 0x30, 0xe5, 0x11, 0x4d, 0xed, 0x33, 0xa8, 0x67, 0xda, 0x46, 0xee, 0x54, 0xa4, 0xfe, 0xa3,
-	0xd5, 0xfa, 0xd7, 0xc9, 0x9e, 0x19, 0x00, 0x3f, 0x48, 0x05, 0x9b, 0x93, 0x85, 0x52, 0xfb, 0x2d,
-	0xb4, 0xae, 0x6f, 0xfe, 0x7c, 0xd1, 0xec, 0x5d, 0xa8, 0x5e, 0x04, 0x49, 0x8e, 0xfa, 0x7e, 0xb8,
-	0xab, 0xd3, 0x1a, 0x29, 0xa2, 0x08, 0x8f, 0x4b, 0xbb, 0x96, 0x7b, 0x17, 0x5a, 0x84, 0xe6, 0x02,
-	0x17, 0xad, 0x38, 0xb0, 0x3e, 0x8a, 0x78, 0x30, 0x4c, 0xd4, 0x85, 0xdd, 0x20, 0x06, 0xee, 0x1f,
-	0x7d, 0xfc, 0xba, 0x63, 0xbd, 0x79, 0x79, 0xb3, 0x57, 0x36, 0x8b, 0x27, 0xbf, 0x7f, 0x69, 0x87,
-	0x35, 0xf9, 0xc4, 0x3c, 0xfc, 0x16, 0x00, 0x00, 0xff, 0xff, 0x0e, 0x6d, 0xd6, 0x20, 0xb7, 0x05,
-	0x00, 0x00,
+	// 686 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x54, 0xdd, 0x6e, 0xd3, 0x30,
+	0x14, 0x26, 0xfd, 0xdb, 0x7a, 0xda, 0x15, 0xb0, 0x26, 0x94, 0x55, 0x6c, 0x2a, 0x01, 0x44, 0x85,
+	0x20, 0x11, 0xe5, 0x82, 0x09, 0xd0, 0x84, 0x06, 0x13, 0x13, 0xda, 0xa4, 0xc9, 0xdb, 0xb8, 0xe0,
+	0xa6, 0xa4, 0xe9, 0x69, 0x9b, 0x35, 0x8d, 0x83, 0xed, 0xec, 0xe7, 0x19, 0x78, 0x07, 0xae, 0xb9,
+	0xe6, 0x01, 0xb8, 0xe7, 0x35, 0x78, 0x12, 0x64, 0xc7, 0xa1, 0x1d, 0x10, 0xb4, 0x8b, 0xaa, 0xfe,
+	0x8e, 0xcf, 0xf7, 0x1d, 0xfb, 0x7c, 0xc7, 0x81, 0xfd, 0x71, 0x28, 0x27, 0xe9, 0xc0, 0x0d, 0xd8,
+	0xcc, 0x13, 0x2c, 0x62, 0x8f, 0x43, 0xe6, 0x8d, 0x23, 0xc6, 0xbc, 0x84, 0xb3, 0x13, 0x0c, 0xa4,
+	0xc8, 0x90, 0x9f, 0x84, 0xde, 0xe9, 0x13, 0x0f, 0x63, 0x89, 0x3c, 0xe1, 0xa1, 0x40, 0x8f, 0x25,
+	0x32, 0x64, 0xb1, 0xf0, 0x4e, 0xce, 0xa4, 0xfa, 0xb9, 0x09, 0x67, 0x92, 0x11, 0x5b, 0x2d, 0xcd,
+	0x96, 0xab, 0x98, 0xae, 0x12, 0x75, 0x43, 0xd6, 0x7e, 0xf4, 0x8f, 0x42, 0xfa, 0x7f, 0x1a, 0xca,
+	0x5c, 0x9e, 0xe3, 0x28, 0xd3, 0x69, 0xaf, 0x8e, 0xd9, 0x98, 0xe9, 0xa5, 0xa7, 0x56, 0x26, 0xba,
+	0x31, 0x66, 0x6c, 0x1c, 0xa1, 0xa7, 0xd1, 0x20, 0x1d, 0x79, 0xc3, 0x94, 0xfb, 0xaa, 0x56, 0xb6,
+	0xef, 0xfc, 0xb0, 0xa0, 0xf5, 0x7e, 0xc2, 0x84, 0xdc, 0x39, 0x97, 0x18, 0x8b, 0x90, 0xc5, 0xe4,
+	0x18, 0xea, 0x09, 0x67, 0xa7, 0xe1, 0x10, 0xb9, 0xb0, 0x2b, 0x9d, 0x72, 0xb7, 0xd1, 0x7b, 0xe6,
+	0x16, 0x1d, 0xd2, 0xbd, 0x4c, 0x76, 0x0f, 0x72, 0xe6, 0x4e, 0x2c, 0xf9, 0x05, 0x9d, 0x2b, 0xb5,
+	0x3f, 0x42, 0xeb, 0xf2, 0x26, 0xb9, 0x01, 0xe5, 0x29, 0x5e, 0xd8, 0x56, 0xc7, 0xea, 0xd6, 0xa9,
+	0x5a, 0x92, 0x4d, 0xa8, 0x9e, 0xfa, 0x51, 0x8a, 0x76, 0xa9, 0x63, 0x75, 0x1b, 0x3d, 0xa7, 0xb8,
+	0x6c, 0x2e, 0x45, 0x33, 0xc2, 0xf3, 0xd2, 0xa6, 0xe5, 0x3c, 0x84, 0x16, 0x65, 0xa9, 0xc4, 0xf9,
+	0x55, 0x6c, 0x58, 0x1a, 0x86, 0xc2, 0x1f, 0x44, 0xa8, 0xab, 0x2c, 0xd3, 0x1c, 0x3a, 0xdf, 0x4a,
+	0xb0, 0x9c, 0x6b, 0x90, 0x1e, 0x54, 0x4e, 0xce, 0xa6, 0x42, 0xe7, 0x34, 0x7a, 0x1b, 0xc5, 0x55,
+	0xdf, 0x9d, 0x4d, 0x05, 0xd5, 0xb9, 0xe4, 0x36, 0xd4, 0xfd, 0x74, 0x18, 0x62, 0x1c, 0xa0, 0xb0,
+	0x4b, 0x9d, 0x72, 0xb7, 0x4e, 0xe7, 0x01, 0x72, 0x0b, 0x6a, 0xa1, 0x10, 0x29, 0x72, 0xbb, 0xac,
+	0x6f, 0x67, 0x10, 0xd9, 0x85, 0xa6, 0x64, 0x53, 0x8c, 0xfb, 0x82, 0xa5, 0x3c, 0x40, 0xbb, 0xa2,
+	0x2b, 0xde, 0x2f, 0xae, 0x78, 0xa4, 0xb2, 0x0f, 0x75, 0x32, 0x6d, 0xc8, 0x39, 0x20, 0xeb, 0x00,
+	0x53, 0xc4, 0xa4, 0xaf, 0x63, 0x76, 0x55, 0xdf, 0xae, 0xae, 0x22, 0x9a, 0x41, 0x0e, 0xe1, 0x66,
+	0x10, 0xf9, 0xe1, 0x4c, 0xf4, 0x25, 0xeb, 0x4f, 0xd0, 0xd7, 0x66, 0xd6, 0xb4, 0x99, 0x0f, 0x8a,
+	0xab, 0xbd, 0x56, 0x94, 0x23, 0xb6, 0xab, 0xf3, 0xe9, 0xf5, 0x4c, 0x21, 0xc7, 0xc2, 0xf9, 0x6c,
+	0x41, 0x45, 0xb5, 0x80, 0x6c, 0x41, 0x8d, 0xe3, 0x8c, 0x49, 0x34, 0x2d, 0xbb, 0x57, 0x2c, 0x49,
+	0x75, 0x9e, 0x62, 0xed, 0x5e, 0xa3, 0x86, 0x45, 0x5e, 0x40, 0x35, 0x62, 0x81, 0x1f, 0x19, 0x9f,
+	0xef, 0x16, 0xd3, 0xf7, 0x54, 0x9a, 0x61, 0x67, 0x9c, 0xed, 0x5a, 0xe6, 0x96, 0xf3, 0xc5, 0x02,
+	0x98, 0xab, 0xab, 0x69, 0x4a, 0x79, 0x94, 0x4f, 0x53, 0xca, 0x23, 0xf2, 0x12, 0x9a, 0x69, 0x22,
+	0x24, 0x47, 0x7f, 0xd6, 0xe7, 0x38, 0x32, 0xc5, 0xd6, 0xdc, 0x80, 0x71, 0x5c, 0x38, 0x5f, 0x66,
+	0x05, 0xc5, 0x11, 0x6d, 0xe4, 0xe9, 0x14, 0x47, 0xe4, 0x15, 0xb4, 0x02, 0x3f, 0x98, 0x60, 0x3f,
+	0x7f, 0x31, 0xc6, 0xac, 0x35, 0x37, 0x7b, 0x52, 0x6e, 0xfe, 0xa4, 0xdc, 0x37, 0x26, 0x81, 0xae,
+	0x68, 0x42, 0x0e, 0x9d, 0x75, 0xa8, 0xff, 0x3e, 0xfe, 0xdf, 0xc3, 0xee, 0x7c, 0xb7, 0xa0, 0xb1,
+	0x60, 0x2f, 0xd9, 0x83, 0xa5, 0xdc, 0x28, 0x4b, 0x1b, 0xd5, 0xbb, 0xd2, 0x58, 0xb8, 0x99, 0x3b,
+	0x66, 0x46, 0x72, 0x09, 0x72, 0x07, 0x9a, 0x9f, 0x52, 0xe4, 0x17, 0xfd, 0xc4, 0xe7, 0xfe, 0x2c,
+	0x1f, 0xd1, 0x86, 0x8e, 0x1d, 0xe8, 0x50, 0x7b, 0x0b, 0x9a, 0x8b, 0x5c, 0x35, 0xb4, 0x19, 0xdb,
+	0x9c, 0xd2, 0x20, 0x15, 0x4f, 0x38, 0x8e, 0xc2, 0x73, 0xdd, 0xc1, 0x3a, 0x35, 0xc8, 0x39, 0x86,
+	0x95, 0x4b, 0x03, 0x43, 0x56, 0xa1, 0xaa, 0x47, 0xc6, 0xf0, 0x33, 0xb0, 0x20, 0x5b, 0xfa, 0x53,
+	0xd6, 0x4f, 0x12, 0x8c, 0x87, 0xba, 0xb1, 0xcb, 0xd4, 0xa0, 0xed, 0xfd, 0xaf, 0x3f, 0x37, 0xac,
+	0x0f, 0x6f, 0xaf, 0xf6, 0x95, 0x4d, 0xa6, 0xe3, 0xff, 0x7f, 0x69, 0x07, 0x35, 0xed, 0xd3, 0xd3,
+	0x5f, 0x01, 0x00, 0x00, 0xff, 0xff, 0x43, 0x7d, 0x46, 0xc7, 0xb7, 0x05, 0x00, 0x00,
 }
 
-func (this *RemoteJwks) Equal(that interface{}) bool {
+func (this *VhostExtension) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*RemoteJwks)
+	that1, ok := that.(*VhostExtension)
 	if !ok {
-		that2, ok := that.(RemoteJwks)
+		that2, ok := that.(VhostExtension)
 		if ok {
 			that1 = &that2
 		} else {
@@ -604,13 +603,39 @@ func (this *RemoteJwks) Equal(that interface{}) bool {
 	} else if this == nil {
 		return false
 	}
-	if this.Url != that1.Url {
+	if len(this.Providers) != len(that1.Providers) {
 		return false
 	}
-	if !this.UpstreamRef.Equal(that1.UpstreamRef) {
+	for i := range this.Providers {
+		if !this.Providers[i].Equal(that1.Providers[i]) {
+			return false
+		}
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return false
 	}
-	if !this.CacheDuration.Equal(that1.CacheDuration) {
+	return true
+}
+func (this *RouteExtension) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*RouteExtension)
+	if !ok {
+		that2, ok := that.(RouteExtension)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Disable != that1.Disable {
 		return false
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
@@ -618,14 +643,14 @@ func (this *RemoteJwks) Equal(that interface{}) bool {
 	}
 	return true
 }
-func (this *LocalJwks) Equal(that interface{}) bool {
+func (this *Provider) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
 	}
 
-	that1, ok := that.(*LocalJwks)
+	that1, ok := that.(*Provider)
 	if !ok {
-		that2, ok := that.(LocalJwks)
+		that2, ok := that.(Provider)
 		if ok {
 			that1 = &that2
 		} else {
@@ -637,8 +662,33 @@ func (this *LocalJwks) Equal(that interface{}) bool {
 	} else if this == nil {
 		return false
 	}
-	if this.Key != that1.Key {
+	if !this.Jwks.Equal(that1.Jwks) {
 		return false
+	}
+	if len(this.Audiences) != len(that1.Audiences) {
+		return false
+	}
+	for i := range this.Audiences {
+		if this.Audiences[i] != that1.Audiences[i] {
+			return false
+		}
+	}
+	if this.Issuer != that1.Issuer {
+		return false
+	}
+	if !this.TokenSource.Equal(that1.TokenSource) {
+		return false
+	}
+	if this.KeepToken != that1.KeepToken {
+		return false
+	}
+	if len(this.ClaimsToHeaders) != len(that1.ClaimsToHeaders) {
+		return false
+	}
+	for i := range this.ClaimsToHeaders {
+		if !this.ClaimsToHeaders[i].Equal(that1.ClaimsToHeaders[i]) {
+			return false
+		}
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return false
@@ -722,6 +772,66 @@ func (this *Jwks_Local) Equal(that interface{}) bool {
 		return false
 	}
 	if !this.Local.Equal(that1.Local) {
+		return false
+	}
+	return true
+}
+func (this *RemoteJwks) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*RemoteJwks)
+	if !ok {
+		that2, ok := that.(RemoteJwks)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Url != that1.Url {
+		return false
+	}
+	if !this.UpstreamRef.Equal(that1.UpstreamRef) {
+		return false
+	}
+	if !this.CacheDuration.Equal(that1.CacheDuration) {
+		return false
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
+		return false
+	}
+	return true
+}
+func (this *LocalJwks) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*LocalJwks)
+	if !ok {
+		that2, ok := that.(LocalJwks)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.Key != that1.Key {
+		return false
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
 		return false
 	}
 	return true
@@ -822,117 +932,6 @@ func (this *ClaimToHeader) Equal(that interface{}) bool {
 		return false
 	}
 	if this.Append != that1.Append {
-		return false
-	}
-	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
-		return false
-	}
-	return true
-}
-func (this *Provider) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*Provider)
-	if !ok {
-		that2, ok := that.(Provider)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	if !this.Jwks.Equal(that1.Jwks) {
-		return false
-	}
-	if len(this.Audiences) != len(that1.Audiences) {
-		return false
-	}
-	for i := range this.Audiences {
-		if this.Audiences[i] != that1.Audiences[i] {
-			return false
-		}
-	}
-	if this.Issuer != that1.Issuer {
-		return false
-	}
-	if !this.TokenSource.Equal(that1.TokenSource) {
-		return false
-	}
-	if this.KeepToken != that1.KeepToken {
-		return false
-	}
-	if len(this.ClaimsToHeaders) != len(that1.ClaimsToHeaders) {
-		return false
-	}
-	for i := range this.ClaimsToHeaders {
-		if !this.ClaimsToHeaders[i].Equal(that1.ClaimsToHeaders[i]) {
-			return false
-		}
-	}
-	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
-		return false
-	}
-	return true
-}
-func (this *VhostExtension) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*VhostExtension)
-	if !ok {
-		that2, ok := that.(VhostExtension)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	if len(this.Providers) != len(that1.Providers) {
-		return false
-	}
-	for i := range this.Providers {
-		if !this.Providers[i].Equal(that1.Providers[i]) {
-			return false
-		}
-	}
-	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
-		return false
-	}
-	return true
-}
-func (this *RouteExtension) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*RouteExtension)
-	if !ok {
-		that2, ok := that.(RouteExtension)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	if this.Disable != that1.Disable {
 		return false
 	}
 	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {

--- a/projects/gloo/pkg/api/v1/enterprise/options/rbac/rbac.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/rbac/rbac.pb.go
@@ -23,194 +23,7 @@ var _ = math.Inf
 // proto package needs to be updated.
 const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 
-// A JWT principal. To use this, JWT option MUST be enabled.
-type JWTPrincipal struct {
-	// Set of claims that make up this principal. Commonly, the 'iss' and 'sub' or 'email' claims are used.
-	// all claims must be present on the JWT.
-	Claims map[string]string `protobuf:"bytes,1,rep,name=claims,proto3" json:"claims,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	// Verify that the JWT came from a specific provider. This usually can be left empty
-	// and a provider will be chosen automatically.
-	Provider             string   `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *JWTPrincipal) Reset()         { *m = JWTPrincipal{} }
-func (m *JWTPrincipal) String() string { return proto.CompactTextString(m) }
-func (*JWTPrincipal) ProtoMessage()    {}
-func (*JWTPrincipal) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b3e839952ea61f0e, []int{0}
-}
-func (m *JWTPrincipal) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_JWTPrincipal.Unmarshal(m, b)
-}
-func (m *JWTPrincipal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_JWTPrincipal.Marshal(b, m, deterministic)
-}
-func (m *JWTPrincipal) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_JWTPrincipal.Merge(m, src)
-}
-func (m *JWTPrincipal) XXX_Size() int {
-	return xxx_messageInfo_JWTPrincipal.Size(m)
-}
-func (m *JWTPrincipal) XXX_DiscardUnknown() {
-	xxx_messageInfo_JWTPrincipal.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_JWTPrincipal proto.InternalMessageInfo
-
-func (m *JWTPrincipal) GetClaims() map[string]string {
-	if m != nil {
-		return m.Claims
-	}
-	return nil
-}
-
-func (m *JWTPrincipal) GetProvider() string {
-	if m != nil {
-		return m.Provider
-	}
-	return ""
-}
-
-// An RBAC principal - the identity entity (usually a user or a service account).
-type Principal struct {
-	JwtPrincipal         *JWTPrincipal `protobuf:"bytes,1,opt,name=jwt_principal,json=jwtPrincipal,proto3" json:"jwt_principal,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
-	XXX_unrecognized     []byte        `json:"-"`
-	XXX_sizecache        int32         `json:"-"`
-}
-
-func (m *Principal) Reset()         { *m = Principal{} }
-func (m *Principal) String() string { return proto.CompactTextString(m) }
-func (*Principal) ProtoMessage()    {}
-func (*Principal) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b3e839952ea61f0e, []int{1}
-}
-func (m *Principal) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Principal.Unmarshal(m, b)
-}
-func (m *Principal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Principal.Marshal(b, m, deterministic)
-}
-func (m *Principal) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Principal.Merge(m, src)
-}
-func (m *Principal) XXX_Size() int {
-	return xxx_messageInfo_Principal.Size(m)
-}
-func (m *Principal) XXX_DiscardUnknown() {
-	xxx_messageInfo_Principal.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Principal proto.InternalMessageInfo
-
-func (m *Principal) GetJwtPrincipal() *JWTPrincipal {
-	if m != nil {
-		return m.JwtPrincipal
-	}
-	return nil
-}
-
-// What permissions should be granted. An empty field means allow-all.
-// If more than one field is added, all of them need to match.
-type Permissions struct {
-	// Paths that have this prefix will be allowed.
-	PathPrefix string `protobuf:"bytes,1,opt,name=path_prefix,json=pathPrefix,proto3" json:"path_prefix,omitempty"`
-	// What http methods (GET, POST, ...) are allowed.
-	Methods              []string `protobuf:"bytes,2,rep,name=methods,proto3" json:"methods,omitempty"`
-	XXX_NoUnkeyedLiteral struct{} `json:"-"`
-	XXX_unrecognized     []byte   `json:"-"`
-	XXX_sizecache        int32    `json:"-"`
-}
-
-func (m *Permissions) Reset()         { *m = Permissions{} }
-func (m *Permissions) String() string { return proto.CompactTextString(m) }
-func (*Permissions) ProtoMessage()    {}
-func (*Permissions) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b3e839952ea61f0e, []int{2}
-}
-func (m *Permissions) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Permissions.Unmarshal(m, b)
-}
-func (m *Permissions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Permissions.Marshal(b, m, deterministic)
-}
-func (m *Permissions) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Permissions.Merge(m, src)
-}
-func (m *Permissions) XXX_Size() int {
-	return xxx_messageInfo_Permissions.Size(m)
-}
-func (m *Permissions) XXX_DiscardUnknown() {
-	xxx_messageInfo_Permissions.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Permissions proto.InternalMessageInfo
-
-func (m *Permissions) GetPathPrefix() string {
-	if m != nil {
-		return m.PathPrefix
-	}
-	return ""
-}
-
-func (m *Permissions) GetMethods() []string {
-	if m != nil {
-		return m.Methods
-	}
-	return nil
-}
-
-type Policy struct {
-	// Principals in this policy.
-	Principals []*Principal `protobuf:"bytes,1,rep,name=principals,proto3" json:"principals,omitempty"`
-	// Permissions granted to the principals.
-	Permissions          *Permissions `protobuf:"bytes,2,opt,name=permissions,proto3" json:"permissions,omitempty"`
-	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
-	XXX_unrecognized     []byte       `json:"-"`
-	XXX_sizecache        int32        `json:"-"`
-}
-
-func (m *Policy) Reset()         { *m = Policy{} }
-func (m *Policy) String() string { return proto.CompactTextString(m) }
-func (*Policy) ProtoMessage()    {}
-func (*Policy) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b3e839952ea61f0e, []int{3}
-}
-func (m *Policy) XXX_Unmarshal(b []byte) error {
-	return xxx_messageInfo_Policy.Unmarshal(m, b)
-}
-func (m *Policy) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
-	return xxx_messageInfo_Policy.Marshal(b, m, deterministic)
-}
-func (m *Policy) XXX_Merge(src proto.Message) {
-	xxx_messageInfo_Policy.Merge(m, src)
-}
-func (m *Policy) XXX_Size() int {
-	return xxx_messageInfo_Policy.Size(m)
-}
-func (m *Policy) XXX_DiscardUnknown() {
-	xxx_messageInfo_Policy.DiscardUnknown(m)
-}
-
-var xxx_messageInfo_Policy proto.InternalMessageInfo
-
-func (m *Policy) GetPrincipals() []*Principal {
-	if m != nil {
-		return m.Principals
-	}
-	return nil
-}
-
-func (m *Policy) GetPermissions() *Permissions {
-	if m != nil {
-		return m.Permissions
-	}
-	return nil
-}
-
+// Global RBAC settings
 type Settings struct {
 	// Require RBAC for all virtual hosts. A vhost without an RBAC policy set will fallback to a deny-all policy.
 	RequireRbac          bool     `protobuf:"varint,1,opt,name=require_rbac,json=requireRbac,proto3" json:"require_rbac,omitempty"`
@@ -223,7 +36,7 @@ func (m *Settings) Reset()         { *m = Settings{} }
 func (m *Settings) String() string { return proto.CompactTextString(m) }
 func (*Settings) ProtoMessage()    {}
 func (*Settings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b3e839952ea61f0e, []int{4}
+	return fileDescriptor_b3e839952ea61f0e, []int{0}
 }
 func (m *Settings) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_Settings.Unmarshal(m, b)
@@ -250,6 +63,7 @@ func (m *Settings) GetRequireRbac() bool {
 	return false
 }
 
+// RBAC settings for Virtual Hosts and Routes.s
 type ExtensionSettings struct {
 	// Disable RBAC checks on this resource (default false). This is useful to allow access to static resources/login page without RBAC checks.
 	// If provided on a route, all route settings override any vhost settings
@@ -265,7 +79,7 @@ func (m *ExtensionSettings) Reset()         { *m = ExtensionSettings{} }
 func (m *ExtensionSettings) String() string { return proto.CompactTextString(m) }
 func (*ExtensionSettings) ProtoMessage()    {}
 func (*ExtensionSettings) Descriptor() ([]byte, []int) {
-	return fileDescriptor_b3e839952ea61f0e, []int{5}
+	return fileDescriptor_b3e839952ea61f0e, []int{1}
 }
 func (m *ExtensionSettings) XXX_Unmarshal(b []byte) error {
 	return xxx_messageInfo_ExtensionSettings.Unmarshal(m, b)
@@ -299,15 +113,203 @@ func (m *ExtensionSettings) GetPolicies() map[string]*Policy {
 	return nil
 }
 
+type Policy struct {
+	// Principals in this policy.
+	Principals []*Principal `protobuf:"bytes,1,rep,name=principals,proto3" json:"principals,omitempty"`
+	// Permissions granted to the principals.
+	Permissions          *Permissions `protobuf:"bytes,2,opt,name=permissions,proto3" json:"permissions,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}     `json:"-"`
+	XXX_unrecognized     []byte       `json:"-"`
+	XXX_sizecache        int32        `json:"-"`
+}
+
+func (m *Policy) Reset()         { *m = Policy{} }
+func (m *Policy) String() string { return proto.CompactTextString(m) }
+func (*Policy) ProtoMessage()    {}
+func (*Policy) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b3e839952ea61f0e, []int{2}
+}
+func (m *Policy) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Policy.Unmarshal(m, b)
+}
+func (m *Policy) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Policy.Marshal(b, m, deterministic)
+}
+func (m *Policy) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Policy.Merge(m, src)
+}
+func (m *Policy) XXX_Size() int {
+	return xxx_messageInfo_Policy.Size(m)
+}
+func (m *Policy) XXX_DiscardUnknown() {
+	xxx_messageInfo_Policy.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Policy proto.InternalMessageInfo
+
+func (m *Policy) GetPrincipals() []*Principal {
+	if m != nil {
+		return m.Principals
+	}
+	return nil
+}
+
+func (m *Policy) GetPermissions() *Permissions {
+	if m != nil {
+		return m.Permissions
+	}
+	return nil
+}
+
+// An RBAC principal - the identity entity (usually a user or a service account).
+type Principal struct {
+	JwtPrincipal         *JWTPrincipal `protobuf:"bytes,1,opt,name=jwt_principal,json=jwtPrincipal,proto3" json:"jwt_principal,omitempty"`
+	XXX_NoUnkeyedLiteral struct{}      `json:"-"`
+	XXX_unrecognized     []byte        `json:"-"`
+	XXX_sizecache        int32         `json:"-"`
+}
+
+func (m *Principal) Reset()         { *m = Principal{} }
+func (m *Principal) String() string { return proto.CompactTextString(m) }
+func (*Principal) ProtoMessage()    {}
+func (*Principal) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b3e839952ea61f0e, []int{3}
+}
+func (m *Principal) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Principal.Unmarshal(m, b)
+}
+func (m *Principal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Principal.Marshal(b, m, deterministic)
+}
+func (m *Principal) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Principal.Merge(m, src)
+}
+func (m *Principal) XXX_Size() int {
+	return xxx_messageInfo_Principal.Size(m)
+}
+func (m *Principal) XXX_DiscardUnknown() {
+	xxx_messageInfo_Principal.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Principal proto.InternalMessageInfo
+
+func (m *Principal) GetJwtPrincipal() *JWTPrincipal {
+	if m != nil {
+		return m.JwtPrincipal
+	}
+	return nil
+}
+
+// A JWT principal. To use this, JWT option MUST be enabled.
+type JWTPrincipal struct {
+	// Set of claims that make up this principal. Commonly, the 'iss' and 'sub' or 'email' claims are used.
+	// all claims must be present on the JWT.
+	Claims map[string]string `protobuf:"bytes,1,rep,name=claims,proto3" json:"claims,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	// Verify that the JWT came from a specific provider. This usually can be left empty
+	// and a provider will be chosen automatically.
+	Provider             string   `protobuf:"bytes,2,opt,name=provider,proto3" json:"provider,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *JWTPrincipal) Reset()         { *m = JWTPrincipal{} }
+func (m *JWTPrincipal) String() string { return proto.CompactTextString(m) }
+func (*JWTPrincipal) ProtoMessage()    {}
+func (*JWTPrincipal) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b3e839952ea61f0e, []int{4}
+}
+func (m *JWTPrincipal) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_JWTPrincipal.Unmarshal(m, b)
+}
+func (m *JWTPrincipal) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_JWTPrincipal.Marshal(b, m, deterministic)
+}
+func (m *JWTPrincipal) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_JWTPrincipal.Merge(m, src)
+}
+func (m *JWTPrincipal) XXX_Size() int {
+	return xxx_messageInfo_JWTPrincipal.Size(m)
+}
+func (m *JWTPrincipal) XXX_DiscardUnknown() {
+	xxx_messageInfo_JWTPrincipal.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_JWTPrincipal proto.InternalMessageInfo
+
+func (m *JWTPrincipal) GetClaims() map[string]string {
+	if m != nil {
+		return m.Claims
+	}
+	return nil
+}
+
+func (m *JWTPrincipal) GetProvider() string {
+	if m != nil {
+		return m.Provider
+	}
+	return ""
+}
+
+// What permissions should be granted. An empty field means allow-all.
+// If more than one field is added, all of them need to match.
+type Permissions struct {
+	// Paths that have this prefix will be allowed.
+	PathPrefix string `protobuf:"bytes,1,opt,name=path_prefix,json=pathPrefix,proto3" json:"path_prefix,omitempty"`
+	// What http methods (GET, POST, ...) are allowed.
+	Methods              []string `protobuf:"bytes,2,rep,name=methods,proto3" json:"methods,omitempty"`
+	XXX_NoUnkeyedLiteral struct{} `json:"-"`
+	XXX_unrecognized     []byte   `json:"-"`
+	XXX_sizecache        int32    `json:"-"`
+}
+
+func (m *Permissions) Reset()         { *m = Permissions{} }
+func (m *Permissions) String() string { return proto.CompactTextString(m) }
+func (*Permissions) ProtoMessage()    {}
+func (*Permissions) Descriptor() ([]byte, []int) {
+	return fileDescriptor_b3e839952ea61f0e, []int{5}
+}
+func (m *Permissions) XXX_Unmarshal(b []byte) error {
+	return xxx_messageInfo_Permissions.Unmarshal(m, b)
+}
+func (m *Permissions) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	return xxx_messageInfo_Permissions.Marshal(b, m, deterministic)
+}
+func (m *Permissions) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_Permissions.Merge(m, src)
+}
+func (m *Permissions) XXX_Size() int {
+	return xxx_messageInfo_Permissions.Size(m)
+}
+func (m *Permissions) XXX_DiscardUnknown() {
+	xxx_messageInfo_Permissions.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_Permissions proto.InternalMessageInfo
+
+func (m *Permissions) GetPathPrefix() string {
+	if m != nil {
+		return m.PathPrefix
+	}
+	return ""
+}
+
+func (m *Permissions) GetMethods() []string {
+	if m != nil {
+		return m.Methods
+	}
+	return nil
+}
+
 func init() {
-	proto.RegisterType((*JWTPrincipal)(nil), "rbac.options.gloo.solo.io.JWTPrincipal")
-	proto.RegisterMapType((map[string]string)(nil), "rbac.options.gloo.solo.io.JWTPrincipal.ClaimsEntry")
-	proto.RegisterType((*Principal)(nil), "rbac.options.gloo.solo.io.Principal")
-	proto.RegisterType((*Permissions)(nil), "rbac.options.gloo.solo.io.Permissions")
-	proto.RegisterType((*Policy)(nil), "rbac.options.gloo.solo.io.Policy")
 	proto.RegisterType((*Settings)(nil), "rbac.options.gloo.solo.io.Settings")
 	proto.RegisterType((*ExtensionSettings)(nil), "rbac.options.gloo.solo.io.ExtensionSettings")
 	proto.RegisterMapType((map[string]*Policy)(nil), "rbac.options.gloo.solo.io.ExtensionSettings.PoliciesEntry")
+	proto.RegisterType((*Policy)(nil), "rbac.options.gloo.solo.io.Policy")
+	proto.RegisterType((*Principal)(nil), "rbac.options.gloo.solo.io.Principal")
+	proto.RegisterType((*JWTPrincipal)(nil), "rbac.options.gloo.solo.io.JWTPrincipal")
+	proto.RegisterMapType((map[string]string)(nil), "rbac.options.gloo.solo.io.JWTPrincipal.ClaimsEntry")
+	proto.RegisterType((*Permissions)(nil), "rbac.options.gloo.solo.io.Permissions")
 }
 
 func init() {
@@ -315,171 +317,39 @@ func init() {
 }
 
 var fileDescriptor_b3e839952ea61f0e = []byte{
-	// 477 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x6e, 0xd3, 0x30,
-	0x18, 0xc7, 0x95, 0x56, 0x74, 0xed, 0xe7, 0x4e, 0x02, 0x6b, 0x87, 0xd0, 0x03, 0x74, 0x11, 0x82,
-	0x5e, 0xe6, 0x88, 0xec, 0x00, 0xec, 0x08, 0x4c, 0xaa, 0x00, 0x41, 0x14, 0x10, 0x08, 0x0e, 0x54,
-	0x49, 0x6a, 0x52, 0x77, 0x69, 0x6c, 0x6c, 0xb7, 0x5b, 0xdf, 0x84, 0x47, 0xe0, 0xcc, 0x23, 0x21,
-	0xf1, 0x1e, 0xc8, 0x4e, 0x9a, 0x06, 0x01, 0x5d, 0x2f, 0x91, 0xff, 0x9f, 0xfd, 0xfb, 0xeb, 0xef,
-	0x2f, 0x9f, 0xe1, 0x4d, 0xc6, 0xf4, 0x6c, 0x99, 0x90, 0x94, 0x2f, 0x7c, 0xc5, 0x73, 0x7e, 0xc2,
-	0xb8, 0x9f, 0xe5, 0x9c, 0xfb, 0x42, 0xf2, 0x39, 0x4d, 0xb5, 0x2a, 0x55, 0x2c, 0x98, 0xbf, 0x7a,
-	0xe8, 0xd3, 0x42, 0x53, 0x29, 0x24, 0x53, 0xd4, 0xe7, 0x42, 0x33, 0x5e, 0x28, 0x5f, 0x26, 0x71,
-	0x6a, 0x3f, 0x44, 0x48, 0xae, 0x39, 0xbe, 0x6d, 0xd7, 0xd5, 0x2e, 0x31, 0x30, 0x31, 0xbe, 0x84,
-	0xf1, 0xc1, 0x51, 0xc6, 0x33, 0x6e, 0x4f, 0xf9, 0x66, 0x55, 0x02, 0xde, 0x0f, 0x07, 0xfa, 0x2f,
-	0x3e, 0xbc, 0x0b, 0x25, 0x2b, 0x52, 0x26, 0xe2, 0x1c, 0xbf, 0x84, 0x4e, 0x9a, 0xc7, 0x6c, 0xa1,
-	0x5c, 0x67, 0xd8, 0x1e, 0xa1, 0xe0, 0x94, 0xfc, 0xd7, 0x92, 0x34, 0x41, 0xf2, 0xcc, 0x52, 0xe7,
-	0x85, 0x96, 0xeb, 0xa8, 0xb2, 0xc0, 0x03, 0xe8, 0x0a, 0xc9, 0x57, 0x6c, 0x4a, 0xa5, 0xdb, 0x1a,
-	0x3a, 0xa3, 0x5e, 0x54, 0xeb, 0xc1, 0x13, 0x40, 0x0d, 0x04, 0xdf, 0x84, 0xf6, 0x05, 0x5d, 0xbb,
-	0x8e, 0x3d, 0x65, 0x96, 0xf8, 0x08, 0x6e, 0xac, 0xe2, 0x7c, 0x49, 0x2b, 0xb2, 0x14, 0x67, 0xad,
-	0xc7, 0x8e, 0xf7, 0x11, 0x7a, 0xdb, 0xc0, 0xaf, 0xe0, 0x70, 0x7e, 0xa9, 0x27, 0x62, 0x53, 0xb0,
-	0x16, 0x28, 0x78, 0xb0, 0x67, 0xee, 0xa8, 0x3f, 0xbf, 0xd4, 0xb5, 0xf2, 0xc6, 0x80, 0x42, 0x2a,
-	0x17, 0x4c, 0x29, 0x83, 0xe1, 0xbb, 0x80, 0x44, 0xac, 0x67, 0x13, 0x21, 0xe9, 0x17, 0x76, 0x55,
-	0xa5, 0x03, 0x53, 0x0a, 0x6d, 0x05, 0xbb, 0x70, 0xb0, 0xa0, 0x7a, 0xc6, 0xa7, 0xca, 0x6d, 0x0d,
-	0xdb, 0xa3, 0x5e, 0xb4, 0x91, 0xde, 0x37, 0x07, 0x3a, 0x21, 0xcf, 0x59, 0xba, 0xc6, 0xcf, 0x01,
-	0xea, 0x78, 0x9b, 0xbe, 0xde, 0xdb, 0x91, 0x6f, 0x1b, 0xae, 0xc1, 0xe1, 0x31, 0x20, 0xb1, 0x8d,
-	0x66, 0xbb, 0x82, 0x82, 0xfb, 0xbb, 0x6c, 0xb6, 0xa7, 0xa3, 0x26, 0xea, 0x9d, 0x40, 0xf7, 0x2d,
-	0xd5, 0x9a, 0x15, 0x99, 0xc2, 0xc7, 0xd0, 0x97, 0xf4, 0xeb, 0x92, 0x49, 0x3a, 0x31, 0x4e, 0xf6,
-	0x8a, 0xdd, 0x08, 0x55, 0xb5, 0x28, 0x89, 0x53, 0xef, 0x97, 0x03, 0xb7, 0xce, 0xaf, 0x34, 0x2d,
-	0x0c, 0x5d, 0x83, 0x2e, 0x1c, 0x4c, 0x99, 0x8a, 0x93, 0x9c, 0x56, 0xcc, 0x46, 0xe2, 0xf7, 0xd0,
-	0x15, 0xe6, 0xe2, 0x8c, 0x96, 0x4d, 0x41, 0xc1, 0xd9, 0x8e, 0x94, 0x7f, 0x39, 0x93, 0xb0, 0x82,
-	0xcb, 0x59, 0xaa, 0xbd, 0x06, 0x9f, 0xe1, 0xf0, 0x8f, 0xad, 0x7f, 0xcc, 0xcc, 0xa3, 0xe6, 0xcc,
-	0xa0, 0xe0, 0x78, 0x57, 0x77, 0xec, 0xbf, 0x69, 0x8c, 0xd5, 0xd3, 0xd7, 0xdf, 0x7f, 0xde, 0x71,
-	0x3e, 0x8d, 0xf7, 0x7b, 0x93, 0xe2, 0x22, 0xbb, 0xe6, 0x5d, 0x26, 0x1d, 0xfb, 0xc4, 0x4e, 0x7f,
-	0x07, 0x00, 0x00, 0xff, 0xff, 0x99, 0x35, 0x5f, 0x04, 0xe6, 0x03, 0x00, 0x00,
+	// 475 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x93, 0xc1, 0x6e, 0xd3, 0x40,
+	0x10, 0x86, 0xe5, 0x56, 0x84, 0x78, 0x9c, 0x4a, 0xb0, 0xea, 0xc1, 0xe4, 0x00, 0xa9, 0x85, 0x20,
+	0x97, 0xda, 0x22, 0x3d, 0x00, 0x3d, 0x02, 0x95, 0x22, 0x40, 0x50, 0x2d, 0x08, 0x04, 0x07, 0x22,
+	0xdb, 0x59, 0x9c, 0x49, 0x1d, 0xcf, 0xb2, 0xbb, 0x49, 0x9b, 0x37, 0xe1, 0x11, 0x38, 0xf3, 0x48,
+	0x48, 0xbc, 0x07, 0xf2, 0xda, 0x71, 0x8d, 0x80, 0xd0, 0x8b, 0xb5, 0x33, 0x3b, 0xff, 0x37, 0x33,
+	0x9e, 0x1d, 0x78, 0x9d, 0xa1, 0x99, 0x2d, 0x93, 0x30, 0xa5, 0x45, 0xa4, 0x29, 0xa7, 0x43, 0xa4,
+	0x28, 0xcb, 0x89, 0x22, 0xa9, 0x68, 0x2e, 0x52, 0xa3, 0x2b, 0x2b, 0x96, 0x18, 0xad, 0x1e, 0x44,
+	0xa2, 0x30, 0x42, 0x49, 0x85, 0x5a, 0x44, 0x24, 0x0d, 0x52, 0xa1, 0x23, 0x95, 0xc4, 0xa9, 0xfd,
+	0x84, 0x52, 0x91, 0x21, 0x76, 0xcb, 0x9e, 0xeb, 0xdb, 0xb0, 0x14, 0x87, 0x25, 0x37, 0x44, 0xea,
+	0xef, 0x67, 0x94, 0x91, 0x8d, 0x8a, 0xca, 0x53, 0x25, 0x08, 0x0e, 0xa1, 0xfb, 0x46, 0x18, 0x83,
+	0x45, 0xa6, 0xd9, 0x01, 0xf4, 0x94, 0xf8, 0xb2, 0x44, 0x25, 0x26, 0x25, 0xc6, 0x77, 0x06, 0xce,
+	0xb0, 0xcb, 0xbd, 0xda, 0xc7, 0x93, 0x38, 0x0d, 0x7e, 0x3a, 0x70, 0xf3, 0xe4, 0xc2, 0x88, 0x42,
+	0x23, 0x15, 0x8d, 0xd0, 0x87, 0xeb, 0x53, 0xd4, 0x71, 0x92, 0x8b, 0x5a, 0xb3, 0x31, 0xd9, 0x3b,
+	0xe8, 0x4a, 0xca, 0x31, 0x45, 0xa1, 0xfd, 0x9d, 0xc1, 0xee, 0xd0, 0x1b, 0x1d, 0x87, 0xff, 0x2c,
+	0x31, 0xfc, 0x83, 0x1c, 0x9e, 0xd6, 0xe2, 0x93, 0xc2, 0xa8, 0x35, 0x6f, 0x58, 0xfd, 0x4f, 0xb0,
+	0xf7, 0xdb, 0x15, 0xbb, 0x01, 0xbb, 0x67, 0x62, 0x6d, 0xd3, 0xbb, 0xbc, 0x3c, 0xb2, 0x87, 0x70,
+	0x6d, 0x15, 0xe7, 0x4b, 0xe1, 0xef, 0x0c, 0x9c, 0xa1, 0x37, 0x3a, 0xd8, 0x92, 0xd7, 0xa2, 0xd6,
+	0xbc, 0x8a, 0x3f, 0xde, 0x79, 0xe4, 0x04, 0x5f, 0x1d, 0xe8, 0x54, 0x5e, 0xf6, 0x0c, 0x40, 0x2a,
+	0x2c, 0x52, 0x94, 0x71, 0xae, 0x7d, 0xc7, 0x36, 0x71, 0x77, 0x1b, 0x6c, 0x13, 0xcc, 0x5b, 0x3a,
+	0x36, 0x06, 0x4f, 0x0a, 0xb5, 0x40, 0x5d, 0xb6, 0xa7, 0xeb, 0x9a, 0xee, 0x6d, 0xc3, 0x5c, 0x46,
+	0xf3, 0xb6, 0x34, 0xf8, 0x00, 0x6e, 0x93, 0x82, 0xbd, 0x84, 0xbd, 0xf9, 0xb9, 0x99, 0x34, 0x89,
+	0xec, 0x0f, 0xf0, 0x46, 0xf7, 0xb7, 0x80, 0x9f, 0xbf, 0x7f, 0x7b, 0x59, 0x62, 0x6f, 0x7e, 0x6e,
+	0x1a, 0x2b, 0xf8, 0xee, 0x40, 0xaf, 0x7d, 0xcd, 0x5e, 0x40, 0x27, 0xcd, 0x63, 0x5c, 0x6c, 0xfa,
+	0x3e, 0xba, 0x22, 0x37, 0x7c, 0x6a, 0x55, 0xd5, 0xd4, 0x6a, 0x04, 0xeb, 0x43, 0x57, 0x2a, 0x5a,
+	0xe1, 0x54, 0x28, 0xdb, 0xbf, 0xcb, 0x1b, 0xbb, 0xff, 0x18, 0xbc, 0x96, 0xe4, 0x2f, 0xd3, 0xdc,
+	0x6f, 0x4f, 0xd3, 0x6d, 0x8f, 0x6a, 0x0c, 0x5e, 0xeb, 0x5f, 0xb1, 0x3b, 0xe0, 0xc9, 0xd8, 0xcc,
+	0x26, 0x52, 0x89, 0xcf, 0x78, 0x51, 0x23, 0xa0, 0x74, 0x9d, 0x5a, 0x4f, 0xf9, 0x58, 0x17, 0xc2,
+	0xcc, 0x68, 0x5a, 0xbd, 0x48, 0x97, 0x6f, 0xcc, 0x27, 0xaf, 0xbe, 0xfd, 0xb8, 0xed, 0x7c, 0x1c,
+	0x5f, 0x6d, 0x27, 0xe5, 0x59, 0xf6, 0x9f, 0xbd, 0x4c, 0x3a, 0x76, 0xc5, 0x8e, 0x7e, 0x05, 0x00,
+	0x00, 0xff, 0xff, 0x8d, 0xa8, 0x1f, 0x33, 0xe6, 0x03, 0x00, 0x00,
 }
 
-func (this *JWTPrincipal) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*JWTPrincipal)
-	if !ok {
-		that2, ok := that.(JWTPrincipal)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	if len(this.Claims) != len(that1.Claims) {
-		return false
-	}
-	for i := range this.Claims {
-		if this.Claims[i] != that1.Claims[i] {
-			return false
-		}
-	}
-	if this.Provider != that1.Provider {
-		return false
-	}
-	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
-		return false
-	}
-	return true
-}
-func (this *Principal) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*Principal)
-	if !ok {
-		that2, ok := that.(Principal)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	if !this.JwtPrincipal.Equal(that1.JwtPrincipal) {
-		return false
-	}
-	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
-		return false
-	}
-	return true
-}
-func (this *Permissions) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*Permissions)
-	if !ok {
-		that2, ok := that.(Permissions)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	if this.PathPrefix != that1.PathPrefix {
-		return false
-	}
-	if len(this.Methods) != len(that1.Methods) {
-		return false
-	}
-	for i := range this.Methods {
-		if this.Methods[i] != that1.Methods[i] {
-			return false
-		}
-	}
-	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
-		return false
-	}
-	return true
-}
-func (this *Policy) Equal(that interface{}) bool {
-	if that == nil {
-		return this == nil
-	}
-
-	that1, ok := that.(*Policy)
-	if !ok {
-		that2, ok := that.(Policy)
-		if ok {
-			that1 = &that2
-		} else {
-			return false
-		}
-	}
-	if that1 == nil {
-		return this == nil
-	} else if this == nil {
-		return false
-	}
-	if len(this.Principals) != len(that1.Principals) {
-		return false
-	}
-	for i := range this.Principals {
-		if !this.Principals[i].Equal(that1.Principals[i]) {
-			return false
-		}
-	}
-	if !this.Permissions.Equal(that1.Permissions) {
-		return false
-	}
-	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
-		return false
-	}
-	return true
-}
 func (this *Settings) Equal(that interface{}) bool {
 	if that == nil {
 		return this == nil
@@ -534,6 +404,138 @@ func (this *ExtensionSettings) Equal(that interface{}) bool {
 	}
 	for i := range this.Policies {
 		if !this.Policies[i].Equal(that1.Policies[i]) {
+			return false
+		}
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
+		return false
+	}
+	return true
+}
+func (this *Policy) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Policy)
+	if !ok {
+		that2, ok := that.(Policy)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Principals) != len(that1.Principals) {
+		return false
+	}
+	for i := range this.Principals {
+		if !this.Principals[i].Equal(that1.Principals[i]) {
+			return false
+		}
+	}
+	if !this.Permissions.Equal(that1.Permissions) {
+		return false
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
+		return false
+	}
+	return true
+}
+func (this *Principal) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Principal)
+	if !ok {
+		that2, ok := that.(Principal)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !this.JwtPrincipal.Equal(that1.JwtPrincipal) {
+		return false
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
+		return false
+	}
+	return true
+}
+func (this *JWTPrincipal) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*JWTPrincipal)
+	if !ok {
+		that2, ok := that.(JWTPrincipal)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if len(this.Claims) != len(that1.Claims) {
+		return false
+	}
+	for i := range this.Claims {
+		if this.Claims[i] != that1.Claims[i] {
+			return false
+		}
+	}
+	if this.Provider != that1.Provider {
+		return false
+	}
+	if !bytes.Equal(this.XXX_unrecognized, that1.XXX_unrecognized) {
+		return false
+	}
+	return true
+}
+func (this *Permissions) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*Permissions)
+	if !ok {
+		that2, ok := that.(Permissions)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if this.PathPrefix != that1.PathPrefix {
+		return false
+	}
+	if len(this.Methods) != len(that1.Methods) {
+		return false
+	}
+	for i := range this.Methods {
+		if this.Methods[i] != that1.Methods[i] {
 			return false
 		}
 	}


### PR DESCRIPTION
Re-order the messages in the security-related proto files so that higher-level messages appear at the top of the file. This will improve the experience of navigating to the protos. We currently link mostly to the messages that represent VirtualHost/Route options, which often are at the bottom of the proto files. This causes the browser to seemingly focus on unrelated messages when navigating to such messages.