### PR TITLE
Remove `make clean` invocation from helm tests

### DIFF
--- a/changelog/v1.2.2/remove-make-clean.yaml
+++ b/changelog/v1.2.2/remove-make-clean.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Do not delete to  `_output` directory during Helm chart unit tests.
+  issueLink: https://github.com/solo-io/gloo/issues/1834

--- a/changelog/v1.2.3/remove-make-clean.yaml
+++ b/changelog/v1.2.3/remove-make-clean.yaml
@@ -1,4 +1,4 @@
 changelog:
 - type: NON_USER_FACING
-  description: Do not delete to  `_output` directory during Helm chart unit tests.
+  description: Do not delete the  `_output` directory during Helm chart unit tests.
   issueLink: https://github.com/solo-io/gloo/issues/1834

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -44,7 +44,6 @@ func TestHelm(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// generate the values.yaml and Chart.yaml files
-	MustMake(".", "-C", "../../", "clean")
 	MustMake(".", "-C", "../../", "prepare-helm")
 })
 


### PR DESCRIPTION
Do not delete to  `_output` directory during Helm chart unit tests.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1834