### PR TITLE
Lds reloads 2

### DIFF
--- a/changelog/v1.3.6/fix-grafana-average-request-time.yaml
+++ b/changelog/v1.3.6/fix-grafana-average-request-time.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Stopped the listeners from reloading too often in certain cases.
+    issueLink: https://github.com/solo-io/gloo/issues/2185

--- a/changelog/v1.3.6/fix-grafana-average-request-time.yaml
+++ b/changelog/v1.3.6/fix-grafana-average-request-time.yaml
@@ -1,4 +1,6 @@
 changelog:
   - type: FIX
-    description: Stopped the listeners from reloading too often in certain cases.
+    description: >
+      Fixes listener config sent to envoy to be idempotent, so that config no longer reloads as "different" when there are no changes.
+      This resolves the issue of the "Average Request Time" graph in grafana showing gaps in the downstream data, among other potential issues.
     issueLink: https://github.com/solo-io/gloo/issues/2185

--- a/projects/gloo/pkg/plugins/grpc/plugin.go
+++ b/projects/gloo/pkg/plugins/grpc/plugin.go
@@ -43,7 +43,6 @@ type ServicesAndDescriptor struct {
 func NewPlugin(transformsAdded *bool) *plugin {
 	return &plugin{
 		recordedUpstreams: make(map[core.ResourceRef]*v1.Upstream),
-		upstreamServices:  make(map[string]ServicesAndDescriptor),
 		transformsAdded:   transformsAdded,
 	}
 }
@@ -51,7 +50,7 @@ func NewPlugin(transformsAdded *bool) *plugin {
 type plugin struct {
 	transformsAdded   *bool
 	recordedUpstreams map[core.ResourceRef]*v1.Upstream
-	upstreamServices  map[string]ServicesAndDescriptor
+	upstreamServices  []ServicesAndDescriptor
 
 	ctx context.Context
 }
@@ -106,10 +105,11 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 	addWellKnownProtos(descriptors)
 
 	p.recordedUpstreams[in.Metadata.Ref()] = in
-	p.upstreamServices[in.Metadata.Name] = ServicesAndDescriptor{
+	p.upstreamServices = append(p.upstreamServices, ServicesAndDescriptor{
 		Descriptors: descriptors,
 		Spec:        grpcSpec,
-	}
+	})
+	contextutils.LoggerFrom(p.ctx).Debugf("in.Metadata.Namespace: %s, in.Metadata.Name: %s", in.Metadata.Namespace, in.Metadata.Name)
 
 	return nil
 }

--- a/projects/gloo/pkg/plugins/plugin_interface.go
+++ b/projects/gloo/pkg/plugins/plugin_interface.go
@@ -107,6 +107,15 @@ func (s StagedListenerFilterList) Less(i, j int) bool {
 	if s[i].ListenerFilter.Name < s[j].ListenerFilter.Name {
 		return true
 	}
+	if s[i].ListenerFilter.Name > s[j].ListenerFilter.Name {
+		return false
+	}
+	if s[i].ListenerFilter.String() < s[j].ListenerFilter.String() {
+		return true
+	}
+	if s[i].ListenerFilter.String() > s[j].ListenerFilter.String() {
+		return false
+	}
 	// ensure stability
 	return i < j
 }
@@ -152,6 +161,15 @@ func (s StagedHttpFilterList) Less(i, j int) bool {
 	}
 	if s[i].HttpFilter.Name < s[j].HttpFilter.Name {
 		return true
+	}
+	if s[i].HttpFilter.Name > s[j].HttpFilter.Name {
+		return false
+	}
+	if s[i].HttpFilter.String() < s[j].HttpFilter.String() {
+		return true
+	}
+	if s[i].HttpFilter.String() > s[j].HttpFilter.String() {
+		return false
 	}
 	// ensure stability
 	return i < j

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -734,7 +734,7 @@ var _ = Describe("Translator", func() {
 			originalHttpFilters = hcmFilter.GetConfig().Fields["http_filters"].GetListValue().Values
 		})
 
-		It ("should have different version and http filters after adding 2 upstreams", func() {
+		It("should have different version and http filters after adding 2 upstreams", func() {
 
 			// add upstreams with same name
 			params.Snapshot.Upstreams = append(params.Snapshot.Upstreams, localUpstream1)
@@ -753,7 +753,7 @@ var _ = Describe("Translator", func() {
 			Expect(upstreamsHttpFilters).ToNot(Equal(originalHttpFilters))
 		})
 
-		It ("should have same version and http filters when http filters with the same name are added in a different order", func() {
+		It("should have same version and http filters when http filters with the same name are added in a different order", func() {
 
 			// add upstreams in the opposite order
 			params.Snapshot.Upstreams = append(params.Snapshot.Upstreams, localUpstream2)


### PR DESCRIPTION
Fix `Less` functions for http filters (`StagedHttpFilterList`) and listener filters (`StagedListenerFilterList`) to handle case of 2 different filters with same name.

This should fix the grafana bug which was caused by the envoy_http_downstream_rq_time stats reloading exceedingly often.

(Also changed upstreamServices from unnecessary map to slice.)
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2185