### PR TITLE
Make FDS run in Blacklist mode for AWS functions

### DIFF
--- a/changelog/v1.2.5/aws-discovery-fix.yaml
+++ b/changelog/v1.2.5/aws-discovery-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: >
+      AWS function discovery is more painful after our change to make FDS run in Whitelist mode
+      by default. This changes FDS so that, in Whitelist mode, AWS functions are discovered as if
+      FDS is running in Blacklist mode.
+    issueLink: https://github.com/solo-io/gloo/issues/1878

--- a/projects/discovery/pkg/fds/syncer/discovery_syncer_test.go
+++ b/projects/discovery/pkg/fds/syncer/discovery_syncer_test.go
@@ -13,7 +13,7 @@ import (
 
 var disabledLabels = map[string]string{FdsLabelKey: disbledLabelValue}
 var enabledLabels = map[string]string{FdsLabelKey: enbledLabelValue}
-var _ = Describe("filterUpstreamsForDiscovery", func() {
+var _ = Describe("selectUpstreamsForDiscovery", func() {
 	disabledNs := &kubernetes.KubeNamespace{KubeNamespace: namespace.KubeNamespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "explicitly-disabled-ns",
@@ -63,7 +63,7 @@ var _ = Describe("filterUpstreamsForDiscovery", func() {
 
 	Context("blacklist mode", func() {
 		BeforeEach(func() {
-			filtered = filterUpstreamsForDiscovery(gloov1.Settings_DiscoveryOptions_BLACKLIST, usList, nsList)
+			filtered = selectUpstreamsForDiscovery(gloov1.Settings_DiscoveryOptions_BLACKLIST, usList, nsList)
 		})
 
 		It("excludes upstreams whose namespace has the disabled label", func() {
@@ -89,7 +89,7 @@ var _ = Describe("filterUpstreamsForDiscovery", func() {
 
 	Context("whitelist mode", func() {
 		BeforeEach(func() {
-			filtered = filterUpstreamsForDiscovery(gloov1.Settings_DiscoveryOptions_WHITELIST, usList, nsList)
+			filtered = selectUpstreamsForDiscovery(gloov1.Settings_DiscoveryOptions_WHITELIST, usList, nsList)
 		})
 
 		It("excludes upstreams whose namespace has the disabled label", func() {
@@ -114,7 +114,7 @@ var _ = Describe("filterUpstreamsForDiscovery", func() {
 			Expect(filtered).To(ContainElement(explicitlyEnabledUs1))
 			Expect(filtered).To(ContainElement(explicitlyEnabledUs2))
 		})
-		FIt("includes AWS upstreams as if they were in blacklist mode", func() {
+		It("includes AWS upstreams as if they were in blacklist mode", func() {
 			Expect(filtered).To(ContainElement(enabledAwsUs1))
 			Expect(filtered).To(ContainElement(enabledAwsUs2))
 			Expect(filtered).To(ContainElement(enabledAwsUs3))

--- a/projects/discovery/pkg/fds/syncer/discovery_syncer_test.go
+++ b/projects/discovery/pkg/fds/syncer/discovery_syncer_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/aws"
 	kubeplugin "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/kubernetes"
 	"github.com/solo-io/solo-kit/api/external/kubernetes/namespace"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/common/kubernetes"
@@ -43,15 +44,20 @@ var _ = Describe("filterUpstreamsForDiscovery", func() {
 	}}
 	nsList := kubernetes.KubeNamespaceList{disabledNs, enabledNs, enabledKubeSystemNs, disabledKubePublicNs, explicitlyEnabledNs}
 
-	disabledUs1 := makeUpstream("disabledUs1", disabledNs.Name, nil)
-	disabledUs2 := makeUpstream("disabledUs2", enabledNs.Name, disabledLabels)
-	disabledUs3 := makeUpstream("disabledUs3", disabledKubePublicNs.Name, nil)
-	enabledUs1 := makeUpstream("enabledUs1", enabledNs.Name, nil)
-	enabledUs2 := makeUpstream("enabledUs2", enabledKubeSystemNs.Name, nil)
-	explicitlyEnabledUs1 := makeUpstream("explicitlyEnabledUs1", explicitlyEnabledNs.Name, nil)
-	explicitlyEnabledUs2 := makeUpstream("explicitlyEnabledUs2", enabledNs.Name, enabledLabels)
+	disabledUs1 := makeKubeUpstream("disabledUs1", disabledNs.Name, nil)
+	disabledUs2 := makeKubeUpstream("disabledUs2", enabledNs.Name, disabledLabels)
+	disabledUs3 := makeKubeUpstream("disabledUs3", disabledKubePublicNs.Name, nil)
+	disabledAwsUs1 := makeAwsUpstream("disabledAwsUs1", disabledNs.Name, nil)
+	disabledAwsUs2 := makeAwsUpstream("disabledAwsUs2", enabledNs.Name, disabledLabels)
+	enabledUs1 := makeKubeUpstream("enabledUs1", enabledNs.Name, nil)
+	enabledUs2 := makeKubeUpstream("enabledUs2", enabledKubeSystemNs.Name, nil)
+	enabledAwsUs1 := makeAwsUpstream("enabledAwsUs1", enabledNs.Name, nil)
+	enabledAwsUs2 := makeAwsUpstream("enabledAwsUs2", disabledNs.Name, enabledLabels)
+	enabledAwsUs3 := makeAwsUpstream("enabledAwsUs3", "other-namespace", enabledLabels)
+	explicitlyEnabledUs1 := makeKubeUpstream("explicitlyEnabledUs1", explicitlyEnabledNs.Name, nil)
+	explicitlyEnabledUs2 := makeKubeUpstream("explicitlyEnabledUs2", enabledNs.Name, enabledLabels)
 
-	usList := gloov1.UpstreamList{disabledUs1, disabledUs2, disabledUs3, enabledUs1, enabledUs2, explicitlyEnabledUs1, explicitlyEnabledUs2}
+	usList := gloov1.UpstreamList{disabledUs1, disabledUs2, disabledUs3, enabledUs1, enabledUs2, explicitlyEnabledUs1, explicitlyEnabledUs2, disabledAwsUs1, enabledAwsUs3, disabledAwsUs2, enabledAwsUs1, enabledAwsUs2}
 
 	var filtered gloov1.UpstreamList
 
@@ -108,13 +114,31 @@ var _ = Describe("filterUpstreamsForDiscovery", func() {
 			Expect(filtered).To(ContainElement(explicitlyEnabledUs1))
 			Expect(filtered).To(ContainElement(explicitlyEnabledUs2))
 		})
+		FIt("includes AWS upstreams as if they were in blacklist mode", func() {
+			Expect(filtered).To(ContainElement(enabledAwsUs1))
+			Expect(filtered).To(ContainElement(enabledAwsUs2))
+			Expect(filtered).To(ContainElement(enabledAwsUs3))
+			Expect(filtered).NotTo(ContainElement(disabledAwsUs1))
+			Expect(filtered).NotTo(ContainElement(disabledAwsUs2))
+		})
 	})
 })
 
-func makeUpstream(name, namespace string, labels map[string]string) *gloov1.Upstream {
+func makeKubeUpstream(name, namespace string, labels map[string]string) *gloov1.Upstream {
 	us := gloov1.NewUpstream("gloo-system", name)
 	us.UpstreamType = &gloov1.Upstream_Kube{
 		Kube: &kubeplugin.UpstreamSpec{ServiceNamespace: namespace},
+	}
+	us.Metadata.Labels = labels
+	return us
+}
+
+func makeAwsUpstream(name, namespace string, labels map[string]string) *gloov1.Upstream {
+	us := gloov1.NewUpstream(namespace, name)
+	us.UpstreamType = &gloov1.Upstream_Aws{
+		Aws: &aws.UpstreamSpec{
+			Region: "test-region",
+		},
 	}
 	us.Metadata.Labels = labels
 	return us


### PR DESCRIPTION
AWS function discovery is more painful after our change to make FDS run in Whitelist mode by default. This changes FDS so that, in Whitelist mode, AWS functions are discovered as if FDS is running in Blacklist mode.

Confirmed using valet that the petclinic demo works and the AWS functions are discovered after this change.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1878