### PR TITLE
Fix changelog formatting errors

### DIFF
--- a/changelog/v1.3.0/auth-endpoint-query-params.yaml
+++ b/changelog/v1.3.0/auth-endpoint-query-params.yaml
@@ -8,27 +8,27 @@ changelog:
 
     The new field is a map, where each key-value pair will result in an additional query parameter:
 
-    ```yaml
-    apiVersion: enterprise.gloo.solo.io/v1
-    kind: AuthConfig
-    metadata:
-      name: google-oidc
-      namespace: gloo-system
-    spec:
-      configs:
-      - oauth:
-          app_url: http://localhost:8080
-          callback_path: /callback
-          client_id: $CLIENT_ID
-          client_secret_ref:
-            name: google
-            namespace: gloo-system
-          issuer_url: https://accounts.google.com
-          auth_endpoint_query_params:
-            key1 : value1
-            key2 : value2
-    ```
+      ```yaml
+      apiVersion: enterprise.gloo.solo.io/v1
+      kind: AuthConfig
+      metadata:
+        name: google-oidc
+        namespace: gloo-system
+      spec:
+        configs:
+        - oauth:
+            app_url: http://localhost:8080
+            callback_path: /callback
+            client_id: $CLIENT_ID
+            client_secret_ref:
+              name: google
+              namespace: gloo-system
+            issuer_url: https://accounts.google.com
+            auth_endpoint_query_params:
+              key1 : value1
+              key2 : value2
+      ```
 
-    We also added a new `--auth-endpoint-query-params` flag to the `glooctl create authconfig` command; the flag takes
-    in a comma-separated list of key value pairs (e.g. a=b,c=d).
+      We also added a new `--auth-endpoint-query-params` flag to the `glooctl create authconfig` command; the flag takes
+      in a comma-separated list of key value pairs (e.g. a=b,c=d).
   issueLink: https://github.com/solo-io/gloo/issues/2030

--- a/changelog/v1.3.6/gloo-mtls.yaml
+++ b/changelog/v1.3.6/gloo-mtls.yaml
@@ -7,14 +7,14 @@ changelog:
       clusters). Turning on mTLS will encrypt the xDS communication between Gloo and Envoy.
     issueLink: https://github.com/solo-io/gloo/issues/2134
   - type: HELM
-    description: >
-      We are introducing a new Helm value `global.glooMtls.enabled` to enable mTLS between Gloo and Envoy.
-      An example of a helm override file that enables MTLS authentication is:
-      ```
-      global:
-        glooMtls:
-          enabled: true
-      ```
+    description: |
+      We are introducing a new Helm value `global.glooMtls.enabled` to enable mTLS between Gloo and Envoy. An example of a helm override file that enables MTLS authentication is:
+        ```
+        global:
+          glooMtls:
+            enabled: true
+        ```
+        For more information, check out the [corresponding documentation](https://docs.solo.io/gloo/latest/security/mtls/).
     issueLink: https://github.com/solo-io/gloo/issues/2134
   - type: FIX
     description: Pin versions of base docker images for Gloo containers

--- a/changelog/v1.3.8/sds-envoy-helm-values.yaml
+++ b/changelog/v1.3.8/sds-envoy-helm-values.yaml
@@ -1,10 +1,8 @@
 changelog:
-  - type: HELM
-    description: >
-      Introducing the new `global.glooMtls.sds` and `global.glooMtls.envoy` Helm values to
-      determine which images will be rendered in the gloo mTLS sds and envoy sidecars.
-      An example of a helm override file that enables mTLS authentication is:
-      ```
+- type: HELM
+  description: |
+    Introducing the new `global.glooMtls.sds` and `global.glooMtls.envoy` Helm values to determine which images will be rendered in the gloo mTLS sds and envoy sidecars. An example of a helm override file that enables mTLS authentication is:
+      ```yaml
       global:
         glooMtls:
           enabled: true
@@ -15,4 +13,5 @@ changelog:
             image:
               tag: test
       ```
-    issueLink: https://github.com/solo-io/gloo/issues/2134
+      For more information, check out the [corresponding documentation](https://docs.solo.io/gloo/latest/security/mtls/).
+  issueLink: https://github.com/solo-io/gloo/issues/2134


### PR DESCRIPTION
Some YAML code blocks are [rendering incorrectly](https://docs.solo.io/gloo/latest/changelog/open_source/) in our changelog docs. This change fixes the problematic entries.