### PR TITLE
Fix manifest release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,21 +428,21 @@ export HELM_VALUES
 $(OUTPUT_DIR)/release-manifest-values.yaml:
 	@echo "$$HELM_VALUES" > $@
 
-install/gloo-gateway.yaml: $(OUTPUT_DIR)/glooctl-darwin-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
+install/gloo-gateway.yaml: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
 ifeq ($(RELEASE),"true")
-	$(OUTPUT_DIR)/glooctl-darwin-amd64 install gateway -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
+	$(OUTPUT_DIR)/glooctl-linux-amd64 install gateway -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
 		--values $(OUTPUT_DIR)/release-manifest-values.yaml --dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
 endif
 
-install/gloo-knative.yaml: $(OUTPUT_DIR)/glooctl-darwin-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
+install/gloo-knative.yaml: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
 ifeq ($(RELEASE),"true")
-	$(OUTPUT_DIR)/glooctl-darwin-amd64 install knative -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
+	$(OUTPUT_DIR)/glooctl-linux-amd64 install knative -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
 		--values $(OUTPUT_DIR)/release-manifest-values.yaml --dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
 endif
 
-install/gloo-ingress.yaml: $(OUTPUT_DIR)/glooctl-darwin-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
+install/gloo-ingress.yaml: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
 ifeq ($(RELEASE),"true")
-	$(OUTPUT_DIR)/glooctl-darwin-amd64 install ingress -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
+	$(OUTPUT_DIR)/glooctl-linux-amd64 install ingress -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
 		--values $(OUTPUT_DIR)/release-manifest-values.yaml --dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -377,27 +377,39 @@ build: gloo glooctl gateway discovery envoyinit certgen ingress
 #----------------------------------------------------------------------------------
 
 HELM_SYNC_DIR := $(OUTPUT_DIR)/helm
-HELM_DIR := install/helm
-INSTALL_NAMESPACE ?= gloo-system
-
-.PHONY: manifest
-manifest: prepare-helm install/gloo-gateway.yaml install/gloo-ingress.yaml \
- 		install/gloo-knative.yaml update-helm-chart
+HELM_DIR := install/helm/gloo
 
 # Creates Chart.yaml and values.yaml. See install/helm/gloo/README.md for more info.
-.PHONY: prepare-helm
-prepare-helm: $(OUTPUT_DIR)/.helm-prepared
+.PHONY: generate-helm-files
+generate-helm-files: $(OUTPUT_DIR)/.helm-prepared
 
 $(OUTPUT_DIR)/.helm-prepared:
-	GO111MODULE=on go run install/helm/gloo/generate.go $(VERSION)
+	GO111MODULE=on go run $(HELM_DIR)/generate.go $(VERSION)
 	touch $@
 
-update-helm-chart:
+package-chart: generate-helm-files
 	mkdir -p $(HELM_SYNC_DIR)/charts
-	helm package --destination $(HELM_SYNC_DIR)/charts $(HELM_DIR)/gloo
+	helm package --destination $(HELM_SYNC_DIR)/charts $(HELM_DIR)
 	helm repo index $(HELM_SYNC_DIR)
 
-HELMFLAGS ?= --namespace $(INSTALL_NAMESPACE) --set namespace.create=true
+.PHONY: fetch-helm
+fetch-helm:
+	gsutil -m rsync -r gs://solo-public-helm/ './_output/helm'
+
+.PHONY: save-helm
+save-helm:
+ifeq ($(RELEASE),"true")
+	gsutil -m rsync -r './_output/helm' gs://solo-public-helm/
+endif
+
+#----------------------------------------------------------------------------------
+# Build the Gloo Manifests that are published as release assets
+#----------------------------------------------------------------------------------
+
+.PHONY: render-manifests
+render-manifests: install/gloo-gateway.yaml install/gloo-ingress.yaml install/gloo-knative.yaml
+
+INSTALL_NAMESPACE ?= gloo-system
 
 MANIFEST_OUTPUT = > /dev/null
 ifneq ($(BUILD_ID),)
@@ -416,36 +428,23 @@ export HELM_VALUES
 $(OUTPUT_DIR)/release-manifest-values.yaml:
 	@echo "$$HELM_VALUES" > $@
 
