### PR TITLE
Port consul runnable e2e osx

### DIFF
--- a/changelog/v1.3.13/consul-e2e-osx-runnable.yaml
+++ b/changelog/v1.3.13/consul-e2e-osx-runnable.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: update consul e2e test to run on OSX locally

--- a/test/e2e/cors_test.go
+++ b/test/e2e/cors_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/cors"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 
 	"github.com/solo-io/gloo/pkg/utils"
 
@@ -181,17 +182,9 @@ func (td *corsTestData) setupProxy(proxy *gloov1.Proxy) error {
 
 func (td *corsTestData) setupInitialProxy(cors *cors.CorsPolicy) {
 	By("Setup proxy")
-	td.per.envoyPort = services.NextBindPort()
+	td.per.envoyPort = defaults.HttpPort
 	proxy := td.per.getGlooCorsProxyWithVersion("", cors)
 	err := td.setupProxy(proxy)
-	Expect(err).NotTo(HaveOccurred())
-	Eventually(func() error {
-		_, err := http.Get(fmt.Sprintf("http://%s:%d/status/200", "localhost", td.per.envoyPort))
-		if err != nil {
-			return err
-		}
-		return nil
-	}, "10s", ".1s").Should(BeNil())
 	// Call with retries to ensure proxy is available
 	Eventually(func() error {
 		proxy, err := td.getGlooCorsProxy(cors)
@@ -199,6 +192,14 @@ func (td *corsTestData) setupInitialProxy(cors *cors.CorsPolicy) {
 			return err
 		}
 		return td.setupProxy(proxy)
+	}, "10s", ".1s").Should(BeNil())
+	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		_, err := http.Get(fmt.Sprintf("http://%s:%d/status/200", "localhost", td.per.envoyPort))
+		if err != nil {
+			return err
+		}
+		return nil
 	}, "10s", ".1s").Should(BeNil())
 }
 


### PR DESCRIPTION
Update the consul e2e test to run locally on Macs. (still runs fine in CI on linux)