### PR TITLE
Fix glooctl to work without cluster-scoped permissions

### DIFF
--- a/changelog/v1.3.16/glooctl-namespaced-rbac.yaml
+++ b/changelog/v1.3.16/glooctl-namespaced-rbac.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: >
+      `glooctl` commands such as `glooctl get vs` now work without cluster-scoped rbac permissions.
+    issueLink: https://github.com/solo-io/gloo/issues/2375

--- a/projects/gloo/cli/pkg/cmd/add/route.go
+++ b/projects/gloo/cli/pkg/cmd/add/route.go
@@ -124,7 +124,7 @@ func addRoute(opts *options.Options) error {
 		Namespace: opts.Metadata.Namespace,
 		Name:      opts.Metadata.Name,
 	}
-	selector := selectionutils.NewVirtualServiceSelector(helpers.MustVirtualServiceClient(), helpers.NewNamespaceLister(), defaults.GlooSystem)
+	selector := selectionutils.NewVirtualServiceSelector(helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace()), helpers.NewNamespaceLister(), defaults.GlooSystem)
 	virtualService, err := selector.SelectOrCreateVirtualService(opts.Top.Ctx, vsRef)
 	if err != nil {
 		return err
@@ -136,7 +136,7 @@ func addRoute(opts *options.Options) error {
 	virtualService.VirtualHost.Routes[index] = v1Route
 
 	if !opts.Add.DryRun {
-		virtualService, err = helpers.MustVirtualServiceClient().Write(virtualService, clients.WriteOpts{
+		virtualService, err = helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace()).Write(virtualService, clients.WriteOpts{
 			Ctx:               opts.Top.Ctx,
 			OverwriteExisting: true,
 		})

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -242,7 +242,7 @@ func checkPods(opts *options.Options) (bool, error) {
 }
 
 func getSettings(opts *options.Options) (*v1.Settings, error) {
-	client := helpers.MustSettingsClient()
+	client := helpers.MustNamespacedSettingsClient(opts.Metadata.GetNamespace())
 	return client.Read(opts.Metadata.Namespace, defaults.SettingsName, clients.ReadOpts{})
 }
 
@@ -256,10 +256,9 @@ func getNamespaces(settings *v1.Settings) ([]string, error) {
 
 func checkUpstreams(namespaces []string) ([]string, bool, error) {
 	fmt.Printf("Checking upstreams... ")
-	client := helpers.MustUpstreamClient()
 	var knownUpstreams []string
 	for _, ns := range namespaces {
-		upstreams, err := client.List(ns, clients.ListOpts{})
+		upstreams, err := helpers.MustNamespacedUpstreamClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return nil, false, err
 		}
@@ -283,9 +282,8 @@ func checkUpstreams(namespaces []string) ([]string, bool, error) {
 
 func checkUpstreamGroups(namespaces []string) (bool, error) {
 	fmt.Printf("Checking upstream groups... ")
-	client := helpers.MustUpstreamGroupClient()
 	for _, ns := range namespaces {
-		upstreamGroups, err := client.List(ns, clients.ListOpts{})
+		upstreamGroups, err := helpers.MustNamespacedUpstreamGroupClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return false, err
 		}
@@ -308,10 +306,9 @@ func checkUpstreamGroups(namespaces []string) (bool, error) {
 
 func checkAuthConfigs(namespaces []string) ([]string, bool, error) {
 	fmt.Printf("Checking auth configs... ")
-	client := helpers.MustAuthConfigClient()
 	var knownAuthConfigs []string
 	for _, ns := range namespaces {
-		authConfigs, err := client.List(ns, clients.ListOpts{})
+		authConfigs, err := helpers.MustNamespacedAuthConfigClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return nil, false, err
 		}
@@ -335,9 +332,8 @@ func checkAuthConfigs(namespaces []string) ([]string, bool, error) {
 
 func checkVirtualServices(namespaces, knownUpstreams []string, knownAuthConfigs []string) (bool, error) {
 	fmt.Printf("Checking virtual services... ")
-	client := helpers.MustVirtualServiceClient()
 	for _, ns := range namespaces {
-		virtualServices, err := client.List(ns, clients.ListOpts{})
+		virtualServices, err := helpers.MustNamespacedVirtualServiceClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return false, err
 		}
@@ -382,9 +378,8 @@ func checkVirtualServices(namespaces, knownUpstreams []string, knownAuthConfigs 
 
 func checkGateways(namespaces []string) (bool, error) {
 	fmt.Printf("Checking gateways... ")
-	client := helpers.MustGatewayClient()
 	for _, ns := range namespaces {
-		gateways, err := client.List(ns, clients.ListOpts{})
+		gateways, err := helpers.MustNamespacedGatewayClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return false, err
 		}
@@ -407,9 +402,8 @@ func checkGateways(namespaces []string) (bool, error) {
 
 func checkProxies(ctx context.Context, namespaces []string, glooNamespace string, deployments *appsv1.DeploymentList) (bool, error) {
 	fmt.Printf("Checking proxies... ")
-	client := helpers.MustProxyClient()
 	for _, ns := range namespaces {
-		proxies, err := client.List(ns, clients.ListOpts{})
+		proxies, err := helpers.MustNamespacedProxyClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return false, err
 		}

--- a/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig.go
+++ b/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig.go
@@ -84,7 +84,7 @@ func createAuthConfig(opts *options.Options, args []string) error {
 	}
 
 	if !opts.Create.DryRun {
-		authConfigClient := helpers.MustAuthConfigClient()
+		authConfigClient := helpers.MustNamespacedAuthConfigClient(opts.Metadata.GetNamespace())
 		ac, err = authConfigClient.Write(ac, clients.WriteOpts{})
 		if err != nil {
 			return err

--- a/projects/gloo/cli/pkg/cmd/create/upstream.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstream.go
@@ -156,7 +156,7 @@ func createUpstream(opts *options.Options) error {
 	}
 
 	if !opts.Create.DryRun {
-		us, err = helpers.MustUpstreamClient().Write(us, clients.WriteOpts{})
+		us, err = helpers.MustNamespacedUpstreamClient(opts.Metadata.GetNamespace()).Write(us, clients.WriteOpts{})
 		if err != nil {
 			return err
 		}

--- a/projects/gloo/cli/pkg/cmd/create/upstreamgroup.go
+++ b/projects/gloo/cli/pkg/cmd/create/upstreamgroup.go
@@ -75,7 +75,7 @@ func createUpstreamGroup(opts *options.Options) error {
 	}
 
 	if !opts.Create.DryRun {
-		ug, err = helpers.MustUpstreamGroupClient().Write(ug, clients.WriteOpts{})
+		ug, err = helpers.MustNamespacedUpstreamGroupClient(opts.Metadata.GetNamespace()).Write(ug, clients.WriteOpts{})
 		if err != nil {
 			return err
 		}
@@ -99,11 +99,10 @@ func upstreamGroupFromOpts(opts *options.Options) (*v1.UpstreamGroup, error) {
 
 func upstreamGroupDestinationsFromOpts(input options.InputUpstreamGroup) ([]*v1.WeightedDestination, error) {
 	// collect upstreams list
-	usClient := helpers.MustUpstreamClient()
 	ussByKey := make(map[string]*v1.Upstream)
 	var usKeys []string
 	for _, ns := range helpers.MustGetNamespaces() {
-		usList, err := usClient.List(ns, clients.ListOpts{})
+		usList, err := helpers.MustNamespacedUpstreamClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return nil, err
 		}

--- a/projects/gloo/cli/pkg/cmd/create/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/create/virtualservice.go
@@ -78,7 +78,7 @@ func createVirtualService(opts *options.Options, args []string) error {
 	}
 
 	if !opts.Create.DryRun {
-		virtualServiceClient := helpers.MustVirtualServiceClient()
+		virtualServiceClient := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace())
 		vs, err = virtualServiceClient.Write(vs, clients.WriteOpts{})
 		if err != nil {
 			return err

--- a/projects/gloo/cli/pkg/cmd/del/proxy.go
+++ b/projects/gloo/cli/pkg/cmd/del/proxy.go
@@ -22,7 +22,7 @@ func Proxy(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Co
 		Long:    "usage: glooctl delete proxy [NAME] [--namespace=namespace]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := common.GetName(args, opts)
-			if err := helpers.MustProxyClient().Delete(opts.Metadata.Namespace, name,
+			if err := helpers.MustNamespacedProxyClient(opts.Metadata.GetNamespace()).Delete(opts.Metadata.Namespace, name,
 				clients.DeleteOpts{Ctx: opts.Top.Ctx}); err != nil {
 				return err
 			}

--- a/projects/gloo/cli/pkg/cmd/del/upstream.go
+++ b/projects/gloo/cli/pkg/cmd/del/upstream.go
@@ -22,7 +22,7 @@ func Upstream(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra
 		Long:    "usage: glooctl delete upstream [NAME] [--namespace=namespace]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := common.GetName(args, opts)
-			if err := helpers.MustUpstreamClient().Delete(opts.Metadata.Namespace, name,
+			if err := helpers.MustNamespacedUpstreamClient(opts.Metadata.GetNamespace()).Delete(opts.Metadata.Namespace, name,
 				clients.DeleteOpts{Ctx: opts.Top.Ctx}); err != nil {
 				return err
 			}

--- a/projects/gloo/cli/pkg/cmd/del/upstreamgroup.go
+++ b/projects/gloo/cli/pkg/cmd/del/upstreamgroup.go
@@ -22,7 +22,7 @@ func UpstreamGroup(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *
 		Long:    "usage: glooctl delete upstreamgroup [NAME] [--namespace=namespace]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := common.GetName(args, opts)
-			if err := helpers.MustUpstreamGroupClient().Delete(opts.Metadata.Namespace, name,
+			if err := helpers.MustNamespacedUpstreamGroupClient(opts.Metadata.GetNamespace()).Delete(opts.Metadata.Namespace, name,
 				clients.DeleteOpts{Ctx: opts.Top.Ctx}); err != nil {
 				return err
 			}

--- a/projects/gloo/cli/pkg/cmd/del/virtualservice.go
+++ b/projects/gloo/cli/pkg/cmd/del/virtualservice.go
@@ -22,7 +22,7 @@ func VirtualService(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) 
 		Long:    "usage: glooctl delete virtualservice [NAME] [--namespace=namespace]",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := common.GetName(args, opts)
-			if err := helpers.MustVirtualServiceClient().Delete(opts.Metadata.Namespace, name,
+			if err := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace()).Delete(opts.Metadata.Namespace, name,
 				clients.DeleteOpts{Ctx: opts.Top.Ctx}); err != nil {
 				return err
 			}

--- a/projects/gloo/cli/pkg/cmd/edit/route/options/options.go
+++ b/projects/gloo/cli/pkg/cmd/edit/route/options/options.go
@@ -17,7 +17,7 @@ type RouteEditInput struct {
 }
 
 func UpdateRoute(opts *RouteEditInput, modify func(*gatewayv1.Route) error) error {
-	vsClient := helpers.MustVirtualServiceClient()
+	vsClient := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace())
 	vs, err := vsClient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 	if err != nil {
 		return errors.Wrapf(err, "Error reading vhost")
@@ -45,10 +45,8 @@ func UpdateRoute(opts *RouteEditInput, modify func(*gatewayv1.Route) error) erro
 }
 
 func EditRoutePreRunE(opts *RouteEditInput) error {
-
 	if opts.Top.Interactive {
-
-		vsclient := helpers.MustVirtualServiceClient()
+		vsclient := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace())
 		vsvc, err := vsclient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 		if err != nil {
 			return err
@@ -61,6 +59,5 @@ func EditRoutePreRunE(opts *RouteEditInput) error {
 			opts.ResourceVersion = vsvc.Metadata.ResourceVersion
 		}
 	}
-
 	return nil
 }

--- a/projects/gloo/cli/pkg/cmd/edit/settings/extauth.go
+++ b/projects/gloo/cli/pkg/cmd/edit/settings/extauth.go
@@ -46,7 +46,7 @@ func ExtAuthConfig(opts *editOptions.EditOptions, optionsFunc ...cliutils.Option
 }
 
 func editSettings(opts *editOptions.EditOptions, optsExt *options.OIDCSettings, args []string) error {
-	settingsClient := helpers.MustSettingsClient()
+	settingsClient := helpers.MustNamespacedSettingsClient(opts.Metadata.GetNamespace())
 	settings, err := settingsClient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 	if err != nil {
 		return errors.Wrapf(err, "Error reading settings")

--- a/projects/gloo/cli/pkg/cmd/edit/settings/ratelimit/custom_server_config.go
+++ b/projects/gloo/cli/pkg/cmd/edit/settings/ratelimit/custom_server_config.go
@@ -33,7 +33,7 @@ func RateLimitCustomConfig(opts *editOptions.EditOptions, optionsFunc ...cliutil
 }
 
 func edit(opts *editOptions.EditOptions) error {
-	settingsClient := helpers.MustSettingsClient()
+	settingsClient := helpers.MustNamespacedSettingsClient(opts.Metadata.GetNamespace())
 	settings, err := settingsClient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 	if err != nil {
 		return errors.Wrapf(err, "Error reading settings")

--- a/projects/gloo/cli/pkg/cmd/edit/settings/ratelimit/ratelimit.go
+++ b/projects/gloo/cli/pkg/cmd/edit/settings/ratelimit/ratelimit.go
@@ -49,7 +49,7 @@ func RateLimitConfig(opts *editOptions.EditOptions, optionsFunc ...cliutils.Opti
 }
 
 func editSettings(opts *editOptions.EditOptions, optsExt *RateLimitSettings, args []string) error {
-	settingsClient := helpers.MustSettingsClient()
+	settingsClient := helpers.MustNamespacedSettingsClient(opts.Metadata.GetNamespace())
 	settings, err := settingsClient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 	if err != nil {
 		return errors.Wrapf(err, "Error reading settings")

--- a/projects/gloo/cli/pkg/cmd/edit/upstream/root.go
+++ b/projects/gloo/cli/pkg/cmd/edit/upstream/root.go
@@ -71,7 +71,7 @@ func addEditUpstreamInteractiveFlags(opts *EditUpstream) error {
 }
 
 func editUpstream(opts *options.EditOptions, optsExt *EditUpstream, args []string) error {
-	upClient := helpers.MustUpstreamClient()
+	upClient := helpers.MustNamespacedUpstreamClient(opts.Metadata.GetNamespace())
 	up, err := upClient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 	if err != nil {
 		return errors.Wrapf(err, "Error reading upstream")

--- a/projects/gloo/cli/pkg/cmd/edit/virtualservice/custom_envoy_config.go
+++ b/projects/gloo/cli/pkg/cmd/edit/virtualservice/custom_envoy_config.go
@@ -36,7 +36,7 @@ func RateLimitCustomConfig(opts *editOptions.EditOptions, optionsFunc ...cliutil
 
 func editVhost(opts *editOptions.EditOptions) error {
 
-	vsClient := helpers.MustVirtualServiceClient()
+	vsClient := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace())
 	vs, err := vsClient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 	if err != nil {
 		return errors.Wrapf(err, "Error reading virtual service")

--- a/projects/gloo/cli/pkg/cmd/edit/virtualservice/root.go
+++ b/projects/gloo/cli/pkg/cmd/edit/virtualservice/root.go
@@ -73,7 +73,7 @@ func addEditVirtualServiceInteractiveFlags(opts *EditVirtualService) error {
 }
 
 func editVirtualService(opts *options.EditOptions, optsExt *EditVirtualService, args []string) error {
-	vsClient := helpers.MustVirtualServiceClient()
+	vsClient := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace())
 	vs, err := vsClient.Read(opts.Metadata.Namespace, opts.Metadata.Name, clients.ReadOpts{})
 	if err != nil {
 		return errors.Wrapf(err, "Error reading virtual service")

--- a/projects/gloo/cli/pkg/cmd/get/root.go
+++ b/projects/gloo/cli/pkg/cmd/get/root.go
@@ -1,6 +1,9 @@
 package get
 
 import (
+	"context"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
@@ -8,12 +11,13 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/prerun"
 	"github.com/solo-io/go-utils/cliutils"
+	"github.com/solo-io/go-utils/contextutils"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var EmptyGetError = eris.New("please provide a subcommand")
-var UnsetNamespaceError = eris.New("Gloo namespace does not exist. Did you install it in another namespace and forgot to add the '-n NAMESPACE' flag?")
+var UnsetNamespaceError = eris.New("Gloo installation namespace does not exist. Did you install it in another namespace and forgot to add the '-n NAMESPACE' flag?")
 
 func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
 	cmd := &cobra.Command{
@@ -27,12 +31,15 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 			if err := prerun.EnableConsulClients(opts); err != nil {
 				return err
 			}
-
 			if !opts.Top.Consul.UseConsul {
 				client := helpers.MustKubeClient()
 				_, err := client.CoreV1().Namespaces().Get(opts.Metadata.Namespace, metav1.GetOptions{})
 				if err != nil {
-					return UnsetNamespaceError
+					if apierrors.IsNotFound(err) {
+						return UnsetNamespaceError
+					}
+					// we would still like to attempt the command even if we don't have rbac to list namespaces, so just log a warning
+					contextutils.LoggerFrom(context.TODO()).Warnf("unable to locate gloo installation namespace", err)
 				}
 			}
 			return nil

--- a/projects/gloo/cli/pkg/cmd/get/root.go
+++ b/projects/gloo/cli/pkg/cmd/get/root.go
@@ -2,6 +2,7 @@ package get
 
 import (
 	"context"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/rotisserie/eris"

--- a/projects/gloo/cli/pkg/cmd/remove/route.go
+++ b/projects/gloo/cli/pkg/cmd/remove/route.go
@@ -53,7 +53,7 @@ func removeRoute(opts *options.Options) error {
 		return errors.Errorf("name of the target virtual service cannot be empty")
 	}
 
-	vs, err := helpers.MustVirtualServiceClient().Read(opts.Metadata.Namespace, opts.Metadata.Name,
+	vs, err := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace()).Read(opts.Metadata.Namespace, opts.Metadata.Name,
 		clients.ReadOpts{Ctx: opts.Top.Ctx})
 	if err != nil {
 		return errors.Wrapf(err, "reading vs %v", opts.Metadata.Ref())
@@ -65,7 +65,7 @@ func removeRoute(opts *options.Options) error {
 
 	vs.VirtualHost.Routes = append(vs.VirtualHost.Routes[:index], vs.VirtualHost.Routes[index+1:]...)
 
-	out, err := helpers.MustVirtualServiceClient().Write(vs, clients.WriteOpts{
+	out, err := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace()).Write(vs, clients.WriteOpts{
 		Ctx:               opts.Top.Ctx,
 		OverwriteExisting: true,
 	})

--- a/projects/gloo/cli/pkg/cmd/route/sort.go
+++ b/projects/gloo/cli/pkg/cmd/route/sort.go
@@ -49,7 +49,7 @@ func sortRoutes(opts *options.Options) error {
 		return errors.Errorf("name of the target virtual service cannot be empty")
 	}
 
-	vs, err := helpers.MustVirtualServiceClient().Read(opts.Metadata.Namespace, opts.Metadata.Name,
+	vs, err := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace()).Read(opts.Metadata.Namespace, opts.Metadata.Name,
 		clients.ReadOpts{Ctx: opts.Top.Ctx})
 	if err != nil {
 		return errors.Wrapf(err, "reading vs %v", opts.Metadata.Ref())
@@ -61,7 +61,7 @@ func sortRoutes(opts *options.Options) error {
 		"...\n", len(vs.VirtualHost.Routes))
 	utils.SortGatewayRoutesByPath(vs.VirtualHost.Routes)
 
-	out, err := helpers.MustVirtualServiceClient().Write(vs, clients.WriteOpts{
+	out, err := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace()).Write(vs, clients.WriteOpts{
 		Ctx:               opts.Top.Ctx,
 		OverwriteExisting: true,
 	})

--- a/projects/gloo/cli/pkg/cmd/version/cmd.go
+++ b/projects/gloo/cli/pkg/cmd/version/cmd.go
@@ -57,32 +57,26 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 }
 
 func GetClientServerVersions(sv ServerVersion) (*version.Version, error) {
-	clientVersion, err := getClientVersion()
-	if err != nil {
-		return nil, err
+	v := &version.Version{
+		Client: getClientVersion(),
 	}
 	serverVersion, err := sv.Get()
 	if err != nil {
-		return &version.Version{
-			Client: clientVersion,
-		}, err
+		return v, err
 	}
-	return &version.Version{
-		Client: clientVersion,
-		Server: serverVersion,
-	}, nil
+	v.Server = serverVersion
+	return v, nil
 }
 
-func getClientVersion() (*version.ClientVersion, error) {
-	vrs := &version.ClientVersion{
+func getClientVersion() *version.ClientVersion {
+	return &version.ClientVersion{
 		Version: linkedversion.Version,
 	}
-	return vrs, nil
 }
 
 func printVersion(sv ServerVersion, w io.Writer, opts *options.Options) error {
 	vrs, _ := GetClientServerVersions(sv)
-	// ignore error so we still print client version even if we can't get server versions (e.g., not deployed, no rbac)
+	// ignoring error so we still print client version even if we can't get server versions (e.g., not deployed, no rbac)
 	switch opts.Top.Output {
 	case printers.JSON:
 		clientVersionStr := string(GetJson(vrs.GetClient()))

--- a/projects/gloo/cli/pkg/cmd/version/cmd.go
+++ b/projects/gloo/cli/pkg/cmd/version/cmd.go
@@ -63,7 +63,9 @@ func GetClientServerVersions(sv ServerVersion) (*version.Version, error) {
 	}
 	serverVersion, err := sv.Get()
 	if err != nil {
-		return nil, err
+		return &version.Version{
+			Client: clientVersion,
+		}, err
 	}
 	return &version.Version{
 		Client: clientVersion,
@@ -79,10 +81,8 @@ func getClientVersion() (*version.ClientVersion, error) {
 }
 
 func printVersion(sv ServerVersion, w io.Writer, opts *options.Options) error {
-	vrs, err := GetClientServerVersions(sv)
-	if err != nil {
-		return err
-	}
+	vrs, _ := GetClientServerVersions(sv)
+	// ignore error so we still print client version even if we can't get server versions (e.g., not deployed, no rbac)
 	switch opts.Top.Output {
 	case printers.JSON:
 		clientVersionStr := string(GetJson(vrs.GetClient()))

--- a/projects/gloo/cli/pkg/cmd/version/version_test.go
+++ b/projects/gloo/cli/pkg/cmd/version/version_test.go
@@ -197,7 +197,7 @@ Server: {"type":"Gateway","enterprise":true,"kubernetes":{"containers":[{"Tag":"
 							Output: test.outputType,
 						},
 					}
-					client.EXPECT().Get().Times(1).Return(nil, nil)
+					client.EXPECT().Get().Times(1).Return(nil, eris.Errorf("fake rbac error"))
 					err := printVersion(client, buf, opts)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(buf.String()).To(ContainSubstring(undefinedServer))

--- a/projects/gloo/cli/pkg/common/create.go
+++ b/projects/gloo/cli/pkg/common/create.go
@@ -19,13 +19,13 @@ func CreateAndPrintObject(yml []byte, outputType printers.OutputType, namespace 
 	}
 	switch res := resource.(type) {
 	case *gloov1.Upstream:
-		us, err := helpers.MustUpstreamClient().Write(res, clients.WriteOpts{})
+		us, err := helpers.MustNamespacedUpstreamClient(namespace).Write(res, clients.WriteOpts{})
 		if err != nil {
 			return eris.Wrapf(err, "saving Upstream to storage")
 		}
 		_ = printers.PrintUpstreams(gloov1.UpstreamList{us}, outputType, nil)
 	case *v1.VirtualService:
-		vs, err := helpers.MustVirtualServiceClient().Write(res, clients.WriteOpts{})
+		vs, err := helpers.MustNamespacedVirtualServiceClient(namespace).Write(res, clients.WriteOpts{})
 		if err != nil {
 			return eris.Wrapf(err, "saving VirtualService to storage")
 		}

--- a/projects/gloo/cli/pkg/common/get.go
+++ b/projects/gloo/cli/pkg/common/get.go
@@ -11,8 +11,7 @@ import (
 
 func GetVirtualServices(name string, opts *options.Options) (v1.VirtualServiceList, error) {
 	var virtualServiceList v1.VirtualServiceList
-
-	virtualServiceClient := helpers.MustVirtualServiceClient()
+	virtualServiceClient := helpers.MustNamespacedVirtualServiceClient(opts.Metadata.GetNamespace())
 	if name == "" {
 		virtualServices, err := virtualServiceClient.List(opts.Metadata.Namespace,
 			clients.ListOpts{Ctx: opts.Top.Ctx, Selector: opts.Get.Selector.MustMap()})
@@ -35,7 +34,7 @@ func GetVirtualServices(name string, opts *options.Options) (v1.VirtualServiceLi
 func GetRouteTables(name string, opts *options.Options) (v1.RouteTableList, error) {
 	var routeTableList v1.RouteTableList
 
-	routeTableClient := helpers.MustRouteTableClient()
+	routeTableClient := helpers.MustNamespacedRouteTableClient(opts.Metadata.GetNamespace())
 	if name == "" {
 		routeTables, err := routeTableClient.List(opts.Metadata.Namespace,
 			clients.ListOpts{Ctx: opts.Top.Ctx, Selector: opts.Get.Selector.MustMap()})
@@ -58,7 +57,7 @@ func GetRouteTables(name string, opts *options.Options) (v1.RouteTableList, erro
 func GetUpstreams(name string, opts *options.Options) (gloov1.UpstreamList, error) {
 	var list gloov1.UpstreamList
 
-	usClient := helpers.MustUpstreamClient()
+	usClient := helpers.MustNamespacedUpstreamClient(opts.Metadata.GetNamespace())
 	if name == "" {
 		uss, err := usClient.List(opts.Metadata.Namespace,
 			clients.ListOpts{Ctx: opts.Top.Ctx, Selector: opts.Get.Selector.MustMap()})
@@ -81,7 +80,7 @@ func GetUpstreams(name string, opts *options.Options) (gloov1.UpstreamList, erro
 func GetUpstreamGroups(name string, opts *options.Options) (gloov1.UpstreamGroupList, error) {
 	var list gloov1.UpstreamGroupList
 
-	ugsClient := helpers.MustUpstreamGroupClient()
+	ugsClient := helpers.MustNamespacedUpstreamGroupClient(opts.Metadata.GetNamespace())
 	if name == "" {
 		ugs, err := ugsClient.List(opts.Metadata.Namespace,
 			clients.ListOpts{Ctx: opts.Top.Ctx, Selector: opts.Get.Selector.MustMap()})
@@ -104,7 +103,7 @@ func GetUpstreamGroups(name string, opts *options.Options) (gloov1.UpstreamGroup
 func GetProxies(name string, opts *options.Options) (gloov1.ProxyList, error) {
 	var list gloov1.ProxyList
 
-	pxClient := helpers.MustProxyClient()
+	pxClient := helpers.MustNamespacedProxyClient(opts.Metadata.GetNamespace())
 	if name == "" {
 		uss, err := pxClient.List(opts.Metadata.Namespace,
 			clients.ListOpts{Ctx: opts.Top.Ctx, Selector: opts.Get.Selector.MustMap()})
@@ -127,7 +126,7 @@ func GetProxies(name string, opts *options.Options) (gloov1.ProxyList, error) {
 func GetAuthConfigs(name string, opts *options.Options) (extauthv1.AuthConfigList, error) {
 	var authConfigList extauthv1.AuthConfigList
 
-	authConfigClient := helpers.MustAuthConfigClient()
+	authConfigClient := helpers.MustNamespacedAuthConfigClient(opts.Metadata.GetNamespace())
 	if name == "" {
 		authConfigs, err := authConfigClient.List(opts.Metadata.Namespace,
 			clients.ListOpts{Ctx: opts.Top.Ctx, Selector: opts.Get.Selector.MustMap()})

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -175,14 +175,23 @@ func (namespaceLister) List() ([]string, error) {
 }
 
 func MustUpstreamClient() v1.UpstreamClient {
-	client, err := UpstreamClient()
+	return MustNamespacedUpstreamClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedUpstreamClient(ns string) v1.UpstreamClient {
+	return MustMultiNamespacedUpstreamClient([]string{ns})
+}
+
+func MustMultiNamespacedUpstreamClient(namespaces []string) v1.UpstreamClient {
+	client, err := UpstreamClient(namespaces)
 	if err != nil {
 		log.Fatalf("failed to create upstream client: %v", err)
 	}
 	return client
 }
 
-func UpstreamClient() (v1.UpstreamClient, error) {
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped upstream client
+func UpstreamClient(namespaces []string) (v1.UpstreamClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return v1.NewUpstreamClient(customFactory)
@@ -194,10 +203,11 @@ func UpstreamClient() (v1.UpstreamClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	upstreamClient, err := v1.NewUpstreamClient(&factory.KubeResourceClientFactory{
-		Crd:             v1.UpstreamCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                v1.UpstreamCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating upstreams client")
@@ -209,14 +219,23 @@ func UpstreamClient() (v1.UpstreamClient, error) {
 }
 
 func MustUpstreamGroupClient() v1.UpstreamGroupClient {
-	client, err := UpstreamGroupClient()
+	return MustNamespacedUpstreamGroupClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedUpstreamGroupClient(ns string) v1.UpstreamGroupClient {
+	return MustMultiNamespacedUpstreamGroupClient([]string{ns})
+}
+
+func MustMultiNamespacedUpstreamGroupClient(namespaces []string) v1.UpstreamGroupClient {
+	client, err := UpstreamGroupClient(namespaces)
 	if err != nil {
 		log.Fatalf("failed to create upstream group client: %v", err)
 	}
 	return client
 }
 
-func UpstreamGroupClient() (v1.UpstreamGroupClient, error) {
+// provide "" (metav1.NamespaceAll)e "" (metav1.NamespaceAll) to get a cluster-scoped upstream group client
+func UpstreamGroupClient(namespaces []string) (v1.UpstreamGroupClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return v1.NewUpstreamGroupClient(customFactory)
@@ -228,10 +247,11 @@ func UpstreamGroupClient() (v1.UpstreamGroupClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	upstreamGroupClient, err := v1.NewUpstreamGroupClient(&factory.KubeResourceClientFactory{
-		Crd:             v1.UpstreamGroupCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                v1.UpstreamGroupCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating upstream groups client")
@@ -243,14 +263,23 @@ func UpstreamGroupClient() (v1.UpstreamGroupClient, error) {
 }
 
 func MustProxyClient() v1.ProxyClient {
-	client, err := ProxyClient()
+	return MustNamespacedProxyClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedProxyClient(ns string) v1.ProxyClient {
+	return MustMultiNamespacedProxyClient([]string{ns})
+}
+
+func MustMultiNamespacedProxyClient(namespaces []string) v1.ProxyClient {
+	client, err := ProxyClient(namespaces)
 	if err != nil {
 		log.Fatalf("failed to create proxy client: %v", err)
 	}
 	return client
 }
 
-func ProxyClient() (v1.ProxyClient, error) {
+// provide "" (metav1.NamespaceAll)e "" (metav1.NamespaceAll) to get a cluster-scoped proxy client
+func ProxyClient(namespaces []string) (v1.ProxyClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return v1.NewProxyClient(customFactory)
@@ -262,10 +291,11 @@ func ProxyClient() (v1.ProxyClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	proxyClient, err := v1.NewProxyClient(&factory.KubeResourceClientFactory{
-		Crd:             v1.ProxyCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                v1.ProxyCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating proxys client")
@@ -277,14 +307,23 @@ func ProxyClient() (v1.ProxyClient, error) {
 }
 
 func MustGatewayClient() gatewayv1.GatewayClient {
-	client, err := GatewayClient()
+	return MustNamespacedGatewayClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedGatewayClient(ns string) gatewayv1.GatewayClient {
+	return MustMultiNamespacedGatewayClient([]string{ns})
+}
+
+func MustMultiNamespacedGatewayClient(namespaces []string) gatewayv1.GatewayClient {
+	client, err := GatewayClient(namespaces)
 	if err != nil {
-		log.Fatalf("failed to create gateway v2 client: %v", err)
+		log.Fatalf("failed to create gateway client: %v", err)
 	}
 	return client
 }
 
-func GatewayClient() (gatewayv1.GatewayClient, error) {
+// provide "" (metav1.NamespaceAll)e "" (metav1.NamespaceAll) to get a cluster-scoped gateway client
+func GatewayClient(namespaces []string) (gatewayv1.GatewayClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return gatewayv1.NewGatewayClient(customFactory)
@@ -296,10 +335,11 @@ func GatewayClient() (gatewayv1.GatewayClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	gatewayClient, err := gatewayv1.NewGatewayClient(&factory.KubeResourceClientFactory{
-		Crd:             gatewayv1.GatewayCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                gatewayv1.GatewayCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating gateway client")
@@ -311,14 +351,23 @@ func GatewayClient() (gatewayv1.GatewayClient, error) {
 }
 
 func MustVirtualServiceClient() gatewayv1.VirtualServiceClient {
-	client, err := VirtualServiceClient()
+	return MustNamespacedVirtualServiceClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedVirtualServiceClient(ns string) gatewayv1.VirtualServiceClient {
+	return MustMultiNamespacedVirtualServiceClient([]string{ns})
+}
+
+func MustMultiNamespacedVirtualServiceClient(namespaces []string) gatewayv1.VirtualServiceClient {
+	client, err := VirtualServiceClient(namespaces)
 	if err != nil {
 		log.Fatalf("failed to create virtualService client: %v", err)
 	}
 	return client
 }
 
-func VirtualServiceClient() (gatewayv1.VirtualServiceClient, error) {
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped virtual service client
+func VirtualServiceClient(namespaces []string) (gatewayv1.VirtualServiceClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return gatewayv1.NewVirtualServiceClient(customFactory)
@@ -330,10 +379,11 @@ func VirtualServiceClient() (gatewayv1.VirtualServiceClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	virtualServiceClient, err := gatewayv1.NewVirtualServiceClient(&factory.KubeResourceClientFactory{
-		Crd:             gatewayv1.VirtualServiceCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                gatewayv1.VirtualServiceCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating virtualServices client")
@@ -345,14 +395,23 @@ func VirtualServiceClient() (gatewayv1.VirtualServiceClient, error) {
 }
 
 func MustRouteTableClient() gatewayv1.RouteTableClient {
-	routeTableClient, err := RouteTableClient()
+	return MustNamespacedRouteTableClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedRouteTableClient(ns string) gatewayv1.RouteTableClient {
+	return MustMultiNamespacedRouteTableClient([]string{ns})
+}
+
+func MustMultiNamespacedRouteTableClient(namespaces []string) gatewayv1.RouteTableClient {
+	client, err := RouteTableClient(namespaces)
 	if err != nil {
 		log.Fatalf("failed to create routeTable client: %v", err)
 	}
-	return routeTableClient
+	return client
 }
 
-func RouteTableClient() (gatewayv1.RouteTableClient, error) {
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped route table client
+func RouteTableClient(namespaces []string) (gatewayv1.RouteTableClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return gatewayv1.NewRouteTableClient(customFactory)
@@ -364,10 +423,11 @@ func RouteTableClient() (gatewayv1.RouteTableClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	routeTableClient, err := gatewayv1.NewRouteTableClient(&factory.KubeResourceClientFactory{
-		Crd:             gatewayv1.RouteTableCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                gatewayv1.RouteTableCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating routeTables client")
@@ -379,14 +439,23 @@ func RouteTableClient() (gatewayv1.RouteTableClient, error) {
 }
 
 func MustSettingsClient() v1.SettingsClient {
-	client, err := SettingsClient()
+	return MustNamespacedSettingsClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedSettingsClient(ns string) v1.SettingsClient {
+	return MustMultiNamespacedSettingsClient([]string{ns})
+}
+
+func MustMultiNamespacedSettingsClient(namespaces []string) v1.SettingsClient {
+	client, err := SettingsClient(namespaces)
 	if err != nil {
 		log.Fatalf("failed to create settings client: %v", err)
 	}
 	return client
 }
 
-func SettingsClient() (v1.SettingsClient, error) {
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped settings client
+func SettingsClient(namespaces []string) (v1.SettingsClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return v1.NewSettingsClient(customFactory)
@@ -398,10 +467,11 @@ func SettingsClient() (v1.SettingsClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	settingsClient, err := v1.NewSettingsClient(&factory.KubeResourceClientFactory{
-		Crd:             v1.SettingsCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                v1.SettingsCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating settings client")
@@ -496,14 +566,23 @@ func ApiExtsClient() (apiexts.Interface, error) {
 }
 
 func MustAuthConfigClient() extauth.AuthConfigClient {
-	client, err := AuthConfigClient()
+	return MustNamespacedAuthConfigClient(metav1.NamespaceAll) // will require cluster-scoped permissions
+}
+
+func MustNamespacedAuthConfigClient(ns string) extauth.AuthConfigClient {
+	return MustMultiNamespacedAuthConfigClient([]string{ns})
+}
+
+func MustMultiNamespacedAuthConfigClient(namespaces []string) extauth.AuthConfigClient {
+	client, err := AuthConfigClient(namespaces)
 	if err != nil {
 		log.Fatalf("failed to create auth config client: %v", err)
 	}
 	return client
 }
 
-func AuthConfigClient() (extauth.AuthConfigClient, error) {
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped authConfig client
+func AuthConfigClient(namespaces []string) (extauth.AuthConfigClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
 		return extauth.NewAuthConfigClient(customFactory)
@@ -515,10 +594,11 @@ func AuthConfigClient() (extauth.AuthConfigClient, error) {
 	}
 	cache := kube.NewKubeCache(context.TODO())
 	authConfigClient, err := extauth.NewAuthConfigClient(&factory.KubeResourceClientFactory{
-		Crd:             extauth.AuthConfigCrd,
-		Cfg:             cfg,
-		SharedCache:     cache,
-		SkipCrdCreation: true,
+		Crd:                extauth.AuthConfigCrd,
+		Cfg:                cfg,
+		SharedCache:        cache,
+		SkipCrdCreation:    true,
+		NamespaceWhitelist: namespaces,
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "creating auth config client")

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -234,7 +234,7 @@ func MustMultiNamespacedUpstreamGroupClient(namespaces []string) v1.UpstreamGrou
 	return client
 }
 
-// provide "" (metav1.NamespaceAll)e "" (metav1.NamespaceAll) to get a cluster-scoped upstream group client
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped upstream group client
 func UpstreamGroupClient(namespaces []string) (v1.UpstreamGroupClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
@@ -278,7 +278,7 @@ func MustMultiNamespacedProxyClient(namespaces []string) v1.ProxyClient {
 	return client
 }
 
-// provide "" (metav1.NamespaceAll)e "" (metav1.NamespaceAll) to get a cluster-scoped proxy client
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped proxy client
 func ProxyClient(namespaces []string) (v1.ProxyClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {
@@ -322,7 +322,7 @@ func MustMultiNamespacedGatewayClient(namespaces []string) gatewayv1.GatewayClie
 	return client
 }
 
-// provide "" (metav1.NamespaceAll)e "" (metav1.NamespaceAll) to get a cluster-scoped gateway client
+// provide "" (metav1.NamespaceAll) to get a cluster-scoped gateway client
 func GatewayClient(namespaces []string) (gatewayv1.GatewayClient, error) {
 	customFactory := getConfigClientFactory()
 	if customFactory != nil {

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -127,7 +127,7 @@ func BuildSuggestedUpgradeCommand(binaryName string, mismatches []*versionutils.
 // Gloo may not be running in a kubernetes environment, so don't error out the whole command
 // if we couldn't find the version
 func warnOnError(err error, logger Logger) {
-	logger.Println("Warning: Could not determine gloo client/server versions (is Gloo running outside of kubernetes?): " + err.Error())
+	logger.Println("Warning: Could not determine gloo server versions (is Gloo running outside of kubernetes?): " + err.Error())
 }
 
 type ContainerVersion struct {

--- a/projects/gloo/cli/pkg/printers/virtualservice.go
+++ b/projects/gloo/cli/pkg/printers/virtualservice.go
@@ -150,7 +150,7 @@ func getStatus(res resources.InputResource, namespace string) string {
 	// If the virtual service was accepted, don't include confusing errors on subresources but note if there's another resource potentially blocking config updates.
 	if resourceStatus == core.Status_Accepted {
 		// if route replacement is turned on, don't say that updates to this resource may be blocked
-		settingsClient, err := helpers.SettingsClient()
+		settingsClient, err := helpers.SettingsClient([]string{namespace})
 		// if we get any errors, ignore and default to more verbose error message
 		if err == nil {
 			settings, err := settingsClient.Read(namespace, defaults.SettingsName, clients.ReadOpts{})

--- a/projects/gloo/cli/pkg/surveyutils/upstreamgroup.go
+++ b/projects/gloo/cli/pkg/surveyutils/upstreamgroup.go
@@ -14,11 +14,10 @@ import (
 func AddUpstreamGroupFlagsInteractive(upstreamGroup *options.InputUpstreamGroup) error {
 
 	// collect upstreams list
-	usClient := helpers.MustUpstreamClient()
 	ussByKey := make(map[string]*v1.Upstream)
 	var usKeys []string
 	for _, ns := range helpers.MustGetNamespaces() {
-		usList, err := usClient.List(ns, clients.ListOpts{})
+		usList, err := helpers.MustNamespacedUpstreamClient(ns).List(ns, clients.ListOpts{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- updates `glooctl` commands to work without cluster-scoped rbac
- updates `glooctl version` to report client version even if server version cannot be determined
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2375