### PR TITLE
Fix occurrences of `matcher` attribute in docs

### DIFF
--- a/docs/content/observability/tracing.md
+++ b/docs/content/observability/tracing.md
@@ -154,8 +154,8 @@ spec:
     domains:
     - '*'
     routes:
-    - matcher:
-        exact: /abc
+    - matchers:
+      - exact: /abc
       routeAction:
         single:
           upstream:

--- a/docs/examples/session-affinity/sample_gloo_config/vs.yaml
+++ b/docs/examples/session-affinity/sample_gloo_config/vs.yaml
@@ -9,8 +9,8 @@ spec:
     - '*'
     name: gloo-system.default
     routes:
-    - matcher:
-        exact: /p1
+    - matchers:
+      - exact: /p1
       routeAction:
         single:
           upstream:

--- a/docs/install/sample_virtualservice.yaml
+++ b/docs/install/sample_virtualservice.yaml
@@ -8,15 +8,15 @@ spec:
     domains:
     - 'docs.solo.io'
     routes:
-    - matcher:
-        prefix: /vabc10/
+    - matchers:
+      - prefix: /vabc10/
       routeAction:
         single:
           upstream:
             name: docs-gloo-docs-vabc10-80
             namespace: gloo-system
-    - matcher:
-        prefix: /vabc11/
+    - matchers:
+      - prefix: /vabc11/
       routeAction:
         single:
           upstream:

--- a/projects/examples/services/sleeper/README.md
+++ b/projects/examples/services/sleeper/README.md
@@ -20,8 +20,8 @@ curl localhost:8080/?time=100s
     domains:
     - '*'
     routes:
-    - matcher:
-        prefix: /sleep
+    - matchers:
+      - prefix: /sleep
       routeAction:
         single:
           upstream:
@@ -52,8 +52,8 @@ curl localhost:8080/?time=100s
     domains:
     - '*'
     routes:
-    - matcher:
-        prefix: /sleep
+    - matchers:
+      - prefix: /sleep
       routeAction:
         single:
           upstream:
@@ -68,8 +68,8 @@ curl localhost:8080/?time=100s
     domains:
     - '*'
     routes:
-    - matcher:
-        prefix: /sleep
+    - matchers:
+      - prefix: /sleep
       redirectAction:
         hostRedirect: solo.io
 ```


### PR DESCRIPTION
Fix occurrences of `matcher` (singular) in the docs.