### PR TITLE
Fix matcher attribute name in docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ generated-code: $(OUTPUT_DIR)/.generated-code verify-enterprise-protos update-li
 SUBDIRS:=$(shell ls -d -- */ | grep -v vendor)
 $(OUTPUT_DIR)/.generated-code:
 	go mod tidy
-	find * -type f | grep .sk.md | xargs --no-run-if-empty rm
+	find * -type f | grep .sk.md | xargs rm
 	rm docs/content/cli/glooctl*; GO111MODULE=on go run projects/gloo/cli/cmd/docs/main.go
 	GO111MODULE=on go generate ./...
 	gofmt -w $(SUBDIRS)

--- a/changelog/v1.3.1/matcher-to-matchers.yaml
+++ b/changelog/v1.3.1/matcher-to-matchers.yaml
@@ -1,4 +1,0 @@
-changelog:
-- type: NON_USER_FACING
-  description: Fix occurrences of `matcher` (singluar) in the docs.
-  issueLink: https://github.com/solo-io/gloo/issues/2078

--- a/changelog/v1.3.1/matcher-to-matchers.yaml
+++ b/changelog/v1.3.1/matcher-to-matchers.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Fix occurrences of `matcher` (singluar) in the docs.
+  issueLink: https://github.com/solo-io/gloo/issues/2078

--- a/changelog/v1.3.2/matcher-to-matchers.yaml
+++ b/changelog/v1.3.2/matcher-to-matchers.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Fix occurrences of `matcher` (singluar) in the docs.
+  issueLink: https://github.com/solo-io/gloo/issues/2078

--- a/docs/content/api/github.com/solo-io/gloo/projects/gateway/api/v1/route_table.proto.sk.md
+++ b/docs/content/api/github.com/solo-io/gloo/projects/gateway/api/v1/route_table.proto.sk.md
@@ -76,13 +76,13 @@ spec:
     domains:
     - 'any.com'
     routes:
-    - matcher:
-        prefix: '/a' # delegate ownership of routes for `any.com/a`
+    - matchers:
+      - prefix: '/a' # delegate ownership of routes for `any.com/a`
       delegateAction:
         name: 'a-routes'
         namespace: 'a'
-    - matcher:
-        prefix: '/b' # delegate ownership of routes for `any.com/b`
+    - matchers:
+      - prefix: '/b' # delegate ownership of routes for `any.com/b`
       delegateAction:
         name: 'b-routes'
         namespace: 'b'
@@ -99,16 +99,16 @@ metadata:
   namespace: 'a'
 spec:
   routes:
-    - matcher:
+    - matchers:
         # the path matchers in this RouteTable must begin with the prefix `/a/`
-        prefix: '/a/1'
+      - prefix: '/a/1'
       routeAction:
         single:
           upstream:
             name: 'foo-upstream'
 
-    - matcher:
-        prefix: '/a/2'
+    - matchers:
+      - prefix: '/a/2'
       routeAction:
         single:
           upstream:
@@ -125,15 +125,15 @@ metadata:
   namespace: 'b'
 spec:
   routes:
-    - matcher:
+    - matchers:
         # the path matchers in this RouteTable must begin with the prefix `/b/`
-        regex: '/b/3'
+      - regex: '/b/3'
       routeAction:
         single:
           upstream:
             name: 'bar-upstream'
-    - matcher:
-        prefix: '/b/c/'
+    - matchers:
+      - prefix: '/b/c/'
       # routes in the RouteTable can perform any action, including a delegateAction
       delegateAction:
         name: 'c-routes'
@@ -152,8 +152,8 @@ metadata:
   namespace: 'c'
 spec:
   routes:
-    - matcher:
-        exact: '/b/c/4'
+    - matchers:
+      - exact: '/b/c/4'
       routeAction:
         single:
           upstream:

--- a/docs/content/api/github.com/solo-io/gloo/projects/gateway/api/v1/virtual_service.proto.sk.md
+++ b/docs/content/api/github.com/solo-io/gloo/projects/gateway/api/v1/virtual_service.proto.sk.md
@@ -57,8 +57,8 @@ spec:
     - '*.mydomain.com'
     - 'mydomain.com'
     routes:
-    - matcher:
-        prefix: '/'
+    - matchers:
+      - prefix: '/'
       # delegate all traffic to the `shared-routes` RouteTable
       delegateAction:
         name: 'shared-routes'
@@ -79,8 +79,8 @@ spec:
     - '*.mydomain.com'
     - 'mydomain.com'
     routes:
