### PR TITLE
fix Fatal when kubeconfig not present. run consulvaulte2e tests witho…

### DIFF
--- a/changelog/v1.2.0/fix-fatal-without-kubeconfig.yaml
+++ b/changelog/v1.2.0/fix-fatal-without-kubeconfig.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/1777
+    description: >
+      Fix a crash in Gloo that occurs when no kubeconfig is present
+       (which is expected in non-Kubernetes environments).

--- a/projects/gloo/pkg/syncer/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup_syncer.go
@@ -531,7 +531,8 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 		if extensions.MetricsHandler == nil {
 			handler, err = metricsservice.NewConfigMapBackedDefaultHandler(opts.WatchOpts.Ctx)
 			if err != nil {
-				contextutils.LoggerFrom(opts.WatchOpts.Ctx).Fatalw("Error starting metrics watcher", zap.Error(err))
+				contextutils.LoggerFrom(opts.WatchOpts.Ctx).Errorw("Error starting metrics watcher", zap.Error(err))
+				return
 			}
 		} else {
 			handler = extensions.MetricsHandler

--- a/test/consulvaulte2e/e2e_suite_test.go
+++ b/test/consulvaulte2e/e2e_suite_test.go
@@ -45,6 +45,10 @@ func TestE2e(t *testing.T) {
 		return
 	}
 
+	// set KUBECONFIG to a nonexistent cfg.
+	// this way we are also testing that Gloo can run without a kubeconfig present
+	os.Setenv("KUBECONFIG", ".")
+
 	helpers.RegisterCommonFailHandlers()
 	helpers.SetupLog()
 	RunSpecs(t, "Consul+Vault E2e Suite")


### PR DESCRIPTION
# the problem

fixes #1777 

# solution

replace a `Fatal` log line with `Error` which is called when no kubeconfig is present

also modifies the `consulvaulte2e` test to run with an empty kubeconfig (getting kube config returns the error `no config provided`) to prevent this regression from occurring again
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1777