### PR TITLE
Strict semver validation

### DIFF
--- a/changelog/v1.4.0-beta1/update-versioning-to-beta-releases.yaml
+++ b/changelog/v1.4.0-beta1/update-versioning-to-beta-releases.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update versioning policy to betas, to match our enterprise and documented release policies.
+    issueLink: https://github.com/solo-io/gloo/issues/2627
+    resolvesIssue: false

--- a/changelog/validation.yaml
+++ b/changelog/validation.yaml
@@ -1,4 +1,3 @@
-relaxSemverValidation: true
 allowedLabels:
   - rc
   - beta


### PR DESCRIPTION
This will enforce strict semver validation, as new features are only developed on master and are bundled together in quarterly releases.

This matches the versioning scheme we have already set forth with Gloo Enterprise, and closely mirrors the Envoy release strategy. (which of course we depend on)