-install/gloo-gateway.yaml: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml prepare-helm
+install/gloo-gateway.yaml: $(OUTPUT_DIR)/glooctl-darwin-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
 ifeq ($(RELEASE),"true")
-	$(OUTPUT_DIR)/glooctl-linux-amd64 install gateway -n $(INSTALL_NAMESPACE) --values $(OUTPUT_DIR)/release-manifest-values.yaml \
-		--dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
+	$(OUTPUT_DIR)/glooctl-darwin-amd64 install gateway -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
+		--values $(OUTPUT_DIR)/release-manifest-values.yaml --dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
 endif
 
-install/gloo-knative.yaml: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml prepare-helm
+install/gloo-knative.yaml: $(OUTPUT_DIR)/glooctl-darwin-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
 ifeq ($(RELEASE),"true")
-	$(OUTPUT_DIR)/glooctl-linux-amd64 install knative -n $(INSTALL_NAMESPACE) --values $(OUTPUT_DIR)/release-manifest-values.yaml \
-    		--dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
+	$(OUTPUT_DIR)/glooctl-darwin-amd64 install knative -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
+		--values $(OUTPUT_DIR)/release-manifest-values.yaml --dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
 endif
 
-install/gloo-ingress.yaml: $(OUTPUT_DIR)/glooctl-linux-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml prepare-helm
+install/gloo-ingress.yaml: $(OUTPUT_DIR)/glooctl-darwin-amd64 $(OUTPUT_DIR)/release-manifest-values.yaml package-chart
 ifeq ($(RELEASE),"true")
-	$(OUTPUT_DIR)/glooctl-linux-amd64 install ingress -n $(INSTALL_NAMESPACE) --values $(OUTPUT_DIR)/release-manifest-values.yaml \
-    		--dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
+	$(OUTPUT_DIR)/glooctl-darwin-amd64 install ingress -n $(INSTALL_NAMESPACE) -f $(HELM_SYNC_DIR)/charts/gloo-$(VERSION).tgz \
+		--values $(OUTPUT_DIR)/release-manifest-values.yaml --dry-run | tee $@ $(OUTPUT_YAML) $(MANIFEST_OUTPUT)
 endif
-
-.PHONY: render-yaml
-render-yaml: install/gloo-gateway.yaml install/gloo-knative.yaml install/gloo-ingress.yaml
-
-.PHONY: save-helm
-save-helm:
-ifeq ($(RELEASE),"true")
-	gsutil -m rsync -r './_output/helm' gs://solo-public-helm/
-endif
-
-.PHONY: fetch-helm
-fetch-helm:
-	gsutil -m rsync -r gs://solo-public-helm/ './_output/helm'
 
 #----------------------------------------------------------------------------------
 # Release
@@ -466,11 +465,11 @@ ASSETS_ONLY := false
 
 # The code does the proper checking for a TAGGED_VERSION
 .PHONY: upload-github-release-assets
-upload-github-release-assets: build-cli render-yaml
+upload-github-release-assets: build-cli render-manifests
 	GO111MODULE=on go run ci/upload_github_release_assets.go $(ASSETS_ONLY)
 
 .PHONY: publish-docs
-publish-docs: prepare-helm
+publish-docs: generate-helm-files
 ifeq ($(RELEASE),"true")
 	cd docs && make docker-push-docs \
 		VERSION=$(VERSION) \
@@ -594,15 +593,15 @@ certgen-docker-test: $(OUTPUT_DIR)/certgen-linux-amd64 $(OUTPUT_DIR)/Dockerfile.
 .PHONY: build-test-chart
 build-test-chart:
 	mkdir -p $(TEST_ASSET_DIR)
-	GO111MODULE=on go run install/helm/gloo/generate.go $(TEST_IMAGE_TAG) $(GCR_REPO_PREFIX) "Always"
-	helm package --destination $(TEST_ASSET_DIR) $(HELM_DIR)/gloo
+	GO111MODULE=on go run $(HELM_DIR)/generate.go $(TEST_IMAGE_TAG) $(GCR_REPO_PREFIX) "Always"
+	helm package --destination $(TEST_ASSET_DIR) $(HELM_DIR)
 	helm repo index $(TEST_ASSET_DIR)
 
 .PHONY: build-kind-chart
 build-kind-chart:
 	mkdir -p $(TEST_ASSET_DIR)
