### PR TITLE
Fix release manifests

### DIFF
--- a/changelog/v1.2.9/fix-released-gloo-manifests.yaml
+++ b/changelog/v1.2.9/fix-released-gloo-manifests.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: >
+    Add CRD resources back to the manifest files that are published as part of a Gloo release.
+  issueLink: https://github.com/solo-io/gloo/issues/1877

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -165,7 +165,7 @@ func setCrdCreateToFalse(config *InstallerConfig) {
 func (i *installer) printReleaseManifest(release *release.Release) error {
 	// Print CRDs
 	for _, crdFile := range release.Chart.CRDs() {
-		_, _ = fmt.Fprintf(i.dryRunOutputWriter, "%s", string(crdFile.Data))
+		_, _ = fmt.Fprintln(i.dryRunOutputWriter, string(crdFile.Data))
 		_, _ = fmt.Fprintln(i.dryRunOutputWriter, "---")
 	}
 


### PR DESCRIPTION
This change adds CRD resources back to the manifest files that are published as part of a Gloo release.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1877