### PR TITLE
Update install docs to prompt users to make helm override yamls

### DIFF
--- a/docs/content/installation/ingress/_index.md
+++ b/docs/content/installation/ingress/_index.md
@@ -35,17 +35,18 @@ As a first step, you have to add the Gloo repository to the list of known chart 
 helm repo add gloo https://storage.googleapis.com/solo-public-helm
 ```
 
-The Gloo chart archive contains the necessary value files for the Ingress deployment option. Run the
-following command to download and extract the archive to the current directory:
-
-```shell
-helm fetch --untar=true --untardir=. gloo/gloo
+Create a `values-ingress.yaml` file with the following overrides:
+```yaml
+gateway:
+  enabled: false
+ingress:
+  enabled: true
 ```
 
 Finally, install Gloo using the following command:
 
 ```shell
-helm install gloo --namespace gloo-system -f gloo/values-ingress.yaml
+helm install gloo --namespace gloo-system -f values-ingress.yaml
 ```
 
 Gloo can be installed to a namespace of your choosing with the `--namespace` flag.

--- a/docs/content/installation/knative/_index.md
+++ b/docs/content/installation/knative/_index.md
@@ -43,23 +43,34 @@ apply to the cluster instead of installing them.
 This is the recommended method for installing Gloo to your production environment as it offers rich customization to
 the Gloo control plane and the proxies Gloo manages.
 
-As a first step, you have to add the Gloo repository to the list of known chart repositories:
+First, make sure you have knative installed. If you do not, you can install knative components without Gloo using
+`glooctl`:
+
+```shell script
+glooctl install knative -g
+```
+
+Now let's install Gloo. If needed, add the Gloo repository to the list of known chart repositories:
 
 ```shell
 helm repo add gloo https://storage.googleapis.com/solo-public-helm
 ```
 
-The Gloo chart archive contains the necessary value files for the Knative deployment option. Run the
-following command to download and extract the archive to the current directory:
-
-```shell
-helm fetch --untar=true --untardir=. gloo/gloo
+Create a `values-knative.yaml` file with the following overrides:
+```yaml
+gateway:
+  enabled: false
+settings:
+  integrations:
+    knative:
+      enabled: true
+      version: {{ . }}  # put installed knative version here!
 ```
 
 Finally, install Gloo using the following command:
 
 ```shell
-helm install gloo --namespace gloo-system -f gloo/values-knative.yaml
+helm install gloo --namespace gloo-system -f values-knative.yaml
 ```
 
 Gloo can be installed to a namespace of your choosing with the `--namespace` flag.

--- a/docs/content/installation/knative/_index.md
+++ b/docs/content/installation/knative/_index.md
@@ -70,7 +70,8 @@ settings:
 Finally, install Gloo using the following command:
 
 ```shell
-helm install gloo --namespace gloo-system -f values-knative.yaml
+kubectl create namespace gloo-system
+helm install gloo gloo/gloo --namespace gloo-system -f values-knative.yaml
 ```
 
 Gloo can be installed to a namespace of your choosing with the `--namespace` flag.


### PR DESCRIPTION
Docs should stop referencing the knative and ingress template yamls that have been consolidated into a single values.yaml file.