### PR TITLE
fix glooctl kubectl timeouts (#2790)

### DIFF
--- a/changelog/v1.3.21/fix-glooctl-kubectl-timeouts.yaml
+++ b/changelog/v1.3.21/fix-glooctl-kubectl-timeouts.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    description: >
+      Some users saw commands such as glooctl check or glooctl proxy dump fail due to
+      harsh timeout restrictions on the port-forward glooctl does under the covers.
+      This results in "Connection Refused" errors that could have been avoided.
+      This PR updates the port forward timeouts from 3 to 30 seconds to allow these
+      commands more time to finish.
+    issueLink: https://github.com/solo-io/gloo/issues/2771

--- a/docs/content/operations/debugging_gloo/_index.md
+++ b/docs/content/operations/debugging_gloo/_index.md
@@ -177,7 +177,7 @@ Each Gloo control plane component comes with a optional debug port that can be e
 kubectl port-forward  -n gloo-system deploy/gloo  9091:9091
 ```
 
-Now you can navigate to [http://localhost:9091](http://localhost:9091) and you get a simple page with some additional endpoints:
+Now you can navigate to http://localhost:9091 and you get a simple page with some additional endpoints:
 
 * `/debug/pprof`
 * `/logging`

--- a/pkg/cliutil/uri.go
+++ b/pkg/cliutil/uri.go
@@ -200,7 +200,7 @@ func PortForwardGet(ctx context.Context, namespace string, resource string, loca
 		return "", nil, err
 	}
 
-	localCtx, cancel := context.WithTimeout(ctx, time.Second*3)
+	localCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
 	// wait for port-forward to be ready

--- a/projects/gloo/cli/pkg/cmd/gateway/dump.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/dump.go
@@ -169,7 +169,7 @@ func getEnvoyStatsDump(opts *options.Options) (string, error) {
 			log.Printf("connecting to envoy failed with err %v", err.Error())
 		case res := <-result:
 			return res, nil
-		case <-time.After(time.Second * 3):
+		case <-time.After(time.Second * 30):
 			return "", errors.Errorf("timed out trying to connect to Envoy admin port")
 		}
 	}

--- a/projects/gloo/cli/pkg/cmd/gateway/logs.go
+++ b/projects/gloo/cli/pkg/cmd/gateway/logs.go
@@ -84,7 +84,7 @@ func getEnvoyLogs(opts *options.Options) error {
 				return errors.Errorf("cancelled")
 			case err := <-errs:
 				log.Printf("connecting to envoy failed with err %v", err.Error())
-			case <-time.After(time.Second * 3):
+			case <-time.After(time.Second * 30):
 				return errors.Errorf("timed out trying to connect to Envoy admin port")
 			case <-done:
 				break waitForDebugMode


### PR DESCRIPTION
* fix glooctl kubectl timeouts
* mark glooctl proxy check setup error as warning
* still return errors when we can't set up a port-forward
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2771