### PR TITLE
Update docs links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If an issue you have is already reported, please add additional information or a
 
 ### Improving the documentation
 
-The docs for Gloo are built from the `/docs` directory. 
+The docs for Gloo are built from the [`/docs`](/docs) directory. 
 
 Improving the documentation, adding examples or use cases can be the easiest way to contribute to Gloo. 
 If you see a piece of content that can be better, open a PR with an improvement, it doesn't matter how small!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ If an issue you have is already reported, please add additional information or a
 
 ### Improving the documentation
 
-The docs for Gloo are built from the combined [solo-docs repo](https://github.com/solo-io/solo-docs). 
+The docs for Gloo are built from the `/docs` directory. 
 
 Improving the documentation, adding examples or use cases can be the easiest way to contribute to Gloo. 
 If you see a piece of content that can be better, open a PR with an improvement, it doesn't matter how small!

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Gloo is a feature-rich, Kubernetes-native ingress controller, and next-generatio
 &nbsp; [**Blog**](https://medium.com/solo-io/announcing-gloo-the-function-gateway-3f0860ef6600) &nbsp; |
 &nbsp; [**Slack**](https://slack.solo.io) &nbsp; |
 &nbsp; [**Twitter**](https://twitter.com/soloio_inc) |
-&nbsp; [**Enterprise Trial**](https://www.solo.io/glooe)
+&nbsp; [**Enterprise Trial**](https://www.solo.io/products/gloo/#enterprise-trial)
 
 <BR><center><img src="https://docs.solo.io/gloo/latest/introduction/gloo_diagram.png" alt="Gloo Architecture" width="906"></center>
 
@@ -42,7 +42,7 @@ Gloo is a feature-rich, Kubernetes-native ingress controller, and next-generatio
 - Follow us on Twitter: [https://twitter.com/soloio_inc](https://twitter.com/soloio_inc)
 - Check out the docs: [https://gloo.solo.io](https://gloo.solo.io)
 - Check out the code and contribute: [Contribution Guide](CONTRIBUTING.md)
-- Contribute to the [Docs](https://github.com/solo-io/solo-docs)
+- Contribute to the [Docs](docs/)
 
 ### Thanks
 

--- a/changelog/v1.2.13/update-readme-solo-docs-refs.yaml
+++ b/changelog/v1.2.13/update-readme-solo-docs-refs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Fix some readme links and update old refs to deprecated solo-docs repo.
+    issueLink: https://github.com/solo-io/gloo/issues/2050

--- a/docs/content/advanced_configuration/session_affinity.md
+++ b/docs/content/advanced_configuration/session_affinity.md
@@ -180,7 +180,8 @@ For example, on a fresh deployment, your first request will be handled by node 1
 Your second request will by handled by node 2, and also return a count of 1.
 After you enable session affinity, repeat requests will return a strictly increasing count response.
 
-The source code for the session affinity app is available in the [solo-docs repo](https://github.com/solo-io/solo-docs). The core logic is shown below.
+The source code for the session affinity app is available [here](../../../docs/examples/session-affinity).
+The core logic is shown below.
 
 {{< highlight golang "hl_lines=24-29" >}}
 package main

--- a/docs/content/advanced_configuration/session_affinity.md
+++ b/docs/content/advanced_configuration/session_affinity.md
@@ -180,7 +180,7 @@ For example, on a fresh deployment, your first request will be handled by node 1
 Your second request will by handled by node 2, and also return a count of 1.
 After you enable session affinity, repeat requests will return a strictly increasing count response.
 
-The source code for the session affinity app is available [here](../../../docs/examples/session-affinity).
+The source code for the session affinity app is available [here](https://github.com/solo-io/gloo/blob/v1.2.12/docs/examples/session-affinity/main.go).
 The core logic is shown below.
 
 {{< highlight golang "hl_lines=24-29" >}}

--- a/docs/content/advanced_configuration/session_affinity.md
+++ b/docs/content/advanced_configuration/session_affinity.md
@@ -227,7 +227,7 @@ func App() error {
 
 The following command will create our DaemonSet and a matching Service.
 
-```
+```yaml
 cat << EOF | kubectl apply -f -
 apiVersion: apps/v1
 kind: DaemonSet


### PR DESCRIPTION
Fix some readme links and update old refs to deprecated solo-docs repo.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2050