### PR TITLE
Fix fds

### DIFF
--- a/changelog/v1.2.2/fds.yaml
+++ b/changelog/v1.2.2/fds.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: Quick fix for regression on FDS with non-kube upstreams. 
+    issueLink: https://github.com/solo-io/gloo/issues/1844
+    resolvesIssue: false

--- a/projects/discovery/pkg/fds/syncer/discovery_syncer.go
+++ b/projects/discovery/pkg/fds/syncer/discovery_syncer.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"context"
+
 	"github.com/solo-io/gloo/pkg/utils/syncutil"
 	"go.uber.org/zap/zapcore"
 

--- a/projects/discovery/pkg/fds/syncer/discovery_syncer.go
+++ b/projects/discovery/pkg/fds/syncer/discovery_syncer.go
@@ -2,7 +2,6 @@ package syncer
 
 import (
 	"context"
-
 	"github.com/solo-io/gloo/pkg/utils/syncutil"
 	"go.uber.org/zap/zapcore"
 
@@ -124,9 +123,10 @@ func filterUpstreamsWhitelist(upstreams v1.UpstreamList, namespaces kubernetes.K
 	return filtered
 }
 
+// TODO: The way we resolve namespace is a bit confusing -- using the service namespace if the upstream is a kube service, or the upstream namespace otherwise
 func getUpstreamNamespace(us *v1.Upstream) string {
 	if kubeSpec := us.GetKube(); kubeSpec != nil {
 		return kubeSpec.ServiceNamespace
 	}
-	return "" // only applies to kube namespaces currently
+	return us.Metadata.Namespace
 }


### PR DESCRIPTION
This is a quick fix to solve a regression where FDS didn't work for AWS due to some faulty logic in how we were computing whitelisted/blacklisted namespaces/upstreams. 

#1844 is going to remain open to address the fact that blacklist should be the default for AWS and azure upstreams, and we have to improve our testing of discovery to prevent regressions like this. 

UPDATE: updated comment above to be more specific to the behavior of AWS and Azure upstreams.