### PR TITLE
Fix flaky e2e tests

### DIFF
--- a/changelog/v1.3.4/deflake-e2e-ci.yaml
+++ b/changelog/v1.3.4/deflake-e2e-ci.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Deflake CI by ensuring we cleanup Envoy after each test (e2e custom auth didn't clean up after itself)
+    issueLink: https://github.com/solo-io/gloo/issues/2245

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,48 +18,47 @@ steps:
   env:
     - 'GIT_SSH_CONFIG=FALSE'
   id: 'prepare-workspace'
-#
-#- name: 'gcr.io/cloud-builders/wget'
-#  entrypoint: ./ci/spell.sh
-#  args: ['check']
-#  dir: &dir '/workspace/gloo'
-#  env:
-#  # The LSCOMMAND is the env var which tells the spell script how to search for the files it needs to fix.
-#  - 'LSCOMMAND=find * -type f | grep -v vendor | grep -v docs/themes | grep -v docs/site'
-#  id: 'check-spelling'
-#
+
+- name: 'gcr.io/cloud-builders/wget'
+  entrypoint: ./ci/spell.sh
+  args: ['check']
+  dir: &dir '/workspace/gloo'
+  env:
+  # The LSCOMMAND is the env var which tells the spell script how to search for the files it needs to fix.
+  - 'LSCOMMAND=find * -type f | grep -v vendor | grep -v docs/themes | grep -v docs/site'
+  id: 'check-spelling'
+
 - name: gcr.io/cloud-builders/gsutil
   entrypoint: 'bash'
   args: ['-c', 'mkdir -p /go/pkg && cd /go/pkg && gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf -']
-  dir: &dir '/workspace/gloo'
-  #dir: *dir
+  dir: *dir
   id: 'untar-mod-cache'
-#
-## Run some basic checks on the repo
-## 1) check formatting of go files
-## 2) ensure that make generated-code produces a clean diff
-## 3) ensure that the site is generated with no warnings (strict = true in mkdocs)
-#
-## e2e-go-mod-ginkgo is produced from https://github.com/solo-io/cloud-builders/e2e-go-mod-ginkgo
-#- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
-#  dir: *dir
-#  entrypoint: make
-#  args: ['check-format']
-#  waitFor: ['untar-mod-cache']
-#  id: 'check-format'
-#
-#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-#  entrypoint: 'bash'
-#  args: ['ci/check-code-and-docs-gen.sh']
-#  env:
-#  - 'TAGGED_VERSION=$TAG_NAME'
-#  dir: *dir
-#  waitFor: ['untar-mod-cache']
-#  id: 'check-code-and-docs-gen'
-#
-## Run all the tests with ginkgo -r -failFast -trace -progress --noColor
-## This requires setting up envoy, AWS, helm, and docker
-## The e2e-go-mod-ginkgo container provides everything else needed for running tests
+
+# Run some basic checks on the repo
+# 1) check formatting of go files
+# 2) ensure that make generated-code produces a clean diff
+# 3) ensure that the site is generated with no warnings (strict = true in mkdocs)
+
+# e2e-go-mod-ginkgo is produced from https://github.com/solo-io/cloud-builders/e2e-go-mod-ginkgo
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
+  dir: *dir
+  entrypoint: make
+  args: ['check-format']
+  waitFor: ['untar-mod-cache']
+  id: 'check-format'
+
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+  entrypoint: 'bash'
+  args: ['ci/check-code-and-docs-gen.sh']
+  env:
+  - 'TAGGED_VERSION=$TAG_NAME'
+  dir: *dir
+  waitFor: ['untar-mod-cache']
+  id: 'check-code-and-docs-gen'
+
+# Run all the tests with ginkgo -r -failFast -trace -progress --noColor
+# This requires setting up envoy, AWS, helm, and docker
+# The e2e-go-mod-ginkgo container provides everything else needed for running tests
 - name: gcr.io/cloud-builders/gsutil
   entrypoint: 'bash'
   args:
@@ -113,123 +112,122 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
   env:
   - 'ENVOY_BINARY=/workspace/envoy'
-  #- 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
-  #- 'RUN_KUBE_TESTS=1'
-  #- 'RUN_CONSUL_TESTS=1'
-  #- 'RUN_VAULT_TESTS=1'
+  - 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
+  - 'RUN_KUBE_TESTS=1'
+  - 'RUN_CONSUL_TESTS=1'
+  - 'RUN_VAULT_TESTS=1'
   - 'DOCKER_CONFIG=/workspace/.docker/'
   dir: *dir
   args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor']
-  waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'set-gcr-zone', 'get-test-credentials']
-#  waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-gcr-zone', 'get-test-credentials']
+  waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-gcr-zone', 'get-test-credentials']
   secretEnv: ['AWS_ARN_ROLE_1']
   id: 'test'
 
