### PR TITLE
Issue and pr templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,23 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: 'Type: Bug'
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. kube apply '...'
+2. curl '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/docs.md
+++ b/.github/ISSUE_TEMPLATE/docs.md
@@ -1,0 +1,22 @@
+---
+name: Docs
+about: Fix our docs or add new information
+title: ''
+labels: 'Type: Docs'
+assignees: ''
+
+---
+
+**Describe the requested changes**
+List the desired changes to be made to the Gloo docs.
+
+**Link to any relevant existing docs**
+1. https://docs.solo.io/gloo/latest/...
+2. ...
+
+**Browser Information**
+If the change isn't related to content, please include your browser version and any other relevant information 
+(e.g., browser zoom) to help us reproduce docs-related bugs.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: 'Type: Enhancement'
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,11 @@
+---
+name: Question
+about: Asking a question \ seeking guidance
+title: ''
+labels: 'Type: Question'
+assignees: ''
+
+---
+
+For a fast response, consider asking your question on the solo slack. get an invite at https://slack.solo.io.
+Also, please check out `gloo.solo.io` for documentation and guides.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # Description
 
-Please include a summary of the changes and include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is fixed.
+Please include a summary of the changes.
 
 This bug fixes ... \ This new feature can be used to ...
 
@@ -10,6 +10,7 @@ Users ran into this bug doing ... \ Users needed this feature to ...
 
 # Checklist:
 
+- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is fixed.
 - [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
 - [ ] If I updated APIs (our protos) or helm values, I ran `make generated-code` to ensure there will be no code diff
 - [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Users ran into this bug doing ... \ Users needed this feature to ...
 
 # Checklist:
 
-- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is fixed.
+- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
 - [ ] If I updated APIs (our protos) or helm values, I ran `make generated-code` to ensure there will be no code diff
 - [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
 - [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,8 +11,8 @@ Users ran into this bug doing ... \ Users needed this feature to ...
 # Checklist:
 
 - [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is fixed.
-- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
 - [ ] If I updated APIs (our protos) or helm values, I ran `make generated-code` to ensure there will be no code diff
+- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
 - [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
 - [ ] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+# Description
+
+Please include a summary of the changes and include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is fixed.
+
+This bug fixes ... \ This new feature can be used to ...
+
+## Context
+
+Users ran into this bug doing ... \ Users needed this feature to ...
+
+# Checklist:
+
+- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
+- [ ] If I updated APIs (our protos) or helm values, I ran `make generated-code` to ensure there will be no code diff
+- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] I have added tests that prove my fix is effective or that my feature works

--- a/changelog/v1.4.0-beta9/issue-and-pr-templates.yaml
+++ b/changelog/v1.4.0-beta9/issue-and-pr-templates.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add issue and PR templates to help direct devs and improve our community profile, https://github.com/solo-io/gloo/community


### PR DESCRIPTION
Bringing back changes from https://github.com/solo-io/gloo/pull/1363 that got lost in the default branch swap during the Gloo 1.0 release several months ago.

Also adding a pr template to help direct devs who want to contribute to gloo