### PR TITLE
Fix Gloo on Consul tutorial for newer versions of Gloo

### DIFF
--- a/changelog/v1.3.7/fix-consul-docs.yaml
+++ b/changelog/v1.3.7/fix-consul-docs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      In Gloo 1.2.13 we removed the auto-creation of Gateway resources. This updates the Consul guide to reflect that change.
+    issueLink: https://github.com/solo-io/gloo/issues/2439

--- a/docs/content/installation/gateway/docker-compose-consul/_index.md
+++ b/docs/content/installation/gateway/docker-compose-consul/_index.md
@@ -107,6 +107,14 @@ With all the containers now running, it is time to configure the *Upstream* for 
 
 ---
 
+## Configuring the Gateway
+
+From the repo root:
+
+```shell script
+curl --request PUT --data-binary @./install/docker-compose-consul/data/gateways/gloo-system/gw-proxy.yaml http://127.0.0.1:8500/v1/kv/gloo/gateway.solo.io/v1/Gateway/gloo-system
+```
+
 ## Configuring Upstream and Virtual Services
 
 The next step is to expose the Pet Store's API through the Gloo gateway. We will do this by creating a service on Consul that Gloo will use as an *Upstream*. Then we will create a *Virtual Service* on Gloo with a routing rule. The configuration data for the *Virtual Service* will be stored in Consul.

--- a/install/docker-compose-consul/data/gateways/gloo-system/gw-proxy.yaml
+++ b/install/docker-compose-consul/data/gateways/gloo-system/gw-proxy.yaml
@@ -1,0 +1,11 @@
+metadata:
+  name: gateway-proxy
+  namespace: gloo-system
+bindAddress: '::'
+bindPort: 8080
+httpGateway: {}
+proxyNames:
+  - gateway-proxy
+ssl: false
+useProxyProto: false
+status: {}

--- a/install/docker-compose-consul/docker-compose.yaml
+++ b/install/docker-compose-consul/docker-compose.yaml
@@ -44,7 +44,7 @@ services:
 
   # Gloo components
   gloo:
-    image: "${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.2.4}"
+    image: "${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.3.7}"
     working_dir: /
     command:
     - "--dir=/data/"
@@ -55,7 +55,7 @@ services:
     restart: always
 
   discovery:
-    image: "${GLOO_REPO:-quay.io/solo-io}/discovery:${GLOO_VERSION:-1.2.4}"
+    image: "${GLOO_REPO:-quay.io/solo-io}/discovery:${GLOO_VERSION:-1.3.7}"
     working_dir: /
     command:
     - "--dir=/data/"
@@ -64,7 +64,7 @@ services:
     restart: always
 
   gateway:
-    image: "${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.2.4}"
+    image: "${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.3.7}"
     working_dir: /
     command:
     - "--dir=/data/"
@@ -73,7 +73,7 @@ services:
     restart: always
 
   gateway-proxy:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.2.4}
+    image: "${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.3.7}"
     entrypoint: ["envoy"]
     command: ["-c", "/config/envoy.yaml", "--disable-hot-restart"]
     volumes:
@@ -83,5 +83,3 @@ services:
     - "8443:8443"
     - "19000:19000"
     restart: always
-
-


### PR DESCRIPTION
In Gloo 1.2.13 we removed the auto-creation of Gateway resources. This updates the Consul guide to reflect that change.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2439