-    - matcher:
-        prefix: '/'
+    - matchers:
+      - prefix: '/'
       # delegate all traffic to the `shared-routes` RouteTable
       delegateAction:
         name: 'shared-routes'
@@ -101,8 +101,8 @@ metadata:
   namespace: 'usernamespace'
 spec:
   routes:
-    - matcher:
-        prefix: '/some-route'
+    - matchers:
+      - prefix: '/some-route'
       routeAction:
         single:
           upstream:

--- a/docs/content/gloo_integrations/cert_manager/_index.md
+++ b/docs/content/gloo_integrations/cert_manager/_index.md
@@ -168,7 +168,7 @@ spec:
   virtualHost:
     routes:
     - matchers:
-       - prefix: /
+      - prefix: /
       route_action:
         single:
           upstream:

--- a/docs/content/gloo_routing/validation/_index.md
+++ b/docs/content/gloo_routing/validation/_index.md
@@ -111,7 +111,6 @@ spec:
 
 Once these are applied to the cluster, we can test that validation is enabled:
 
-
 ```bash
 kubectl apply -f - <<EOF
 apiVersion: gateway.solo.io/v1
@@ -123,7 +122,8 @@ spec:
   virtualHost:
     routes:
       # this route is missing a path specifier and will be rejected
-      - matcher: {}
+      - matchers:
+        - prefix: /
         routeAction:
           single:
             upstream:

--- a/docs/content/gloo_routing/virtual_services/https_redirect.md
+++ b/docs/content/gloo_routing/virtual_services/https_redirect.md
@@ -44,8 +44,8 @@ spec:
     domains:
     - docs.solo.io
     routes:
-    - matcher:
-        prefix: /
+    - matchers:
+      - prefix: /
       redirectAction:
         hostRedirect: docs.solo.io
         httpsRedirect: true
@@ -67,6 +67,6 @@ spec:
     domains:
     - 'docs.solo.io'
     routes:
-    - matcher:
+    - matchers:
 # (put the https routes here)
 {{< /highlight >}}

--- a/docs/content/observability/tracing.md
+++ b/docs/content/observability/tracing.md
@@ -154,8 +154,8 @@ spec:
     domains:
     - '*'
     routes:
-    - matcher:
-        exact: /abc
+    - matchers:
+      - exact: /abc
       routeAction:
         single:
           upstream:

--- a/docs/content/security/auth/configuration_format_history/_index.md
+++ b/docs/content/security/auth/configuration_format_history/_index.md
@@ -87,8 +87,8 @@ spec:
               name: basic-auth # Default auth config for this virtual host and all its child resources
               namespace: gloo-system
     routes:
-    - matcher:
-        prefix: /super-secret
+    - matchers:
+      - prefix: /super-secret
       routeAction:
         single:
           upstream:
@@ -100,8 +100,8 @@ spec:
             extauth:
               name: admin-auth # More specific config overwrites the parent default
               namespace: gloo-system
-    - matcher:
-        prefix: /public
+    - matchers:
+      - prefix: /public
       routeAction:
         single:
           upstream:
@@ -112,8 +112,8 @@ spec:
           configs:
             extauth:
               disable: true # Disable auth for this route
-    - matcher:
-        prefix: /
+    - matchers:
+      - prefix: /
       routeAction:
         single:
           upstream:
@@ -146,8 +146,8 @@ spec:
     domains:
       - 'foo's
     routes:
-      - matcher:
-          prefix: /authenticated
+      - matchers:
+        - prefix: /authenticated
         routeAction:
           single:
             upstream:
@@ -188,8 +188,8 @@ spec:
     domains:
       - 'foo's
     routes:
-      - matcher:
-          prefix: /authenticated
+      - matchers:
+        - prefix: /authenticated
         routeAction:
           single:
             upstream:
@@ -221,15 +221,15 @@ spec:
     domains:
       - 'foo'
     routes:
-      - matcher:
-          prefix: /authenticated
+      - matchers:
+        - prefix: /authenticated
         routeAction:
           single:
             upstream:
               name: my-upstream
               namespace: gloo-system
-      - matcher:
-          prefix: /skip-auth
+      - matchers:
+        - prefix: /skip-auth
         routeAction:
           single:
             upstream:

--- a/docs/examples/session-affinity/sample_gloo_config/vs.yaml
+++ b/docs/examples/session-affinity/sample_gloo_config/vs.yaml
@@ -9,8 +9,8 @@ spec:
     - '*'
     name: gloo-system.default
     routes:
-    - matcher:
-        exact: /p1
+    - matchers:
+      - exact: /p1
       routeAction:
         single:
           upstream:

--- a/docs/install/sample_virtualservice.yaml
+++ b/docs/install/sample_virtualservice.yaml
@@ -8,15 +8,15 @@ spec:
     domains:
     - 'docs.solo.io'
     routes:
-    - matcher:
-        prefix: /vabc10/
+    - matchers:
+      - prefix: /vabc10/
       routeAction:
         single:
           upstream:
             name: docs-gloo-docs-vabc10-80
             namespace: gloo-system
-    - matcher:
-        prefix: /vabc11/
+    - matchers:
+      - prefix: /vabc11/
       routeAction:
         single:
           upstream:

--- a/projects/examples/services/sleeper/README.md
+++ b/projects/examples/services/sleeper/README.md
@@ -20,8 +20,8 @@ curl localhost:8080/?time=100s
     domains:
     - '*'
     routes:
-    - matcher:
-        prefix: /sleep
+    - matchers:
+      - prefix: /sleep
       routeAction:
         single:
           upstream:
@@ -52,8 +52,8 @@ curl localhost:8080/?time=100s
     domains:
     - '*'
     routes:
-    - matcher:
-        prefix: /sleep
+    - matchers:
+      - prefix: /sleep
       routeAction:
         single:
           upstream:
@@ -68,8 +68,8 @@ curl localhost:8080/?time=100s
     domains:
     - '*'
     routes:
-    - matcher:
-        prefix: /sleep
+    - matchers:
+      - prefix: /sleep
       redirectAction:
         hostRedirect: solo.io
 ```

