### PR TITLE
Port reference document

### DIFF
--- a/docs/content/reference/gloo_port_reference.md
+++ b/docs/content/reference/gloo_port_reference.md
@@ -6,35 +6,35 @@ weight: 35
 
 Gloo Gateway and Gloo Enterprise both deploy containers that listen on certain ports for incoming traffic. This document lists out the pods and services that make up Gloo and Gloo Enterprise, and the ports which these pods and services listen on. It is also possible to set up mutual TLS (mTLS) for communication between Gloo resources. The addition of mTLS changes the ports and traffic flows slightly, which is addressed in this document as well.
 
-This document is specific to the pods and service deployed in a Kubernetes environment. Deploying Gloo using the HashiCorp stack is also supported, and the port mappings and services should be the same.
+This document is specific to the pods and services deployed in a Kubernetes environment. Deploying Gloo using the HashiCorp stack is also supported, and the port mappings and services should be the same.
 
 {{% notice note %}}
-It is possible to customize some port settings by providing custom values to the Helm chart that installs Gloo OSS and Gloo Enterprise. The port reference below is for an installation of Gloo that uses the default settings in the Helm chart.
+It is possible to customize some port settings by providing custom values to the Helm chart that installs Gloo open-source and Gloo Enterprise. The port reference below is for an installation of Gloo that uses the default settings in the Helm chart.
 {{% /notice %}}
 
 ---
 
-## Gloo Gateway OSS
+## Gloo Gateway Open-source
 
-Gloo open-source is the free, open-source version of Gloo Gateway. The installation process uses a Helm chart to create the necessary custom resource definitions (CRDs), deployments, services, pods, etc. The services and pods listen on specific ports to enable communication between the components that make up Gloo and outside sources that will consume Upstream resources through Gloo.
+Gloo open-source software is the free, open-source version of Gloo Gateway. The installation process uses a Helm chart to create the necessary custom resource definitions (CRDs), deployments, services, pods, etc. The services and pods listen on specific ports to enable communication between the components that make up Gloo and outside sources that will consume Upstream resources through Gloo.
 
 ### What's included
 
 A standard installation of Gloo Gateway includes four primary components:
 
 * **Gateway**
-  * Translate Gateway, Virtual Service, and RouteTable custom resources into a Proxy custom resource.
-  * Validate proposed configurations before application.
+  * Translates Gateway, Virtual Service, and RouteTable custom resources into a Proxy custom resource.
+  * Validates proposed configurations before application.
 * **Gloo**
-  * Create an Envoy configuration from multiple custom resources.
-  * Serve Envoy configurations using xDS.
-  * Validate Proxy configurations for the Gateway.
+  * Creates an Envoy configuration from multiple custom resources.
+  * Serves Envoy configurations using xDS.
+  * Validates Proxy configurations for the Gateway.
 * **Proxy**
-  * Receive and load configuration from Gloo xDS.
-  * Proxy incoming traffic.
+  * Receives and loads configuration from Gloo xDS.
+  * Proxies incoming traffic.
 * **Discovery**
-  * Discover Upstreams in the cluster.
-  * Discover functions with the Function Discovery Service.
+  * Discovers Upstreams in the cluster.
+  * Discovers functions with the Function Discovery Service.
 
 ### Pods and ports
 

