### PR TITLE
Update FDS docs error

### DIFF
--- a/docs/content/advanced_configuration/fds_mode.md
+++ b/docs/content/advanced_configuration/fds_mode.md
@@ -88,9 +88,9 @@ spec:
     fdsMode: WHITELIST
 {{< /highlight >}}
 
-## Blacklisting Namespaces & Services
+## Blacklisting Namespaces & Upstreams
 
-When running in `BLACKLIST` mode, blacklist services by adding the following label:
+When running in `BLACKLIST` mode, blacklist upstreams by adding the following label:
 
 `discovery.solo.io/function_discovery=disabled`.
 
@@ -98,18 +98,18 @@ E.g. with
 
 ```bash
 kubectl label namespace default discovery.solo.io/function_discovery=disabled
-kubectl label service -n myapp myservice discovery.solo.io/function_discovery=disabled
+kubectl label upstream -n myapp myupstream discovery.solo.io/function_discovery=disabled
 ```
 
-This label can be applied to namespaces, services, and upstreams.
+This label can be applied to namespaces and upstreams.
 
-To enable FDS for specific services/upstreams in a blacklisted namespace:
+To enable FDS for specific upstreams in a blacklisted namespace:
 
 `discovery.solo.io/function_discovery=enabled`
 
-## Whitelisting Namespaces & Services
+## Whitelisting Namespaces & Upstreams
 
-When running in `WHITELIST` mode, whitelist services by adding the following label:
+When running in `WHITELIST` mode, whitelist `Upstreams` by adding the following label:
 
 `discovery.solo.io/function_discovery=enabled`.
 
@@ -117,11 +117,11 @@ E.g. with
 
 ```bash
 kubectl label namespace default discovery.solo.io/function_discovery=enabled
-kubectl label service -n myapp myservice discovery.solo.io/function_discovery=enabled
+kubectl label upstream -n myapp myupstream discovery.solo.io/function_discovery=enabled
 ```
 
-This label can be applied to namespaces, services, and upstreams.
+This label can be applied to namespaces and upstreams.
 
-To disble FDS for specific services/upstreams in a whitelisted namespace:
+To disable FDS for specific services/upstreams in a whitelisted namespace:
 
 `discovery.solo.io/function_discovery=disabled`


### PR DESCRIPTION
FDS does not actually look at kubernetes services, only the discovered upstreams. Update the docs to reflect this behavior.