### PR TITLE
Fix plugin manifest example in docs

### DIFF
--- a/changelog/v1.3.3/fix-plugin-manifest-example.yaml
+++ b/changelog/v1.3.3/fix-plugin-manifest-example.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Fix extauth plugin manifest example on docs.
+  issueLink: https://github.com/solo-io/gloo/issues/2294

--- a/docs/content/dev/writing_auth_plugins/_index.md
+++ b/docs/content/dev/writing_auth_plugins/_index.md
@@ -307,20 +307,17 @@ three arguments:
 | Arg Name | Description | Optional |
 | ---- | ----------- | -------- |
 | pluginDir | Path to a directory containing the plugin `.so` files to verify |  No |
-| manifest | A .yaml file containing information required to load the plugins | No |
+| manifest | A .yaml file containing information required to load the plugin | No |
 | debug | Set debug log level | Yes |
 
 The `manifest` file is needed to instruct the script on how to load the plugins. It intentionally has a very similar 
 format as the configuration defined on the `AuthConfig` resource:
 
 ```yaml
-plugins:
-- name: MyPlugin
-  pluginFileName: Plugin.so
-  exportedSymbolName: MyPlugin
-- name: AnotherPlugin
-  plugin_file_name: AnotherFile.so
-  exported_symbol_name: AnotherSymbol
+name: MyPlugin
+pluginFileName: Plugin.so
+exportedSymbolName: MyPlugin
+config: {} # plugin-specific config
 ```
 
 Here is the sample output of a successful run of the script:
@@ -331,7 +328,7 @@ Here is the sample output of a successful run of the script:
 {"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"scripts/verify_plugins.go:62","msg":"Successfully verified that plugins can be loaded by Gloo!"}
 ```
 
-{{% notice note %}}
+{{% notice note %}}s
 The script is compiled to run on `linux` with `amd64` architectures. We will explain how it is supposed to be used in the next section.
 {{% /notice %}}
  

--- a/docs/content/dev/writing_auth_plugins/_index.md
+++ b/docs/content/dev/writing_auth_plugins/_index.md
@@ -328,7 +328,7 @@ Here is the sample output of a successful run of the script:
 {"level":"info","ts":"2019-08-21T17:02:22.803Z","logger":"verify-plugins","caller":"scripts/verify_plugins.go:62","msg":"Successfully verified that plugins can be loaded by Gloo!"}
 ```
 
-{{% notice note %}}s
+{{% notice note %}}
 The script is compiled to run on `linux` with `amd64` architectures. We will explain how it is supposed to be used in the next section.
 {{% /notice %}}
  


### PR DESCRIPTION
Example shows old format for plugin manifests.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2294