--- a/docs/content/reference/gloo_port_reference.md
+++ b/docs/content/reference/gloo_port_reference.md
@@ -1,0 +1,152 @@
+---
+title: "Gloo Port Reference"
+description: Listing of ports used by Gloo Gateway and Gloo Enterprise
+weight: 35
+---
+
+Gloo Gateway and Gloo Enterprise both deploy containers that listen on certain ports for incoming traffic. This document lists out the pods and services that make up Gloo and Gloo Enterprise, and the ports which these pods and services listen on. It is also possible to set up mutual TLS (mTLS) for communication between Gloo resources. The addition of mTLS changes the ports and traffic flows slightly, which is addressed in this document as well.
+
+This document is specific to the pods and service deployed in a Kubernetes environment. Deploying Gloo using the HashiCorp stack is also supported, and the port mappings and services should be the same.
+
+{{% notice note %}}
+It is possible to customize some port settings by providing custom values to the Helm chart that installs Gloo OSS and Gloo Enterprise. The port reference below is for an installation of Gloo that uses the default settings in the Helm chart.
+{{% /notice %}}
+
+---
+
+## Gloo Gateway OSS
+
+Gloo open-source is the free, open-source version of Gloo Gateway. The installation process uses a Helm chart to create the necessary custom resource definitions (CRDs), deployments, services, pods, etc. The services and pods listen on specific ports to enable communication between the components that make up Gloo and outside sources that will consume Upstream resources through Gloo.
+
+### What's included
+
+A standard installation of Gloo Gateway includes four primary components:
+
+* **Gateway**
+  * Translate Gateway, Virtual Service, and RouteTable custom resources into a Proxy custom resource.
+  * Validate proposed configurations before application.
+* **Gloo**
+  * Create an Envoy configuration from multiple custom resources.
+  * Serve Envoy configurations using xDS.
+  * Validate Proxy configurations for the Gateway.
+* **Proxy**
+  * Receive and load configuration from Gloo xDS.
+  * Proxy incoming traffic.
+* **Discovery**
+  * Discover Upstreams in the cluster.
+  * Discover functions with the Function Discovery Service.
+
+### Pods and ports
+
+The four primary components are instantiated using pods and services. The following table lists the deployed pods and ports in use by each pod, as well as the optional `access-log` pod if Access Logging has been enabled.
+
+| Pod | Port | Usage |
+|-----|------|-------|
+| gateway | 8443 | Validation |
+| gloo | 9977 | xDS Server |
+| gloo | 9988 | Validation |
+| gloo | 9979 | WASM cache |
+| gloo | 9966 | Metrics gRPC |
+| gateway-proxy | 8080 | HTTP |
+| gateway-proxy | 8443 | HTTPS |
+| gateway-proxy | 19000 | Envoy admin |
+| access-log | 8083 | Access logging |
+
+The `discovery` pod does not listen on any ports as it uses outbound connections only.
+
+### Services and ports
+
+The following table lists the services backed by the deployed pods.
+
+| Service | Port | Target | Target Port | Usage |
+|---------|------|--------|-------------|-------|
+| gateway | 443 | gateway | 8443 | Validation |
+| gloo | 9977 | gloo | 9977 | xDS Server |
+| gloo | 9988 | gloo | 9988 | Validation |
+| gloo | 9979 | gloo | 9979 | WASM cache |
+| gloo | 9966 | gloo | 9966 | Metrics gRPC |
+| gateway-proxy | 80 | gateway-proxy | 8080 | HTTP |
+| gateway-proxy | 443 | gateway-proxy | 8443 | HTTPS |
+| access-log | 8083 | access-log | 8083 | Access logging |
+
+---
+
+## Gloo Enterprise
+
+Gloo Enterprise (GlooE) adds many pods and services to provide the extra functionality included in the paid offering. More information on what is included in Gloo Enterprise can be found on the [Gloo product page](https://www.solo.io/products/gloo/). 
+
+### What's included
+
+At a high level, the following additional components are available in GlooE.
+
+* API and UI server
+* External authentication
+* Prometheus metrics collection
+* Prometheus server
+* Grafana dashboard creation and presentation
+* Rate-limiting
+
+The Prometheus server and Grafana dashboard are optional components. If you have an existing instance of either, they can be used instead. More information is available in the [Observability section]({{< versioned_link_path fromRoot="/introduction/observability/" >}}) of the docs.
+
+### Pods and ports
+
+The GlooE components are instantiated using pods and services. The following table lists the deployed pods and ports in use by each pod.
+
+| Pod | Port | Usage |
+|-----|------|-------|
+| api-server | 8080 | UI server |
+| api-server | 10101 | API Server |
+| extauth | 8083 | External authentication |
+| grafana | 80 | Grafana (unused) |
+| grafana | 3000 | Grafana UI |
+| prometheus-kube-state-metrics | 8080 | Kubernetes metric collection |
+| prometheus-server | 9090 | Prometheus server |
+| rate-limit | 18081 | Rate-limiting |
+| redis | 6379 | Rate-limiting |
+
+There is an `observability` pod that automatically configures dashboards on the Grafana instance. It does not accept inbound traffic, so it is not included in the table above.
+
+### Services and ports
+
+The following table lists the services backed by the deployed pods.
+
+| Service | Port | Target | Target Port | Usage |
+|---------|------|--------|-------------|-------|
+| apiserver-ui | 8080 | api-server | 8080 | Gloo UI |
+| extauth | 8083 | extauth | 8083 | External authentication |
+| glooe-grafana | 80 | grafana | 3000 | Grafana UI |
+| glooe-prometheus-kube-state-metrics | 80 | prometheus-kube-state-metrics | 8080 | Kubernetes metric collection |
+| glooe-prometheus-server | 80 | prometheus-server | 9090 | Prometheus server |
+| rate-limit | 18081 | rate-limit | 18081 | Rate-limiting |
+| redis | 6379 | redis | 6379 | Rate-limiting |
+
+---
+
+## mTLS considerations
+
+Gloo supports the use of mutual TLS (mTLS) communication between the Gloo pod and other services, including the Envoy proxy, Extauth server, and Rate-limiting server. Enabling mTLS includes the addition of sidecars for multiple pods, Envoy proxy for TLS termination and SDS for certificate rotation and management. More information on the details of mTLS implementation are available in the [mTLS doc]({{< versioned_link_path fromRoot="/guides/security/tls/mtls/" >}}).
+
+### Updated pods
+
+The following pods are updated to support mTLS:
+* **Gloo**: Envoy and SDS sidecars are added.
+* **Gateway-proxy**: SDS sidecars added and ConfigMap updated for mTLS.
+* **ExtAuth**: Envoy and SDS sidecars are added.
+* **Rate-limit**: Envoy and SDS sidecars are added.
+
+The additional Envoy sidecar has an admin port listening on 8081 for each pod.
+
+### Updated traffic flow
+
+The Envoy sidecar on the Gloo, Extauth, and Rate-limit pods will be intercepting the inbound traffic for each pod and performing the TLS decryption before passing the traffic to the main container. This does not alter the ports being used by the pods and services, but it does create additional ports that are used internally within the pod for communication. For instance, the Gloo pod continues to listen on 9977 as the xDS server. Internally, the Gloo container is listening on 127.0.0.1:9999 for xDS requests. The Envoy sidecar in the pod accepts requests on 9977, decrypts the request, and sends it to port 9999 on the localhost for processing.
+
+---
+
+## Summary and next steps
+
+This document provides the ports being used by pods and services on a default installation of Gloo Gateway and Gloo Enterprise. Some of these ports can be customized, and additional components can be added that introduce more pods and services. To better understand the architecture of Gloo, we recommend reading the following docs:
+
+* [Gloo Architecture]({{< versioned_link_path fromRoot="/introduction/architecture/" >}})
+* [Custom Resource Usage]({{< versioned_link_path fromRoot="/introduction/architecture/custom_resources/" >}})
+* [Deployment Options]({{< versioned_link_path fromRoot="/introduction/architecture/deployment_options/" >}})
+* [mTLS Deployment]({{< versioned_link_path fromRoot="/guides/security/tls/mtls/" >}})


### PR DESCRIPTION
Adding a port reference document with the ports used by all pods and services in Gloo Gateway and Gloo Enterprise.