### PR TITLE
Paper cuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,13 +538,17 @@ docker-push: $(DOCKER_IMAGES)
 	docker push quay.io/solo-io/sds:$(VERSION) && \
 	docker push quay.io/solo-io/access-logger:$(VERSION)
 
+CLUSTER_NAME ?= kind
+
 push-kind-images: docker
 	kind load docker-image quay.io/solo-io/gateway:$(VERSION) --name $(CLUSTER_NAME)
 	kind load docker-image quay.io/solo-io/ingress:$(VERSION) --name $(CLUSTER_NAME)
 	kind load docker-image quay.io/solo-io/discovery:$(VERSION) --name $(CLUSTER_NAME)
 	kind load docker-image quay.io/solo-io/gloo:$(VERSION) --name $(CLUSTER_NAME)
 	kind load docker-image quay.io/solo-io/gloo-envoy-wrapper:$(VERSION) --name $(CLUSTER_NAME)
+	kind load docker-image quay.io/solo-io/gloo-envoy-wasm-wrapper:$(VERSION) --name $(CLUSTER_NAME)
 	kind load docker-image quay.io/solo-io/certgen:$(VERSION) --name $(CLUSTER_NAME)
+	kind load docker-image quay.io/solo-io/access-logger:$(VERSION) --name $(CLUSTER_NAME)
 
 
 #----------------------------------------------------------------------------------
@@ -575,6 +579,7 @@ build-test-chart:
 
 .PHONY: build-kind-chart
 build-kind-chart:
+	rm -rf $(TEST_ASSET_DIR)
 	mkdir -p $(TEST_ASSET_DIR)
 	GO111MODULE=on go run $(HELM_DIR)/generate.go --version $(VERSION)
 	helm package --destination $(TEST_ASSET_DIR) $(HELM_DIR)

--- a/changelog/v1.3.9/kind-improvements.yaml
+++ b/changelog/v1.3.9/kind-improvements.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Use `PullIfNotPresent` image pull policy instead of `Always` for non-release chart value generation. `Always` is not needed anymore as we now use tags based on git commits, and not the constant `dev`.

--- a/install/helm/gloo/generate.go
+++ b/install/helm/gloo/generate.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ghodss/yaml"
 	errors "github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/install/helm/gloo/generate"
-	glooVersion "github.com/solo-io/gloo/pkg/version"
 	"github.com/solo-io/go-utils/installutils/helmchart"
 	"github.com/solo-io/go-utils/log"
 )
@@ -22,8 +21,6 @@ var (
 	// Helm docs are generated during builds. Since version changes each build, substitute with descriptive text.
 	// Provide an example to clarify format (1.2.3, not v1.2.3).
 	helmDocsVersionText = "<release_version, ex: 1.2.3>"
-
-	always = "Always"
 
 	flagOpts = defaultFlagOptions
 )
@@ -87,24 +84,6 @@ func generateValuesYaml(version, repositoryPrefix, globalPullPolicy string) erro
 	cfg, err := generateValuesConfig(version, repositoryPrefix, globalPullPolicy)
 	if err != nil {
 		return err
-	}
-
-	// customize config as needed for dev builds
-	if !glooVersion.IsReleaseVersion() {
-		cfg.Gloo.Deployment.Image.PullPolicy = always
-		cfg.Discovery.Deployment.Image.PullPolicy = always
-		cfg.Gateway.Deployment.Image.PullPolicy = always
-		cfg.Gateway.CertGenJob.Image.PullPolicy = always
-
-		cfg.AccessLogger.Image.PullPolicy = always
-
-		cfg.Ingress.Deployment.Image.PullPolicy = always
-		cfg.IngressProxy.Deployment.Image.PullPolicy = always
-		cfg.Settings.Integrations.Knative.Proxy.Image.PullPolicy = always
-
-		for _, v := range cfg.GatewayProxies {
-			v.PodTemplate.Image.PullPolicy = always
-		}
 	}
 
 	return writeYaml(cfg, valuesOutput)

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -52,11 +52,10 @@ var _ = BeforeSuite(func() {
 		Expect(err).NotTo(HaveOccurred())
 		// remove the "v" prefix
 		version = gitInfo.Tag[1:]
-		pullPolicy = v1.PullAlways
 	} else {
 		version = version[1:]
-		pullPolicy = v1.PullIfNotPresent
 	}
+	pullPolicy = v1.PullIfNotPresent
 	// generate the values.yaml and Chart.yaml files
 	MustMake(".", "-C", "../../", "generate-helm-files", "-B")
 })

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -405,7 +405,7 @@ var _ = Describe("Helm Test", func() {
 								Value: "8083",
 							},
 						)
