### PR TITLE
Fix changelogs, relax semver changelog validation

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -746,7 +746,10 @@
 [[projects]]
   digest = "1:f92fd6e98da2322ddd7f60b9fd647b11bb67c6ab01dfdfb59f8f5ded2e7522d6"
   name = "github.com/golang/mock"
-  packages = ["gomock"]
+  packages = [
+    "gomock",
+    "mockgen/model",
+  ]
   pruneopts = "UT"
   revision = "9fa652df1129bef0e734c9cf9bf6dbae9ef3b9fa"
   version = "1.3.1"
@@ -1658,7 +1661,7 @@
   revision = "171e4740d00f71bdc66de3aea93a1b8606f1c1a0"
 
 [[projects]]
-  digest = "1:19fe561085bef5a18bdd917fcb2d55bd552f28ba65d6b1dd9766117d375a01a8"
+  digest = "1:4c12e45652c8834542b6edeac1f13f373243b357b5d71a2bc281704131760593"
   name = "github.com/solo-io/go-utils"
   packages = [
     "certutils",
@@ -1699,8 +1702,19 @@
     "vfsutils",
   ]
   pruneopts = "UT"
-  revision = "01471632103fbbd9302f9d876d8c81db331081ee"
-  version = "v0.11.0"
+  revision = "f608560ec7751f786a0c902167cb046a9e431397"
+  version = "v0.11.7"
+
+[[projects]]
+  digest = "1:58948f05e3ef5eddc9c334f2a8eaa2abf2fe3f2a39dd2d0c7a0574874401492b"
+  name = "github.com/solo-io/protoc-gen-ext"
+  packages = [
+    "extproto",
+    "pkg/hasher",
+  ]
+  pruneopts = "UT"
+  revision = "1a24aaf46919946df1c65ddc9ab4aff86f530b82"
+  version = "v0.0.6"
 
 [[projects]]
   digest = "1:3f4ac0fb4306bc49eb2111c4898bfb6e98e1ca7805a0b8c7692ebc41ad5dadc3"
@@ -1715,7 +1729,7 @@
   version = "v0.1.2"
 
 [[projects]]
-  digest = "1:e501317a58a4e3b5bd510932e9a9c855714623cfc98144b09f7aa93a02d44431"
+  digest = "1:d3ac93af321367583ff22878fdc43cc50eba474936ddf29afafb0d795b1339f8"
   name = "github.com/solo-io/solo-kit"
   packages = [
     "api/external/kubernetes/configmap",
@@ -1786,8 +1800,25 @@
     "test/setup",
   ]
   pruneopts = "UT"
-  revision = "d556dcb3dbbaecdd7b483beaa612a322d3a45bb7"
-  version = "v0.11.13"
+  revision = "6f2c5d2fd22bf267af62308daa41d7389317b781"
+  version = "v0.11.16"
+
+[[projects]]
+  digest = "1:7a9de87a6acc3189ca35c1101fedc5d3d00a047bdf3ae4d0c0f589f3dd1759ce"
+  name = "github.com/solo-io/wasme"
+  packages = [
+    "pkg/auth/store",
+    "pkg/cache",
+    "pkg/config",
+    "pkg/consts",
+    "pkg/defaults",
+    "pkg/model",
+    "pkg/pull",
+    "pkg/resolver",
+  ]
+  pruneopts = "UT"
+  revision = "7594a1b3ad3f0daf9df77f852d1002781dd40b19"
+  version = "v0.0.9"
 
 [[projects]]
   digest = "1:bb495ec276ab82d3dd08504bbc0594a65de8c3b22c6f2aaa92d05b73fbf3a82e"
@@ -2030,6 +2061,19 @@
   ]
   pruneopts = "UT"
   revision = "fdd1cda4f05fd1fd86124f0ef9ce31a0b72c8448"
+
+[[projects]]
+  branch = "master"
+  digest = "1:1ec79de2c381494b56be9cb968899e77818957301fe9302ddecb6d6ad5f62748"
+  name = "golang.org/x/mod"
+  packages = [
+    "internal/lazyregexp",
+    "modfile",
+    "module",
+    "semver",
+  ]
+  pruneopts = "UT"
+  revision = "331c550502dddccec70ff032beba72756bb428f2"
 
 [[projects]]
   digest = "1:1b6e369fbcea4e377fbea25aa05bb4a36dbaa24c3796023df40ae77c48ad8853"
