### PR TITLE
Fix install error on release versions of glooctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ z := $(shell mkdir -p $(OUTPUT_DIR))
 SOURCES := $(shell find . -name "*.go" | grep -v test.go | grep -v '\.\#*')
 RELEASE := "true"
 ifeq ($(TAGGED_VERSION),)
-	TAGGED_VERSION := $(shell git describe --tags --dirty --always)
+	TAGGED_VERSION := $(shell git describe --tags --dirty)
 	RELEASE := "false"
 endif
 VERSION ?= $(shell echo $(TAGGED_VERSION) | cut -c 2-)

--- a/changelog/v1.3.2/push-helm-chart-to-registry.yaml
+++ b/changelog/v1.3.2/push-helm-chart-to-registry.yaml
@@ -3,6 +3,6 @@ changelog:
     description: >
       Publish helm charts for all CI builds (not just releases) to make it easier
       to test projects built on non-release versions of Gloo. Images will be tagged
-      with the output of `git describe --tags --dirty --always`.
+      with the output of `git describe --tags --dirty`.
       Helm charts can then be pulled with: `HELM_EXPERIMENTAL_OCI helm pull gcr.io/solo-public/gloo-helm:<tag_name>`.
     issueLink: https://github.com/solo-io/gloo/issues/2074

--- a/changelog/v1.3.2/push-images-all-builds.yaml
+++ b/changelog/v1.3.2/push-images-all-builds.yaml
@@ -3,5 +3,5 @@ changelog:
     description: >
       Publish container images for all CI builds (not just releases) to make it easier
       to test projects built on non-release versions of Gloo. Images will be tagged
-      with the output of git describe --tags --dirty --always.
+      with the output of git describe --tags --dirty.
     issueLink: https://github.com/solo-io/gloo/issues/2074

--- a/changelog/v1.3.3/fix-glooctl-install.yaml
+++ b/changelog/v1.3.3/fix-glooctl-install.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix `glooctl install` command when `-f` flag is omitted to no longer error erroneously.
+    issueLink: https://github.com/solo-io/gloo/issues/508

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -91,11 +91,7 @@ func generateValuesYaml(version, repositoryPrefix, globalPullPolicy string) erro
 	}
 
 	// customize config as needed for dev builds
