### PR TITLE
Bump solo-kit version

### DIFF
--- a/changelog/v1.3.4/bump-solokit-resource-version-err-fixes.yaml
+++ b/changelog/v1.3.4/bump-solokit-resource-version-err-fixes.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: solo-kit
+    dependencyTag: v0.13.1

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/solo-io/go-utils v0.13.1
 	github.com/solo-io/protoc-gen-ext v0.0.7
 	github.com/solo-io/reporting-client v0.1.2
-	github.com/solo-io/solo-kit v0.13.0
+	github.com/solo-io/solo-kit v0.13.1
 	github.com/solo-io/wasme v0.0.1
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -851,8 +851,8 @@ github.com/solo-io/protoc-gen-ext v0.0.7/go.mod h1:zZIFs9Ch3EU3uQgL2ZwCHlUGAtwiz
 github.com/solo-io/reporting-client v0.1.2 h1:U585Q5UlB5/UUewtgEAQz94SWuNRBxoHc4tPthhnYko=
 github.com/solo-io/reporting-client v0.1.2/go.mod h1:FmBDzwc1zEwayCCrlP+1w7NcpM0FIuvU+NSePj4wJq8=
 github.com/solo-io/solo-kit v0.6.3/go.mod h1:oBaQ6tOwuO97u7w+s3TeI08YLHcbiWemInx0XkDfKFw=
-github.com/solo-io/solo-kit v0.13.0 h1:XY2o8C23fKL1Zledr7rorLQW90MPAkbO8bNdXb10awg=
-github.com/solo-io/solo-kit v0.13.0/go.mod h1:Sukhlm32r1cSJIztPQ6RZxroK0VP4TGOkTecaBXTEoo=
+github.com/solo-io/solo-kit v0.13.1 h1:9TT/fka69oYWBWYrwwsx4GDL6p7kMvVIclUGV/wqI3Q=
+github.com/solo-io/solo-kit v0.13.1/go.mod h1:Sukhlm32r1cSJIztPQ6RZxroK0VP4TGOkTecaBXTEoo=
 github.com/solo-io/wasme v0.0.1 h1:SjYWzJZ2IGVGTI0WS1/Gv2I74FLvibieLgyl6+TYciU=
 github.com/solo-io/wasme v0.0.1/go.mod h1:Zb85GQMTyx7NEyEINCUiofKE9KZLjQVF6obvHOHBQE8=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=


### PR DESCRIPTION
Picks up fixes to solo-kit's generated Reconciler and Reporter (v2), which is used in Gloo's proxy reconciler and gloo/gateway's status report writing logic.

In addition, this should help deflake other uses of these generated interfaces in our regression tests.

Earlier versions of the solo-kit code didn't properly handle resource version errors and retrying them (often only retrying once before giving up, without any backoff)