### PR TITLE
Update changelog (#2697)

### DIFF
--- a/changelog/v1.4.0-beta1/update-versioning-to-beta-releases.yaml
+++ b/changelog/v1.4.0-beta1/update-versioning-to-beta-releases.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update versioning policy to betas, to match our enterprise and documented release policies.
+    issueLink: https://github.com/solo-io/gloo/issues/2627
+    resolvesIssue: false

--- a/changelog/validation.yaml
+++ b/changelog/validation.yaml
@@ -1,4 +1,3 @@
-relaxSemverValidation: true
 allowedLabels:
   - rc
   - beta


### PR DESCRIPTION
* Update changelog , cherrypick of https://github.com/solo-io/gloo/pull/2697

Had to redo this change because we undid it in https://github.com/solo-io/gloo/pull/2711 to fix a regression in 1.3.16, which allowed us to release the fix in 1.3.17 before preparing for 1.4.0-beta1