### PR TITLE
allow unsafe html

### DIFF
--- a/docs/docs.toml
+++ b/docs/docs.toml
@@ -63,3 +63,10 @@ weight = 10
 # remove the default hugo taxonomies (tag and category directories)
 disableKinds = ["taxonomy", "taxonomyTerm"]
 [taxonomies]
+
+# fix link generation issue
+[markup]
+  defaultMarkdownHandler = "goldmark"
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true


### PR DESCRIPTION
Regarding issue #2506 

This change to the docs.toml config will allow unsafe html to be processed by the markdown rendering engine. That appears to be what is preventing the children content lists from including the proper formatting and links.