### PR TITLE
fix hard-coded cluster.local domain

### DIFF
--- a/changelog/v1.3.3/fix-certgen-domain.yaml
+++ b/changelog/v1.3.3/fix-certgen-domain.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix cert-gen job for clusters using non-default  domain suffix.
+    issueLink: https://github.com/solo-io/gloo/issues/2288

--- a/changelog/v1.3.3/fix-certgen-domain.yaml
+++ b/changelog/v1.3.3/fix-certgen-domain.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: FIX
-    description: Fix cert-gen job for clusters using non-default  domain suffix.
+    description: Fix cert-gen job for clusters using non-default domain suffix.
     issueLink: https://github.com/solo-io/gloo/issues/2288

--- a/jobs/pkg/certgen/gen_certs.go
+++ b/jobs/pkg/certgen/gen_certs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/solo-io/go-utils/certutils"
 	"k8s.io/client-go/util/cert"
+	"knative.dev/pkg/network"
 )
 
 func GenCerts(svcName, svcNamespace string) (*certutils.Certificates, error) {
@@ -17,7 +18,7 @@ func GenCerts(svcName, svcNamespace string) (*certutils.Certificates, error) {
 				svcName,
 				fmt.Sprintf("%s.%s", svcName, svcNamespace),
 				fmt.Sprintf("%s.%s.svc", svcName, svcNamespace),
-				fmt.Sprintf("%s.%s.svc.cluster.local", svcName, svcNamespace),
+				fmt.Sprintf("%s.%s.svc.%s", svcName, svcNamespace, network.GetClusterDomainName()),
 			},
 		},
 		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},


### PR DESCRIPTION
potential bug for validation webhook server with clusters using non-default domain
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2288