### PR TITLE
Make glooctl version warning more intelligent

### DIFF
--- a/changelog/v1.2.4/glooctl-version-warning-fix.yaml
+++ b/changelog/v1.2.4/glooctl-version-warning-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: >
+      Output the glooctl version warning to stderr rather than stdout. Also, base the decision on whether or
+      not to warn about a version mismatch solely on the versions of the open-source discovery containers
+      that we find in the cluster.
+    issueLink: https://github.com/solo-io/gloo/issues/1852

--- a/changelog/v1.2.4/glooctl-version-warning-fix.yaml
+++ b/changelog/v1.2.4/glooctl-version-warning-fix.yaml
@@ -1,7 +1,0 @@
-changelog:
-  - type: FIX
-    description: >
-      Output the glooctl version warning to stderr rather than stdout. Also, base the decision on whether or
-      not to warn about a version mismatch solely on the versions of the open-source discovery containers
-      that we find in the cluster.
-    issueLink: https://github.com/solo-io/gloo/issues/1852

--- a/changelog/v1.2.5/glooctl-version-warning-fix.yaml
+++ b/changelog/v1.2.5/glooctl-version-warning-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: >
+      Output the glooctl version warning to stderr rather than stdout. Also, base the decision on whether or
+      not to warn about a version mismatch solely on the versions of the open-source discovery containers
+      that we find in the cluster.
+    issueLink: https://github.com/solo-io/gloo/issues/1852

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -4,9 +4,10 @@ import (
 	"fmt"
 	"os"
 
+	linkedversion "github.com/solo-io/gloo/pkg/version"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/version"
-	version2 "github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/version"
+	versioncmd "github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/version"
+	versiondiscovery "github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/version"
 	"github.com/solo-io/go-utils/errors"
 	"github.com/solo-io/go-utils/versionutils"
 	"github.com/spf13/cobra"
@@ -15,8 +16,12 @@ import (
 	"strings"
 )
 
+const (
+	ContainerNameToCheck = "discovery"
+)
+
 func VersionMismatchWarning(opts *options.Options, cmd *cobra.Command) error {
-	return WarnOnMismatch(os.Args[0], version.NewKube(opts.Metadata.Namespace), &defaultLogger{})
+	return WarnOnMismatch(os.Args[0], versioncmd.NewKube(opts.Metadata.Namespace), &defaultLogger{})
 }
 
 // use this logger interface, so that in the unit test we can accumulate lines that were output
@@ -29,16 +34,16 @@ type defaultLogger struct {
 }
 
 func (d *defaultLogger) Printf(format string, args ...interface{}) {
-	fmt.Printf(format, args...)
+	fmt.Fprintf(os.Stderr, format, args...)
 }
 
 func (d *defaultLogger) Println(str string) {
-	fmt.Println(str)
+	fmt.Fprintln(os.Stderr, str)
 }
 
 // visible for testing
-func WarnOnMismatch(binaryName string, sv version.ServerVersion, logger Logger) error {
-	clientServerVersions, err := version.GetClientServerVersions(sv)
+func WarnOnMismatch(binaryName string, sv versioncmd.ServerVersion, logger Logger) error {
+	clientServerVersions, err := versioncmd.GetClientServerVersions(sv)
 	if err != nil {
 		warnOnError(err, logger)
 		return nil
@@ -57,32 +62,25 @@ func WarnOnMismatch(binaryName string, sv version.ServerVersion, logger Logger) 
 		return nil
 	}
 
-	containerMetadatas, err := buildContainerMetadata(clientServerVersions.Server)
+	openSourceVersions, err := getOpenSourceVersions(clientServerVersions.Server)
 	if err != nil {
 		warnOnError(err, logger)
 		return nil
 	}
 
-	var minorVersionMismatches []*ContainerVersion
-	var majorVersionMismatches []*ContainerVersion
-	for _, containerMetadata := range containerMetadatas {
-		if containerMetadata.Version.Major == glooctlVersion.Major && containerMetadata.Version.Minor != glooctlVersion.Minor {
-			minorVersionMismatches = append(minorVersionMismatches, containerMetadata)
+	var minorVersionMismatches []*versionutils.Version
+	var majorVersionMismatches []*versionutils.Version
+	for _, openSourceVersion := range openSourceVersions {
+		if openSourceVersion.Major == glooctlVersion.Major && openSourceVersion.Minor != glooctlVersion.Minor {
+			minorVersionMismatches = append(minorVersionMismatches, openSourceVersion)
 		}
-		if containerMetadata.Version.Major != glooctlVersion.Major {
-			majorVersionMismatches = append(majorVersionMismatches, containerMetadata)
+		if openSourceVersion.Major != glooctlVersion.Major {
+			majorVersionMismatches = append(majorVersionMismatches, openSourceVersion)
 		}
 	}
 
 	if len(minorVersionMismatches) > 0 || len(majorVersionMismatches) > 0 {
 		logger.Println("----------")
-		if len(minorVersionMismatches) > 0 {
-			logger.Println(BuildVersionMismatchMessage(minorVersionMismatches, glooctlVersionStr, "minor"))
-		}
-		if len(majorVersionMismatches) > 0 {
-			logger.Println(BuildVersionMismatchMessage(majorVersionMismatches, glooctlVersionStr, "major"))
-		}
-		logger.Println("")
 		logger.Println(BuildSuggestedUpgradeCommand(binaryName, append(minorVersionMismatches, majorVersionMismatches...)))
 		logger.Println("----------\n")
 	}
@@ -91,22 +89,13 @@ func WarnOnMismatch(binaryName string, sv version.ServerVersion, logger Logger) 
 }
 
 // visible for testing
-func BuildVersionMismatchMessage(mismatches []*ContainerVersion, glooctlVersion, mismatchKind string) string {
-	var containersToReport []string
-	for _, mismatch := range mismatches {
-		containersToReport = append(containersToReport, fmt.Sprintf("%s@%s", mismatch.ContainerName, mismatch.Version.String()))
-	}
-	return fmt.Sprintf("WARNING: glooctl@%s has a different %s version than the following server containers: %s", glooctlVersion, mismatchKind, strings.Join(containersToReport, ", "))
-}
-
-// visible for testing
-func BuildSuggestedUpgradeCommand(binaryName string, mismatches []*ContainerVersion) string {
+func BuildSuggestedUpgradeCommand(binaryName string, mismatches []*versionutils.Version) string {
 	versions := sets.NewString()
 	for _, mismatch := range mismatches {
-		versions.Insert(mismatch.Version.String())
+		versions.Insert(mismatch.String())
 	}
 
-	message := ""
+	message := fmt.Sprintf("glooctl binary version (%s) differs from server components (%v) by at least a minor version.\n", linkedversion.Version, versions.List())
 
 	if versions.Len() > 1 {
 		message += "Multiple server versions found. Consider running any of:"
@@ -133,11 +122,12 @@ type ContainerVersion struct {
 	Version       *versionutils.Version
 }
 
-func buildContainerMetadata(podVersions []*version2.ServerVersion) ([]*ContainerVersion, error) {
-	var versions []*ContainerVersion
+// return an array of open source gloo versions found in the cluster
+// this is determined by looking at all the versions of discovery that we can find
+func getOpenSourceVersions(podVersions []*versiondiscovery.ServerVersion) (versions []*versionutils.Version, err error) {
 	for _, podVersion := range podVersions {
 		switch podVersion.VersionType.(type) {
-		case *version2.ServerVersion_Kubernetes:
+		case *versiondiscovery.ServerVersion_Kubernetes:
 			for _, container := range podVersion.GetKubernetes().Containers {
 				containerVersion, err := versionutils.ParseVersion("v" + container.Tag)
 				if err != nil {
@@ -147,10 +137,9 @@ func buildContainerMetadata(podVersions []*version2.ServerVersion) ([]*Container
 					continue
 				}
 
-				versions = append(versions, &ContainerVersion{
-					ContainerName: container.Name,
-					Version:       containerVersion,
-				})
+				if container.Name == ContainerNameToCheck {
+					versions = append(versions, containerVersion)
+				}
 			}
 		default:
 			return nil, errors.Errorf("Unhandled server version type: %v", podVersion.VersionType)

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -97,7 +97,7 @@ func BuildSuggestedUpgradeCommand(binaryName string, mismatches []*versionutils.
 		versions.Insert(mismatch.String())
 	}
 
-	message := fmt.Sprintf("glooctl binary version (%s) differs from server components (%v) by at least a minor version.\n", linkedversion.Version, versions.List())
+	message := fmt.Sprintf("glooctl binary version (%s) differs from server components (%v) by at least a minor version.\n", linkedversion.Version, strings.Join(versions.List(), ","))
 
 	if versions.Len() > 1 {
 		message += "Multiple server versions found. Consider running any of:"

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -34,10 +34,12 @@ type defaultLogger struct {
 }
 
 func (d *defaultLogger) Printf(format string, args ...interface{}) {
+	// important that this remains writing to stderr, as we don't want this output to interfere with things like $(glooctl proxy url)
 	fmt.Fprintf(os.Stderr, format, args...)
 }
 
 func (d *defaultLogger) Println(str string) {
+	// important that this remains writing to stderr, as we don't want this output to interfere with things like $(glooctl proxy url)
 	fmt.Fprintln(os.Stderr, str)
 }
 


### PR DESCRIPTION
```
➜ TAGGED_VERSION=v1.0.0 make glooctl -B && curl -v $(./_output/glooctl proxy url)/status/201
GO111MODULE=on go build -ldflags="-X github.com/solo-io/gloo/pkg/version.Version=1.0.0" -gcflags=all="-N -l" -o /Users/grahamgoudeau/go/src/github.com/solo-io/gloo/_output/glooctl projects/gloo/cli/cmd/main.go
----------
glooctl binary version (1.0.0) differs from server components (v1.2.1) by at least a minor version.
Consider running:
./_output/glooctl upgrade --release=v1.2.1
----------

*   Trying 192.168.64.7...
* TCP_NODELAY set
* Connected to 192.168.64.7 (192.168.64.7) port 32555 (#0)
> GET /status/201 HTTP/1.1
> Host: 192.168.64.7:32555
> User-Agent: curl/7.54.0
> Accept: */*
>
< HTTP/1.1 201 Created
```

In the state described in the ticket (enterprise 1.0.0-rc3 deployed with OS gloo 1.2.1 and using glooctl 1.2.0), no warning is printed.

Output the glooctl version warning to stderr rather than stdout. Also, base the decision on whether or not to warn about a version mismatch solely on the versions of the open-source discovery containers that we find in the cluster.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1852