### PR TITLE
Allow a custom name for the gateway-proxy service

### DIFF
--- a/changelog/v1.3.7/custom-gateway-proxy-svc-name.yaml
+++ b/changelog/v1.3.7/custom-gateway-proxy-svc-name.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: HELM
+    description: Allow for gateway-proxy to have a custom service name
+    issueLink: https://github.com/solo-io/gloo/issues/2446

--- a/docs/content/installation/gateway/kubernetes/values.txt
+++ b/docs/content/installation/gateway/kubernetes/values.txt
@@ -129,6 +129,7 @@
 |gatewayProxies.NAME.service.clusterIP|string||static clusterIP (or `None`) when `gatewayProxies[].gatewayProxy.service.type` is `ClusterIP`|
 |gatewayProxies.NAME.service.extraAnnotations.NAME|string|||
 |gatewayProxies.NAME.service.externalTrafficPolicy|string|||
+|gatewayProxies.NAME.service.name|string|||
 |gatewayProxies.NAME.antiAffinity|bool||configure anti affinity such that pods are prefferably not co-located|
 |gatewayProxies.NAME.tracing.provider|string|||
 |gatewayProxies.NAME.tracing.cluster|string|||
@@ -180,6 +181,7 @@
 |gatewayProxies.gatewayProxy.service.clusterIP|string||static clusterIP (or `None`) when `gatewayProxies[].gatewayProxy.service.type` is `ClusterIP`|
 |gatewayProxies.gatewayProxy.service.extraAnnotations.NAME|string|||
 |gatewayProxies.gatewayProxy.service.externalTrafficPolicy|string|||
+|gatewayProxies.gatewayProxy.service.name|string|||
 |gatewayProxies.gatewayProxy.antiAffinity|bool|false|configure anti affinity such that pods are prefferably not co-located|
 |gatewayProxies.gatewayProxy.tracing.provider|string|||
 |gatewayProxies.gatewayProxy.tracing.cluster|string|||

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -246,6 +246,7 @@ type GatewayProxyService struct {
 	ClusterIP             string            "json:\"clusterIP,omitempty\" desc:\"static clusterIP (or `None`) when `gatewayProxies[].gatewayProxy.service.type` is `ClusterIP`\""
 	ExtraAnnotations      map[string]string `json:"extraAnnotations,omitempty"`
 	ExternalTrafficPolicy string            `json:"externalTrafficPolicy,omitempty"`
+	Name                  string            `json:"name,omitempty", desc:"Custom name override for the service resource of the proxy"`
 }
 
 type Tracing struct {

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.gateway.enabled }}
 {{- range $name, $spec := .Values.gatewayProxies }}
+{{- $svcName := default $name $spec.service.name }}
 ---
 apiVersion: v1
 kind: Service
@@ -8,7 +9,7 @@ metadata:
     app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
-  name: {{ $name | kebabcase }}
+  name: {{ $svcName | kebabcase }}
   namespace: {{ $.Release.Namespace }}
 {{- if $spec.service.extraAnnotations }}
   annotations:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -600,6 +600,16 @@ var _ = Describe("Helm Test", func() {
 						})
 						testManifest.ExpectService(gatewayProxyService)
 					})
+
+					It("sets custom service name", func() {
+						gatewayProxyService.ObjectMeta.Name = "gateway-proxy-custom"
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"gatewayProxies.gatewayProxy.service.name=gateway-proxy-custom",
+							},
+						})
+						testManifest.ExpectService(gatewayProxyService)
+					})
 				})
 
 				Context("gateway-proxy deployment", func() {


### PR DESCRIPTION
This is if you want to have your gateway-proxy's service name be different from the deploy/configmap/pod. I added a test for this as well.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2446