--- a/projects/gateway/api/v1/route_table.proto
+++ b/projects/gateway/api/v1/route_table.proto
@@ -65,13 +65,13 @@ import "gloo/projects/gateway/api/v1/virtual_service.proto";
 *     domains:
 *     - 'any.com'
 *     routes:
-*     - matcher:
-*         prefix: '/a' # delegate ownership of routes for `any.com/a`
+*     - matchers:
+*       - prefix: '/a' # delegate ownership of routes for `any.com/a`
 *       delegateAction:
 *         name: 'a-routes'
 *         namespace: 'a'
-*     - matcher:
-*         prefix: '/b' # delegate ownership of routes for `any.com/b`
+*     - matchers:
+*       - prefix: '/b' # delegate ownership of routes for `any.com/b`
 *       delegateAction:
 *         name: 'b-routes'
 *         namespace: 'b'
@@ -88,16 +88,16 @@ import "gloo/projects/gateway/api/v1/virtual_service.proto";
 *   namespace: 'a'
 * spec:
 *   routes:
-*     - matcher:
+*     - matchers:
 *         # the path matchers in this RouteTable must begin with the prefix `/a/`
-*         prefix: '/a/1'
+*       - prefix: '/a/1'
 *       routeAction:
 *         single:
 *           upstream:
 *             name: 'foo-upstream'
 *
-*     - matcher:
-*         prefix: '/a/2'
+*     - matchers:
+*       - prefix: '/a/2'
 *       routeAction:
 *         single:
 *           upstream:
@@ -114,15 +114,15 @@ import "gloo/projects/gateway/api/v1/virtual_service.proto";
 *   namespace: 'b'
 * spec:
 *   routes:
-*     - matcher:
+*     - matchers:
 *         # the path matchers in this RouteTable must begin with the prefix `/b/`
-*         regex: '/b/3'
+*       - regex: '/b/3'
 *       routeAction:
 *         single:
 *           upstream:
 *             name: 'bar-upstream'
-*     - matcher:
-*         prefix: '/b/c/'
+*     - matchers:
+*       - prefix: '/b/c/'
 *       # routes in the RouteTable can perform any action, including a delegateAction
 *       delegateAction:
 *         name: 'c-routes'
@@ -141,8 +141,8 @@ import "gloo/projects/gateway/api/v1/virtual_service.proto";
 *   namespace: 'c'
 * spec:
 *   routes:
-*     - matcher:
-*         exact: '/b/c/4'
+*     - matchers:
+*       - exact: '/b/c/4'
 *       routeAction:
 *         single:
 *           upstream:

--- a/projects/gateway/api/v1/virtual_service.proto
+++ b/projects/gateway/api/v1/virtual_service.proto
@@ -48,8 +48,8 @@ import "gloo/projects/gloo/api/v1/core/matchers/matchers.proto";
 *     - '*.mydomain.com'
 *     - 'mydomain.com'
 *     routes:
-*     - matcher:
-*         prefix: '/'
+*     - matchers:
+*       - prefix: '/'
 *       # delegate all traffic to the `shared-routes` RouteTable
 *       delegateAction:
 *         name: 'shared-routes'
