### PR TITLE
Fix ingress proxy creation on Knative > 1.9

### DIFF
--- a/changelog/v1.3.6/fix-double-loadbalancer.yaml
+++ b/changelog/v1.3.6/fix-double-loadbalancer.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix Helm charts for knative installs so version specific templates only match the provided version
+    issueLink: https://github.com/solo-io/gloo/issues/2448

--- a/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][0-7]+[.][0-9]" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare "< 0.8.0" .Values.settings.integrations.knative.version ) }}
 
 # configmap
 apiVersion: v1

--- a/install/helm/gloo/templates/16-clusteringress-proxy-service.yaml
+++ b/install/helm/gloo/templates/16-clusteringress-proxy-service.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.settings.integrations.knative.enabled }}
-{{- if (regexMatch "[0-9]+[.][0-7]+[.][0-9]+" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare "< 0.8.0" .Values.settings.integrations.knative.version ) }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -31,7 +31,7 @@ spec:
 {{- end }}
 {{- if .Values.settings.integrations.knative.enabled }}
   knative:
-{{- if (regexMatch "[0-9]+[.][0-7]+[.][0-9]+" .Values.settings.integrations.knative.version ) }}
+{{- if (semverCompare "< 0.8.0" .Values.settings.integrations.knative.version ) }}
     clusterIngressProxyAddress: "clusteringress-proxy.{{ .Release.Namespace }}.svc.{{ $.Values.k8s.clusterName}}"
 {{- else }}
     knativeExternalProxyAddress: "knative-external-proxy.{{ .Release.Namespace }}.svc.{{ $.Values.k8s.clusterName}}"


### PR DESCRIPTION
When using the Knative charts to install Gloo, two ingress proxies would be created if the knative version was > 1.9. This was because a regex identifying whether the version was > 1.7 contained a bug that made it match everything where the minor version contained any digit <8.

This PR removes the regex and uses the same `semverCompare` method used to identify versions above 1.7.

Fixes #2448
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2448