### PR TITLE
This adds a clean error when python is missing

### DIFF
--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+if ! [ -x "$(command -v python)" ]; then
+     echo Python is required to install glooctl
+     exit 1
+ fi
+
 if [ -z "${GLOO_VERSION:-}" ]; then
   GLOO_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | python -c "import sys; from distutils.version import LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  releases.sort(key=LooseVersion, reverse=True); print('\n'.join(releases))")
 else


### PR DESCRIPTION
### Solution
This PR prints a clear message as to why the installation script has failed making the UX a little bit more user friendly.

EXAMPLE OUTPUT:

```
user@master01:~$ curl -sL https://run.solo.io/gloo/install | sh
sh: 6: python: not found
user@master01:~$ # Modified installer ->
user@master01:~$ ./install
Python is required to install glooctl
user@master01:~$ sudo apt-get install -y python
Reading package lists... Done

[ some time later]

Setting up python2.7 (2.7.11-7ubuntu1) ...
Setting up libpython-stdlib:amd64 (2.7.11-1) ...
Setting up python (2.7.11-1) ...
user@master01:~$ ./install
Attempting to download glooctl version v1.0.0-rc2
Downloading glooctl-linux-amd64...
```
### Context
This PR prints a clear message as to why the installation script has failed making the UX a little bit more user friendly.