-## Build and tag docker images
-#- name: 'gcr.io/cloud-builders/docker'
-#  entrypoint: 'bash'
-#  env:
-#  - 'DOCKER_CONFIG=/workspace/docker-config'
-#  args: ['-c', 'docker login quay.io --username "solo-io+solobot" --password $$QUAY_IO_PASSWORD']
-#  secretEnv: ['QUAY_IO_PASSWORD']
-#  waitFor: ['prepare-workspace']
-#  id: 'docker-login'
-#
-#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-#  args: ['docker']
-#  env:
-#    - 'TAGGED_VERSION=$TAG_NAME'
-#    - 'BUILD_ID=$BUILD_ID'
-#    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
-#  dir: *dir
-#  waitFor: ['prepare-workspace', 'check-code-and-docs-gen']
-#  id: 'compile'
-#
-#  # 1) Run make targets to push docker images
-#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-#  args: ['docker-push']
-#  env:
-#  - 'DOCKER_CONFIG=/workspace/docker-config'
-#  - 'TAGGED_VERSION=$TAG_NAME'
-#  dir: *dir
-#  secretEnv: ['GITHUB_TOKEN']
-#  waitFor: ['compile']
-#  id: 'docker-push'
-#
-## 2) Publish helm chart, compile manifests, produce release artifacts, deploy docs
-## isolating this portion of the release in order to force the manifest to be regenerated with the tagged version
-#- name: gcr.io/cloud-builders/gcloud
-#  args: ['auth', 'configure-docker']
-#  env:
-#    - 'DOCKER_CONFIG=/workspace/docker-config'
-#  dir: *dir
-#  waitFor: ['compile']
-#  id: 'gcr-auth'
-#
-## Run regression tests
-#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-#  args: ['build-test-assets']
-#  env:
-#    - 'BUILD_ID=$BUILD_ID'
-#    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
-#    - 'TAGGED_VERSION=$TAG_NAME'
-#  dir: *dir
-#  waitFor: ['compile', 'docker-login', 'docker-push', 'test']
-#  id: 'build-test-assets'
-#
-#- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
-#  env:
-#    - 'RUN_KUBE2E_TESTS=1'
-#    - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
-#  dir: *dir
-#  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor', 'test/kube2e']
-#  waitFor: ['build-test-assets', 'docker-push']
-#  id: 'regression-tests'
-#
-#- name: gcr.io/cloud-builders/gcloud
-#  env:
-#    - 'KUBECONFIG=/workspace/kube-e2e'
-#  args: ['container', 'clusters', 'get-credentials', 'kube2e-tests']
-#  waitFor: ['set-gcr-zone']
-#  id: 'get-regression-clusterlock-credentials'
-#
-#- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
-#  env:
-#    - 'KUBECONFIG=/workspace/kube-e2e'
-#    - 'RUN_KUBE2E_TESTS=1'
-#    - 'CLUSTER_LOCK_TESTS=1'
-#    - 'CLOUDSDK_CONTAINER_CLUSTER=kube2e-tests'
-#  dir: *dir
-#  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor', 'test/kube2e']
-#  waitFor: ['build-test-assets', 'docker-push', 'get-regression-clusterlock-credentials']
-#  id: 'regression-tests-cluster-lock'
-#
-#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-#  args: ['package-chart', 'render-manifests', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', 'push-chart-to-registry', '-B']
-#  env:
-#    - 'DOCKER_CONFIG=/workspace/docker-config'
-#    - 'HELM_REPOSITORY_CACHE=/builder/home/.cache/helm/registry'
-#    - 'TAGGED_VERSION=$TAG_NAME'
-#    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
-#  dir: *dir
-#  secretEnv: ['GITHUB_TOKEN']
-#  waitFor: ['gcr-auth', 'regression-tests', 'regression-tests-cluster-lock']
-#  id: 'release-chart'
-#
-## 3) Sync helm chart data back to google storage bucket
-#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-#  args: ['save-helm']
-#  env:
-#    - 'TAGGED_VERSION=$TAG_NAME'
-#  dir: *dir
-#  waitFor: ['release-chart']
-#  id: 'save-helm-chart'
+# Build and tag docker images
+- name: 'gcr.io/cloud-builders/docker'
+  entrypoint: 'bash'
+  env:
+  - 'DOCKER_CONFIG=/workspace/docker-config'
+  args: ['-c', 'docker login quay.io --username "solo-io+solobot" --password $$QUAY_IO_PASSWORD']
+  secretEnv: ['QUAY_IO_PASSWORD']
+  waitFor: ['prepare-workspace']
+  id: 'docker-login'
+
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+  args: ['docker']
+  env:
+    - 'TAGGED_VERSION=$TAG_NAME'
+    - 'BUILD_ID=$BUILD_ID'
+    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
+  dir: *dir
+  waitFor: ['prepare-workspace', 'check-code-and-docs-gen']
+  id: 'compile'
+
+  # 1) Run make targets to push docker images
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+  args: ['docker-push']
+  env:
+  - 'DOCKER_CONFIG=/workspace/docker-config'
+  - 'TAGGED_VERSION=$TAG_NAME'
+  dir: *dir
+  secretEnv: ['GITHUB_TOKEN']
+  waitFor: ['compile']
+  id: 'docker-push'
+
+# 2) Publish helm chart, compile manifests, produce release artifacts, deploy docs
+# isolating this portion of the release in order to force the manifest to be regenerated with the tagged version
+- name: gcr.io/cloud-builders/gcloud
+  args: ['auth', 'configure-docker']
+  env:
+    - 'DOCKER_CONFIG=/workspace/docker-config'
+  dir: *dir
+  waitFor: ['compile']
+  id: 'gcr-auth'
+
+# Run regression tests
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+  args: ['build-test-assets']
+  env:
+    - 'BUILD_ID=$BUILD_ID'
+    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
+    - 'TAGGED_VERSION=$TAG_NAME'
+  dir: *dir
+  waitFor: ['compile', 'docker-login', 'docker-push', 'test']
+  id: 'build-test-assets'
+
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
+  env:
+    - 'RUN_KUBE2E_TESTS=1'
+    - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
+  dir: *dir
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor', 'test/kube2e']
+  waitFor: ['build-test-assets', 'docker-push']
+  id: 'regression-tests'
+
+- name: gcr.io/cloud-builders/gcloud
+  env:
+    - 'KUBECONFIG=/workspace/kube-e2e'
+  args: ['container', 'clusters', 'get-credentials', 'kube2e-tests']
+  waitFor: ['set-gcr-zone']
+  id: 'get-regression-clusterlock-credentials'
+
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
+  env:
+    - 'KUBECONFIG=/workspace/kube-e2e'
+    - 'RUN_KUBE2E_TESTS=1'
+    - 'CLUSTER_LOCK_TESTS=1'
+    - 'CLOUDSDK_CONTAINER_CLUSTER=kube2e-tests'
+  dir: *dir
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor', 'test/kube2e']
+  waitFor: ['build-test-assets', 'docker-push', 'get-regression-clusterlock-credentials']
+  id: 'regression-tests-cluster-lock'
+
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+  args: ['package-chart', 'render-manifests', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', 'push-chart-to-registry', '-B']
+  env:
+    - 'DOCKER_CONFIG=/workspace/docker-config'
+    - 'HELM_REPOSITORY_CACHE=/builder/home/.cache/helm/registry'
+    - 'TAGGED_VERSION=$TAG_NAME'
+    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
+  dir: *dir
+  secretEnv: ['GITHUB_TOKEN']
+  waitFor: ['gcr-auth', 'regression-tests', 'regression-tests-cluster-lock']
+  id: 'release-chart'
+
+# 3) Sync helm chart data back to google storage bucket
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+  args: ['save-helm']
+  env:
+    - 'TAGGED_VERSION=$TAG_NAME'
+  dir: *dir
+  waitFor: ['release-chart']
+  id: 'save-helm-chart'
 
 secrets:
 - kmsKeyName: projects/solo-public/locations/global/keyRings/build/cryptoKeys/build-key
   secretEnv:
-#    GITHUB_TOKEN: CiQABlzmSYYiveU0gTxGH2139eaBUedjV3vNCxQmJU+nRPlfQ/YSUQCCPGSGzbGp49fwDYuefAx9V94b8mivdp9AqB7zQAa07VtGJmrGdg9ZuhKGFrrgqxwABE0LLVNHyngCSHYSYMH8Vn/mRtT7wQuEHBlKVGtqPw==
-#    QUAY_IO_PASSWORD: CiQABlzmSRx5TcOqbldXa/d/+bkmAfpNAWa3PTS06WvuloZL+vASaQCCPGSGCogonVZVEUNx4G3YJtWi18gSuNx4PvLe08q8xAflTMFkjsyQirAOK3Y2oCvgYwiw/ITcuydjkpMjxDygFyENXS9FKFJoAXHlPQE5qidKr8xxmxF5ezhmjGB0gjyjXIIkbSEnBg==
+    GITHUB_TOKEN: CiQABlzmSYYiveU0gTxGH2139eaBUedjV3vNCxQmJU+nRPlfQ/YSUQCCPGSGzbGp49fwDYuefAx9V94b8mivdp9AqB7zQAa07VtGJmrGdg9ZuhKGFrrgqxwABE0LLVNHyngCSHYSYMH8Vn/mRtT7wQuEHBlKVGtqPw==
+    QUAY_IO_PASSWORD: CiQABlzmSRx5TcOqbldXa/d/+bkmAfpNAWa3PTS06WvuloZL+vASaQCCPGSGCogonVZVEUNx4G3YJtWi18gSuNx4PvLe08q8xAflTMFkjsyQirAOK3Y2oCvgYwiw/ITcuydjkpMjxDygFyENXS9FKFJoAXHlPQE5qidKr8xxmxF5ezhmjGB0gjyjXIIkbSEnBg==
     AWS_ARN_ROLE_1: CiQABlzmSTKWrIEGaH8UvsX3Wp8pz8ClQODVSjIZAiHuE9gNhM4SXACCPGSGCDSNJtdfkA0BLLmKTJLIM06XXEOV4iIooqlLfo9p7EOzOwqZaV9DFygO8/oKQqTFstc1vKgOz7YHrMaCx3GzqiHN2u//UmHRpvIwrDDfuIP5XNa0aOrj
 
 timeout: 5400s

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,47 +18,48 @@ steps:
   env:
     - 'GIT_SSH_CONFIG=FALSE'
   id: 'prepare-workspace'
-
-- name: 'gcr.io/cloud-builders/wget'
-  entrypoint: ./ci/spell.sh
-  args: ['check']
-  dir: &dir '/workspace/gloo'
-  env:
-  # The LSCOMMAND is the env var which tells the spell script how to search for the files it needs to fix.
-  - 'LSCOMMAND=find * -type f | grep -v vendor | grep -v docs/themes | grep -v docs/site'
-  id: 'check-spelling'
-
+#
+#- name: 'gcr.io/cloud-builders/wget'
+#  entrypoint: ./ci/spell.sh
+#  args: ['check']
+#  dir: &dir '/workspace/gloo'
+#  env:
+#  # The LSCOMMAND is the env var which tells the spell script how to search for the files it needs to fix.
+#  - 'LSCOMMAND=find * -type f | grep -v vendor | grep -v docs/themes | grep -v docs/site'
+#  id: 'check-spelling'
+#
 - name: gcr.io/cloud-builders/gsutil
   entrypoint: 'bash'
   args: ['-c', 'mkdir -p /go/pkg && cd /go/pkg && gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf -']
-  dir: *dir
+  dir: &dir '/workspace/gloo'
+  #dir: *dir
   id: 'untar-mod-cache'
-
-# Run some basic checks on the repo
-# 1) check formatting of go files
-# 2) ensure that make generated-code produces a clean diff
-# 3) ensure that the site is generated with no warnings (strict = true in mkdocs)
-
-# e2e-go-mod-ginkgo is produced from https://github.com/solo-io/cloud-builders/e2e-go-mod-ginkgo
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
-  dir: *dir
-  entrypoint: make
-  args: ['check-format']
-  waitFor: ['untar-mod-cache']
-  id: 'check-format'
-
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-  entrypoint: 'bash'
-  args: ['ci/check-code-and-docs-gen.sh']
-  env:
-  - 'TAGGED_VERSION=$TAG_NAME'
-  dir: *dir
-  waitFor: ['untar-mod-cache']
-  id: 'check-code-and-docs-gen'
-
-# Run all the tests with ginkgo -r -failFast -trace -progress --noColor
-# This requires setting up envoy, AWS, helm, and docker
-# The e2e-go-mod-ginkgo container provides everything else needed for running tests
+#
+## Run some basic checks on the repo
+## 1) check formatting of go files
+## 2) ensure that make generated-code produces a clean diff
+## 3) ensure that the site is generated with no warnings (strict = true in mkdocs)
+#
+## e2e-go-mod-ginkgo is produced from https://github.com/solo-io/cloud-builders/e2e-go-mod-ginkgo
+#- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
+#  dir: *dir
+#  entrypoint: make
+#  args: ['check-format']
+#  waitFor: ['untar-mod-cache']
+#  id: 'check-format'
+#
+#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+#  entrypoint: 'bash'
+#  args: ['ci/check-code-and-docs-gen.sh']
+#  env:
+#  - 'TAGGED_VERSION=$TAG_NAME'
+#  dir: *dir
+#  waitFor: ['untar-mod-cache']
+#  id: 'check-code-and-docs-gen'
+#
+## Run all the tests with ginkgo -r -failFast -trace -progress --noColor
+## This requires setting up envoy, AWS, helm, and docker
+## The e2e-go-mod-ginkgo container provides everything else needed for running tests
 - name: gcr.io/cloud-builders/gsutil
   entrypoint: 'bash'
   args:
@@ -112,122 +113,123 @@ steps:
 - name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
   env:
   - 'ENVOY_BINARY=/workspace/envoy'
-  - 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
-  - 'RUN_KUBE_TESTS=1'
-  - 'RUN_CONSUL_TESTS=1'
-  - 'RUN_VAULT_TESTS=1'
+  #- 'AWS_SHARED_CREDENTIALS_FILE=/workspace/aws_credentials'
+  #- 'RUN_KUBE_TESTS=1'
+  #- 'RUN_CONSUL_TESTS=1'
+  #- 'RUN_VAULT_TESTS=1'
   - 'DOCKER_CONFIG=/workspace/.docker/'
   dir: *dir
   args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor']
-  waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-gcr-zone', 'get-test-credentials']
+  waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'set-gcr-zone', 'get-test-credentials']
+#  waitFor: ['get-envoy', 'setup-aws-creds', 'fetch-helm', 'check-code-and-docs-gen', 'set-gcr-zone', 'get-test-credentials']
   secretEnv: ['AWS_ARN_ROLE_1']
   id: 'test'
 