@@ -3174,6 +3218,7 @@
     "github.com/gogo/protobuf/protoc-gen-gogo/descriptor",
     "github.com/gogo/protobuf/types",
     "github.com/golang/mock/gomock",
+    "github.com/golang/mock/mockgen/model",
     "github.com/golang/protobuf/jsonpb",
     "github.com/golang/protobuf/proto",
     "github.com/golang/protobuf/protoc-gen-go/descriptor",
@@ -3209,6 +3254,7 @@
     "github.com/onsi/gomega/gexec",
     "github.com/onsi/gomega/gstruct",
     "github.com/onsi/gomega/types",
+    "github.com/opencontainers/go-digest",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/api",
     "github.com/prometheus/client_golang/api/prometheus/v1",
@@ -3282,6 +3328,7 @@
     "github.com/solo-io/solo-kit/pkg/utils/protoutils",
     "github.com/solo-io/solo-kit/test/helpers",
     "github.com/solo-io/solo-kit/test/setup",
+    "github.com/solo-io/wasme/pkg/defaults",
     "github.com/spf13/afero",
     "github.com/spf13/cobra",
     "github.com/spf13/pflag",
@@ -3294,6 +3341,7 @@
     "go.uber.org/multierr",
     "go.uber.org/zap",
     "go.uber.org/zap/zapcore",
