### PR TITLE
hermetic codegen

### DIFF
--- a/changelog/v1.3.3/fix-hermetic-codegen.yaml
+++ b/changelog/v1.3.3/fix-hermetic-codegen.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Ensure that codegen creates the same mocks every time it is run.
+    issueLink: https://github.com/solo-io/gloo/issues/2239

--- a/pkg/utils/selectionutils/virtual_service.go
+++ b/pkg/utils/selectionutils/virtual_service.go
@@ -12,8 +12,6 @@ import (
 	"go.uber.org/zap"
 )
 
-//go:generate mockgen -destination mocks/mock_virtual_service.go -package mocks github.com/solo-io/gloo/pkg/utils/selectionutils VirtualServiceSelector
-
 type VirtualServiceSelector interface {
 	SelectOrCreateVirtualService(ctx context.Context, ref *core.ResourceRef) (*gatewayv1.VirtualService, error)
 }

--- a/projects/metrics/pkg/metricsservice/service.go
+++ b/projects/metrics/pkg/metricsservice/service.go
@@ -19,8 +19,6 @@ const (
 	ListenerStatPrefix = "listener"
 )
 
-//go:generate mockgen -destination mocks/mock_metrics_stream.go -package mocks github.com/envoyproxy/go-control-plane/envoy/service/metrics/v2 MetricsService_StreamMetricsServer
-
 // server is used to implement envoymet.MetricsServiceServer.
 type Server struct {
 	opts           *Options


### PR DESCRIPTION
When we generate a mock file twice, we cause a race condition. Usually this isn't a problem, unless the different mockgen's have different import aliases, which causes the make code-check step in the cloudbuild.yaml to fail.

This removes the additional mockgen call in two places, which was causing non-hermetic codegen.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2239