### PR TITLE
respect knative ingressclass annotation

### DIFF
--- a/changelog/v1.2.13/support-knative-annotations.yaml
+++ b/changelog/v1.2.13/support-knative-annotations.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    description: Support Knative Ingress Class Annotations. If env var REQUIRE_INGRESS_CLASS=true on the Knative Ingress Controller, only ingresses with the annotation 'networking.knative.dev/ingress.class=gloo.ingress.networking.knative.dev' will be processed. Set Helm value Values.settings.integrations.knative.requireIngressClass=true to enable with Helm.
+    issueLink: https://github.com/solo-io/gloo/issues/2040

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -19,7 +19,7 @@
 |settings.integrations.knative.proxy.resources.limits.cpu|string||amount of CPUs|
 |settings.integrations.knative.proxy.resources.requests.memory|string||amount of memory|
 |settings.integrations.knative.proxy.resources.requests.cpu|string||amount of CPUs|
-|settings.integrations.knative.requireIngressClass|bool||only serve traffic for Knative Ingress objects with the annotation 'networking.knative.dev/ingress.class: gloo.ingress.networking.knative.dev'. This can be configured via the |
+|settings.integrations.knative.requireIngressClass|bool||only serve traffic for Knative Ingress objects with the annotation 'networking.knative.dev/ingress.class: gloo.ingress.networking.knative.dev'.|
 |settings.create|bool|true|create a Settings CRD which provides bootstrap configuration to Gloo controllers|
 |settings.extensions|interface|||
 |settings.singleNamespace|bool|false|Enable to use install namespace as WatchNamespace and WriteNamespace|

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -19,6 +19,7 @@
 |settings.integrations.knative.proxy.resources.limits.cpu|string||amount of CPUs|
 |settings.integrations.knative.proxy.resources.requests.memory|string||amount of memory|
 |settings.integrations.knative.proxy.resources.requests.cpu|string||amount of CPUs|
+|settings.integrations.knative.requireIngressClass|bool||only serve traffic for Knative Ingress objects with the annotation 'networking.knative.dev/ingress.class: gloo.ingress.networking.knative.dev'. This can be configured via the |
 |settings.create|bool|true|create a Settings CRD which provides bootstrap configuration to Gloo controllers|
 |settings.extensions|interface|||
 |settings.singleNamespace|bool|false|Enable to use install namespace as WatchNamespace and WriteNamespace|

--- a/go.sum
+++ b/go.sum
@@ -58,6 +58,7 @@ github.com/Azure/go-autorest/autorest/date v0.2.0/go.mod h1:vcORJHLJEh643/Ioh9+v
 github.com/Azure/go-autorest/autorest/mocks v0.1.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0 h1:Ww5g4zThfD/6cLb4z6xxgeyDa7QDkizMkJKe0ysZXp0=
 github.com/Azure/go-autorest/autorest/mocks v0.2.0/go.mod h1:OTyCOPRA2IgIlWxVYxBee2F5Gr4kF2zd2J5cFRaIDN0=
+github.com/Azure/go-autorest/autorest/mocks v0.3.0 h1:qJumjCaCudz+OcqE9/XtEPfvtOjOmKaui4EOpFI6zZc=
 github.com/Azure/go-autorest/autorest/mocks v0.3.0/go.mod h1:a8FDP3DYzQ4RYfVAxAN3SVSiiO77gL2j2ronKKP0syM=
 github.com/Azure/go-autorest/autorest/to v0.2.0 h1:nQOZzFCudTh+TvquAtCRjM01VEYx85e9qbwt5ncW4L8=
 github.com/Azure/go-autorest/autorest/to v0.2.0/go.mod h1:GunWKJp1AEqgMaGLV+iocmRAJWqST1wQYhyyjXJ3SJc=
@@ -427,6 +428,7 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fogleman/gg v1.3.0/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
 github.com/frankban/quicktest v1.4.0/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
