### PR TITLE
Fix Kubernetes typo in docs

### DIFF
--- a/changelog/v1.3.13/fix-typo-in-docs.yaml
+++ b/changelog/v1.3.13/fix-typo-in-docs.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: fix typo in Kubernetes word across documentation

--- a/docs/content/gloo_integrations/cert_manager/_index.md
+++ b/docs/content/gloo_integrations/cert_manager/_index.md
@@ -151,7 +151,7 @@ Configure gloo's default virtual service to route to the function and use the ce
 We can create a virtual service and routes in one of two ways:
 
 1. The glooctl command line
-1. A Kuberentes CRD
+1. A Kubernetes CRD
 
 Please choose **one** of these ways outline below to proceed.
 

--- a/docs/content/installation/preparation.md
+++ b/docs/content/installation/preparation.md
@@ -33,7 +33,7 @@ There are a number of options when it comes to installing Gloo Gateway. The requ
 
 ### Kubernetes Deployments
 
-Not sure how you will deploy Gloo? This [section]({{% versioned_link_path fromRoot="/installation/platform_configuration/cluster_setup/" %}}) is for you. Gloo Gateway deploys as a set of containers, and is usually deployed on a Kubernetes cluster. In order to install Gloo Gateway, you will need access to a Kubernetes deployment. That could be a local cluster using *minikube* or *minishift*. It could be a hosted cluster on one of the public clouds such as *Google Kubernetes Engine*, *Elastic Kubernetes Service*, or *Azure Kuberentes Service*. You could even host your own Kubernetes cluster in your datacenter! 
+Not sure how you will deploy Gloo? This [section]({{% versioned_link_path fromRoot="/installation/platform_configuration/cluster_setup/" %}}) is for you. Gloo Gateway deploys as a set of containers, and is usually deployed on a Kubernetes cluster. In order to install Gloo Gateway, you will need access to a Kubernetes deployment. That could be a local cluster using *minikube* or *minishift*. It could be a hosted cluster on one of the public clouds such as *Google Kubernetes Engine*, *Elastic Kubernetes Service*, or *Azure Kubernetes Service*. You could even host your own Kubernetes cluster in your datacenter! 
 
 As long as you can run *kubectl* and have cluster-admin permissions, you're all set.
 

--- a/docs/content/security/auth/jwt/_index.md
+++ b/docs/content/security/auth/jwt/_index.md
@@ -62,7 +62,7 @@ values for the issuer and audience claims to verify, as well as {{< protobuf nam
 We have a few guides that go into more detail:
 
 - [JWT and Access Control](./access_control) - Demonstrates how to use Gloo as an internal API Gateway
-  in a Kubernetes environment. Gloo is used to verify Kuberentes service account JWTs and to define
+  in a Kubernetes environment. Gloo is used to verify Kubernetes service account JWTs and to define
   an RBAC policy on what those service accounts are allowed to access.
 - [JWT Claim Based Routing](./claim_routing) - Shows a method of using JWT claims to perform routing
   decisions. This can be used, for example, to send your own organization employees to a canary build


### PR DESCRIPTION
Hi,

I noticed minor typos with the Kubernetes word across the documentation. This PR aims to fix all of them. That's a pretty small contribution but I thought it might be useful.

Thank you for maintaining Gloo. Keep up the great work.