### PR TITLE
Install knative docs

### DIFF
--- a/docs/content/gloo_integrations/knative/_index.md
+++ b/docs/content/gloo_integrations/knative/_index.md
@@ -63,7 +63,7 @@ run `glooctl proxy url --name knative-external-proxy`
      `{service-name}.{namespace}.example.com`. You can discover the appropriate *Host* header by checking the URL Knative has assigned to the `helloworld-go` service created above.
   
      ```
-     $ kubectl get ksvc helloworld-go -n default  --output=custom-columns=NAME:.metadata.name,URL:.status.url
+     kubectl get ksvc helloworld-go -n default  --output=custom-columns=NAME:.metadata.name,URL:.status.url
      ```
   
      ```     NAME            URL
@@ -75,7 +75,7 @@ run `glooctl proxy url --name knative-external-proxy`
      using the `Host` and URL of the Gloo Gateway from above:
   
      ```
-     $ curl -H "Host: helloworld-go.default.example.com" $(glooctl proxy url --name knative-external-proxy)
+     curl -H "Host: helloworld-go.default.example.com" $(glooctl proxy url --name knative-external-proxy)
      ```
   
      ```

--- a/docs/content/installation/knative/_index.md
+++ b/docs/content/installation/knative/_index.md
@@ -43,23 +43,30 @@ apply to the cluster instead of installing them.
 This is the recommended method for installing Gloo to your production environment as it offers rich customization to
 the Gloo control plane and the proxies Gloo manages.
 
+Note that we are using Helm 3 here. You can check which version of helm you are using by running `helm version`.
+
 As a first step, you have to add the Gloo repository to the list of known chart repositories:
 
 ```shell
 helm repo add gloo https://storage.googleapis.com/solo-public-helm
 ```
 
-The Gloo chart archive contains the necessary value files for the Knative deployment option. Run the
-following command to download and extract the archive to the current directory:
+Copy the following into a `knative-values.yaml` file in the current directory:
 
 ```shell
-helm fetch --untar=true --untardir=. gloo/gloo
+gateway:
+  enabled: false
+settings:
+  integrations:
+    knative:
+      enabled: true
+      version: 0.10.0
 ```
 
 Finally, install Gloo using the following command:
 
 ```shell
-helm install gloo --namespace gloo-system -f gloo/values-knative.yaml
+helm install gloo gloo/gloo --namespace gloo-system -f knative-values.yaml
 ```
 
 Gloo can be installed to a namespace of your choosing with the `--namespace` flag.


### PR DESCRIPTION
We don't have docs for supporting GlooE with Knative, but it can be done via helm with the following steps:

1. Create a file knative-values.yaml with:
```
gloo:
  gateway:
    enabled: false
  settings:
    create: true
    integrations:
      knative:
        enabled: true
        proxy:
          httpPort: 80
          httpsPort: 443
          image:
            repository: gloo-envoy-wrapper
            tag: 1.2.10
          replicas: 1
        version: 0.10.0
    invalidConfigPolicy:
      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators
        should run `glooctl check` to find and fix config errors.
      invalidRouteResponseCode: 404
    linkerd: false
    singleNamespace: false
```
2. Run glooctl install knative -g
3. helm repo add glooe http://storage.googleapis.com/gloo-ee-helm
4. helm install glooe https://storage.googleapis.com/gloo-ee-helm/charts/gloo-ee-1.0.0-rc8.tgz --namespace gloo-system --values knative-values.yaml --set-string license_key=YOUR_LICENSE_KEY 