### PR TITLE
Fix untar mod cache flake

### DIFF
--- a/changelog/v1.4.0-beta8/fix-untar-mod-cache-flake.yaml
+++ b/changelog/v1.4.0-beta8/fix-untar-mod-cache-flake.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Make untar mod cache cloudbuild step succeed regardless because it is only a speed optimization.
+    issueLink: https://github.com/solo-io/gloo/issues/2894

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ steps:
 # All steps after this must set working directory to use the cloned Gloo source
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
-# gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo ./
+# gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo --project solo-public
 - name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.3.0'
   args:
     - "--repo-name"

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
 
 - name: gcr.io/cloud-builders/gsutil
   entrypoint: 'bash'
-  args: ['-c', 'mkdir -p /go/pkg && cd /go/pkg && gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf -']
+  args: ['-c', 'mkdir -p /go/pkg && cd /go/pkg && gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"']
   dir: *dir
   id: 'untar-mod-cache'
 


### PR DESCRIPTION
We have seen some flakes in CI where we have been unable to successfully download our go mod cache dependencies and untar them, which has failed CI runs.

Since the mod cache is just a speed optimization (we can download the dependencies later), we can opt to pass the cloudbuild step even if google has a server side error, or we hit download limits from the server.

a sample build where we hit the flake, and the step passes anyways, using these changes: https://console.cloud.google.com/cloud-build/builds/3c076ba6-0816-4965-8f5d-155b42b02571?project=solo-public

the idea came from: https://medium.com/@davidstanke/make-a-cloud-build-step-that-always-succeeds-9d23290a2f4e

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2894