### PR TITLE
Fix broken go-utils/errors import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ BUILD_ID := $(BUILD_ID)
 TEST_ASSET_DIR := $(ROOTDIR)/_test
 
 #----------------------------------------------------------------------------------
-# Marcos
+# Macros
 #----------------------------------------------------------------------------------
 
 # This macro takes a relative path as its only argument and returns all the files

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -126,7 +126,7 @@ steps:
   - 'DOCKER_CONFIG=/workspace/.docker/'
   - 'HELM_HOME=/root/.helm'
   dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=10', '--noColor']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '--noColor']
   waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-test-zone', 'get-test-credentials']
   secretEnv: ['AWS_ARN_ROLE_1']
   id: 'test'

--- a/projects/gateway/pkg/validation/notification_channel.go
+++ b/projects/gateway/pkg/validation/notification_channel.go
@@ -3,9 +3,9 @@ package validation
 import (
 	"context"
 
+	errors "github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	"github.com/solo-io/go-utils/contextutils"
-	"github.com/solo-io/go-utils/errors"
 	"go.uber.org/zap"
 )
 

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -496,7 +496,7 @@ func routesContainRefs(list []*v1.Route, refs refSet) bool {
 
 		var routeTableRef *core.ResourceRef
 		// handle deprecated route table resource reference format
-		// TODO: remove when we remove the deprecated fields from the API
+		// TODO(marco): remove when we remove the deprecated fields from the API
 		if delegate.Namespace != "" || delegate.Name != "" {
 			routeTableRef = &core.ResourceRef{
 				Namespace: delegate.Namespace,
@@ -505,8 +505,9 @@ func routesContainRefs(list []*v1.Route, refs refSet) bool {
 		} else {
 			switch selectorType := delegate.GetDelegationType().(type) {
 			case *v1.DelegateAction_Selector:
-				// TODO(marco): handle selector
-				break
+				// Selectors do not represent hard referential constraints, i.e. we can safely remove
+				// a route table even when it is matches by one or more selectors. Hence, skip this check.
+				continue
 			case *v1.DelegateAction_Ref:
 				routeTableRef = selectorType.Ref
 			}


### PR DESCRIPTION
A bad merge resulted in a leftover reference to the  `github.com/solo-io/go-utils/errors` package, which does not exist anymore.