### PR TITLE
Fix duplicate websocket upgrade configs noisy logging

### DIFF
--- a/changelog/v1.3.10/fix-filterchain-copying.yaml
+++ b/changelog/v1.3.10/fix-filterchain-copying.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix noisy logging on duplicate upgrade websocket config when using Gloo with SSL & SNI.
+    issueLink: https://github.com/solo-io/gloo/issues/2500

--- a/projects/gloo/pkg/plugins/hcm/plugin.go
+++ b/projects/gloo/pkg/plugins/hcm/plugin.go
@@ -53,8 +53,8 @@ func (p *Plugin) ProcessListener(params plugins.Params, in *v1.Listener, out *en
 		return nil
 	}
 	hcmSettings := hl.HttpListener.GetOptions().GetHttpConnectionManagerSettings()
-	for _, f := range out.FilterChains {
-		for i, filter := range f.Filters {
+	for _, fc := range out.FilterChains {
+		for i, filter := range fc.Filters {
 			if filter.Name == util.HTTPConnectionManager {
 				// get config
 				var cfg envoyhttp.HttpConnectionManager
@@ -76,7 +76,7 @@ func (p *Plugin) ProcessListener(params plugins.Params, in *v1.Listener, out *en
 					}
 				}
 
-				f.Filters[i], err = translatorutil.NewFilterWithConfig(util.HTTPConnectionManager, &cfg)
+				fc.Filters[i], err = translatorutil.NewFilterWithConfig(util.HTTPConnectionManager, &cfg)
 				// this should never error
 				if err != nil {
 					return err

--- a/projects/gloo/pkg/plugins/tcp/plugin.go
+++ b/projects/gloo/pkg/plugins/tcp/plugin.go
@@ -5,6 +5,7 @@ import (
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoylistener "github.com/envoyproxy/go-control-plane/envoy/api/v2/listener"
 	envoytcp "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/tcp_proxy/v2"
+	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/pkg/utils/gogoutils"
@@ -182,6 +183,12 @@ func (p *Plugin) computerTcpFilterChain(snap *v1.ApiSnapshot, listener *v1.Liste
 }
 
 func newSslFilterChain(downstreamConfig *envoyauth.DownstreamTlsContext, sniDomains []string, useProxyProto *types.BoolValue, listenerFilters []*envoylistener.Filter) *envoylistener.FilterChain {
+
+	// copy listenerFilter so we can modify filter chain later without changing the filters on all of them!
+	listenerFiltersCopy := make([]*envoylistener.Filter, len(listenerFilters))
+	for i, lf := range listenerFilters {
+		listenerFiltersCopy[i] = proto.Clone(lf).(*envoylistener.Filter)
+	}
 
 	return &envoylistener.FilterChain{
 		FilterChainMatch: &envoylistener.FilterChainMatch{

--- a/projects/gloo/pkg/plugins/tcp/plugin.go
+++ b/projects/gloo/pkg/plugins/tcp/plugin.go
@@ -194,7 +194,7 @@ func newSslFilterChain(downstreamConfig *envoyauth.DownstreamTlsContext, sniDoma
 		FilterChainMatch: &envoylistener.FilterChainMatch{
 			ServerNames: sniDomains,
 		},
-		Filters: listenerFilters,
+		Filters: listenerFiltersCopy,
 		TransportSocket: &envoycore.TransportSocket{
 			Name:       pluginutils.TlsTransportSocket,
 			ConfigType: &envoycore.TransportSocket_TypedConfig{TypedConfig: pluginutils.MustMessageToAny(downstreamConfig)},

--- a/projects/gloo/pkg/translator/listener.go
+++ b/projects/gloo/pkg/translator/listener.go
@@ -2,9 +2,10 @@ package translator
 
 import (
 	"fmt"
-	"github.com/gogo/protobuf/proto"
 	"sort"
 	"strings"
+
+	"github.com/gogo/protobuf/proto"
 
 	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"

--- a/projects/gloo/pkg/translator/listener.go
+++ b/projects/gloo/pkg/translator/listener.go
@@ -222,11 +222,18 @@ func validateListenerPorts(proxy *v1.Proxy, listenerReport *validationapi.Listen
 
 func newSslFilterChain(downstreamConfig *envoyauth.DownstreamTlsContext, sniDomains []string, useProxyProto *types.BoolValue, listenerFilters []*envoylistener.Filter) *envoylistener.FilterChain {
 
+	// copy listenerFilter so we can modify filter chain later without changing the filters on all of them!
+	listenerFiltersCopy := make([]*envoylistener.Filter, len(listenerFilters))
+	for i, lf := range listenerFilters {
+		tmp := *lf
+		listenerFiltersCopy[i] = &tmp
+	}
+
 	return &envoylistener.FilterChain{
 		FilterChainMatch: &envoylistener.FilterChainMatch{
 			ServerNames: sniDomains,
 		},
-		Filters: listenerFilters,
+		Filters: listenerFiltersCopy,
 
 		TransportSocket: &envoycore.TransportSocket{
 			Name:       pluginutils.TlsTransportSocket,

--- a/projects/gloo/pkg/translator/listener.go
+++ b/projects/gloo/pkg/translator/listener.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	"fmt"
+	"github.com/gogo/protobuf/proto"
 	"sort"
 	"strings"
 
@@ -225,8 +226,7 @@ func newSslFilterChain(downstreamConfig *envoyauth.DownstreamTlsContext, sniDoma
 	// copy listenerFilter so we can modify filter chain later without changing the filters on all of them!
 	listenerFiltersCopy := make([]*envoylistener.Filter, len(listenerFilters))
 	for i, lf := range listenerFilters {
-		tmp := *lf
-		listenerFiltersCopy[i] = &tmp
+		listenerFiltersCopy[i] = proto.Clone(lf).(*envoylistener.Filter)
 	}
 
 	return &envoylistener.FilterChain{


### PR DESCRIPTION
### Change

Fix noisy logging on duplicate upgrade websocket config when using Gloo with SSL & SNI.

### Context

Harmless fix, as we were only side-affecting the upgrade configs in a dangerous way, but by resetting the list before appending in each loop (as we did to make this more code more defensive here: https://github.com/solo-io/gloo/pull/1990) there is no potential for error (despite these dangerous-looking logs).

Fixing this may prevent future bugs in the affected function and cleans up logging, which is nice.

### Succinct summary of bug
We loop over filters here: https://github.com/solo-io/gloo/blob/v1.3.9/projects/gloo/pkg/plugins/hcm/plugin.go#L57

and modify them here: https://github.com/solo-io/gloo/blob/v1.3.9/projects/gloo/pkg/plugins/hcm/plugin.go#L68

but when we make new filter chains, we are reusing the same filter pointers: https://github.com/solo-io/gloo/blob/v1.3.9/projects/gloo/pkg/translator/listener.go#L229

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2500