### PR TITLE
Fix changelog accuracy

### DIFF
--- a/changelog/v1.3.20/fix-proxy-garbage-collection.yaml
+++ b/changelog/v1.3.20/fix-proxy-garbage-collection.yaml
@@ -1,9 +1,9 @@
 changelog:
 - type: FIX
   description: >
-    With `disableProxyGarbageCollection` enabled (the default), Gloo used to clear the extauth
-    and ratelimit snapshots from the XDS cache, resulting in null configurations temporarily in
-    the extauth and ratelimit services. This caused blips of invalid 403/429 responses. To fix this,
-    Gloo now detects any valid `TranslatorSyncerExtension`'s Envoy Node ID keys through its `Sync()`
+    With proxy garbage collection enabled (enabled by default via `disableProxyGarbageCollection`=`false`),
+    Gloo used to clear the extauth and ratelimit snapshots from the XDS cache, resulting in null configurations
+    temporarily in the extauth and ratelimit services. This caused blips of invalid 403/429 responses. To fix
+    this, Gloo now detects any valid `TranslatorSyncerExtension`'s Envoy Node ID keys through its `Sync()`
     function, so Gloo doesn't garbage collect these snapshots anymore.
   issueLink: https://github.com/solo-io/gloo/issues/2721


### PR DESCRIPTION
The changelog had an error with the default setting -- this fixes it so it will be rendered properly in the next update of ours docs