### PR TITLE
Add appendix to show auto-routing to consul services

### DIFF
--- a/changelog/v1.3.11/add-consul-appendix-dynamic-routing-docs.yaml
+++ b/changelog/v1.3.11/add-consul-appendix-dynamic-routing-docs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add docs section to show how to route to automatically generated consul routes from discovered consul services.
+    issueLink: https://github.com/solo-io/gloo/issues/2308
+    resolvesIssue: false

--- a/docs/content/dev/example-proxy-controller.go
+++ b/docs/content/dev/example-proxy-controller.go
@@ -99,9 +99,10 @@ func initGlooClients(ctx context.Context) (v1.UpstreamClient, v1.ProxyClient) {
 
 	// initialize the CRD client for Gloo Upstreams
 	upstreamClient, err := v1.NewUpstreamClient(&factory.KubeResourceClientFactory{
-		Crd:         v1.UpstreamCrd,
-		Cfg:         restConfig,
-		SharedCache: cache,
+		Crd:             v1.UpstreamCrd,
+		Cfg:             restConfig,
+		SharedCache:     cache,
+		SkipCrdCreation: true,
 	})
 	must(err)
 
@@ -111,9 +112,10 @@ func initGlooClients(ctx context.Context) (v1.UpstreamClient, v1.ProxyClient) {
 
 	// initialize the CRD client for Gloo Proxies
 	proxyClient, err := v1.NewProxyClient(&factory.KubeResourceClientFactory{
-		Crd:         v1.ProxyCrd,
-		Cfg:         restConfig,
-		SharedCache: cache,
+		Crd:             v1.ProxyCrd,
+		Cfg:             restConfig,
+		SharedCache:     cache,
+		SkipCrdCreation: true,
 	})
 	must(err)
 

--- a/docs/content/dev/example-proxy-controller.md
+++ b/docs/content/dev/example-proxy-controller.md
@@ -4,7 +4,8 @@ weight: 2
 ---
 
 In this tutorial, we're going to show how to use Gloo's {{< protobuf name="gloo.solo.io.Proxy" display="Proxy API">}}
-to build a router which automatically creates routes for every existing kubernetes service.
+to build a router which automatically creates routes for every existing kubernetes service. Then we will show how to
+enable the same functionality for consul services as well.
 
 ## Why Write a Custom Proxy Controller
 
@@ -1085,7 +1086,7 @@ potential use cases. Take a look at our
 wide range of configuration options Proxies expose such as request transformation, SSL termination, serverless computing, 
 and much more.
 
-## Appendix - Auto-routing with consul services
+## Appendix - Auto-Generated Routes for Discovered Consul Services
 
 The rest of this guide assumes you've been running on minikube, but this setup can be extrapolated to production/more
 complex setups.
@@ -1095,7 +1096,7 @@ Run consul on your local machine:
 consul agent -dev --client=0.0.0.0
 ```
 
-Get the Host IP address reachable from within minikube:
+Get the Host IP address where consul will be reachable from within minikube pods:
 ```shell script
 minikube ssh "route -n | grep ^0.0.0.0 | awk '{ print \$2 }'"
 ```
@@ -1118,7 +1119,7 @@ cat > petstore-service.json <<EOF
 EOF
 ```
 
-register the consul service:
+Register the consul service:
 ```shell script
 curl -v \
     -XPUT \
@@ -1126,7 +1127,7 @@ curl -v \
     "http://127.0.0.1:8500/v1/agent/service/register"
 ```
 
-confirm the upstream was discovered:
+Confirm the upstream was discovered:
 ```shell script
 kubectl get us -n gloo-system petstore
 ```
@@ -1147,4 +1148,4 @@ returns
 [{"id":1,"name":"Dog","status":"available"},{"id":2,"name":"Cat","status":"pending"}]
 ```
 
-Nice! You've configured Gloo to auto-route to discovered consul services!
+Nice. You've configured Gloo to proactively create routes to discovered consul services!

--- a/docs/content/dev/example-proxy-controller.md
+++ b/docs/content/dev/example-proxy-controller.md
@@ -601,11 +601,18 @@ and [deploy it as a pod](https://github.com/solo-io/gloo/tree/master/example/pro
 inside of Kubernetes, let's just try running it locally. [Make sure you have Gloo installed]({{% versioned_link_path fromRoot="/installation" %}})
 in your cluster so that Discovery will create some Upstreams for us.
 
-Once that's done, to see our code in action, simply run `go run example/proxycontroller/proxycontroller.go` from repo root!
 
-```bash
+
+{{< tabs >}}
+{{< tab name="run locally" codelang="bash">}}
 go run example/proxycontroller/proxycontroller.go
-```
+{{< /tab >}}
+{{< tab name="run in k8s" codelang="bash">}}
+kubectl apply -f https://raw.githubusercontent.com/solo-io/gloo/master/example/proxycontroller/install/proxycontroller.yaml
+{{< /tab >}}
+{{< /tabs >}}
+
+The logs should show:
 ```
 2019/02/11 11:27:30 wrote proxy object: listeners:<name:"my-amazing-listener" bind_address:"::" bind_port:8080 http_listener:<virtual_hosts:<name:"default-kubernetes-443" domains:"default-kubernetes-443" routes:<matchers:<prefix:"/" > route_action:<single:<upstream:<name:"default-kubernetes-443" namespace:"gloo-system" > > > > > virtual_hosts:<name:"gloo-system-gateway-proxy-8080" domains:"gloo-system-gateway-proxy-8080" routes:<matchers:<prefix:"/" > route_action:<single:<upstream:<name:"gloo-system-gateway-proxy-8080" namespace:"gloo-system" > > > > > virtual_hosts:<name:"gloo-system-gloo-9977" domains:"gloo-system-gloo-9977" routes:<matchers:<prefix:"/" > route_action:<single:<upstream:<name:"gloo-system-gloo-9977" namespace:"gloo-system" > > > > > virtual_hosts:<name:"kube-system-kube-dns-53" domains:"kube-system-kube-dns-53" routes:<matchers:<prefix:"/" > route_action:<single:<upstream:<name:"kube-system-kube-dns-53" namespace:"gloo-system" > > > > > virtual_hosts:<name:"kube-system-tiller-deploy-44134" domains:"kube-system-tiller-deploy-44134" routes:<matchers:<prefix:"/" > route_action:<single:<upstream:<name:"kube-system-tiller-deploy-44134" namespace:"gloo-system" > > > > > > > status:<> metadata:<name:"my-cool-proxy" namespace:"gloo-system" resource_version:"455073" > 
 ```

--- a/docs/content/dev/example-proxy-controller.md
+++ b/docs/content/dev/example-proxy-controller.md
@@ -596,9 +596,10 @@ func must(err error) {
 
 ### Run
 
-While it's possible to package this application in a Docker container and deploy it as a pod inside of Kubernetes, let's 
-just try running it locally. [Make sure you have Gloo installed]({{% versioned_link_path fromRoot="/installation" %}}) in your cluster so 
-that Discovery will create some Upstreams for us.
+While it's possible to package [this application in a Docker container](https://github.com/solo-io/gloo/tree/master/example/proxycontroller/Dockerfile)
+and [deploy it as a pod](https://github.com/solo-io/gloo/tree/master/example/proxycontroller/install/proxycontroller.yaml)
+inside of Kubernetes, let's just try running it locally. [Make sure you have Gloo installed]({{% versioned_link_path fromRoot="/installation" %}})
+in your cluster so that Discovery will create some Upstreams for us.
 
 Once that's done, to see our code in action, simply run `go run example/proxycontroller/proxycontroller.go` from repo root!
 

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine:3.11.3
+
+COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
+
+ENTRYPOINT ["/usr/local/bin/proxycontroller"]

--- a/example/proxycontroller/Makefile
+++ b/example/proxycontroller/Makefile
@@ -1,0 +1,26 @@
+ifeq ($(TAGGED_VERSION),)
+	TAGGED_VERSION := $(shell git describe --tags --dirty)
+	RELEASE := "false"
+endif
+VERSION ?= $(shell echo $(TAGGED_VERSION) | cut -c 2-)
+
+GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64
+GCFLAGS := all="-N -l"
+
+OUTPUT_DIR=_output
+
+$(OUTPUT_DIR)/proxycontroller-linux-amd64:
+	$(GO_BUILD_FLAGS) GOOS=linux go build -gcflags=$(GCFLAGS) -o $@ proxycontroller.go
+
+.PHONY: proxycontroller
+proxycontroller: $(OUTPUT_DIR)/proxycontroller-linux-amd64
+
+$(OUTPUT_DIR)/Dockerfile.proxycontroller: Dockerfile
+	cp $< $@
+
+proxycontroller-docker: $(OUTPUT_DIR)/proxycontroller-linux-amd64 $(OUTPUT_DIR)/Dockerfile.proxycontroller
+	docker build $(OUTPUT_DIR) -f $(OUTPUT_DIR)/Dockerfile.proxycontroller \
+		-t quay.io/solo-io/proxycontroller:$(VERSION)
+
+proxycontroller-docker-push:
+	docker push quay.io/solo-io/proxycontroller:$(VERSION)

--- a/example/proxycontroller/install/my-cool-proxy.yaml
+++ b/example/proxycontroller/install/my-cool-proxy.yaml
@@ -71,7 +71,6 @@ metadata:
   name: my-cool-proxy
   namespace: default
 spec:
-  replicas:
   selector:
     matchLabels:
       gloo: my-cool-proxy

--- a/example/proxycontroller/install/proxycontroller.yaml
+++ b/example/proxycontroller/install/proxycontroller.yaml
@@ -14,6 +14,7 @@ spec:
       labels:
         gloo: proxycontroller
     spec:
+      # serviceAccountName: proxycontroller             # <- you'll likely need to create a service account and necessary permissions for your controller
       containers:
         - image: quay.io/solo-io/proxycontroller:1.2.12 # <- change this if you rebuild and push your controller to another registry
           imagePullPolicy: Always

--- a/example/proxycontroller/install/proxycontroller.yaml
+++ b/example/proxycontroller/install/proxycontroller.yaml
@@ -14,8 +14,8 @@ spec:
       labels:
         gloo: proxycontroller
     spec:
-      # serviceAccountName: proxycontroller             # <- you'll likely need to create a service account and necessary permissions for your controller
+      serviceAccountName: gloo # <- hijack the gloo service account rather than make a new one for this demo controller
       containers:
         - image: quay.io/solo-io/proxycontroller:1.2.12 # <- change this if you rebuild and push your controller to another registry
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           name: proxycontroller

--- a/example/proxycontroller/install/proxycontroller.yaml
+++ b/example/proxycontroller/install/proxycontroller.yaml
@@ -14,8 +14,39 @@ spec:
       labels:
         gloo: proxycontroller
     spec:
-      serviceAccountName: gloo # <- hijack the gloo service account rather than make a new one for this demo controller
+      serviceAccountName: proxycontroller
       containers:
-        - image: quay.io/solo-io/proxycontroller:1.2.12 # <- change this if you rebuild and push your controller to another registry
+        - image: quay.io/solo-io/proxycontroller:1.2.12
           imagePullPolicy: IfNotPresent
           name: proxycontroller
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: proxycontroller
+rules:
+  - apiGroups:
+      - "gloo.solo.io"
+    resources:
+      - proxies
+      - upstreams
+    verbs: ["get", "list", "watch", "create", "update", "delete"]
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: proxycontroller-binding
+subjects:
+  - kind: ServiceAccount
+    name: proxycontroller
+    namespace: gloo-system
+roleRef:
+  kind: ClusterRole
+  name: proxycontroller
+  apiGroup: ""
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: proxycontroller
+  namespace: gloo-system

--- a/example/proxycontroller/install/proxycontroller.yaml
+++ b/example/proxycontroller/install/proxycontroller.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    gloo: proxycontroller
+  name: proxycontroller
+  namespace: gloo-system
+spec:
+  selector:
+    matchLabels:
+      gloo: proxycontroller
+  template:
+    metadata:
+      labels:
+        gloo: proxycontroller
+    spec:
+      containers:
+        - image: quay.io/solo-io/proxycontroller:1.2.12 # <- change this if you rebuild and push your controller to another registry
+          imagePullPolicy: Always
+          name: proxycontroller

--- a/example/proxycontroller/proxycontroller.go
+++ b/example/proxycontroller/proxycontroller.go
@@ -97,9 +97,10 @@ func initGlooClients(ctx context.Context) (v1.UpstreamClient, v1.ProxyClient) {
 
 	// initialize the CRD client for Gloo Upstreams
 	upstreamClient, err := v1.NewUpstreamClient(&factory.KubeResourceClientFactory{
-		Crd:         v1.UpstreamCrd,
-		Cfg:         restConfig,
-		SharedCache: cache,
+		Crd:             v1.UpstreamCrd,
+		Cfg:             restConfig,
+		SharedCache:     cache,
+		SkipCrdCreation: true,
 	})
 	must(err)
 
@@ -109,9 +110,10 @@ func initGlooClients(ctx context.Context) (v1.UpstreamClient, v1.ProxyClient) {
 
 	// initialize the CRD client for Gloo Proxies
 	proxyClient, err := v1.NewProxyClient(&factory.KubeResourceClientFactory{
-		Crd:         v1.ProxyCrd,
-		Cfg:         restConfig,
-		SharedCache: cache,
+		Crd:             v1.ProxyCrd,
+		Cfg:             restConfig,
+		SharedCache:     cache,
+		SkipCrdCreation: true,
 	})
 	must(err)
 


### PR DESCRIPTION
### Changes

- Expand on the proxy controller example to show how to route to auto-discovered consul services by passing the upstream name in the host header.
- Create a docker container and deploy yaml for the sample proxy controller
- Improve docs copy-pasteability