@@ -70,8 +70,8 @@ import "gloo/projects/gloo/api/v1/core/matchers/matchers.proto";
 *     - '*.mydomain.com'
 *     - 'mydomain.com'
 *     routes:
-*     - matcher:
-*         prefix: '/'
+*     - matchers:
+*       - prefix: '/'
 *       # delegate all traffic to the `shared-routes` RouteTable
 *       delegateAction:
 *         name: 'shared-routes'
@@ -92,8 +92,8 @@ import "gloo/projects/gloo/api/v1/core/matchers/matchers.proto";
 *   namespace: 'usernamespace'
 * spec:
 *   routes:
-*     - matcher:
-*         prefix: '/some-route'
+*     - matchers:
+*       - prefix: '/some-route'
 *       routeAction:
 *         single:
 *           upstream:

--- a/projects/gateway/pkg/api/v1/route_table.pb.go
+++ b/projects/gateway/pkg/api/v1/route_table.pb.go
@@ -77,13 +77,13 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //     domains:
 //     - 'any.com'
 //     routes:
-//     - matcher:
-//         prefix: '/a' # delegate ownership of routes for `any.com/a`
+//     - matchers:
+//       - prefix: '/a' # delegate ownership of routes for `any.com/a`
 //       delegateAction:
 //         name: 'a-routes'
 //         namespace: 'a'
-//     - matcher:
-//         prefix: '/b' # delegate ownership of routes for `any.com/b`
+//     - matchers:
+//       - prefix: '/b' # delegate ownership of routes for `any.com/b`
 //       delegateAction:
 //         name: 'b-routes'
 //         namespace: 'b'
@@ -100,16 +100,16 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   namespace: 'a'
 // spec:
 //   routes:
-//     - matcher:
+//     - matchers:
 //         # the path matchers in this RouteTable must begin with the prefix `/a/`
-//         prefix: '/a/1'
+//       - prefix: '/a/1'
 //       routeAction:
 //         single:
 //           upstream:
 //             name: 'foo-upstream'
 //
-//     - matcher:
-//         prefix: '/a/2'
+//     - matchers:
+//       - prefix: '/a/2'
 //       routeAction:
 //         single:
 //           upstream:
@@ -126,15 +126,15 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   namespace: 'b'
 // spec:
 //   routes:
-//     - matcher:
+//     - matchers:
 //         # the path matchers in this RouteTable must begin with the prefix `/b/`
-//         regex: '/b/3'
+//       - regex: '/b/3'
 //       routeAction:
 //         single:
 //           upstream:
 //             name: 'bar-upstream'
-//     - matcher:
-//         prefix: '/b/c/'
+//     - matchers:
+//       - prefix: '/b/c/'
 //       # routes in the RouteTable can perform any action, including a delegateAction
 //       delegateAction:
 //         name: 'c-routes'
@@ -153,8 +153,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   namespace: 'c'
 // spec:
 //   routes:
-//     - matcher:
-//         exact: '/b/c/4'
+//     - matchers:
+//       - exact: '/b/c/4'
 //       routeAction:
 //         single:
 //           upstream:

--- a/projects/gateway/pkg/api/v1/virtual_service.pb.go
+++ b/projects/gateway/pkg/api/v1/virtual_service.pb.go
@@ -58,8 +58,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //     - '*.mydomain.com'
 //     - 'mydomain.com'
 //     routes:
-//     - matcher:
-//         prefix: '/'
+//     - matchers:
+//       - prefix: '/'
 //       # delegate all traffic to the `shared-routes` RouteTable
 //       delegateAction:
 //         name: 'shared-routes'
@@ -80,8 +80,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //     - '*.mydomain.com'
 //     - 'mydomain.com'
 //     routes:
-//     - matcher:
-//         prefix: '/'
+//     - matchers:
+//       - prefix: '/'
 //       # delegate all traffic to the `shared-routes` RouteTable
 //       delegateAction:
 //         name: 'shared-routes'
@@ -102,8 +102,8 @@ const _ = proto.GoGoProtoPackageIsVersion3 // please upgrade the proto package
 //   namespace: 'usernamespace'
 // spec:
 //   routes:
-//     - matcher:
-//         prefix: '/some-route'
+//     - matchers:
+//       - prefix: '/some-route'
 //       routeAction:
 //         single:
 //           upstream:


### PR DESCRIPTION
Fix occurrences of `matcher` (singular) in the docs. The v1 API changed this attribute to `matchers`.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2078