### PR TITLE
Allow updating settings and default gateways when upgrading via Helm

### DIFF
--- a/changelog/v1.2.16/allow-upgrade-settings-default-gw.yaml
+++ b/changelog/v1.2.16/allow-upgrade-settings-default-gw.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  description: Allow updating settings and default gateway resources when upgrading via Helm.
+  issueLink: https://github.com/solo-io/gloo/issues/2317

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -10,7 +10,7 @@ metadata:
   # We need this because the Gloo controllers will try to write default settings objects
   # and if any of them is able to do so before this resource gets applied, installation will fail.
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
 spec:
   gloo:
     xdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.xdsPort }}"

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -14,7 +14,7 @@ metadata:
   # We need this because the gateway controller will try to write default gateway objects
   # and if it is able to do so before this resource gets applied, installation will fail.
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
 spec:
   bindAddress: "::"
   bindPort: {{ $spec.podTemplate.httpPort }}
@@ -41,7 +41,7 @@ metadata:
   # We need this because the gateway controller will try to write default gateway objects
   # and if it is able to do so before this resource gets applied, installation will fail.
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
 spec:
   bindAddress: "::"
   bindPort: {{ $spec.podTemplate.httpsPort }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -781,7 +781,7 @@ metadata:
   name: default
   namespace: ` + namespace + `
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
 spec:
  discovery:
    fdsMode: WHITELIST


### PR DESCRIPTION
Our default settings and gateway resources are currently written only on installs. This change causes them to be created on upgrades as well. This way users can use `helm upgrade` to just update those settings.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2317