### PR TITLE
Cross-referenced CORS and general grammer/format

### DIFF
--- a/docs/content/security/auth/_index.md
+++ b/docs/content/security/auth/_index.md
@@ -4,57 +4,43 @@ weight: 10
 description: Authenticate and authorize requests to your services using Gloo's external auth service.
 ---
 
-### Why Authenticate in API Gateway Environments
-API Gateways act as a control point for the outside world to access the various application services 
-(monoliths, microservices, serverless functions) running in your environment. In microservices or hybrid application 
-architecture, any number of these workloads will need to accept incoming requests from external end users (clients). 
-Incoming requests can be treated as anonymous or authenticated and depending on the service, you may want to 
-establish and validate who the client is, the service they are requesting and define any access or traffic 
-control policies.
+## Why Authenticate in API Gateway Environments
 
-### Authentication in Gloo
+API Gateways act as a control point for the outside world to access the various application services (monoliths, microservices, serverless functions) running in your environment. In microservices or hybrid application architecture, any number of these workloads need to accept incoming requests from external end users (clients). Incoming requests are treated as anonymous or authenticated and depending on the service. You may want to establish and validate who the client is, the service they are requesting, and define any access or traffic control policies.
+
+## Authentication in Gloo
+
 {{% notice note %}}
-This section refers specifically to the **Gloo Enterprise** external auth server. If you are using the open source version 
-of Gloo, please refer to the [Custom Auth section]({{< versioned_link_path fromRoot="/security/auth/custom_auth" >}})
-of the security docs.
+This section refers specifically to the **Gloo Enterprise** external auth server. If you are using the open source version of Gloo, please refer to the [Custom Auth section]({{< versioned_link_path fromRoot="/security/auth/custom_auth" >}}) of the security docs.
 {{% /notice %}}
 
-Gloo Enterprise provides a variety of authentication options to meet the needs of your environment. They range from 
-supporting basic use cases to complex and fine grained secure access control. Architecturally, Gloo uses a dedicated
-auth server to verify the user credentials and determine their permissions. Gloo provides an auth server that can support 
-several authN/Z implementations, but also allows you to provide your own auth server to implement custom logic. 
+Gloo Enterprise provides a variety of authentication options to meet the needs of your environment. They range from supporting basic use cases to complex and fine grained secure access control. Architecturally, Gloo uses a dedicated auth server to verify the user credentials and determine their permissions. Gloo provides an auth server that can support several authN/Z implementations and also allows you to provide your auth server to implement custom logic.
 
-#### Switching Between Ext Auth Deployment Modes
-By default, Gloo's built-in Auth Server is deployed as its own Kubernetes pod. This means that, in order to 
-authenticate a request, Gloo (which runs in a separate pod) needs to communicate with the service over the network.
-In case you deem this overhead not to be acceptable for your use case, you can deploy the server in **sidecar mode**.
+{{% notice info %}}
+If you are seeing authentication errors for `OPTIONS` requests, and your application is doing CORS, please refer to the [Understanding CORS]({{< versioned_link_path fromRoot="/security/cors" >}}) docs.
+{{% /notice %}}
 
-In this configuration, the Ext Auth server will run as an additional container inside the `gateway-proxy` pod(s) that run 
-Gloo's Envoy instance(s) and communication with Envoy will occur via Unix Domain Sockets instead of TCP. This cuts out 
-the overhead associated with the TCP protocol and can provide huge performance benefits (40%+ in some benchmarks).
+### Switching Between Ext Auth Deployment Modes
 
-You can activate this mode by [installing Gloo with Helm]({{< versioned_link_path fromRoot="/installation/enterprise#installing-on-kubernetes-with-helm" >}})
-and providing the following value overrides:
+By default, Gloo's built-in Auth Server deploys as a Kubernetes pod. To authenticate a request, Gloo needs to communicate with the authentication service over the network. In case you deem this overhead not to be acceptable for your use case, you can deploy the server in **sidecar mode**.
 
