### PR TITLE
knative: fix knative internal/external lb assumption

### DIFF
--- a/changelog/v1.3.4/fix-knative-internal-gateway.yaml
+++ b/changelog/v1.3.4/fix-knative-internal-gateway.yaml
@@ -1,4 +1,7 @@
 changelog:
   - type: FIX
-    description: Ensure Knative Services are exposed on the internal Knative proxy.
+    description: >
+      Ensure Knative Services are exposed on the internal Knative proxy. currently this assumption is made but not documented
+      by Knative's visibility setting: [knative/serving#6642](https://github.com/knative/serving/issues/6642). In order for Knative Eventing to work with Gloo,
+       Gloo must load cluster-local services on the internal proxy as well.
     issueLink: https://github.com/solo-io/gloo/issues/2336

--- a/changelog/v1.3.4/fix-knative-internal-gateway.yaml
+++ b/changelog/v1.3.4/fix-knative-internal-gateway.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Ensure Knative Services are exposed on the internal Knative proxy.
+    issueLink: https://github.com/solo-io/gloo/issues/2336

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -118,7 +118,7 @@ steps:
   - 'RUN_VAULT_TESTS=1'
   - 'DOCKER_CONFIG=/workspace/.docker/'
   dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-randomizeSuites', '-noColor']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor']
   waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-gcr-zone', 'get-test-credentials']
   secretEnv: ['AWS_ARN_ROLE_1']
   id: 'test'
@@ -180,7 +180,7 @@ steps:
     - 'RUN_KUBE2E_TESTS=1'
     - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
   dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-randomizeSuites', '-noColor', 'test/kube2e']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4',  '-noColor', 'test/kube2e']
   waitFor: ['build-test-assets', 'docker-push']
   id: 'regression-tests'
 
@@ -198,7 +198,7 @@ steps:
     - 'CLUSTER_LOCK_TESTS=1'
     - 'CLOUDSDK_CONTAINER_CLUSTER=kube2e-tests'
   dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-randomizeSuites', '-noColor', 'test/kube2e']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor', 'test/kube2e']
   waitFor: ['build-test-assets', 'docker-push', 'get-regression-clusterlock-credentials']
   id: 'regression-tests-cluster-lock'
 

--- a/projects/clusteringress/README.md
+++ b/projects/clusteringress/README.md
@@ -29,7 +29,7 @@ Next, add Gloo to your path with:
 
 Verify the CLI is installed and running correctly with:
 
-`glooctl --version`
+`glooctl version`
 
 #### 2. Install Knative and Gloo to your Kubernetes Cluster using Glooctl
 

--- a/projects/knative/README.md
+++ b/projects/knative/README.md
@@ -29,7 +29,7 @@ Next, add Gloo to your path with:
 
 Verify the CLI is installed and running correctly with:
 
-`glooctl --version`
+`glooctl version`
 
 #### 2. Install Knative and Gloo to your Kubernetes Cluster using Glooctl
 


### PR DESCRIPTION
this change adds all knative services to the `internal` proxy. this is based on the implicit Knative assumption that `External` ingresses will be available on the internal proxy
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2336