### PR TITLE
envoy cve 3/3/2020

### DIFF
--- a/changelog/v1.3.11/envoy-cve.yaml
+++ b/changelog/v1.3.11/envoy-cve.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-gloo
+  dependencyTag: 1.3.0
+  description: >
+    Upgrade envoy-gloo version to handle CVE https://groups.google.com/forum/#!topic/envoy-announce/sVqmxy0un2s
+

--- a/projects/envoyinit/cmd/Dockerfile.envoyinit
+++ b/projects/envoyinit/cmd/Dockerfile.envoyinit
@@ -1,4 +1,4 @@
-FROM quay.io/solo-io/envoy-gloo:0.1.20
+FROM quay.io/solo-io/envoy-gloo:1.3.0
 
 COPY envoyinit-linux-amd64 /usr/local/bin/envoyinit
 


### PR DESCRIPTION
Envoy did a security release today: https://groups.google.com/forum/#!topic/envoy-announce/sVqmxy0un2s

Bump version of envoy-gloo to a version of envoy with the vulnerability fixed.