+    "golang.org/x/mod/modfile",
     "golang.org/x/oauth2/google",
     "golang.org/x/sync/errgroup",
     "google.golang.org/api/compute/v1",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -53,7 +53,7 @@ ignored = [
 
 [[override]]
   name = "github.com/solo-io/go-utils"
-  version = "0.11.0"
+  version = "0.11.7"
 
 [[constraint]]
   name = "github.com/hashicorp/consul"

--- a/changelog/v1.2.13/dedupe-stats-config.yaml
+++ b/changelog/v1.2.13/dedupe-stats-config.yaml
@@ -1,0 +1,10 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: go-utils
+  dependencyTag: v0.11.5
+  description: Update go-utils to version 0.11.5
+  issueLink: https://github.com/solo-io/gloo/issues/1998
+- type: NON_USER_FACING
+  description: Upgrade the stats server version to DRY out start up config
+  issueLink: https://github.com/solo-io/gloo/issues/1998

--- a/changelog/v1.2.13/placeholder.yaml
+++ b/changelog/v1.2.13/placeholder.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      GlooE depends on Gloo v1.2.12. We released [v1.2.13](https://github.com/solo-io/gloo/releases/tag/v1.2.13) off of
+      master (with new features) instead this branch, `v1.2.x`, which was incorrect.
+
+      To account for this, we will skip this tag on this branch, and the next valid 1.2.x tag should come from this
+      branch.
+
+      v1.2.13 was marked as a pre-release.

--- a/changelog/v1.2.14/dep-bump.yaml
+++ b/changelog/v1.2.14/dep-bump.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: go-utils
+    dependencyTag: v0.11.7

--- a/changelog/v1.2.14/placeholder.yaml
+++ b/changelog/v1.2.14/placeholder.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      GlooE depends on Gloo v1.2.12. We released [v1.2.14](https://github.com/solo-io/gloo/releases/tag/v1.2.14) off of
+      master (with new features) instead this branch, `v1.2.x`, which was incorrect.
+
+      To account for this, we will skip this tag on this branch, and the next valid 1.2.x tag should come from this
+      branch.
+
+      v1.2.14 was marked as a pre-release.

--- a/changelog/v1.2.15/placeholder.yaml
+++ b/changelog/v1.2.15/placeholder.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      GlooE depends on Gloo v1.2.12. We released [v1.2.13](https://github.com/solo-io/gloo/releases/tag/v1.2.13) and
+      [v1.2.14](https://github.com/solo-io/gloo/releases/tag/v1.2.14) off of master (with new features) instead this
+      branch, `v1.2.x`, which was incorrect.
+
+      To account for this, we skip `v1.2.13` and `v1.2.14` tags on this branch. This file exists to ensure that the
+      next release tag is `v1.2.15`, which is the successor for `v1.2.12`, which Gloo Enterprise 1.2.0 tracks.

--- a/changelog/validation.yaml
+++ b/changelog/validation.yaml
@@ -1,0 +1,1 @@
+relaxSemverValidation: true

--- a/docs/cmd/generate_changelog_doc.go
+++ b/docs/cmd/generate_changelog_doc.go
@@ -144,17 +144,16 @@ func generateChangelogMd(opts *options, args []string) error {
 	}
 	target := args[0]
 
-	var repoRootPath, repo, changelogDirPath string
+	changelogDirPath := changelogutils.ChangelogDirectory
+	var repoRootPath, repo string
 	switch target {
 	case glooDocGen:
 		repoRootPath = ".."
 		repo = "gloo"
-		changelogDirPath = "../changelog"
 	case glooEDocGen:
 		// files should already be there because we download them in CI, via `download-glooe-changelog` make target
 		repoRootPath = "../../solo-projects"
 		repo = "solo-projects"
-		changelogDirPath = "../../solo-projects/changelog"
 	default:
 		return InvalidInputError(target)
 	}

--- a/go.mod
+++ b/go.mod
@@ -75,9 +75,11 @@ require (
 	go.opencensus.io v0.22.2
 	go.uber.org/multierr v1.4.0
 	go.uber.org/zap v1.13.0
+	golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 // indirect
 	golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/tools v0.0.0-20191212051200-825cb0626375 // indirect
+	golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 // indirect
+	golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3 // indirect
 	google.golang.org/api v0.10.0 // indirect
 	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
 	google.golang.org/grpc v1.25.1

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,6 @@ require (
 	github.com/hashicorp/memberlist v0.1.4 // indirect
 	github.com/hashicorp/vault/api v1.0.5-0.20190730042357-746c0b111519
 	github.com/hinshun/vt10x v0.0.0-20180809195222-d55458df857c
-	github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 // indirect
 	github.com/ilackarms/protoc-gen-doc v1.0.0 // indirect
 	github.com/ilackarms/protokit v0.0.0-20181231193355-ee2393f3bbf0 // indirect
 	github.com/inconshreveable/go-update v0.0.0-20160112193335-8152e7eb6ccf
@@ -52,7 +51,7 @@ require (
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.3
-	github.com/onsi/ginkgo v1.10.1
+	github.com/onsi/ginkgo v1.10.3
 	github.com/onsi/gomega v1.7.1
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/pkg/errors v0.8.1
@@ -64,7 +63,8 @@ require (
 	github.com/radovskyb/watcher v1.0.7 // indirect
 	github.com/solo-io/envoy-operator v0.1.1
 	github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f
-	github.com/solo-io/go-utils v0.11.0
+	github.com/solo-io/go-utils v0.11.7
+	github.com/solo-io/protoc-gen-ext v0.0.4
 	github.com/solo-io/reporting-client v0.1.2
 	github.com/solo-io/solo-kit v0.11.13
 	github.com/solo-io/wasme v0.0.1
@@ -77,7 +77,6 @@ require (
 	go.uber.org/zap v1.13.0
 	golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
-	golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 // indirect
 	golang.org/x/tools v0.0.0-20191212051200-825cb0626375 // indirect
 	google.golang.org/api v0.10.0 // indirect
 	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11

--- a/go.sum
+++ b/go.sum
@@ -623,6 +623,7 @@ github.com/lucas-clemente/aes12 v0.0.0-20171027163421-cd47fb39b79f/go.mod h1:JpH
 github.com/lucas-clemente/quic-clients v0.1.0/go.mod h1:y5xVIEoObKqULIKivu+gD/LU90pL73bTdtQjPBvtCBk=
 github.com/lucas-clemente/quic-go v0.10.2/go.mod h1:hvaRS9IHjFLMq76puFJeWNfmn+H70QZ/CXoxqw9bzao=
 github.com/lucas-clemente/quic-go-certificates v0.0.0-20160823095156-d2f86524cced/go.mod h1:NCcRLrOTZbzhZvixZLlERbJtDtYsmMw8Jc4vS8Z0g58=
+github.com/lyft/protoc-gen-star v0.4.14/go.mod h1:mE8fbna26u7aEA2QCVvvfBU/ZrPgocG1206xAFPcs94=
 github.com/lyft/protoc-gen-validate v0.0.6/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
@@ -720,6 +721,7 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -847,6 +849,14 @@ github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f h1:CHgAq6
 github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f/go.mod h1:lojsKFoQQH0O/ElLmagtWINB9zAaq04E8z0xIVS/gLU=
 github.com/solo-io/go-utils v0.11.0 h1:x4LB+TnWr6uWI8oP89d6FvGXbGFrsFpuHj5ovAiK68A=
 github.com/solo-io/go-utils v0.11.0/go.mod h1:R8lbLuLtMaTOhD+6wGpdxj60r1Vwt63fHe1UxlObHig=
+github.com/solo-io/go-utils v0.11.2/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2YYYYgYBJso=
+github.com/solo-io/go-utils v0.11.6 h1:JIMHjLr4wfYAIcitg36ULYE5O2dKBg1Z9s+BZx06jZ0=
+github.com/solo-io/go-utils v0.11.6/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2YYYYgYBJso=
+github.com/solo-io/go-utils v0.11.7 h1:ID4lnyxqphmwNJm5ruwemj2iFaIZ88HE5/ziF7i4ZM8=
+github.com/solo-io/go-utils v0.11.7/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2YYYYgYBJso=
+github.com/solo-io/protoc-gen-ext v0.0.2/go.mod h1:zZIFs9Ch3EU3uQgL2ZwCHlUGAtwiz4Cbw6tBcmaNsEk=
+github.com/solo-io/protoc-gen-ext v0.0.4 h1:OFuoFLf7ru6qqvG+jVksPT4TnVouBy/bTuIWdTeJbnk=
+github.com/solo-io/protoc-gen-ext v0.0.4/go.mod h1:zZIFs9Ch3EU3uQgL2ZwCHlUGAtwiz4Cbw6tBcmaNsEk=
 github.com/solo-io/reporting-client v0.1.2 h1:U585Q5UlB5/UUewtgEAQz94SWuNRBxoHc4tPthhnYko=
 github.com/solo-io/reporting-client v0.1.2/go.mod h1:FmBDzwc1zEwayCCrlP+1w7NcpM0FIuvU+NSePj4wJq8=
 github.com/solo-io/solo-kit v0.6.3/go.mod h1:oBaQ6tOwuO97u7w+s3TeI08YLHcbiWemInx0XkDfKFw=

--- a/go.sum
+++ b/go.sum
@@ -721,6 +721,7 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.8.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.1 h1:q/mM8GF/n0shIN8SaAZ0V+jnLPzen6WIVZdiwrRlMlo=
 github.com/onsi/ginkgo v1.10.1/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.3.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
@@ -989,6 +990,8 @@ golang.org/x/crypto v0.0.0-20191028145041-f83a4685e152 h1:ZC1Xn5A1nlpSmQCIva4bZ3
 golang.org/x/crypto v0.0.0-20191028145041-f83a4685e152/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413 h1:ULYEB3JvPRE/IfO+9uO7vKV/xzVTO7XPAwm8xbf4w2g=
 golang.org/x/crypto v0.0.0-20191206172530-e9b2fee46413/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876 h1:sKJQZMuxjOAR/Uo2LBfU90onWEf1dF4C+0hPJCc9Mpc=
+golang.org/x/crypto v0.0.0-20191227163750-53104e6ec876/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190125153040-c74c464bbbf2/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190312203227-4b39c73a6495/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
@@ -1006,6 +1009,7 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e h1:JgcxKXxCjrA2tyDP/aNU9K0Ck5Czfk6C7e2tMw7+bSI=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd h1:ePuNC7PZ6O5BzgPn9bZayERXBdfZjUYoXEf5BTfDfh8=
 golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20170114055629-f2499483f923/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1089,6 +1093,8 @@ golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab h1:FvshnhkKW+LO3HWHodML8kuVX
 golang.org/x/sys v0.0.0-20191206220618-eeba5f6aabab/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449 h1:gSbV7h1NRL2G1xTg/owz62CST1oJBmxy4QpMMregXVQ=
 golang.org/x/sys v0.0.0-20191210023423-ac6580df4449/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8 h1:JA8d3MPx/IToSyXZG/RhwYEtfrKO1Fxrqe8KrkiLXKM=
+golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1135,6 +1141,8 @@ golang.org/x/tools v0.0.0-20191209225234-22774f7dae43 h1:NfPq5mgc5ArFgVLCpeS4z07
 golang.org/x/tools v0.0.0-20191209225234-22774f7dae43/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191212051200-825cb0626375 h1:hrBCt+pkb1irxFjg/GeadSn24gLxi5/Z861I53OkQbc=
 golang.org/x/tools v0.0.0-20191212051200-825cb0626375/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3 h1:2+KluhQfJ1YhW+TB1KrISS2SfiG1pLEoseB0D4VF/bo=
+golang.org/x/tools v0.0.0-20191230220329-2aa90c603ae3/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898 h1:/atklqdjdhuosWIl6AIbOeHJjicWYPqR9bpxqxYG2pA=

--- a/projects/accesslogger/cmd/main.go
+++ b/projects/accesslogger/cmd/main.go
@@ -1,19 +1,11 @@
 package main
 
 import (
-	"os"
-
 	"github.com/solo-io/gloo/projects/accesslogger/pkg/runner"
 	"github.com/solo-io/go-utils/stats"
 )
 
-const (
-	START_STATS_SERVER = "START_STATS_SERVER"
-)
-
 func main() {
-	if os.Getenv(START_STATS_SERVER) != "" {
-		stats.StartStatsServer()
-	}
+	stats.ConditionallyStartStatsServer()
 	runner.Run()
 }

--- a/projects/accesslogger/pkg/runner/run.go
+++ b/projects/accesslogger/pkg/runner/run.go
@@ -28,11 +28,9 @@ func Run() {
 	ctx := contextutils.WithLogger(context.Background(), "access_log")
 
 	if clientSettings.DebugPort != 0 {
-
-		debugPort := fmt.Sprintf("%d", clientSettings.DebugPort)
 		// TODO(yuval-k): we need to start the stats server before calling contextutils
 		// need to think of a better way to express this dependency, or preferably, fix it.
-		stats.StartStatsServerWithPort(debugPort)
+		stats.StartStatsServerWithPort(stats.StartupOptions{Port: clientSettings.DebugPort})
 	}
 
 	opts := loggingservice.Options{

--- a/projects/discovery/cmd/main.go
+++ b/projects/discovery/cmd/main.go
@@ -1,22 +1,14 @@
 package main
 
 import (
-	"os"
-
 	fdssetup "github.com/solo-io/gloo/projects/discovery/pkg/fds/setup"
 	uds "github.com/solo-io/gloo/projects/discovery/pkg/uds/setup"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/stats"
 )
 
-const (
-	START_STATS_SERVER = "START_STATS_SERVER"
-)
-
 func main() {
-	if os.Getenv(START_STATS_SERVER) != "" {
-		stats.StartStatsServer()
-	}
+	stats.ConditionallyStartStatsServer()
 	if err := run(); err != nil {
 		log.Fatalf("err in main: %v", err.Error())
 	}

--- a/projects/gateway/cmd/main.go
+++ b/projects/gateway/cmd/main.go
@@ -1,21 +1,13 @@
 package main
 
 import (
-	"os"
-
 	"github.com/solo-io/gloo/projects/gateway/pkg/setup"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/stats"
 )
 
-const (
-	START_STATS_SERVER = "START_STATS_SERVER"
-)
-
 func main() {
-	if os.Getenv(START_STATS_SERVER) != "" {
-		stats.StartStatsServer()
-	}
+	stats.ConditionallyStartStatsServer()
 	if err := setup.Main(nil); err != nil {
 		log.Fatalf("err in main: %v", err.Error())
 	}

--- a/projects/gloo/cmd/main.go
+++ b/projects/gloo/cmd/main.go
@@ -2,21 +2,14 @@ package main
 
 import (
 	"context"
-	"os"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/setup"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/stats"
 )
 
-const (
-	START_STATS_SERVER = "START_STATS_SERVER"
-)
-
 func main() {
-	if os.Getenv(START_STATS_SERVER) != "" {
-		stats.StartStatsServer()
-	}
+	stats.ConditionallyStartStatsServer()
 
 	if err := setup.Main(context.Background()); err != nil {
 		log.Fatalf("err in main: %v", err.Error())


### PR DESCRIPTION
* Relaxes semver validation in changelog validation
* Updates go-utils to handle `validation.yaml` living in the changelog directory
* Adds placeholder changelogs to ensure that the our changelog bot validation points us towards the next desired release tag.

We are skipping `v1.2.13` and `v1.2.14`, which were released off of master instead of this branch.