+github.com/frankban/quicktest v1.4.1 h1:Wv2VwvNn73pAdFIVUQRXYDFp31lXKbqblIXo/Q5GPSg=
 github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -545,6 +547,7 @@ github.com/go-swagger/go-swagger v0.21.0/go.mod h1:tDb8PdDVFcaE8EPXkMOsuxpL3UEPi
 github.com/go-swagger/scan-repo-boundary v0.0.0-20180623220736-973b3573c013/go.mod h1:b65mBPzqzZWxOZGxSWrqs4GInLIn+u99Q9q7p+GKni0=
 github.com/go-test/deep v1.0.1/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
+github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
 github.com/go-test/deep v1.0.2/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gobuffalo/attrs v0.0.0-20190219185331-f338c9388485/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
 github.com/gobuffalo/attrs v0.0.0-20190224210810-a9411de4debd/go.mod h1:4duuawTqi2wkkpB4ePgWMaai6/Kc6WEz83bhFwpHzj0=
@@ -1083,6 +1086,7 @@ github.com/hashicorp/consul/api v1.3.0 h1:HXNYlRkkM/t+Y/Yhxtwcy02dlYwIaoxzvxPnS+
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/sdk v0.1.1 h1:LnuDWGNsoajlhGyHJvuWW6FVqRl8JOTPqS6CPTsYjhY=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
+github.com/hashicorp/consul/sdk v0.3.0 h1:UOxjlb4xVNF93jak1mzzoBatyFju9nrkxpVwIp/QqxQ=
 github.com/hashicorp/consul/sdk v0.3.0/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
@@ -1099,6 +1103,7 @@ github.com/hashicorp/go-hclog v0.0.0-20180709165350-ff2cf002a8dd/go.mod h1:9bjs9
 github.com/hashicorp/go-hclog v0.8.0/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v0.10.0 h1:b86HUuA126IcSHyC55WjPo7KtCOVeTCKIjr+3lBhPxI=
 github.com/hashicorp/go-hclog v0.10.0/go.mod h1:whpDNt7SSdeAju8AWKIWsul05p54N/39EeqMAyrmvFQ=
 github.com/hashicorp/go-immutable-radix v1.0.0 h1:AKDB1HM5PWEA7i4nhcpwOrO2byshxBjXVn/J/3+z5/0=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -1157,6 +1162,7 @@ github.com/hashicorp/memberlist v0.1.3 h1:EmmoJme1matNzb+hMpDuR/0sbJSUisxyqBGG67
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/memberlist v0.1.4 h1:gkyML/r71w3FL8gUi74Vk76avkj/9lYAY9lvg0OcoGs=
 github.com/hashicorp/memberlist v0.1.4/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
+github.com/hashicorp/memberlist v0.1.5 h1:AYBsgJOW9gab/toO5tEB8lWetVgDKZycqkebJ8xxpqM=
 github.com/hashicorp/memberlist v0.1.5/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/net-rpc-msgpackrpc v0.0.0-20151116020338-a14192a58a69/go.mod h1:/z+jUGRBlwVpUZfjute9jWaF6/HuhjuFQuL1YXzVD1Q=
 github.com/hashicorp/nomad/api v0.0.0-20190412184103-1c38ced33adf/go.mod h1:BDngVi1f4UA6aJq9WYTgxhfWSE1+42xshvstLU2fRGk=
@@ -1475,6 +1481,7 @@ github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3N
 github.com/miekg/dns v1.1.3/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.4 h1:rCMZsU2ScVSYcAsOXgmC6+AKOK+6pmQTOcw03nfwYV0=
 github.com/miekg/dns v1.1.4/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
