### PR TITLE
Make Route Tables filtering function public

### DIFF
--- a/changelog/v1.3.2/route-table-merging.yaml
+++ b/changelog/v1.3.2/route-table-merging.yaml
@@ -1,9 +1,23 @@
 changelog:
 - type: NEW_FEATURE
   description: >
-    Update the delegation API to support delegating to multiple route tables. Route tables to delegate to can be
-    selected by either namespaces, labels, or both, using the new `RouteTableSelector` field.
-    The routes of all matching route tables will be merged and the resulting route set will be sorted by descending
-    specificity of the matchers on each route, i.e. matchers with longer prefixes will appear first (delegated routes can only have prefix matchers).
+    Update the Delegation API to support delegating routing decisions to multiple `RouteTables`. `RouteTables` to
+    delegate to can be selected by either namespaces, labels, or both, using the new `RouteTableSelector` field.
+    The routes of all matching `RouteTables` will be merged and the resulting route set will be sorted by descending
+    specificity of the matchers on each route, e.g. matchers with longer prefixes will appear first.
+    This feature is meant to replace the __virtual service merging__ feature that we deprecated with the stable v1
+    release of Gloo. __Virtual service merging__ allowed users to define multiple `VirtualServices` for the same domain,
+    which Gloo would then merge into a single `VirtualHost` on the `Proxy` resource. Although useful to many users,
+    this feature could lead to confusion: the API is not self-documenting with respect to the merging behavior and
+    multiple users could inadvertently step on each other's toes when defining routes for the same domain.
+    As of this release, __virtual service merging__ is not supported anymore; defining two virtual services with
+    overlapping domain sets **will result in an error**. To be able to define the routes for a given domain on different
+    resources, users can now use the Delegation API. With the new `RouteTableSelector` attribute, the Delegation API
+    now enables the same use cases as __virtual service merging__ and has the advantage of surfacing the fact that
+    multiple resources define routes for the same domains to the API.
+    To give a simple example, a Gloo administrator can define a `VirtualService` with a single route that delegates
+    all requests for a domain to any `RouteTables` that have the `domain: example.com` label (namespaces to search
+    can be configured as well); this will allow users to add routes for that domain by creating their own `RouteTables`
+    (with a `domain: example.com` label) without having to request updates to the parent `VirtualService`.
   issueLink: https://github.com/solo-io/gloo/issues/2054
   resolvesIssue: false

--- a/changelog/v1.3.3/public-route-table-selection-func.yaml
+++ b/changelog/v1.3.3/public-route-table-selection-func.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Make the utility function to filter `RouteTables` by a `selector` public.

--- a/projects/gateway/pkg/translator/route_converter.go
+++ b/projects/gateway/pkg/translator/route_converter.go
@@ -193,7 +193,7 @@ func (rv *routeVisitor) selectRouteTables(delegateAction *gatewayv1.DelegateActi
 		routeTables = gatewayv1.RouteTableList{routeTable}
 
 	} else if rtSelector := delegateAction.GetSelector(); rtSelector != nil {
-		routeTables = routeTablesForSelector(rv.tables, rtSelector, rv.rootResource.GetMetadata().Namespace)
+		routeTables = RouteTablesForSelector(rv.tables, rtSelector, rv.rootResource.GetMetadata().Namespace)
 
 		if len(routeTables) == 0 {
 			rv.addWarning(NoMatchingRouteTablesWarning)
@@ -298,7 +298,9 @@ func getRouteTableRef(delegate *gatewayv1.DelegateAction) *core.ResourceRef {
 	return delegate.GetRef()
 }
 
-func routeTablesForSelector(routeTables gatewayv1.RouteTableList, selector *gatewayv1.RouteTableSelector, ownerNamespace string) gatewayv1.RouteTableList {
+// Returns the subset of `routeTables` that matches the given `selector`.
+// Search will be restricted to the `ownerNamespace` if the selector does not specify any namespaces.
+func RouteTablesForSelector(routeTables gatewayv1.RouteTableList, selector *gatewayv1.RouteTableSelector, ownerNamespace string) gatewayv1.RouteTableList {
 	type nsSelectorType int
 	const (
 		// Match route tables in the owner namespace


### PR DESCRIPTION
Also updated the changelog for the new route table selector feature to provide more details, hence the `skip-changelog`.