### PR TITLE
Fix helm race

### DIFF
--- a/changelog/v1.2.1/make-settings-hook.yaml
+++ b/changelog/v1.2.1/make-settings-hook.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/1838
+    description: >
+      The template for the settings resource needs to be a Helm pre-install hook to prevent races during install.
+      The hook annotation was accidentally removed with the `1.2.0` release; this change adds it back.

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -7,6 +7,10 @@ metadata:
     app: gloo
   name: default
   namespace: {{ .Release.Namespace }}
+  # We need this because the gateway controller will try to write default settings objects
+  # and if it is able to do so before this resource gets applied, installation will fail.
+  annotations:
+    "helm.sh/hook": pre-install
 spec:
   gloo:
     xdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.xdsPort }}"

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -7,8 +7,8 @@ metadata:
     app: gloo
   name: default
   namespace: {{ .Release.Namespace }}
-  # We need this because the gateway controller will try to write default settings objects
-  # and if it is able to do so before this resource gets applied, installation will fail.
+  # We need this because the Gloo controllers will try to write default settings objects
+  # and if any of them is able to do so before this resource gets applied, installation will fail.
   annotations:
     "helm.sh/hook": pre-install
 spec:

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -1,5 +1,5 @@
 namespace:
-  create: false
+  create: true
 k8s:
   clusterName: cluster.local
 settings:

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -1,5 +1,5 @@
 namespace:
-  create: true
+  create: false
 k8s:
   clusterName: cluster.local
 settings:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -702,10 +702,12 @@ spec:
 apiVersion: gloo.solo.io/v1
 kind: Settings
 metadata:
- labels:
-   app: gloo
- name: default
- namespace: ` + namespace + `
+  labels:
+    app: gloo
+  name: default
+  namespace: ` + namespace + `
+  annotations:
+    "helm.sh/hook": pre-install
 spec:
  discovery:
    fdsMode: WHITELIST


### PR DESCRIPTION
The template for the settings resource needs to be a Helm pre-install hook to prevent races during install. The hook annotation was accidentally removed with the `1.2.0` release; this change adds it back.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1838