-| option                                                    | type     | description                                                                                                                                                                                                                                                    |
-| --------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| global.extensions.extAuth.envoySidecar                    | bool     | Deploy ext-auth as a sidecar to Envoy instances. Communication occurs over Unix Domain Sockets instead of TCP. Default is `false` |
-| global.extensions.extAuth.standaloneDeployment            | bool     | Deploy ext-auth as a standalone deployment. Communication occurs over TCP. Default is `true` |
+In this configuration, the Ext Auth server runs as an additional container inside the `gateway-proxy` pod(s) that run Gloo's Envoy instance(s), and communication with Envoy occurs via Unix Domain Sockets instead of TCP. This cuts out the overhead associated with the TCP protocol and can provide substantial performance benefits (40%+ in some benchmarks).
 
-Note that you can provide any combination of values for these two overrides, including setting both to `true` if you'd like to 
-more easily test the latency improvement gained by using the sidecar mode. Regardless of the deployment mode used, the values set
-in `global.extensions.extAuth` will apply to both instances of Ext Auth.
+You can activate this mode by [installing Gloo with Helm]({{< versioned_link_path fromRoot="/installation/enterprise#installing-on-kubernetes-with-helm" >}}) and providing the following value overrides:
 
-You can set which auth server Envoy queries by updating your settings to use the proper Ext Auth upstream.
-On install, Gloo manually creates an upstream for each instance of Ext Auth that you have deployed; standalone deployments get an upstream named
-`extauth` and sidecar deployments get an upstream named `extauth-sidecar`. If you are deploying both standalone and sidecar, or 
-just standalone, the default upstream name in your settings will be `extauth`. If you are deploying just the sidecar, the default upstream name in your 
-settings will be `extauth-sidecar`.
+| option                                         | type | description                                                                                                                       |
+| ---------------------------------------------- | ---- | --------------------------------------------------------------------------------------------------------------------------------- |
+| global.extensions.extAuth.envoySidecar         | bool | Deploy ext-auth as a sidecar to Envoy instances. Communication occurs over Unix Domain Sockets instead of TCP. Default is `false` |
+| global.extensions.extAuth.standaloneDeployment | bool | Deploy ext-auth as a standalone deployment. Communication occurs over TCP. Default is `true`                                      |
+
+Note that you can provide any combination of values for these two overrides, including setting both to `true` if you'd like to more easily test the latency improvement gained by using the sidecar mode. Regardless of the deployment mode used, the values set in `global.extensions.extAuth` applies to both instances of Ext Auth.
+
+You can set which auth server Envoy queries by updating your settings to use the proper Ext Auth upstream. On install, Gloo manually creates an upstream for each instance of Ext Auth that you have deployed; standalone deployments get an upstream named `extauth`, and sidecar deployments get an upstream named `extauth-sidecar`. If you are deploying both standalone and sidecar or just standalone, the default upstream name in your settings is `extauth`. If you are deploying just the sidecar, the default upstream name in your settings is `extauth-sidecar`.
 
 Here is a look at a snippet of the `default` settings after a fresh install of Gloo, using the default Helm configuration; note the Ext Auth server ref specifically.
 
 ```shell
-$ kubectl -n gloo-system get settings default -oyaml
+kubectl --namespace gloo-system get settings default --output yaml
 ```
 
 {{< highlight yaml "hl_lines=15-18" >}}
@@ -89,16 +75,13 @@ spec:
   ...
 {{< /highlight >}}
 
-#### Auth Configuration overview
+### Auth Configuration Overview
 
 {{% notice info %}}
 {{% extauth_version_info_note %}}
 {{% /notice %}}
 
-Authentication configuration is defined in {{< protobuf display="AuthConfig" name="enterprise.gloo.solo.io.AuthConfig">}} resources. 
-`AuthConfig`s are top-level resources, which means that if you are running in Kubernetes, they will be stored in a dedicated CRD.
-Here is an example of a simple `AuthConfig` CRD:
-
+Authentication configuration is defined in {{< protobuf display="AuthConfig" name="enterprise.gloo.solo.io.AuthConfig" >}} resources. `AuthConfig`s are top-level resources, which means that if you are running in Kubernetes, they will be stored in a dedicated CRD. Here is an example of a simple `AuthConfig` CRD:
 
 ```yaml
 apiVersion: enterprise.gloo.solo.io/v1
@@ -117,22 +100,17 @@ spec:
       realm: gloo
 ```
 
