### PR TITLE
Clarify confusing TLS docs

### DIFF
--- a/changelog/v1.3.13/clarify-tls-docs.yaml
+++ b/changelog/v1.3.13/clarify-tls-docs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: clarify some confusing TLS docs and fix some formatting
+    issueLink: https://github.com/solo-io/gloo/issues/2534
+    resolvesIssue: false

--- a/docs/content/gloo_routing/tls/client_tls.md
+++ b/docs/content/gloo_routing/tls/client_tls.md
@@ -206,7 +206,7 @@ kubectl get upstream -n gloo-system \
     default-example-tls-server-8080 -o yaml
 ```
 
-{{< highlight yaml "hl_lines=18-21" >}}
+{{< highlight yaml "hl_lines=17-20" >}}
 apiVersion: gloo.solo.io/v1
 kind: Upstream
 metadata:


### PR DESCRIPTION
Clarifies some confusing information documented about TLS configuration in Gloo.

Also ensures that our example doesn't depend on the original virtual service's filter chain matcher to resolve the request. By using `--resolve` flag on `curl` we can ensure we send the proper SNI name with the request.