-						container.PullPolicy = "Always"
+						container.PullPolicy = "IfNotPresent"
 						svcBuilder := &ResourceBuilder{
 							Namespace:  namespace,
 							Name:       accessLoggerName,
@@ -1173,7 +1173,7 @@ spec:
       serviceAccountName: gateway
       containers:
       - image: quay.io/solo-io/gateway:` + version + `
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         name: gateway
         ports:
           - containerPort: 8443
@@ -1241,7 +1241,7 @@ spec:
       serviceAccountName: certgen
       containers:
         - image: quay.io/solo-io/certgen:` + version + `
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: certgen
           env:
             - name: POD_NAMESPACE
@@ -1877,7 +1877,7 @@ metadata:
 													v1.ResourceCPU:    resource.MustParse("500m"),
 												},
 											},
-											ImagePullPolicy: "Always",
+											ImagePullPolicy: "IfNotPresent",
 											SecurityContext: &v1.SecurityContext{
 												Capabilities:             &v1.Capabilities{Add: nil, Drop: []v1.Capability{"ALL"}},
 												RunAsUser:                pointer.Int64Ptr(10101),

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -199,7 +199,7 @@ func UpdateSettings(f func(settings *v1.Settings)) {
 }
 
 func getHelmValuesOverrideFile() (filename string, cleanup func()) {
-	values, err := ioutil.TempFile("", "*.yaml")
+	values, err := ioutil.TempFile("", "values-*.yaml")
 	Expect(err).NotTo(HaveOccurred())
 
 	// disabling usage statistics is not important to the functionality of the tests,
@@ -208,6 +208,8 @@ func getHelmValuesOverrideFile() (filename string, cleanup func()) {
 	// same cluster in CI.
 	_, err = values.Write([]byte(`
 global:
+  image:
+    pullPolicy: IfNotPresent
   glooRbac:
     namespaced: true
     nameSuffix: e2e-test-rbac-suffix

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"bufio"
 	"context"
 	"fmt"
 	"io/ioutil"
@@ -10,6 +11,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync/atomic"
 	"text/template"
 
@@ -132,6 +134,36 @@ type EnvoyFactory struct {
 	instances []*EnvoyInstance
 }
 
+func getEnvoyImageTag() string {
+	eit := os.Getenv("ENVOY_IMAGE_TAG")
+	if eit != "" {
+		return eit
+	}
+
+	// get project base
+	gomod, err := exec.Command("go", "env", "GOMOD").CombinedOutput()
+	Expect(err).NotTo(HaveOccurred())
+	gomodfile := strings.TrimSpace(string(gomod))
+	projectbase, _ := filepath.Split(gomodfile)
+
+	envoyinit := filepath.Join(projectbase, "projects/envoyinit/cmd/Dockerfile.envoyinit")
+	inFile, err := os.Open(envoyinit)
+	Expect(err).NotTo(HaveOccurred())
+
+	defer inFile.Close()
+
+	scanner := bufio.NewScanner(inFile)
+	for scanner.Scan() {
+		line := scanner.Text()
+		parts := strings.Split(strings.TrimSpace(line), ":")
+		if len(parts) == 2 {
+			return parts[1]
+		}
+
+	}
+	return ""
+}
+
 func NewEnvoyFactory() (*EnvoyFactory, error) {
 	// if an envoy binary is explicitly specified
 	// use it
@@ -164,7 +196,7 @@ func NewEnvoyFactory() (*EnvoyFactory, error) {
 			return nil, err
 		}
 
-		envoyImageTag := os.Getenv("ENVOY_IMAGE_TAG")
+		envoyImageTag := getEnvoyImageTag()
 		if envoyImageTag == "" {
 			panic("Must set the ENVOY_IMAGE_TAG env var. Find valid tag names here https://quay.io/repository/solo-io/gloo-envoy-wrapper?tab=tags")
 		}
@@ -384,7 +416,7 @@ func (ei *EnvoyInstance) Clean() error {
 }
 
 func (ei *EnvoyInstance) runContainer(ctx context.Context) error {
-	envoyImageTag := os.Getenv("ENVOY_IMAGE_TAG")
+	envoyImageTag := getEnvoyImageTag()
 	if envoyImageTag == "" {
 		return errors.New("Must set the ENVOY_IMAGE_TAG env var. Find valid tag names here https://quay.io/repository/solo-io/gloo-envoy-wrapper?tab=tags")
 	}


### PR DESCRIPTION
changes to allow me to use kind with regression tests.
- no need to use pull policy always, now that we have unique tags for each commit (using always in kind requires pushing the images, which is otherwise not required in kind)
- fix the helm tests accordingly
- getEnvoyImageTag to use by default the tag from the Dockerfile. this allows me to run local e2e tests easier.