### PR TITLE
Fix default branch detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ ifeq ($(ON_DEFAULT_BRANCH_HEAD), "true")
 endif
 
 print-git-info:
+	@echo Stupid diff
 	@echo CHECKED_OUT_SHA: $(CHECKED_OUT_SHA)
 	@echo DEFAULT_BRANCH_REF: $(DEFAULT_BRANCH_REF)
 	@echo DEFAULT_BRANCH_HEAD_SHA: $(DEFAULT_BRANCH_HEAD_SHA)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,6 @@ ifeq ($(ON_DEFAULT_BRANCH_HEAD), "true")
 endif
 
 print-git-info:
-	@echo Stupid diff
 	@echo CHECKED_OUT_SHA: $(CHECKED_OUT_SHA)
 	@echo DEFAULT_BRANCH_REF: $(DEFAULT_BRANCH_REF)
 	@echo DEFAULT_BRANCH_HEAD_SHA: $(DEFAULT_BRANCH_HEAD_SHA)

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ DEFAULT_BRANCH_NAME := $(shell git symbolic-ref refs/remotes/origin/HEAD | sed '
 # If we get back a result, it mean we are on the default branch.
 EMPTY_IF_NOT_DEFAULT := $(shell git branch --contains $(CHECKED_OUT_SHA) | grep -ow $(DEFAULT_BRANCH_NAME))
 
-# If commit is also the HEAD of the remote default branch, then we are on the default branch.
 ON_DEFAULT_BRANCH := false
 ifneq ($(EMPTY_IF_NOT_DEFAULT),)
     ON_DEFAULT_BRANCH = true

--- a/changelog/v1.3.3/fix-default-branch-detection.yaml
+++ b/changelog/v1.3.3/fix-default-branch-detection.yaml
@@ -1,4 +1,4 @@
 changelog:
 - type: FIX
   description: Fix logic to determine whether we are on the default branch.
-  issueLink: https://github.com/solo-io/gloo/issues/2159
+  issueLink: https://github.com/solo-io/gloo/issues/2220

--- a/changelog/v1.3.3/fix-default-branch-detection.yaml
+++ b/changelog/v1.3.3/fix-default-branch-detection.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Fix logic to determine whether we are on the default branch.
+  issueLink: https://github.com/solo-io/gloo/issues/2159

--- a/projects/gloo/pkg/plugins/wasm/mocks/mock_cache.go
+++ b/projects/gloo/pkg/plugins/wasm/mocks/mock_cache.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	go_digest "github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // MockCache is a mock of Cache interface
@@ -38,10 +38,10 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // Add mocks base method
-func (m *MockCache) Add(arg0 context.Context, arg1 string) (go_digest.Digest, error) {
+func (m *MockCache) Add(arg0 context.Context, arg1 string) (digest.Digest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Add", arg0, arg1)
-	ret0, _ := ret[0].(go_digest.Digest)
+	ret0, _ := ret[0].(digest.Digest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -53,7 +53,7 @@ func (mr *MockCacheMockRecorder) Add(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockCache) Get(arg0 context.Context, arg1 go_digest.Digest) (io.ReadCloser, error) {
+func (m *MockCache) Get(arg0 context.Context, arg1 digest.Digest) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(io.ReadCloser)

--- a/projects/metrics/pkg/metricsservice/mocks/mock_metrics_stream.go
+++ b/projects/metrics/pkg/metricsservice/mocks/mock_metrics_stream.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v2"
+	envoy_service_metrics_v2 "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v2"
 	gomock "github.com/golang/mock/gomock"
 	metadata "google.golang.org/grpc/metadata"
 )
@@ -51,10 +51,10 @@ func (mr *MockMetricsService_StreamMetricsServerMockRecorder) Context() *gomock.
 }
 
 // Recv mocks base method
-func (m *MockMetricsService_StreamMetricsServer) Recv() (*v2.StreamMetricsMessage, error) {
+func (m *MockMetricsService_StreamMetricsServer) Recv() (*envoy_service_metrics_v2.StreamMetricsMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Recv")
-	ret0, _ := ret[0].(*v2.StreamMetricsMessage)
+	ret0, _ := ret[0].(*envoy_service_metrics_v2.StreamMetricsMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -80,7 +80,7 @@ func (mr *MockMetricsService_StreamMetricsServerMockRecorder) RecvMsg(arg0 inter
 }
 
 // SendAndClose mocks base method
-func (m *MockMetricsService_StreamMetricsServer) SendAndClose(arg0 *v2.StreamMetricsResponse) error {
+func (m *MockMetricsService_StreamMetricsServer) SendAndClose(arg0 *envoy_service_metrics_v2.StreamMetricsResponse) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendAndClose", arg0)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
The problem with the previous version of this check was that in CI we check out a commit by its SHA (not by branch name) which puts the repo in a detached HEAD state, which in turn causes 

```make
CURRENT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD)
```

to evaluate to `HEAD` instead of the branch name.

This caused `ASSETS_ONLY` to always be true:

```make
ASSETS_ONLY := true
# This would be: if "master" == "HEAD"
ifeq ($(DEFAULT_BRANCH), $(CURRENT_BRANCH))
    ASSETS_ONLY = false
endif
```




BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2220