### PR TITLE
Remove --upgrade flag from glooctl install gateway

### DIFF
--- a/changelog/v1.2.11/remove-install-gateway-upgrade.yaml
+++ b/changelog/v1.2.11/remove-install-gateway-upgrade.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Remove `-upgrade` flag `glooctl install gateway`
+  issueLink: https://github.com/solo-io/gloo/issues/1982

--- a/changelog/v1.2.11/remove-install-gateway-upgrade.yaml
+++ b/changelog/v1.2.11/remove-install-gateway-upgrade.yaml
@@ -1,4 +1,4 @@
 changelog:
 - type: FIX
-  description: Remove `-upgrade` flag `glooctl install gateway`
+  description: Remove `glooctl install gateway --upgrade` flag, since we have removed the v2 Gateway CRD.
   issueLink: https://github.com/solo-io/gloo/issues/1982

--- a/docs/content/cli/glooctl_install.md
+++ b/docs/content/cli/glooctl_install.md
@@ -19,7 +19,6 @@ choose which version of Gloo to install.
   -h, --help                  help for install
   -n, --namespace string      namespace to install gloo into (default "gloo-system")
       --release-name string   helm release name (default "gloo")
-  -u, --upgrade               Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
       --values strings        List of files with value overrides for the Gloo Helm chart, (e.g. --values file1,file2 or --values file1 --values file2)
   -v, --verbose               If true, output from kubectl commands will print to stdout/stderr
       --with-admin-console    install gloo and a read-only version of its admin console

--- a/docs/content/cli/glooctl_install_gateway.md
+++ b/docs/content/cli/glooctl_install_gateway.md
@@ -36,7 +36,6 @@ glooctl install gateway [flags]
       --kubeconfig string          kubeconfig to use, if not standard one
   -n, --namespace string           namespace to install gloo into (default "gloo-system")
       --release-name string        helm release name (default "gloo")
-  -u, --upgrade                    Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
       --use-consul                 use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --values strings             List of files with value overrides for the Gloo Helm chart, (e.g. --values file1,file2 or --values file1 --values file2)
   -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_gateway_enterprise.md
+++ b/docs/content/cli/glooctl_install_gateway_enterprise.md
@@ -37,7 +37,6 @@ glooctl install gateway enterprise [flags]
       --kubeconfig string          kubeconfig to use, if not standard one
   -n, --namespace string           namespace to install gloo into (default "gloo-system")
       --release-name string        helm release name (default "gloo")
-  -u, --upgrade                    Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
       --use-consul                 use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --values strings             List of files with value overrides for the Gloo Helm chart, (e.g. --values file1,file2 or --values file1 --values file2)
   -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_ingress.md
+++ b/docs/content/cli/glooctl_install_ingress.md
@@ -36,7 +36,6 @@ glooctl install ingress [flags]
       --kubeconfig string          kubeconfig to use, if not standard one
   -n, --namespace string           namespace to install gloo into (default "gloo-system")
       --release-name string        helm release name (default "gloo")
-  -u, --upgrade                    Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
       --use-consul                 use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --values strings             List of files with value overrides for the Gloo Helm chart, (e.g. --values file1,file2 or --values file1 --values file2)
   -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr

--- a/docs/content/cli/glooctl_install_knative.md
+++ b/docs/content/cli/glooctl_install_knative.md
@@ -42,7 +42,6 @@ glooctl install knative [flags]
       --kubeconfig string          kubeconfig to use, if not standard one
   -n, --namespace string           namespace to install gloo into (default "gloo-system")
       --release-name string        helm release name (default "gloo")
-  -u, --upgrade                    Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo
       --use-consul                 use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --values strings             List of files with value overrides for the Gloo Helm chart, (e.g. --values file1,file2 or --values file1 --values file2)
   -v, --verbose                    If true, output from kubectl commands will print to stdout/stderr

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -18,11 +18,6 @@ var _ = Describe("Install", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("shouldn't get errors for gateway upgrade dry run", func() {
-		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway --file %s --dry-run --upgrade", file))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	It("shouldn't get errors for gateway dry run with multiple values", func() {
 		outputYaml, err := testutils.GlooctlOut(fmt.Sprintf("install gateway --file %s --dry-run --values %s,%s ", file, values1, values2))
 		Expect(err).NotTo(HaveOccurred())
@@ -34,11 +29,6 @@ var _ = Describe("Install", func() {
 
 	It("shouldn't get errors for enterprise dry run", func() {
 		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway enterprise --file %s --dry-run %s", file, licenseKey))
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("shouldn't get errors for enterprise upgrade dry run", func() {
-		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway enterprise --file %s --dry-run --upgrade", file))
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/projects/gloo/cli/pkg/cmd/options/options.go
+++ b/projects/gloo/cli/pkg/cmd/options/options.go
@@ -45,7 +45,6 @@ type Top struct {
 
 type Install struct {
 	DryRun                  bool
-	Upgrade                 bool
 	CreateNamespace         bool
 	Namespace               string
 	HelmChartOverride       string

--- a/projects/gloo/cli/pkg/flagutils/install.go
+++ b/projects/gloo/cli/pkg/flagutils/install.go
@@ -9,7 +9,6 @@ import (
 
 func AddInstallFlags(set *pflag.FlagSet, install *options.Install) {
 	set.BoolVarP(&install.DryRun, "dry-run", "d", false, "Dump the raw installation yaml instead of applying it to kubernetes")
-	set.BoolVarP(&install.Upgrade, "upgrade", "u", false, "Upgrade an existing v1 gateway installation to use v2 CRDs. Set this when upgrading from v0.17.x or earlier versions of gloo")
 	set.StringVarP(&install.HelmChartOverride, "file", "f", "", "Install Gloo from this Helm chart archive file rather than from a release")
 	set.StringSliceVarP(&install.HelmChartValueFileNames, "values", "", []string{}, "List of files with value overrides for the Gloo Helm chart, (e.g. --values file1,file2 or --values file1 --values file2)")
 	set.StringVar(&install.HelmReleaseName, "release-name", constants.GlooReleaseName, "helm release name")


### PR DESCRIPTION
The upgrade command has been depreciated, and should no longer be usable.