### PR TITLE
Ensure that all namespaced resources are assigned a namespace

### DIFF
--- a/changelog/v1.2.3/helm-namespace-fix.yaml
+++ b/changelog/v1.2.3/helm-namespace-fix.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    description: >
+      Ensure that our usage of the Helm client libraries assigns a namespace to all resources, even those
+      whose YAML definition does not specify a namespace. This is to fix the bug where observability resources
+      can wind up in the default namespace set by the user's kube config; as of the time of writing, Prometheus's
+      chart defines resources that are namespaced but do not have a namespace explicitly set on them.
+    issueLink: https://github.com/solo-io/gloo/issues/1857

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
+
 	"helm.sh/helm/v3/pkg/release"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
@@ -19,7 +21,6 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"helm.sh/helm/v3/pkg/action"
 	"helm.sh/helm/v3/pkg/chart/loader"
-	"helm.sh/helm/v3/pkg/cli"
 	"helm.sh/helm/v3/pkg/strvals"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -249,7 +250,7 @@ func readValuesFile(filePath string) (map[string]interface{}, error) {
 }
 
 func buildRenderer(namespace string) (*action.Install, error) {
-	settings := cli.New()
+	settings := install.NewCLISettings(namespace)
 	actionConfig := new(action.Configuration)
 	noOpDebugLog := func(format string, v ...interface{}) {}
 

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"html/template"
 
+	"k8s.io/apimachinery/pkg/util/sets"
+
 	"github.com/gogo/protobuf/proto"
 	"github.com/solo-io/reporting-client/pkg/client"
 	"helm.sh/helm/v3/pkg/releaseutil"
@@ -143,6 +145,24 @@ var _ = Describe("Helm Test", func() {
 					"prometheus.io/port":   "9091",
 					"prometheus.io/scrape": "true",
 				}
+			})
+
+			It("should have all resources marked with a namespace", func() {
+				prepareMakefile(namespace, helmValues{})
+
+				nonNamespacedKinds := sets.NewString(
+					"ClusterRole",
+					"ClusterRoleBinding",
+					"ValidatingWebhookConfiguration",
+				)
+
+				// all non-namespaced resources should have a namespace set on them
+				// this tests that nothing winds up in the default kube namespace from your config when you install (unless that's what you intended)
+				testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+					return !nonNamespacedKinds.Has(resource.GetKind())
+				}).ExpectAll(func(resource *unstructured.Unstructured) {
+					Expect(resource.GetNamespace()).NotTo(BeEmpty(), fmt.Sprintf("Resource %+v does not have a namespace", resource))
+				})
 			})
 
 			Context("gateway", func() {

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -156,7 +156,7 @@ var _ = Describe("Helm Test", func() {
 					"ValidatingWebhookConfiguration",
 				)
 
-				// all non-namespaced resources should have a namespace set on them
+				// all namespaced resources should have a namespace set on them
 				// this tests that nothing winds up in the default kube namespace from your config when you install (unless that's what you intended)
 				testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
 					return !nonNamespacedKinds.Has(resource.GetKind())


### PR DESCRIPTION
Ensure that our usage of the Helm client libraries assigns a namespace to all resources, even those whose YAML definition does not specify a namespace. This is to fix the bug where observability resources can wind up in the default namespace set by the user's kube config; as of the time of writing, Prometheus's chart defines resources that are namespaced but do not have a namespace explicitly set on them.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1857