-	GO111MODULE=on go run install/helm/gloo/generate.go $(VERSION)
-	helm package --destination $(TEST_ASSET_DIR) $(HELM_DIR)/gloo
+	GO111MODULE=on go run $(HELM_DIR)/generate.go $(VERSION)
+	helm package --destination $(TEST_ASSET_DIR) $(HELM_DIR)
 	helm repo index $(TEST_ASSET_DIR)
 
 
@@ -619,9 +618,9 @@ build-kind-chart:
 .PHONY: build-tagged-chart
 build-tagged-chart:
 	mkdir -p $(TEST_ASSET_DIR)
-	GO111MODULE=on go run install/helm/gloo/generate.go $(TAGGED_VERSION) $(GCR_REPO_PREFIX) "Always"
+	GO111MODULE=on go run $(HELM_DIR)/generate.go $(TAGGED_VERSION) $(GCR_REPO_PREFIX) "Always"
 	mkdir -p $(HELM_SYNC_DIR)/charts
-	helm package --destination $(HELM_SYNC_DIR)/charts $(HELM_DIR)/gloo
+	helm package --destination $(HELM_SYNC_DIR)/charts $(HELM_DIR)
 	helm repo index $(HELM_SYNC_DIR)
 
 .PHONY: save-tagged-helm

--- a/changelog/v1.2.10/fix-manifest-release.yaml
+++ b/changelog/v1.2.10/fix-manifest-release.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: FIX
+  description: Fix manifest rendering step during release builds.

--- a/changelog/v1.2.10/fix-manifest-release.yaml
+++ b/changelog/v1.2.10/fix-manifest-release.yaml
@@ -1,3 +1,3 @@
 changelog:
-- type: FIX
+- type: NON_USER_FACING
   description: Fix manifest rendering step during release builds.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -206,7 +206,7 @@ steps:
 # 2) Publish helm chart, compile manifests, produce release artifacts, deploy docs
 # isolating this portion of the release in order to force the manifest to be regenerated with the tagged version
 - name: 'gcr.io/$PROJECT_ID/go-make:0.1.17'
-  args: ['manifest', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', '-B']
+  args: ['package-chart', 'render-manifests', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', '-B']
   env:
   - 'TAGGED_VERSION=$TAG_NAME'
   - 'PROJECT_ROOT=github.com/solo-io/gloo'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -233,7 +233,7 @@ secrets:
     QUAY_IO_PASSWORD: CiQABlzmSRx5TcOqbldXa/d/+bkmAfpNAWa3PTS06WvuloZL+vASaQCCPGSGCogonVZVEUNx4G3YJtWi18gSuNx4PvLe08q8xAflTMFkjsyQirAOK3Y2oCvgYwiw/ITcuydjkpMjxDygFyENXS9FKFJoAXHlPQE5qidKr8xxmxF5ezhmjGB0gjyjXIIkbSEnBg==
     AWS_ARN_ROLE_1: CiQABlzmSTKWrIEGaH8UvsX3Wp8pz8ClQODVSjIZAiHuE9gNhM4SXACCPGSGCDSNJtdfkA0BLLmKTJLIM06XXEOV4iIooqlLfo9p7EOzOwqZaV9DFygO8/oKQqTFstc1vKgOz7YHrMaCx3GzqiHN2u//UmHRpvIwrDDfuIP5XNa0aOrj
 
-timeout: 4200s
+timeout: 5400s
 tags: ['gloo']
 options:
   machineType: 'N1_HIGHCPU_32'

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -52,7 +52,7 @@ func TestHelm(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	// generate the values.yaml and Chart.yaml files
-	MustMake(".", "-C", "../../", "prepare-helm")
+	MustMake(".", "-C", "../../", "generate-helm-files")
 })
 
 type renderTestCase struct {


### PR DESCRIPTION
Fix manifest rendering step during release builds. Problem was that we were trying to render using the remote chart which had not been published yet (see [this build](https://storage.googleapis.com/solo-public-build-logs/logs.html?buildid=8d94d30b-6194-428b-8b47-329c768cc4cc)).