### PR TITLE
Remove unnecessary post-upgrade Helm hooks (port to 1.2.x)

### DIFF
--- a/changelog/v1.2.16/fix-more-helm-hooks.yaml
+++ b/changelog/v1.2.16/fix-more-helm-hooks.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Remove unnecessary `post-upgrade` Helm hooks.
+  issueLink: https://github.com/solo-io/gloo/issues/2212

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -109,8 +109,8 @@ rules:
 # on each other (RBAC resources needed by the job), and we cannot write a job to clean them up as this would result
 # in a catch-22 (this second job would in turn need its own RBAC resources and who would clean up those?).
 #
-# To be able to clean up these hook resources, which are needed only temporarily during the pre-install(/upgrade) phase,
-# we redefine them as `post-install(upgrade)` hooks with a `hook-delete-policy`. This way Helm will reapply them and
+# To be able to clean up these hook resources, which are needed only temporarily during the pre-install phase,
+# we redefine them as `post-install` hooks with a `hook-delete-policy`. This way Helm will reapply them and
 # immediately delete them after the installation completes. Note that we have to explicitly define a `before-hook-creation`
 # policy as well, to avoid failing on existing resources (`before-hook-creation` is the default `hook-delete-policy`
 # if none is specified`).
@@ -123,7 +123,7 @@ metadata:
     app: gloo
     gloo: gateway
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "solo.io/hook-cleanup": "true" # Used internally to mark "hook cleanup" resources
   name: gateway-certgen
@@ -140,7 +140,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "solo.io/hook-cleanup": "true" # Used internally to mark "hook cleanup" resources
 subjects:
@@ -163,7 +163,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "solo.io/hook-cleanup": "true" # Used internally to mark "hook cleanup" resources
 rules:

--- a/projects/gloo/cli/pkg/cmd/install/installer_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer_test.go
@@ -58,7 +58,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook": post-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
     "` + constants.HookCleanupResourceAnnotation + `": "true" # Used internally to mark "hook cleanup" resources
 rules:


### PR DESCRIPTION
Port of #2287.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2212