-The resource `spec` consists of an array of `configs` that will be executed in sequence when a request matches the 
-`AuthConfig` (more on how requests are matched to `AuthConfigs` shortly). If any one of these "authentication steps" 
-fails, the request will be denied. In most cases an `AuthConfig` will contain a single `config`.
+The resource `spec` consists of an array of `configs` that will be executed in sequence when a request matches the `AuthConfig` (more on how requests are matched to `AuthConfigs` shortly). If any one of these "authentication steps" fails, the request will be denied. In most cases an `AuthConfig` will contain a single `config`.
 
-##### Configuration format
-Once an `AuthConfig` has been created, it can be used to authenticate your `Virtual Services` (or on the lower-level `Proxy` resources). 
-You can define authentication configuration your Virtual Services at three different levels:
- 
+#### Configuration Format
+
+Once an `AuthConfig` is created, it can be used to authenticate your `Virtual Services` (or on the lower-level `Proxy` resources). You can define authentication configuration your Virtual Services at three different levels:
+
 - on **VirtualHosts**,
 - on **Routes**, and
 - on **WeightedDestinations**.
 
-The configuration format is the same in all three cases. It must be specified under the relevant `plugins` attribute 
-(`VirtualHostPlugins`, `RoutePlugins`, or `WeightedDestinationPlugins`) and can take one of two forms. 
-The first is used to enable authentication and requires you to reference an existing `AuthConfig`. An example Virtual Host 
-configuration of this kind is the following:
+The configuration format is the same in all three cases. It must be specified under the relevant `plugins` attribute (`VirtualHostPlugins`, `RoutePlugins`, or `WeightedDestinationPlugins`) and can take one of two forms. The first is used to enable authentication and requires you to reference an existing `AuthConfig`. An example Virtual Host configuration of this kind is the following:
 
 ```yaml
 virtualHostPlugins:
@@ -143,9 +121,9 @@ virtualHostPlugins:
       namespace: gloo-system
 ```
 
-In case of a route or weighted destination the top attribute would be names `routePlugins` and `weightedDestinationPlugins` respectively.
+In the case of a route or weighted destination, the top attribute would be names `routePlugins` and `weightedDestinationPlugins`, respectively.
 
-The second form is used to explicitly disable authentication:
+The second form is used to disable authentication explicitly:
 
 ```yaml
 virtualHostPlugins: #  use `routePlugins` or `weightedDestinationPlugins` for routes or weighted destinations respectively
@@ -154,19 +132,20 @@ virtualHostPlugins: #  use `routePlugins` or `weightedDestinationPlugins` for ro
       disable: true
 ```
 
-##### Inheritance rules
+#### Inheritance Rules
+
 By default, an `AuthConfig` defined on a `Virtual Service` attribute is inherited by all the child attribute:
 
-- `AuthConfig` resources defined on `VirtualHosts` are inherited by `Route`s and `WeightedDestination`s.
-- `AuthConfig` resources defined on `Route`s are inherited by `WeightedDestination`s.
+- `AuthConfig`s defined on `VirtualHosts` are inherited by `Route`s and `WeightedDestination`s.
+- `AuthConfig`s defined on `Route`s are inherited by `WeightedDestination`s.
 
 There are two exceptions to this rule:
 
-- if the child attribute attribute defines its own `AuthConfig`, or
+- if the child attribute defines an `AuthConfig`, or
 - if the child explicitly disables authentication via the `disable: true` configuration.
 
-#### Implementations
-We have seen how `AuthConfigs` can be used to define granular authentication configurations for `Virtual Services`. For 
-a detailed overview of the authN/authZ models implemented by Gloo, check out our individual guides:
+### Implementations
+
+We have seen how `AuthConfigs` can be used to define granular authentication configurations for `Virtual Services`. For a detailed overview of the authN/authZ models implemented by Gloo, check out the other guides:
 
 {{% children description="true" %}}


### PR DESCRIPTION
Added cross-reference to CORS doc from authentication page as some users were seeing authentication errors on OPTIONS requests and had not configured CORS correctly.