### PR TITLE
Port disable k8s dest fix

### DIFF
--- a/changelog/v1.2.16/helm-value-to-disable-k8s-dest.yaml
+++ b/changelog/v1.2.16/helm-value-to-disable-k8s-dest.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  description: Expose the `disableKubernetesDestinations` settings field as a Helm chart value.
+  issueLink: https://github.com/solo-io/gloo/issues/2299

--- a/changelog/v1.2.16/helm-value-to-disable-k8s-dest.yaml
+++ b/changelog/v1.2.16/helm-value-to-disable-k8s-dest.yaml
@@ -1,4 +1,0 @@
-changelog:
-- type: NEW_FEATURE
-  description: Expose the `disableKubernetesDestinations` settings field as a Helm chart value.
-  issueLink: https://github.com/solo-io/gloo/issues/2299

--- a/changelog/v1.2.18/helm-value-to-disable-k8s-dest.yaml
+++ b/changelog/v1.2.18/helm-value-to-disable-k8s-dest.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  description: >
+    Expose the `disableKubernetesDestinations` settings field as a Helm chart value, which if enabled in a Gloo
+    deployment monitoring a large number of kubernetes services, can drastically reduce Gloo memory usage.
+  issueLink: https://github.com/solo-io/gloo/issues/2299

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -26,6 +26,7 @@
 |settings.invalidConfigPolicy.invalidRouteResponseCode|int64|404|the response code for the direct response|
 |settings.invalidConfigPolicy.invalidRouteResponseBody|string|Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.|the response body for the direct response|
 |settings.linkerd|bool|false|Enable automatic Linkerd integration in Gloo.|
+|settings.disableKubernetesDestinations|bool|false|Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature, Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them. If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result in significant overhead. If you do not plan on using this feature, you can set this flag to true to turn it off.|
 |gloo.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |gloo.deployment.image.repository|string|gloo|image name (repository) for the container.|
 |gloo.deployment.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -95,14 +95,15 @@ type KnativeProxy struct {
 }
 
 type Settings struct {
-	WatchNamespaces     []string             `json:"watchNamespaces,omitempty" desc:"whitelist of namespaces for gloo to watch for services and CRDs. Empty list means all namespaces"`
-	WriteNamespace      string               `json:"writeNamespace,omitempty" desc:"namespace where intermediary CRDs will be written to, e.g. Upstreams written by Gloo Discovery."`
-	Integrations        *Integrations        `json:"integrations,omitempty"`
-	Create              bool                 `json:"create" desc:"create a Settings CRD which provides bootstrap configuration to Gloo controllers"`
-	Extensions          interface{}          `json:"extensions,omitempty"`
-	SingleNamespace     bool                 `json:"singleNamespace" desc:"Enable to use install namespace as WatchNamespace and WriteNamespace"`
-	InvalidConfigPolicy *InvalidConfigPolicy `json:"invalidConfigPolicy,omitempty" desc:"Define policies for Gloo to handle invalid configuration"`
-	Linkerd             bool                 `json:"linkerd" desc:"Enable automatic Linkerd integration in Gloo."`
+	WatchNamespaces               []string             `json:"watchNamespaces,omitempty" desc:"whitelist of namespaces for gloo to watch for services and CRDs. Empty list means all namespaces"`
+	WriteNamespace                string               `json:"writeNamespace,omitempty" desc:"namespace where intermediary CRDs will be written to, e.g. Upstreams written by Gloo Discovery."`
+	Integrations                  *Integrations        `json:"integrations,omitempty"`
+	Create                        bool                 `json:"create" desc:"create a Settings CRD which provides bootstrap configuration to Gloo controllers"`
+	Extensions                    interface{}          `json:"extensions,omitempty"`
+	SingleNamespace               bool                 `json:"singleNamespace" desc:"Enable to use install namespace as WatchNamespace and WriteNamespace"`
+	InvalidConfigPolicy           *InvalidConfigPolicy `json:"invalidConfigPolicy,omitempty" desc:"Define policies for Gloo to handle invalid configuration"`
+	Linkerd                       bool                 `json:"linkerd" desc:"Enable automatic Linkerd integration in Gloo."`
+	DisableKubernetesDestinations bool                 `json:"disableKubernetesDestinations" desc:"Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature, Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them. If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result in significant overhead. If you do not plan on using this feature, you can set this flag to true to turn it off."`
 }
 
 type InvalidConfigPolicy struct {

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -17,6 +17,7 @@ spec:
     invalidConfigPolicy:
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}
 {{- end }}
+    disableKubernetesDestinations: {{ .Values.settings.disableKubernetesDestinations | default false }}
 
 {{- if .Values.settings.writeNamespace }}
   discoveryNamespace: {{ .Values.settings.writeNamespace }}

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -24,8 +24,13 @@ settings:
         httpsPort: 443
         replicas: 1
         stats: true
-  # namespaces that Gloo should watch. this includes watches set for pods, services, as well as CRD configuration objects
+  # Namespaces that Gloo should watch. This includes watches set for pods, services, as well as CRD configuration objects.
   watchNamespaces: []
+  # Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature,
+  # Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them.
+  # If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result
+  # in significant overhead. If you do not plan on using this feature, you can set this flag to true to turn it off.
+  disableKubernetesDestinations: false
 gloo:
   deployment:
     image:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -808,6 +808,9 @@ metadata:
     app: gloo
   name: default
   namespace: ` + namespace + `
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
  discovery:
    fdsMode: WHITELIST

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -782,6 +782,7 @@ spec:
      proxyValidationServerAddr: gloo:9988
  gloo:
    xdsBindAddr: 0.0.0.0:9977
+   disableKubernetesDestinations: false
    invalidConfigPolicy:
      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
        ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
@@ -795,6 +796,46 @@ spec:
 `)
 
 						prepareMakefile(namespace, helmValues{})
+						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
+					})
+
+					It("correctly sets the `disableKubernetesDestinations` field in the settings", func() {
+						settings := makeUnstructured(`
+apiVersion: gloo.solo.io/v1
+kind: Settings
+metadata:
+  labels:
+    app: gloo
+  name: default
+  namespace: ` + namespace + `
+spec:
+ discovery:
+   fdsMode: WHITELIST
+ gateway:
+   readGatewaysFromAllNamespaces: false
+   validation:
+     alwaysAccept: true
+     proxyValidationServerAddr: gloo:9988
+ gloo:
+   xdsBindAddr: 0.0.0.0:9977
+   disableKubernetesDestinations: true
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
+       ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
+     invalidRouteResponseCode: 404
+
+ kubernetesArtifactSource: {}
+ kubernetesConfigSource: {}
+ kubernetesSecretSource: {}
+ refreshRate: 60s
+ discoveryNamespace: ` + namespace + `
+`)
+
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"settings.disableKubernetesDestinations=true",
+							},
+						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
 


### PR DESCRIPTION
Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature, Gloo scans the cluster for Kubernetes services and creates a special type of in-memory Upstream to represent them.

If the cluster contains a lot of services and you do not restrict the namespaces Gloo is watching, this can result in significant overhead. If users do not plan on using this feature, they can now provide a helm value to turn it off.

Port of https://github.com/solo-io/gloo/pull/2302
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2299