### PR TITLE
Expose `disableKubernetesDestinations` setting as Helm chart value

### DIFF
--- a/changelog/v1.3.3/helm-value-to-disable-k8s-dest.yaml
+++ b/changelog/v1.3.3/helm-value-to-disable-k8s-dest.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  description: Expose the `disableKubernetesDestinations` settings field as a Helm chart value.
+  issueLink: https://github.com/solo-io/gloo/issues/2299

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -27,6 +27,7 @@
 |settings.invalidConfigPolicy.invalidRouteResponseCode|int64|404|the response code for the direct response|
 |settings.invalidConfigPolicy.invalidRouteResponseBody|string|Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.|the response body for the direct response|
 |settings.linkerd|bool|false|Enable automatic Linkerd integration in Gloo.|
+|settings.disableKubernetesDestinations|bool|false|Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature, Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them. If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result in significant overhead. If you do not plan on using this feature, you can set this flag to true to turn it off.|
 |gloo.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |gloo.deployment.image.repository|string|gloo|image name (repository) for the container.|
 |gloo.deployment.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -101,14 +101,15 @@ type KnativeProxy struct {
 }
 
 type Settings struct {
-	WatchNamespaces     []string             `json:"watchNamespaces,omitempty" desc:"whitelist of namespaces for gloo to watch for services and CRDs. Empty list means all namespaces"`
-	WriteNamespace      string               `json:"writeNamespace,omitempty" desc:"namespace where intermediary CRDs will be written to, e.g. Upstreams written by Gloo Discovery."`
-	Integrations        *Integrations        `json:"integrations,omitempty"`
-	Create              bool                 `json:"create" desc:"create a Settings CRD which provides bootstrap configuration to Gloo controllers"`
-	Extensions          interface{}          `json:"extensions,omitempty"`
-	SingleNamespace     bool                 `json:"singleNamespace" desc:"Enable to use install namespace as WatchNamespace and WriteNamespace"`
-	InvalidConfigPolicy *InvalidConfigPolicy `json:"invalidConfigPolicy,omitempty" desc:"Define policies for Gloo to handle invalid configuration"`
-	Linkerd             bool                 `json:"linkerd" desc:"Enable automatic Linkerd integration in Gloo."`
+	WatchNamespaces               []string             `json:"watchNamespaces,omitempty" desc:"whitelist of namespaces for gloo to watch for services and CRDs. Empty list means all namespaces"`
+	WriteNamespace                string               `json:"writeNamespace,omitempty" desc:"namespace where intermediary CRDs will be written to, e.g. Upstreams written by Gloo Discovery."`
+	Integrations                  *Integrations        `json:"integrations,omitempty"`
+	Create                        bool                 `json:"create" desc:"create a Settings CRD which provides bootstrap configuration to Gloo controllers"`
+	Extensions                    interface{}          `json:"extensions,omitempty"`
+	SingleNamespace               bool                 `json:"singleNamespace" desc:"Enable to use install namespace as WatchNamespace and WriteNamespace"`
+	InvalidConfigPolicy           *InvalidConfigPolicy `json:"invalidConfigPolicy,omitempty" desc:"Define policies for Gloo to handle invalid configuration"`
+	Linkerd                       bool                 `json:"linkerd" desc:"Enable automatic Linkerd integration in Gloo."`
+	DisableKubernetesDestinations bool                 `json:"disableKubernetesDestinations" desc:"Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature, Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them. If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result in significant overhead. If you do not plan on using this feature, you can set this flag to true to turn it off."`
 }
 
 type InvalidConfigPolicy struct {

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -14,6 +14,7 @@ spec:
     invalidConfigPolicy:
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}
 {{- end }}
+    disableKubernetesDestinations: {{ .Values.settings.disableKubernetesDestinations | default false }}
 
 {{- if .Values.settings.writeNamespace }}
   discoveryNamespace: {{ .Values.settings.writeNamespace }}

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -23,8 +23,13 @@ settings:
         httpPort: 80
         httpsPort: 443
         replicas: 1
-  # namespaces that Gloo should watch. this includes watches set for pods, services, as well as CRD configuration objects
+  # Namespaces that Gloo should watch. This includes watches set for pods, services, as well as CRD configuration objects.
   watchNamespaces: []
+  # Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature,
+  # Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them.
+  # If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result
+  # in significant overhead. If you do not plan on using this feature, you can set this flag to true to turn it off.
+  disableKubernetesDestinations: false
 gloo:
   deployment:
     image:


### PR DESCRIPTION
Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature, Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them.
If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result in significant overhead. If users do not plan on using this feature, they can now provide a helm value to turn it off.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2299