### PR TITLE
1893 - move glooctl version check to individual commands for non-kube…

### DIFF
--- a/changelog/v1.2.10/non-kube-version-check.yaml
+++ b/changelog/v1.2.10/non-kube-version-check.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/1893
+    description: >
+      glooctl assumed a kube-based environment when checking for a client/Server version
+      mismtach. When using Consul, this caused a delay in the glooctl command while the connection
+      to kubernetes timed out and a kubernetes error message. The version check for non-kubernetes
+      environments is now disabled. 

--- a/projects/gloo/cli/pkg/cmd/add/root.go
+++ b/projects/gloo/cli/pkg/cmd/add/root.go
@@ -18,7 +18,7 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Add.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Add.Consul); err != nil {
 				return err
 			}
 			if err := prerun.HarmonizeDryRunAndOutputFormat(opts, cmd); err != nil {

--- a/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig.go
+++ b/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig.go
@@ -46,7 +46,7 @@ func AuthConfigCreate(opts *options.Options, optionsFunc ...cliutils.OptionsFunc
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Create.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Create.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/create/upstream.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream.go
@@ -47,7 +47,7 @@ func Upstream(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Create.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Create.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/create/upstreamgroup.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstreamgroup.go
@@ -38,7 +38,7 @@ func UpstreamGroup(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Create.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Create.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/create/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/create/virtualservice.go
@@ -40,7 +40,7 @@ func VSCreate(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Create.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Create.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/del/root.go
+++ b/projects/gloo/cli/pkg/cmd/del/root.go
@@ -21,7 +21,7 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Delete.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Delete.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/edit/root.go
+++ b/projects/gloo/cli/pkg/cmd/edit/root.go
@@ -19,10 +19,10 @@ import (
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	editFlags := &editOptions.EditOptions{Options: opts}
-	return RootCmdWithEditOpts(editFlags, optionsFunc...)
+	return RootCmdWithEditOpts(opts, editFlags, optionsFunc...)
 }
 
-func RootCmdWithEditOpts(opts *editOptions.EditOptions, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
+func RootCmdWithEditOpts(opts *options.Options, editOpts *editOptions.EditOptions, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     constants.EDIT_COMMAND.Use,
 		Aliases: constants.EDIT_COMMAND.Aliases,
@@ -30,31 +30,31 @@ func RootCmdWithEditOpts(opts *editOptions.EditOptions, optionsFunc ...cliutils.
 		Long:    constants.EDIT_COMMAND.Long,
 
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			err := argsutils.MetadataArgsParse(opts.Options, args)
+			err := argsutils.MetadataArgsParse(editOpts.Options, args)
 			if err != nil {
 				return err
 			}
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Edit.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, editOpts.Edit.Consul); err != nil {
 				return err
 			}
 			return nil
 		},
 	}
-	flagutils.AddOutputFlag(cmd.PersistentFlags(), &opts.Top.Output)
-	flagutils.AddMetadataFlags(cmd.PersistentFlags(), &opts.Metadata)
+	flagutils.AddOutputFlag(cmd.PersistentFlags(), &editOpts.Top.Output)
+	flagutils.AddMetadataFlags(cmd.PersistentFlags(), &editOpts.Metadata)
 
 	// add resource version flag. this is not needed in interactive mode, as we can do an edit
 	// atomically in that case
-	addEditFlags(cmd.PersistentFlags(), opts)
-	flagutils.AddConsulConfigFlags(cmd.PersistentFlags(), &opts.Edit.Consul)
+	addEditFlags(cmd.PersistentFlags(), editOpts)
+	flagutils.AddConsulConfigFlags(cmd.PersistentFlags(), &editOpts.Edit.Consul)
 
-	cmd.AddCommand(settings.RootCmd(opts, optionsFunc...))
-	cmd.AddCommand(route.RootCmd(opts, optionsFunc...))
-	cmd.AddCommand(virtualservice.RootCmd(opts, optionsFunc...))
-	cmd.AddCommand(upstream.RootCmd(opts, optionsFunc...))
+	cmd.AddCommand(settings.RootCmd(editOpts, optionsFunc...))
+	cmd.AddCommand(route.RootCmd(editOpts, optionsFunc...))
+	cmd.AddCommand(virtualservice.RootCmd(editOpts, optionsFunc...))
+	cmd.AddCommand(upstream.RootCmd(editOpts, optionsFunc...))
 	return cmd
 }
 

--- a/projects/gloo/cli/pkg/cmd/get/root.go
+++ b/projects/gloo/cli/pkg/cmd/get/root.go
@@ -18,13 +18,10 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 		Aliases: constants.GET_COMMAND.Aliases,
 		Short:   constants.GET_COMMAND.Short,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := prerun.VersionMismatchWarning(opts); err != nil {
-				return err
-			}
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Get.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Get.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/get/root.go
+++ b/projects/gloo/cli/pkg/cmd/get/root.go
@@ -18,6 +18,9 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 		Aliases: constants.GET_COMMAND.Aliases,
 		Short:   constants.GET_COMMAND.Short,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := prerun.VersionMismatchWarning(opts); err != nil {
+				return err
+			}
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}

--- a/projects/gloo/cli/pkg/cmd/remove/root.go
+++ b/projects/gloo/cli/pkg/cmd/remove/root.go
@@ -17,7 +17,7 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Remove.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Remove.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -90,7 +90,6 @@ func GlooCli() *cobra.Command {
 		ReadConfigFile,
 		prerun.SetKubeConfigEnv,
 		prerun.ReportUsage,
-		prerun.VersionMismatchWarning,
 	}
 
 	return App(opts, preRunFuncs, optionsFunc)

--- a/projects/gloo/cli/pkg/cmd/route/root.go
+++ b/projects/gloo/cli/pkg/cmd/route/root.go
@@ -17,7 +17,7 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 			if err := prerun.CallParentPrerun(cmd, args); err != nil {
 				return err
 			}
-			if err := prerun.EnableConsulClients(opts.Route.Consul); err != nil {
+			if err := prerun.EnableConsulClients(opts, opts.Route.Consul); err != nil {
 				return err
 			}
 			return nil

--- a/projects/gloo/cli/pkg/prerun/prerun_consul.go
+++ b/projects/gloo/cli/pkg/prerun/prerun_consul.go
@@ -6,7 +6,11 @@ import (
 	"github.com/solo-io/go-utils/errors"
 )
 
-func EnableConsulClients(consul options.Consul) error {
+func EnableConsulClients(opts *options.Options, consul options.Consul) error {
+	if err := VersionMismatchWarning(opts, consul); err != nil {
+		return err
+	}
+
 	if consul.UseConsul {
 		client, err := consul.Client()
 		if err != nil {

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -20,10 +20,13 @@ const (
 )
 
 func VersionMismatchWarning(opts *options.Options, consul options.Consul) error {
-	if !consul.UseConsul {
-		return WarnOnMismatch(os.Args[0], versioncmd.NewKube(opts.Metadata.Namespace), &defaultLogger{})
+	// Only Kubernetes provides client/server version information. Only check for a version
+	// mismatch if Kubernetes is enabled (i.e. Consul is not enabled)
+	if consul.UseConsul {
+		return nil
 	}
-	return nil
+
+	return WarnOnMismatch(os.Args[0], versioncmd.NewKube(opts.Metadata.Namespace), &defaultLogger{})
 }
 
 // use this logger interface, so that in the unit test we can accumulate lines that were output

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -10,7 +10,6 @@ import (
 	versiondiscovery "github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/version"
 	"github.com/solo-io/go-utils/errors"
 	"github.com/solo-io/go-utils/versionutils"
-	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"strings"
@@ -20,8 +19,11 @@ const (
 	ContainerNameToCheck = "discovery"
 )
 
-func VersionMismatchWarning(opts *options.Options, cmd *cobra.Command) error {
-	return WarnOnMismatch(os.Args[0], versioncmd.NewKube(opts.Metadata.Namespace), &defaultLogger{})
+func VersionMismatchWarning(opts *options.Options) error {
+	if !opts.Get.Consul.UseConsul {
+		return WarnOnMismatch(os.Args[0], versioncmd.NewKube(opts.Metadata.Namespace), &defaultLogger{})
+	}
+	return nil
 }
 
 // use this logger interface, so that in the unit test we can accumulate lines that were output

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -19,8 +19,8 @@ const (
 	ContainerNameToCheck = "discovery"
 )
 
-func VersionMismatchWarning(opts *options.Options) error {
-	if !opts.Get.Consul.UseConsul {
+func VersionMismatchWarning(opts *options.Options, consul options.Consul) error {
+	if !consul.UseConsul {
 		return WarnOnMismatch(os.Args[0], versioncmd.NewKube(opts.Metadata.Namespace), &defaultLogger{})
 	}
 	return nil


### PR DESCRIPTION

### Solution
Currently when any glooctl command is run there is an initial kube-based check of the client/server version. In non-kube envs (e.g. consul) this causes a significant delay in every command while glooctl times out looking for kube and issues a kube-specific warning. By moving the version check to the individual commands the version check can only be done in kube (e.g. non-consul) environments 

I have only updated the GET command in initial PR pending review,. 

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1893