### PR TITLE
Harden github release asset retry logic

### DIFF
--- a/changelog/v1.3.9/bump-go-utils.yaml
+++ b/changelog/v1.3.9/bump-go-utils.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: go-utils
+    dependencyTag: v0.14.1
+    description: Update go-utils to version 0.14.1, which includes fixes to make our release asset logic more resilient to transient github failures.

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/rotisserie/eris v0.1.1
 	github.com/solo-io/envoy-operator v0.1.1
 	github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f
-	github.com/solo-io/go-utils v0.13.1
+	github.com/solo-io/go-utils v0.14.1
 	github.com/solo-io/protoc-gen-ext v0.0.7
 	github.com/solo-io/reporting-client v0.1.2
 	github.com/solo-io/solo-kit v0.13.2

--- a/go.sum
+++ b/go.sum
@@ -897,8 +897,6 @@ github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f/go.mod h1
 github.com/solo-io/go-utils v0.11.0/go.mod h1:R8lbLuLtMaTOhD+6wGpdxj60r1Vwt63fHe1UxlObHig=
 github.com/solo-io/go-utils v0.11.7/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2YYYYgYBJso=
 github.com/solo-io/go-utils v0.13.0/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
-github.com/solo-io/go-utils v0.13.1 h1:DrZs3rqdPpkA+FxU8b7VuXOfDNUX3Kex0pE47gC7VNA=
-github.com/solo-io/go-utils v0.13.1/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
 github.com/solo-io/go-utils v0.14.1 h1:V61dGoFiM2XKUMl+PdQAteXAXn2Ra98Dal5qSO9uKxk=
 github.com/solo-io/go-utils v0.14.1/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
 github.com/solo-io/protoc-gen-ext v0.0.7 h1:s9uFGtAoSsXL7vukWKPgofkxzHUeje7m6+0C3rYA2fU=

--- a/go.sum
+++ b/go.sum
@@ -899,6 +899,7 @@ github.com/solo-io/go-utils v0.11.7/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2Y
 github.com/solo-io/go-utils v0.13.0/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
 github.com/solo-io/go-utils v0.13.1 h1:DrZs3rqdPpkA+FxU8b7VuXOfDNUX3Kex0pE47gC7VNA=
 github.com/solo-io/go-utils v0.13.1/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
+github.com/solo-io/go-utils v0.14.1/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
 github.com/solo-io/protoc-gen-ext v0.0.7 h1:s9uFGtAoSsXL7vukWKPgofkxzHUeje7m6+0C3rYA2fU=
 github.com/solo-io/protoc-gen-ext v0.0.7/go.mod h1:zZIFs9Ch3EU3uQgL2ZwCHlUGAtwiz4Cbw6tBcmaNsEk=
 github.com/solo-io/reporting-client v0.1.2 h1:U585Q5UlB5/UUewtgEAQz94SWuNRBxoHc4tPthhnYko=

--- a/go.sum
+++ b/go.sum
@@ -899,6 +899,7 @@ github.com/solo-io/go-utils v0.11.7/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2Y
 github.com/solo-io/go-utils v0.13.0/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
 github.com/solo-io/go-utils v0.13.1 h1:DrZs3rqdPpkA+FxU8b7VuXOfDNUX3Kex0pE47gC7VNA=
 github.com/solo-io/go-utils v0.13.1/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
+github.com/solo-io/go-utils v0.14.1 h1:V61dGoFiM2XKUMl+PdQAteXAXn2Ra98Dal5qSO9uKxk=
 github.com/solo-io/go-utils v0.14.1/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
 github.com/solo-io/protoc-gen-ext v0.0.7 h1:s9uFGtAoSsXL7vukWKPgofkxzHUeje7m6+0C3rYA2fU=
 github.com/solo-io/protoc-gen-ext v0.0.7/go.mod h1:zZIFs9Ch3EU3uQgL2ZwCHlUGAtwiz4Cbw6tBcmaNsEk=


### PR DESCRIPTION
Update go-utils to version 0.14.1, which includes fixes to make our release asset logic more resilient to transient github failures.
