### PR TITLE
remove cross-ns calls from glooctl installation

### DIFF
--- a/changelog/v1.2.13/glooctl-in-cluster.yaml
+++ b/changelog/v1.2.13/glooctl-in-cluster.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >
+      Reduce permissions needed to run glooctl in cluster by removing cross-namespace calls from install command.
+    issueLink: https://github.com/solo-io/gloo/issues/1765 

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -27,8 +27,12 @@ func VersionMismatchWarning(opts *options.Options, cmd *cobra.Command) error {
 	if opts.Top.Consul.UseConsul {
 		return nil
 	}
+	nsToCheck := opts.Metadata.Namespace
+	if opts.Install.Namespace != "" {
+		nsToCheck = opts.Install.Namespace
+	}
 
-	return WarnOnMismatch(os.Args[0], versioncmd.NewKube(opts.Metadata.Namespace), &defaultLogger{})
+	return WarnOnMismatch(os.Args[0], versioncmd.NewKube(nsToCheck), &defaultLogger{})
 }
 
 // use this logger interface, so that in the unit test we can accumulate lines that were output


### PR DESCRIPTION
Currently, `glooctl install` first checks for version compatibility. It looks in the `gloo-system` ns even if a different install namespace is specified. This means glooctl needs cluster roles to install gloo. This pr is a step away from that requirement