### PR TITLE
Direct response header manipulation

### DIFF
--- a/changelog/v1.2.8/direct-response-header-manipulation.yaml
+++ b/changelog/v1.2.8/direct-response-header-manipulation.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: NEW_FEATURE
+  description: >
+    Gloo now allows updating headers for direct responses. This includes the ability to copy request headers to the
+    direct response via the `%REQ(header-name)%` format specifier.
+    See [here](https://github.com/envoyproxy/envoy/pull/8782) for more information.
+  issueLink: https://github.com/solo-io/gloo/issues/1912
+
+

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/avast/retry-go v2.4.3+incompatible
 	github.com/aws/aws-sdk-go v1.25.44
 	github.com/cespare/xxhash/v2 v2.1.1 // indirect
+	github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa // indirect
 	github.com/docker/docker v1.13.1 // indirect
 	github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f // indirect
 	github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f // indirect
@@ -77,7 +78,7 @@ require (
 	golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
-	golang.org/x/tools v0.0.0-20191209225234-22774f7dae43 // indirect
+	golang.org/x/tools v0.0.0-20191212051200-825cb0626375 // indirect
 	google.golang.org/api v0.10.0 // indirect
 	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
 	google.golang.org/grpc v1.25.1

--- a/go.sum
+++ b/go.sum
@@ -193,6 +193,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1hF1U=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa h1:Wg+722vs7a2zQH5lR9QWYsVbplKeffaQFIs5FTdfNNo=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa/go.mod h1:6Arca19mRx58CA7OWEd7Wu1NpC1rd3uDnNs6s1pj/DI=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -1121,6 +1123,8 @@ golang.org/x/tools v0.0.0-20191127201027-ecd32218bd7f h1:3MlESg/jvTr87F4ttA/q4B+
 golang.org/x/tools v0.0.0-20191127201027-ecd32218bd7f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191209225234-22774f7dae43 h1:NfPq5mgc5ArFgVLCpeS4z07IoxSAqVfV/gQ5vxdgaxI=
 golang.org/x/tools v0.0.0-20191209225234-22774f7dae43/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191212051200-825cb0626375 h1:hrBCt+pkb1irxFjg/GeadSn24gLxi5/Z861I53OkQbc=
+golang.org/x/tools v0.0.0-20191212051200-825cb0626375/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/headers"
+
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/pluginutils"
@@ -241,7 +243,7 @@ func (t *translatorInstance) setAction(params plugins.RouteParams, routeReport *
 
 		// run the plugins for RouteActionPlugin
 		for _, plug := range t.plugins {
-			routePlugin, ok := plug.(plugins.RouteActionPlugin)
+			routeActionPlugin, ok := plug.(plugins.RouteActionPlugin)
 			if !ok || in.GetRouteAction() == nil || out.GetRoute() == nil {
 				continue
 			}
@@ -249,7 +251,7 @@ func (t *translatorInstance) setAction(params plugins.RouteParams, routeReport *
 				RouteParams: params,
 				Route:       in,
 			}
-			if err := routePlugin.ProcessRouteAction(raParams, in.GetRouteAction(), out.GetRoute()); err != nil {
+			if err := routeActionPlugin.ProcessRouteAction(raParams, in.GetRouteAction(), out.GetRoute()); err != nil {
 				// same as above
 				if isWarningErr(err) {
 					continue
@@ -267,6 +269,24 @@ func (t *translatorInstance) setAction(params plugins.RouteParams, routeReport *
 				Status: action.DirectResponseAction.Status,
 				Body:   DataSourceFromString(action.DirectResponseAction.Body),
 			},
+		}
+
+		// DirectResponseAction supports header manipulation, so we want to process the corresponding plugin.
+		// See here: https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/route/route.proto#route-directresponseaction
+		for _, plug := range t.plugins {
+			routePlugin, ok := plug.(*headers.Plugin)
+			if !ok {
+				continue
+			}
+			if err := routePlugin.ProcessRoute(params, in, out); err != nil {
+				if isWarningErr(err) {
+					continue
+				}
+				validation.AppendRouteError(routeReport,
+					validationapi.RouteReport_Error_ProcessingError,
+					fmt.Sprintf("%T: %v", routePlugin, err.Error()),
+				)
+			}
 		}
 
 	case *v1.Route_RedirectAction:


### PR DESCRIPTION
Currently Gloo skips the processing of route plugins on DirectResponseAction route actions. Envoy supports header manipulation on direct responses. This PR exposes that feature through Gloo.

This includes the ability to copy request headers to the direct response via the `%REQ(header-name)%` format specifier.