### PR TITLE
Upgrade to Go 1.14, and Go 1.14 compatibility changes

### DIFF
--- a/.github/workflows/check-code-and-docs-gen.yaml
+++ b/.github/workflows/check-code-and-docs-gen.yaml
@@ -5,10 +5,10 @@ jobs:
     name: Build
     runs-on: ubuntu-18.04
     steps:
-    - name: Set up Go 1.13
+    - name: Set up Go 1.14
       uses: actions/setup-go@v1
       with:
-        go-version: 1.13
+        go-version: 1.14
       id: go
     - name: Install Protoc
       uses: Arduino/actions/setup-protoc@master

--- a/changelog/v1.3.13/fix-go-1.14-compatibility.yaml
+++ b/changelog/v1.3.13/fix-go-1.14-compatibility.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: |
+      Fix go v1.14 compatibility issue.
+    issueLink: https://github.com/solo-io/gloo/issues/2532

--- a/changelog/v1.3.13/fix-go-1.14-compatibility.yaml
+++ b/changelog/v1.3.13/fix-go-1.14-compatibility.yaml
@@ -1,5 +1,6 @@
 changelog:
   - type: FIX
-    description: |
-      Fix go v1.14 compatibility issue.
+    description: >
+      Fix Gloo linker compatibility in go 1.14; now we properly link the client version in `glooctl` when building on
+      go 1.14 (this just fixes our homebrew formula, as the shipped binary had always been built with go 1.13).
     issueLink: https://github.com/solo-io/gloo/issues/2532

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -8,17 +8,17 @@ steps:
     path: '/go/pkg'
   id: 'untar-mod-cache'
 
-- name: 'golang:1.13'
+- name: 'golang:1.14'
   args: ['go', 'mod', 'download']
   volumes: *vol
   id: 'download'
 
-- name: 'golang:1.13'
+- name: 'golang:1.14'
   args: ['go', 'mod', 'tidy']
   volumes: *vol
   id: 'tidy'
 
-- name: 'golang:1.13'
+- name: 'golang:1.14'
   entrypoint: 'bash'
   volumes: *vol
   args: ['-c', ' cd /go/pkg && tar -zvcf gloo-mod.tar.gz mod']

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Masterminds/semver/v3 v3.0.1

--- a/pkg/version/linked.go
+++ b/pkg/version/linked.go
@@ -5,10 +5,16 @@ import (
 	"github.com/solo-io/go-utils/versionutils/git"
 )
 
-var UndefinedVersion = "undefined"
-
-// This will be set by the linker during build
-var Version = UndefinedVersion
+var (
+	UndefinedVersion = "undefined"
+	// Will be set by the linker during build. Does not include "v" prefix.
+	Version string
+)
+func init() {
+	if Version == "" {
+		Version = UndefinedVersion
+	}
+}
 
 func IsReleaseVersion() bool {
 	if Version == UndefinedVersion {

--- a/pkg/version/linked.go
+++ b/pkg/version/linked.go
@@ -10,6 +10,7 @@ var (
 	// Will be set by the linker during build. Does not include "v" prefix.
 	Version string
 )
+
 func init() {
 	if Version == "" {
 		Version = UndefinedVersion

--- a/projects/gloo/pkg/api/v1/options/protocol_upgrade/protocol_upgrade.pb.go
+++ b/projects/gloo/pkg/api/v1/options/protocol_upgrade/protocol_upgrade.pb.go
@@ -101,8 +101,10 @@ type ProtocolUpgradeConfig_ProtocolUpgradeSpec struct {
 func (m *ProtocolUpgradeConfig_ProtocolUpgradeSpec) Reset() {
 	*m = ProtocolUpgradeConfig_ProtocolUpgradeSpec{}
 }
-func (m *ProtocolUpgradeConfig_ProtocolUpgradeSpec) String() string { return proto.CompactTextString(m) }
-func (*ProtocolUpgradeConfig_ProtocolUpgradeSpec) ProtoMessage()    {}
+func (m *ProtocolUpgradeConfig_ProtocolUpgradeSpec) String() string {
+	return proto.CompactTextString(m)
+}
+func (*ProtocolUpgradeConfig_ProtocolUpgradeSpec) ProtoMessage() {}
 func (*ProtocolUpgradeConfig_ProtocolUpgradeSpec) Descriptor() ([]byte, []int) {
 	return fileDescriptor_384550b21127c365, []int{0, 0}
 }


### PR DESCRIPTION
Supersedes https://github.com/solo-io/gloo/pull/2570
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2532