+github.com/miekg/dns v1.1.15 h1:CSSIDtllwGLMoA6zjdKnaE6Tx6eVUxQ29LUgGetiDCI=
 github.com/miekg/dns v1.1.15/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mindprince/gonvml v0.0.0-20171110221305-fee913ce8fb2/go.mod h1:2eu9pRWp8mo84xCg6KswZ+USQHjwgRhNp06sozOdsTY=
 github.com/mistifyio/go-zfs v2.1.1+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -81,9 +81,10 @@ type Integrations struct {
 }
 
 type Knative struct {
-	Enabled *bool         `json:"enabled" desc:"enabled knative components"`
-	Version *string       `json:"version,omitEmpty" desc:"the version of knative installed to the cluster. if using version < 0.8.0, gloo will use Knative's ClusterIngress API for configuration rather than the namespace-scoped Ingress"`
-	Proxy   *KnativeProxy `json:"proxy,omitempty"`
+	Enabled             *bool         `json:"enabled" desc:"enabled knative components"`
+	Version             *string       `json:"version,omitEmpty" desc:"the version of knative installed to the cluster. if using version < 0.8.0, gloo will use Knative's ClusterIngress API for configuration rather than the namespace-scoped Ingress"`
+	Proxy               *KnativeProxy `json:"proxy,omitempty"`
+	RequireIngressClass *bool         `json:"requireIngressClass" desc:"only serve traffic for Knative Ingress objects with the annotation 'networking.knative.dev/ingress.class: gloo.ingress.networking.knative.dev'. This can be configured via the "`
 }
 
 type KnativeProxy struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -84,7 +84,7 @@ type Knative struct {
 	Enabled             *bool         `json:"enabled" desc:"enabled knative components"`
 	Version             *string       `json:"version,omitEmpty" desc:"the version of knative installed to the cluster. if using version < 0.8.0, gloo will use Knative's ClusterIngress API for configuration rather than the namespace-scoped Ingress"`
 	Proxy               *KnativeProxy `json:"proxy,omitempty"`
-	RequireIngressClass *bool         `json:"requireIngressClass" desc:"only serve traffic for Knative Ingress objects with the annotation 'networking.knative.dev/ingress.class: gloo.ingress.networking.knative.dev'. This can be configured via the "`
+	RequireIngressClass *bool         `json:"requireIngressClass" desc:"only serve traffic for Knative Ingress objects with the annotation 'networking.knative.dev/ingress.class: gloo.ingress.networking.knative.dev'."`
 }
 
 type KnativeProxy struct {

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: "true"
 {{- else }}
 
-  {{- if or (.Values.ingress.requireIngressClass .Values.settings.integrations.knative.requireIngressClass) }}
+  {{- if or .Values.ingress.requireIngressClass .Values.settings.integrations.knative.requireIngressClass }}
         - name: "REQUIRE_INGRESS_CLASS"
           value: "true"
   {{- end }}

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: "true"
 {{- else }}
 
-  {{- if or (.Values.ingress.requireIngressClass .Values.settings.integrations.knative.requireIngressClass }}
+  {{- if or (.Values.ingress.requireIngressClass .Values.settings.integrations.knative.requireIngressClass) }}
         - name: "REQUIRE_INGRESS_CLASS"
           value: "true"
   {{- end }}

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: "true"
 {{- else }}
 
-  {{- if .Values.ingress.requireIngressClass }}
+  {{- if or (.Values.ingress.requireIngressClass .Values.settings.integrations.knative.requireIngressClass }}
         - name: "REQUIRE_INGRESS_CLASS"
           value: "true"
   {{- end }}

--- a/projects/ingress/pkg/setup/setup_syncer.go
+++ b/projects/ingress/pkg/setup/setup_syncer.go
@@ -263,6 +263,7 @@ func RunIngress(opts Opts) error {
 				proxyClient,
 				knative.NetworkingV1alpha1(),
 				writeErrs,
+				opts.RequireIngressClass,
 			)
 			knativeTranslatorEventLoop := knativev1.NewTranslatorEventLoop(knativeTranslatorEmitter, knativeTranslatorSync)
 			knativeTranslatorEventLoopErrs, err := knativeTranslatorEventLoop.Run(opts.WatchNamespaces, opts.WatchOpts)

--- a/projects/knative/pkg/translator/translate.go
+++ b/projects/knative/pkg/translator/translate.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"knative.dev/serving/pkg/apis/networking"
+
 	"knative.dev/pkg/network"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
@@ -24,6 +26,11 @@ import (
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	knativev1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+)
+
+const (
+	ingressClassAnnotation = networking.IngressClassAnnotationKey
+	glooIngressClass       = "gloo.ingress.networking.knative.dev"
 )
 
 const (

--- a/projects/knative/pkg/translator/translator_syncer.go
+++ b/projects/knative/pkg/translator/translator_syncer.go
@@ -30,9 +30,10 @@ type translatorSyncer struct {
 	proxyClient          gloov1.ProxyClient
 	proxyReconciler      gloov1.ProxyReconciler
 	ingressClient        knativeclient.IngressesGetter
+	requireIngressClass  bool
 }
 
-func NewSyncer(externalProxyAddress, internalProxyAddress, writeNamespace string, proxyClient gloov1.ProxyClient, ingressClient knativeclient.IngressesGetter, writeErrs chan error) v1.TranslatorSyncer {
+func NewSyncer(externalProxyAddress, internalProxyAddress, writeNamespace string, proxyClient gloov1.ProxyClient, ingressClient knativeclient.IngressesGetter, writeErrs chan error, requireIngressClass bool) v1.TranslatorSyncer {
 	return &translatorSyncer{
 		externalProxyAddress: externalProxyAddress,
 		internalProxyAddress: internalProxyAddress,
@@ -41,6 +42,7 @@ func NewSyncer(externalProxyAddress, internalProxyAddress, writeNamespace string
 		proxyClient:          proxyClient,
 		ingressClient:        ingressClient,
 		proxyReconciler:      gloov1.NewProxyReconciler(proxyClient),
+		requireIngressClass:  requireIngressClass,
 	}
 }
 
@@ -49,7 +51,17 @@ const (
 	internalProxyName = "knative-internal-proxy"
 )
 
-// TODO (ilackarms): make sure that sync happens if proxies get updated as well; may need to resync
+// enforce ingress class if requirement is set
+func (s *translatorSyncer) shouldProcess(ingress *v1alpha1.Ingress) bool {
+	if !s.requireIngressClass {
+		return true
+	}
+	if len(ingress.Annotations) == 0 {
+		return false
+	}
+	return ingress.Annotations[ingressClassAnnotation] == glooIngressClass
+}
+
 func (s *translatorSyncer) Sync(ctx context.Context, snap *v1.TranslatorSnapshot) error {
 	ctx = contextutils.WithLogger(ctx, "translatorSyncer")
 
@@ -71,6 +83,10 @@ func (s *translatorSyncer) Sync(ctx context.Context, snap *v1.TranslatorSnapshot
 	var externalIngresses, internalIngresses v1alpha1.IngressList
 
 	for _, ing := range snap.Ingresses {
+		if !s.shouldProcess(ing) {
+			continue
+		}
+
 		if ing.IsPublic() {
 			externalIngresses = append(externalIngresses, ing)
 		} else {

--- a/projects/knative/pkg/translator/translator_syncer_test.go
+++ b/projects/knative/pkg/translator/translator_syncer_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"time"
 
+	knativev1 "github.com/solo-io/gloo/projects/knative/pkg/api/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -16,22 +19,88 @@ import (
 	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
-	v1alpha12 "knative.dev/serving/pkg/apis/networking/v1alpha1"
+	knativev1alpha1 "knative.dev/serving/pkg/apis/networking/v1alpha1"
 	v1alpha13 "knative.dev/serving/pkg/client/clientset/versioned/typed/networking/v1alpha1"
 )
 
 var _ = Describe("TranslatorSyncer", func() {
-	It("propagates successful proxy status to the ingresses it was created from", func() {
-		proxyAddressExternal := "proxy-external-address"
-		proxyAddressInternal := "proxy-internal-address"
-		namespace := "write-namespace"
-		proxyClient, _ := v1.NewProxyClient(&factory.MemoryResourceClientFactory{Cache: memory.NewInMemoryResourceCache()})
-		ingress := &v1alpha1.Ingress{Ingress: knative.Ingress{ObjectMeta: v12.ObjectMeta{Generation: 1}}}
-		knativeClient := &mockCiClient{ci: toKube(ingress)}
-
-		syncer := NewSyncer(proxyAddressExternal, proxyAddressInternal, namespace, proxyClient, knativeClient, make(chan error)).(*translatorSyncer)
-		proxy := &v1.Proxy{Metadata: core.Metadata{Name: "hi", Namespace: "howareyou"}}
+	var (
+		proxyAddressExternal = "proxy-external-address"
+		proxyAddressInternal = "proxy-internal-address"
+		namespace            = "write-namespace"
+		proxyClient          v1.ProxyClient
+		knativeClient        v1alpha13.IngressesGetter
+		ingress              *v1alpha1.Ingress
+		proxy                *v1.Proxy
+	)
+	BeforeEach(func() {
+		proxyClient, _ = v1.NewProxyClient(&factory.MemoryResourceClientFactory{Cache: memory.NewInMemoryResourceCache()})
+		ingress = &v1alpha1.Ingress{Ingress: knative.Ingress{ObjectMeta: v12.ObjectMeta{Generation: 1},
+			Spec: knativev1alpha1.IngressSpec{
+				Rules: []knativev1alpha1.IngressRule{{
+					Hosts: []string{"*"},
+					HTTP: &knativev1alpha1.HTTPIngressRuleValue{
+						Paths: []knativev1alpha1.HTTPIngressPath{
+							{
+								Path: "/hay",
+								Splits: []knativev1alpha1.IngressBackendSplit{
+									{
+										IngressBackend: knativev1alpha1.IngressBackend{
+											ServiceName:      "a",
+											ServiceNamespace: "b",
+											ServicePort: intstr.IntOrString{
+												Type:   intstr.Int,
+												IntVal: 1234,
+											},
+										},
+									},
+								},
+							},
+						}},
+				},
+				}},
+		}}
+		knativeClient = &mockCiClient{ci: toKube(ingress)}
+		proxy = &v1.Proxy{Metadata: core.Metadata{Name: "hi", Namespace: "howareyou"}}
 		proxy, _ = proxyClient.Write(proxy, clients.WriteOpts{})
+	})
+	It("only processes annotated proxies when requireIngressClass is set to true successful proxy status to the ingresses it was created from", func() {
+		syncer := NewSyncer(proxyAddressExternal, proxyAddressInternal, namespace, proxyClient, knativeClient, make(chan error), true).(*translatorSyncer)
+
+		// expect ingress without class to be ignored
+		err := syncer.Sync(context.TODO(), &knativev1.TranslatorSnapshot{
+			Ingresses: []*v1alpha1.Ingress{ingress},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// expect the ingress to be ignored
+		// we should have no listeners
+		proxies, err := proxyClient.List(namespace, clients.ListOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(proxies).To(HaveLen(2))
+		Expect(proxies[0].Listeners).To(HaveLen(0))
+
+		ingress.Annotations = map[string]string{
+			ingressClassAnnotation: glooIngressClass,
+		}
+
+		err = syncer.Sync(context.TODO(), &knativev1.TranslatorSnapshot{
+			Ingresses: []*v1alpha1.Ingress{ingress},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// expect a proxy to be created
+		proxies, err = proxyClient.List(namespace, clients.ListOpts{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(proxies).To(HaveLen(2))
+		Expect(proxies[0].Listeners).To(HaveLen(1))
+		Expect(proxies[0].Listeners[0].GetHttpListener()).NotTo(BeNil())
+		Expect(proxies[0].Listeners[0].GetHttpListener().VirtualHosts).To(HaveLen(1))
+	})
+
+	It("propagates successful proxy status to the ingresses it was created from", func() {
+		// requireIngressClass = true
+		syncer := NewSyncer(proxyAddressExternal, proxyAddressInternal, namespace, proxyClient, knativeClient, make(chan error), false).(*translatorSyncer)
 
 		go func() {
 			defer GinkgoRecover()
@@ -45,34 +114,34 @@ var _ = Describe("TranslatorSyncer", func() {
 		err := syncer.propagateProxyStatus(context.TODO(), proxy, v1alpha1.IngressList{ingress})
 		Expect(err).NotTo(HaveOccurred())
 
-		ci, err := knativeClient.Get(ingress.Name, v12.GetOptions{})
+		ci, err := knativeClient.Ingresses(ingress.Namespace).Get(ingress.Name, v12.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(ci.Status.IsReady()).To(BeTrue())
 	})
 })
 
-func toKube(ci *v1alpha1.Ingress) *v1alpha12.Ingress {
-	kubeCi := v1alpha12.Ingress(ci.Ingress)
+func toKube(ci *v1alpha1.Ingress) *knativev1alpha1.Ingress {
+	kubeCi := knativev1alpha1.Ingress(ci.Ingress)
 	return &kubeCi
 }
 
-type mockCiClient struct{ ci *v1alpha12.Ingress }
+type mockCiClient struct{ ci *knativev1alpha1.Ingress }
 
 func (c *mockCiClient) Ingresses(namespace string) v1alpha13.IngressInterface {
 	return c
 }
 
-func (c *mockCiClient) UpdateStatus(ci *v1alpha12.Ingress) (*v1alpha12.Ingress, error) {
+func (c *mockCiClient) UpdateStatus(ci *knativev1alpha1.Ingress) (*knativev1alpha1.Ingress, error) {
 	c.ci.Status = ci.Status
 	return ci, nil
 }
 
-func (*mockCiClient) Create(*v1alpha12.Ingress) (*v1alpha12.Ingress, error) {
+func (*mockCiClient) Create(*knativev1alpha1.Ingress) (*knativev1alpha1.Ingress, error) {
 	panic("implement me")
 }
 
-func (*mockCiClient) Update(*v1alpha12.Ingress) (*v1alpha12.Ingress, error) {
+func (*mockCiClient) Update(*knativev1alpha1.Ingress) (*knativev1alpha1.Ingress, error) {
 	panic("implement me")
 }
 
@@ -84,11 +153,11 @@ func (*mockCiClient) DeleteCollection(options *v12.DeleteOptions, listOptions v1
 	panic("implement me")
 }
 
-func (c *mockCiClient) Get(name string, options v12.GetOptions) (*v1alpha12.Ingress, error) {
+func (c *mockCiClient) Get(name string, options v12.GetOptions) (*knativev1alpha1.Ingress, error) {
 	return c.ci, nil
 }
 
-func (*mockCiClient) List(opts v12.ListOptions) (*v1alpha12.IngressList, error) {
+func (*mockCiClient) List(opts v12.ListOptions) (*knativev1alpha1.IngressList, error) {
 	panic("implement me")
 }
 
@@ -96,6 +165,6 @@ func (*mockCiClient) Watch(opts v12.ListOptions) (watch.Interface, error) {
 	panic("implement me")
 }
 
-func (*mockCiClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *v1alpha12.Ingress, err error) {
+func (*mockCiClient) Patch(name string, pt types.PatchType, data []byte, subresources ...string) (result *knativev1alpha1.Ingress, err error) {
 	panic("implement me")
 }


### PR DESCRIPTION
this PR adds support for knative's ingress annotation as described in #2040 

support is off by default but can be enabled via the helm chart (which sets an environment variable on the knative ingress controller)
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2040