### PR TITLE
This adds a clean error when python is missing (#1759)

### DIFF
--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+if ! [ -x "$(command -v python)" ]; then
+     echo Python is required to install glooctl
+     exit 1
+ fi
+
 if [ -z "${GLOO_VERSION:-}" ]; then
   GLOO_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | python -c "import sys; from distutils.version import LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  releases.sort(key=LooseVersion, reverse=True); print('\n'.join(releases))")
 else


### PR DESCRIPTION
port of https://github.com/solo-io/gloo/pull/1759

this is needed in the meantime until we rename `feature-rc1` to `master`, as our docs/CI link to the script in the master branch