-# Build and tag docker images
-- name: 'gcr.io/cloud-builders/docker'
-  entrypoint: 'bash'
-  env:
-  - 'DOCKER_CONFIG=/workspace/docker-config'
-  args: ['-c', 'docker login quay.io --username "solo-io+solobot" --password $$QUAY_IO_PASSWORD']
-  secretEnv: ['QUAY_IO_PASSWORD']
-  waitFor: ['prepare-workspace']
-  id: 'docker-login'
-
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-  args: ['docker']
-  env:
-    - 'TAGGED_VERSION=$TAG_NAME'
-    - 'BUILD_ID=$BUILD_ID'
-    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
-  dir: *dir
-  waitFor: ['prepare-workspace', 'check-code-and-docs-gen']
-  id: 'compile'
-
-  # 1) Run make targets to push docker images
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-  args: ['docker-push']
-  env:
-  - 'DOCKER_CONFIG=/workspace/docker-config'
-  - 'TAGGED_VERSION=$TAG_NAME'
-  dir: *dir
-  secretEnv: ['GITHUB_TOKEN']
-  waitFor: ['compile']
-  id: 'docker-push'
-
-# 2) Publish helm chart, compile manifests, produce release artifacts, deploy docs
-# isolating this portion of the release in order to force the manifest to be regenerated with the tagged version
-- name: gcr.io/cloud-builders/gcloud
-  args: ['auth', 'configure-docker']
-  env:
-    - 'DOCKER_CONFIG=/workspace/docker-config'
-  dir: *dir
-  waitFor: ['compile']
-  id: 'gcr-auth'
-
-# Run regression tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-  args: ['build-test-assets']
-  env:
-    - 'BUILD_ID=$BUILD_ID'
-    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
-    - 'TAGGED_VERSION=$TAG_NAME'
-  dir: *dir
-  waitFor: ['compile', 'docker-login', 'docker-push', 'test']
-  id: 'build-test-assets'
-
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
-  env:
-    - 'RUN_KUBE2E_TESTS=1'
-    - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
-  dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor', 'test/kube2e']
-  waitFor: ['build-test-assets', 'docker-push']
-  id: 'regression-tests'
-
-- name: gcr.io/cloud-builders/gcloud
-  env:
-    - 'KUBECONFIG=/workspace/kube-e2e'
-  args: ['container', 'clusters', 'get-credentials', 'kube2e-tests']
-  waitFor: ['set-gcr-zone']
-  id: 'get-regression-clusterlock-credentials'
-
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
-  env:
-    - 'KUBECONFIG=/workspace/kube-e2e'
-    - 'RUN_KUBE2E_TESTS=1'
-    - 'CLUSTER_LOCK_TESTS=1'
-    - 'CLOUDSDK_CONTAINER_CLUSTER=kube2e-tests'
-  dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor', 'test/kube2e']
-  waitFor: ['build-test-assets', 'docker-push', 'get-regression-clusterlock-credentials']
-  id: 'regression-tests-cluster-lock'
-
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-  args: ['package-chart', 'render-manifests', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', 'push-chart-to-registry', '-B']
-  env:
-    - 'DOCKER_CONFIG=/workspace/docker-config'
-    - 'HELM_REPOSITORY_CACHE=/builder/home/.cache/helm/registry'
-    - 'TAGGED_VERSION=$TAG_NAME'
-    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
-  dir: *dir
-  secretEnv: ['GITHUB_TOKEN']
-  waitFor: ['gcr-auth', 'regression-tests', 'regression-tests-cluster-lock']
-  id: 'release-chart'
-
-# 3) Sync helm chart data back to google storage bucket
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
-  args: ['save-helm']
-  env:
-    - 'TAGGED_VERSION=$TAG_NAME'
-  dir: *dir
-  waitFor: ['release-chart']
-  id: 'save-helm-chart'
+## Build and tag docker images
+#- name: 'gcr.io/cloud-builders/docker'
+#  entrypoint: 'bash'
+#  env:
+#  - 'DOCKER_CONFIG=/workspace/docker-config'
+#  args: ['-c', 'docker login quay.io --username "solo-io+solobot" --password $$QUAY_IO_PASSWORD']
+#  secretEnv: ['QUAY_IO_PASSWORD']
+#  waitFor: ['prepare-workspace']
+#  id: 'docker-login'
+#
+#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+#  args: ['docker']
+#  env:
+#    - 'TAGGED_VERSION=$TAG_NAME'
+#    - 'BUILD_ID=$BUILD_ID'
+#    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
+#  dir: *dir
+#  waitFor: ['prepare-workspace', 'check-code-and-docs-gen']
+#  id: 'compile'
+#
+#  # 1) Run make targets to push docker images
+#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+#  args: ['docker-push']
+#  env:
+#  - 'DOCKER_CONFIG=/workspace/docker-config'
+#  - 'TAGGED_VERSION=$TAG_NAME'
+#  dir: *dir
+#  secretEnv: ['GITHUB_TOKEN']
+#  waitFor: ['compile']
+#  id: 'docker-push'
+#
+## 2) Publish helm chart, compile manifests, produce release artifacts, deploy docs
+## isolating this portion of the release in order to force the manifest to be regenerated with the tagged version
+#- name: gcr.io/cloud-builders/gcloud
+#  args: ['auth', 'configure-docker']
+#  env:
+#    - 'DOCKER_CONFIG=/workspace/docker-config'
+#  dir: *dir
+#  waitFor: ['compile']
+#  id: 'gcr-auth'
+#
+## Run regression tests
+#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+#  args: ['build-test-assets']
+#  env:
+#    - 'BUILD_ID=$BUILD_ID'
+#    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
+#    - 'TAGGED_VERSION=$TAG_NAME'
+#  dir: *dir
+#  waitFor: ['compile', 'docker-login', 'docker-push', 'test']
+#  id: 'build-test-assets'
+#
+#- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
+#  env:
+#    - 'RUN_KUBE2E_TESTS=1'
+#    - 'CLOUDSDK_CONTAINER_CLUSTER=test-cluster-roles'
+#  dir: *dir
+#  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor', 'test/kube2e']
+#  waitFor: ['build-test-assets', 'docker-push']
+#  id: 'regression-tests'
+#
+#- name: gcr.io/cloud-builders/gcloud
+#  env:
+#    - 'KUBECONFIG=/workspace/kube-e2e'
+#  args: ['container', 'clusters', 'get-credentials', 'kube2e-tests']
+#  waitFor: ['set-gcr-zone']
+#  id: 'get-regression-clusterlock-credentials'
+#
+#- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.2.1'
+#  env:
+#    - 'KUBECONFIG=/workspace/kube-e2e'
+#    - 'RUN_KUBE2E_TESTS=1'
+#    - 'CLUSTER_LOCK_TESTS=1'
+#    - 'CLOUDSDK_CONTAINER_CLUSTER=kube2e-tests'
+#  dir: *dir
+#  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending',  '-noColor', 'test/kube2e']
+#  waitFor: ['build-test-assets', 'docker-push', 'get-regression-clusterlock-credentials']
+#  id: 'regression-tests-cluster-lock'
+#
+#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+#  args: ['package-chart', 'render-manifests', 'upload-github-release-assets', 'download-glooe-changelog', 'publish-docs', 'push-chart-to-registry', '-B']
+#  env:
+#    - 'DOCKER_CONFIG=/workspace/docker-config'
+#    - 'HELM_REPOSITORY_CACHE=/builder/home/.cache/helm/registry'
+#    - 'TAGGED_VERSION=$TAG_NAME'
+#    - 'GCLOUD_PROJECT_ID=$PROJECT_ID'
+#  dir: *dir
+#  secretEnv: ['GITHUB_TOKEN']
+#  waitFor: ['gcr-auth', 'regression-tests', 'regression-tests-cluster-lock']
+#  id: 'release-chart'
+#
+## 3) Sync helm chart data back to google storage bucket
+#- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.2.1'
+#  args: ['save-helm']
+#  env:
+#    - 'TAGGED_VERSION=$TAG_NAME'
+#  dir: *dir
+#  waitFor: ['release-chart']
+#  id: 'save-helm-chart'
 
 secrets:
 - kmsKeyName: projects/solo-public/locations/global/keyRings/build/cryptoKeys/build-key
   secretEnv:
-    GITHUB_TOKEN: CiQABlzmSYYiveU0gTxGH2139eaBUedjV3vNCxQmJU+nRPlfQ/YSUQCCPGSGzbGp49fwDYuefAx9V94b8mivdp9AqB7zQAa07VtGJmrGdg9ZuhKGFrrgqxwABE0LLVNHyngCSHYSYMH8Vn/mRtT7wQuEHBlKVGtqPw==
-    QUAY_IO_PASSWORD: CiQABlzmSRx5TcOqbldXa/d/+bkmAfpNAWa3PTS06WvuloZL+vASaQCCPGSGCogonVZVEUNx4G3YJtWi18gSuNx4PvLe08q8xAflTMFkjsyQirAOK3Y2oCvgYwiw/ITcuydjkpMjxDygFyENXS9FKFJoAXHlPQE5qidKr8xxmxF5ezhmjGB0gjyjXIIkbSEnBg==
+#    GITHUB_TOKEN: CiQABlzmSYYiveU0gTxGH2139eaBUedjV3vNCxQmJU+nRPlfQ/YSUQCCPGSGzbGp49fwDYuefAx9V94b8mivdp9AqB7zQAa07VtGJmrGdg9ZuhKGFrrgqxwABE0LLVNHyngCSHYSYMH8Vn/mRtT7wQuEHBlKVGtqPw==
+#    QUAY_IO_PASSWORD: CiQABlzmSRx5TcOqbldXa/d/+bkmAfpNAWa3PTS06WvuloZL+vASaQCCPGSGCogonVZVEUNx4G3YJtWi18gSuNx4PvLe08q8xAflTMFkjsyQirAOK3Y2oCvgYwiw/ITcuydjkpMjxDygFyENXS9FKFJoAXHlPQE5qidKr8xxmxF5ezhmjGB0gjyjXIIkbSEnBg==
     AWS_ARN_ROLE_1: CiQABlzmSTKWrIEGaH8UvsX3Wp8pz8ClQODVSjIZAiHuE9gNhM4SXACCPGSGCDSNJtdfkA0BLLmKTJLIM06XXEOV4iIooqlLfo9p7EOzOwqZaV9DFygO8/oKQqTFstc1vKgOz7YHrMaCx3GzqiHN2u//UmHRpvIwrDDfuIP5XNa0aOrj
 
 timeout: 5400s

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Consul e2e", func() {
 		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
 
 		// Start Envoy
-		envoyPort = uint32(defaults.HttpPort)
+		envoyPort = defaults.HttpPort
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -41,7 +41,8 @@ var _ = Describe("CustomAuth", func() {
 		ctx, cancel = context.WithCancel(context.Background())
 
 		// Initialize Envoy instance
-		envoyInstance, err := envoyFactory.NewEnvoyInstance()
+		var err error
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start custom extauth server and create upstream for it

--- a/test/e2e/route_transformation_test.go
+++ b/test/e2e/route_transformation_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Transformations", func() {
 		Expect(err).NotTo(HaveOccurred())
 		err = envoyInstance.Run(testClients.GlooPort)
 		Expect(err).NotTo(HaveOccurred())
-		envoyPort = services.NextBindPort()
+		envoyPort = defaults.HttpPort
 
 		tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())
 
@@ -124,7 +124,7 @@ var _ = Describe("Transformations", func() {
 			},
 			Listeners: []*gloov1.Listener{{
 				Name:        "listener",
-				BindAddress: "127.0.0.1",
+				BindAddress: "0.0.0.0",
 				BindPort:    envoyPort,
 				ListenerType: &gloov1.Listener_HttpListener{
 					HttpListener: &gloov1.HttpListener{


### PR DESCRIPTION
Ran e2e tests in CI via `gcloud builds submit` with 10-20 consecutive successes

Fixes e2e test flakes by ensuring we cleanup Envoy after each test (we missed a case in the custom auth e2e tests). Locally running the e2e custom auth test followed by grpc_web was a guaranteed way to reproduce the grpc flake linked in this issue, and cleaning up Envoy fixes the grpc test to run properly. 

Also allows us to run the transformation tests on a Mac.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2245