-	isReleaseVersion, err := glooVersion.IsReleaseVersion()
-	if err != nil {
-		return err
-	}
-	if !isReleaseVersion {
+	if !glooVersion.IsReleaseVersion() {
 		cfg.Gloo.Deployment.Image.PullPolicy = always
 		cfg.Discovery.Deployment.Image.PullPolicy = always
 		cfg.Gateway.Deployment.Image.PullPolicy = always

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -45,8 +45,7 @@ func TestHelm(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	version = os.Getenv("TAGGED_VERSION")
-	isReleaseVersion, err := glooVersion.IsReleaseVersion()
-	Expect(err).NotTo(HaveOccurred())
+	isReleaseVersion := glooVersion.IsReleaseVersion()
 	if !isReleaseVersion {
 		vVersion, err := glooVersion.VersionFromGitDescribe()
 		Expect(err).NotTo(HaveOccurred())

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -7,6 +7,8 @@ import (
 	"path"
 	"testing"
 
+	"github.com/solo-io/go-utils/versionutils/git"
+
 	glooVersion "github.com/solo-io/gloo/pkg/version"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
@@ -46,10 +48,10 @@ func TestHelm(t *testing.T) {
 var _ = BeforeSuite(func() {
 	version = os.Getenv("TAGGED_VERSION")
 	if !glooVersion.IsReleaseVersion() {
-		vVersion, err := glooVersion.VersionFromGitDescribe()
+		gitInfo, err := git.GetGitRefInfo("./")
 		Expect(err).NotTo(HaveOccurred())
 		// remove the "v" prefix
-		version = vVersion[1:]
+		version = gitInfo.Tag[1:]
 		pullPolicy = v1.PullAlways
 	} else {
 		version = version[1:]

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -45,8 +45,7 @@ func TestHelm(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	version = os.Getenv("TAGGED_VERSION")
-	isReleaseVersion := glooVersion.IsReleaseVersion()
-	if !isReleaseVersion {
+	if !glooVersion.IsReleaseVersion() {
 		vVersion, err := glooVersion.VersionFromGitDescribe()
 		Expect(err).NotTo(HaveOccurred())
 		// remove the "v" prefix

--- a/pkg/version/linked.go
+++ b/pkg/version/linked.go
@@ -1,21 +1,13 @@
 package version
 
 import (
-	"bytes"
-	"os/exec"
 	"strings"
-
-	"github.com/rotisserie/eris"
 )
 
 var UndefinedVersion = "undefined"
 
 // This will be set by the linker during build
 var Version = UndefinedVersion
-
-var InvalidVersionError = func(err error) error {
-	return eris.Wrapf(err, "invalid version")
-}
 
 func IsReleaseVersion() bool {
 	if Version == UndefinedVersion {
@@ -25,18 +17,4 @@ func IsReleaseVersion() bool {
 	// thus if we can split the version into more than one part, then it is not a release version
 	parts := strings.Split(Version, "-")
 	return len(parts) == 1
-}
-
-// VersionFromGitDescribe is the canonical means of deriving
-func VersionFromGitDescribe() (string, error) {
-	cmd := exec.Command("git", "describe", "--tags", "--dirty", "--always")
-	outBuf := bytes.NewBuffer([]byte{})
-	errBuf := bytes.NewBuffer([]byte{})
-	cmd.Stdout = outBuf
-	cmd.Stderr = errBuf
-	err := cmd.Run()
-	if err != nil {
-		return "", InvalidVersionError(err)
-	}
-	return strings.TrimSpace(outBuf.String()), nil
 }

--- a/pkg/version/linked.go
+++ b/pkg/version/linked.go
@@ -1,7 +1,8 @@
 package version
 
 import (
-	"strings"
+	"github.com/solo-io/go-utils/versionutils"
+	"github.com/solo-io/go-utils/versionutils/git"
 )
 
 var UndefinedVersion = "undefined"
@@ -13,8 +14,7 @@ func IsReleaseVersion() bool {
 	if Version == UndefinedVersion {
 		return false
 	}
-	// if not a tagged release, linked version will look like: 1.3.2-8-gc032db6d8
-	// thus if we can split the version into more than one part, then it is not a release version
-	parts := strings.Split(Version, "-")
-	return len(parts) == 1
+	tag := git.AppendTagPrefix(Version)
+	_, err := versionutils.ParseVersion(tag)
+	return err == nil
 }

--- a/pkg/version/linked.go
+++ b/pkg/version/linked.go
@@ -18,7 +18,13 @@ var InvalidVersionError = func(err error) error {
 }
 
 func IsReleaseVersion() bool {
-	return Version != UndefinedVersion
+	if Version == UndefinedVersion {
+		return false
+	}
+	// if not a tagged release, linked version will look like: 1.3.2-8-gc032db6d8
+	// thus if we can split the version into more than one part, then it is not a release version
+	parts := strings.Split(Version, "-")
+	return len(parts) == 1
 }
 
 // VersionFromGitDescribe is the canonical means of deriving

--- a/pkg/version/linked.go
+++ b/pkg/version/linked.go
@@ -17,21 +17,8 @@ var InvalidVersionError = func(err error) error {
 	return eris.Wrapf(err, "invalid version")
 }
 
-func IsReleaseVersion() (bool, error) {
-	atTag, err := checkedoutAtTag()
-	if err != nil {
-		return false, err
-	}
-	return Version != UndefinedVersion && atTag, nil
-}
-
-func checkedoutAtTag() (bool, error) {
-	version, err := VersionFromGitDescribe()
-	if err != nil {
-		return false, err
-	}
-	parts := strings.Split(version, "-")
-	return len(parts) == 1, nil
+func IsReleaseVersion() bool {
+	return Version != UndefinedVersion
 }
 
 // VersionFromGitDescribe is the canonical means of deriving

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -35,6 +35,12 @@ var _ = Describe("Install", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
+	It("should error for gateway dry run on released glooctl with bad linked version", func() {
+		version.Version = "1.3.2-11-g271bd663c" // pretend we set this using linker on a release build of glooctl
+		_, err := testutils.GlooctlOut("install gateway --dry-run")
+		Expect(err).To(MatchError(install.UnreleasedWithoutOverrideErr))
+	})
+
 	It("shouldn't get errors for gateway dry run with file override", func() {
 		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway --file %s --dry-run", file))
 		Expect(err).NotTo(HaveOccurred())

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -18,7 +18,12 @@ var _ = Describe("Install", func() {
 	const licenseKey = "--license-key=fake-license-key"
 	const overrideVersion = "0.20.7"
 
-	It("shouldn't get errors for gateway dry run", func() {
+	It("should error for gateway dry run on unreleased glooctl", func() {
+		_, err := testutils.GlooctlOut("install gateway --dry-run")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("shouldn't get errors for gateway dry run with file override", func() {
 		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway --file %s --dry-run", file))
 		Expect(err).NotTo(HaveOccurred())
 	})

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/solo-io/gloo/pkg/version"
+
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
 
 	"github.com/solo-io/go-utils/testutils/exec"
@@ -18,9 +20,19 @@ var _ = Describe("Install", func() {
 	const licenseKey = "--license-key=fake-license-key"
 	const overrideVersion = "0.20.7"
 
+	BeforeEach(func() {
+		version.Version = version.UndefinedVersion // we're testing an "unreleased" glooctl
+	})
+
 	It("should error for gateway dry run on unreleased glooctl", func() {
 		_, err := testutils.GlooctlOut("install gateway --dry-run")
-		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(install.UnreleasedWithoutOverrideErr))
+	})
+
+	It("shouldn't error for gateway dry run on released glooctl", func() {
+		version.Version = "1.3.2" // pretend we set this using linker on a release build of glooctl
+		_, err := testutils.GlooctlOut("install gateway --dry-run")
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("shouldn't get errors for gateway dry run with file override", func() {

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -309,11 +309,7 @@ func getChartUri(chartOverride, versionOverride string, withUi, enterprise bool)
 }
 
 func getDefaultGlooInstallVersion(chartOverride string) (string, error) {
-	isReleaseVersion, err := version.IsReleaseVersion()
-	if err != nil {
-		return "", err
-	}
-	if !isReleaseVersion && chartOverride == "" {
+	if !version.IsReleaseVersion() && chartOverride == "" {
 		return "", eris.Errorf("you must provide a Gloo Helm chart URI via the 'file' option " +
 			"when running an unreleased version of glooctl")
 	}

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -33,6 +33,8 @@ var (
 	ChartAndReleaseFlagErr = func(chartOverride, versionOverride string) error {
 		return eris.Errorf("you may not specify both a chart with -f and a release version with --version. Received: %s and %s", chartOverride, versionOverride)
 	}
+	UnreleasedWithoutOverrideErr = eris.Errorf("you must provide a Gloo Helm chart URI via the 'file' option " +
+		"when running an unreleased version of glooctl")
 )
 
 type Installer interface {
@@ -310,8 +312,7 @@ func getChartUri(chartOverride, versionOverride string, withUi, enterprise bool)
 
 func getDefaultGlooInstallVersion(chartOverride string) (string, error) {
 	if !version.IsReleaseVersion() && chartOverride == "" {
-		return "", eris.Errorf("you must provide a Gloo Helm chart URI via the 'file' option " +
-			"when running an unreleased version of glooctl")
+		return "", UnreleasedWithoutOverrideErr
 	}
 	return version.Version, nil
 }

--- a/projects/gloo/pkg/plugins/wasm/mocks/mock_cache.go
+++ b/projects/gloo/pkg/plugins/wasm/mocks/mock_cache.go
@@ -11,7 +11,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	go_digest "github.com/opencontainers/go-digest"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // MockCache is a mock of Cache interface
@@ -38,10 +38,10 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // Add mocks base method
-func (m *MockCache) Add(arg0 context.Context, arg1 string) (go_digest.Digest, error) {
+func (m *MockCache) Add(arg0 context.Context, arg1 string) (digest.Digest, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Add", arg0, arg1)
-	ret0, _ := ret[0].(go_digest.Digest)
+	ret0, _ := ret[0].(digest.Digest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -53,7 +53,7 @@ func (mr *MockCacheMockRecorder) Add(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Get mocks base method
-func (m *MockCache) Get(arg0 context.Context, arg1 go_digest.Digest) (io.ReadCloser, error) {
+func (m *MockCache) Get(arg0 context.Context, arg1 digest.Digest) (io.ReadCloser, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Get", arg0, arg1)
 	ret0, _ := ret[0].(io.ReadCloser)

--- a/projects/metrics/pkg/metricsservice/mocks/mock_metrics_stream.go
+++ b/projects/metrics/pkg/metricsservice/mocks/mock_metrics_stream.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v2 "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v2"
+	envoy_service_metrics_v2 "github.com/envoyproxy/go-control-plane/envoy/service/metrics/v2"
 	gomock "github.com/golang/mock/gomock"
 	metadata "google.golang.org/grpc/metadata"
 )
@@ -51,10 +51,10 @@ func (mr *MockMetricsService_StreamMetricsServerMockRecorder) Context() *gomock.
 }
 
 // Recv mocks base method
-func (m *MockMetricsService_StreamMetricsServer) Recv() (*v2.StreamMetricsMessage, error) {
+func (m *MockMetricsService_StreamMetricsServer) Recv() (*envoy_service_metrics_v2.StreamMetricsMessage, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Recv")
-	ret0, _ := ret[0].(*v2.StreamMetricsMessage)
+	ret0, _ := ret[0].(*envoy_service_metrics_v2.StreamMetricsMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -80,7 +80,7 @@ func (mr *MockMetricsService_StreamMetricsServerMockRecorder) RecvMsg(arg0 inter
 }
 
 // SendAndClose mocks base method
-func (m *MockMetricsService_StreamMetricsServer) SendAndClose(arg0 *v2.StreamMetricsResponse) error {
+func (m *MockMetricsService_StreamMetricsServer) SendAndClose(arg0 *envoy_service_metrics_v2.StreamMetricsResponse) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendAndClose", arg0)
 	ret0, _ := ret[0].(error)


### PR DESCRIPTION
Fix `glooctl install` command when `-f` flag is omitted to no longer error erroneously.

The problem was that in https://github.com/solo-io/gloo/pull/2075 we added https://github.com/solo-io/gloo/pull/2075/files#diff-89f8111040160d60e5a3daefca1edcc8R28-R35

`checkedoutAtTag` uses your git context to determine whether or not a build is a release build, rather than using the version linked into the binary. `glooctl install` checks whether or not it is itself a released version of `glooctl` to determine whether users need to use the `-f` flag. Thus, any invocation of `glooctl install` without a valid git context for Gloo would fail.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/508