### PR TITLE
Fix table formatting on setup

### DIFF
--- a/docs/content/installation/_index.md
+++ b/docs/content/installation/_index.md
@@ -7,14 +7,14 @@ weight: 20
 
 Gloo Open-Source runs in 3 different modes to enable different use cases:
 
-<dic markdown=1>
+<div markdown=1>
 <table>
   <tr height="100">
     <td width="10%">
       <a href="{{% versioned_link_path fromRoot="/installation/gateway/" %}}"><img src='{{% versioned_link_path fromRoot="/img/Gloo-01.png" %}}' width="60"/></a>
     </td>
     <td>
-     Run Gloo in `gateway` mode to function as an API Gateway. This is the most fully-featured and customizable installation of Gloo, and is our <a href="{{% versioned_link_path fromRoot="/installation/gateway/" %}}"><b>recommended install for first-time users</b></a>. The Gloo Gateway can be configured via Kubernetes Custom Resources, Consul Key-Value storage, or `.yaml` files on Gloo's local filesystem.
+     Run Gloo in <code>gateway</code> mode to function as an API Gateway. This is the most fully-featured and customizable installation of Gloo, and is our <a href="{{% versioned_link_path fromRoot="/installation/gateway/" %}}"><b>recommended install for first-time users</b></a>. The Gloo Gateway can be configured via Kubernetes Custom Resources, Consul Key-Value storage, or <code>.yaml</code> files on Gloo's local filesystem.
     </td>
   </tr>
   <tr height="100">
@@ -22,19 +22,18 @@ Gloo Open-Source runs in 3 different modes to enable different use cases:
       <a href="{{% versioned_link_path fromRoot="/installation/knative/" %}}"><img src='{{% versioned_link_path fromRoot="/img/knative.png" %}}' width="60"/></a>
     </td>
     <td>
-     Run Gloo in `knative` mode to serve as the Gateway/Ingress for Knative, configured automatically by [Knative Serving](https://github.com/knative/serving) to route to [Knative Services](https://github.com/knative/serving/blob/master/docs/spec/spec.md).
+     Run Gloo in <code>knative</code> mode to serve as the Gateway/Ingress for Knative, configured automatically by <a href="https://github.com/knative/serving">Knative Serving</a> to route to <a href="https://github.com/knative/serving/blob/master/docs/spec/spec.md">Knative Services</a>.
     </td>
   </tr>
   <tr height="100">
     <td width="10%">
       <a href="{{% versioned_link_path fromRoot="/installation/ingress/" %}}"><img src='{{% versioned_link_path fromRoot="/img/ingress.png" %}}' width="60"/></a>
     </td>
-    <td>Run Gloo in `ingress` mode to act as a standard Kubernetes Ingress controller. In this mode, Gloo will import
-        its configuration from the `extensions/v1beta1.Ingress` Kubernetes resource. This can be used to achieve compatibility with the standard Kubernetes ingress API. Note that Gloo's Ingress API does not support customization via annotations. If you wish to extend Gloo beyond the functions of basic ingress, it is recommended to run Gloo in `gateway` mode.
+    <td>Run Gloo in <code>ingress</code> mode to act as a standard Kubernetes Ingress controller. In this mode, Gloo will import its configuration from the <code>extensions/v1beta1.Ingress</code> Kubernetes resource. This can be used to achieve compatibility with the standard Kubernetes ingress API. Note that Gloo's Ingress API does not support customization via annotations. If you wish to extend Gloo beyond the functions of basic ingress, it is recommended to run Gloo in <code>gateway</code> mode.
     </td>
   </tr>
 </table>
-</dic>
+</div>
 
 {{% notice note %}}
 Note: The installation modes are not mutually exclusive, e.g. if you wish to run `gateway` in conjunction with `ingress`, it can be done by installing both options to the same (or different) namespaces.
@@ -44,7 +43,7 @@ Note: The installation modes are not mutually exclusive, e.g. if you wish to run
 
 Gloo Enterprise has a single installation workflow:
 
-<dic markdown=1>
+<div markdown=1>
 <table>
   <tr height="100">
     <td width="10%">
@@ -55,4 +54,4 @@ Gloo Enterprise has a single installation workflow:
     </td>
   </tr>
 </table>
-</dic>
+</div>

--- a/docs/content/installation/gateway/_index.md
+++ b/docs/content/installation/gateway/_index.md
@@ -8,20 +8,61 @@ weight: 30
 
 There are two primary ways to install the Gloo Gateway in production:
 
-|    |    |
-|----|----|
-|![Kubernetes]({{< versioned_link_path fromRoot="/img/kube.png" >}}) | Install the Gloo Gateway on [Kubernetes]({{< versioned_link_path fromRoot="/installation/gateway/kubernetes" >}}), using Kubernetes Custom Resources to configure routing. |
-| ![HashiCorp]({{< versioned_link_path fromRoot="/img/nomad.png" >}}) | Run Gloo on a [HashiCorp Nomad Cluster]({{< versioned_link_path fromRoot="/installation/gateway/nomad" >}}), using Consul for configuration and Vault for secret storage. |
+<div markdown=1>
+<table>
+  <tr height="100">
+    <td width="10%">
+      <a href="{{< versioned_link_path fromRoot="/installation/gateway/kubernetes" >}}"><img src='{{< versioned_link_path fromRoot="/img/kube.png" >}}' width="60"/></a>
+    </td>
+    <td>
+     Install the Gloo Gateway on <a href="{{< versioned_link_path fromRoot="/installation/gateway/kubernetes" >}}">Kubernetes</a>, using Kubernetes Custom Resources to configure routing.
+    </td>
+  </tr>
+  <tr height="100">
+    <td width="10%">
+      <a href="{{< versioned_link_path fromRoot="/installation/gateway/nomad" >}}"><img src='{{< versioned_link_path fromRoot="/img/nomad.png" >}}' width="60"/></a>
+    </td>
+    <td>
+     Run Gloo on a <a href="{{< versioned_link_path fromRoot="/installation/gateway/nomad" >}}">HashiCorp Nomad Cluster</a>, using Consul for configuration and Vault for secret storage.
+    </td>
+  </tr>
+</table>
+</div>
 
 The Enterprise version of Gloo can be installed using the following guide:
 
-|    |    |
-|----|----|
-| ![Gloo Enterprise]({{< versioned_link_path fromRoot="/img/gloo-ee.png" >}}) | [Gloo Enterprise]({{< versioned_link_path fromRoot="/installation/enterprise/" >}}) is based on the open-source Gloo Gateway with additional (closed source) UI and plugins. |
+<div markdown=1>
+<table>
+  <tr height="100">
+    <td width="10%">
+      <a href="{{< versioned_link_path fromRoot="/installation/enterprise/" >}}"><img src='{{< versioned_link_path fromRoot="/img/gloo-ee.png" >}}' width="60"/></a>
+    </td>
+    <td>
+     <a href="{{< versioned_link_path fromRoot="/installation/enterprise/" >}}">Gloo Enterprise</a> is based on the open-source Gloo Gateway with additional (closed source) UI and plugins.
+    </td>
+  </tr>
+</table>
+</div>
 
 You also install Gloo Gateway in a development scenario on your local workstation using one of the following guides:
 
-|    |    |
-|----|----|
-| ![Docker with HashiCorp]({{< versioned_link_path fromRoot="/img/consul.png" >}}) | [Run Gloo locally with Docker Compose]({{< versioned_link_path fromRoot="/installation/gateway/development/docker-compose-consul" >}}), using HashiCorp Consul for configuration and HashiCorp Vault for secret storage. |
-| ![Docker with files]({{< versioned_link_path fromRoot="/img/docker.png" >}}) | [Run Gloo locally with Docker Compose]({{< versioned_link_path fromRoot="/installation/gateway/development/docker-compose-file" >}}), using `yaml` files which are mounted to the Gloo container for configuration and secret storage. |
+<div markdown=1>
+<table>
+  <tr height="100">
+    <td width="10%">
+      <a href="{{< versioned_link_path fromRoot="/installation/gateway/development/docker-compose-consul" >}}"><img src='{{< versioned_link_path fromRoot="/img/consul.png" >}}' width="60"/></a>
+    </td>
+    <td>
+     <a href="{{< versioned_link_path fromRoot="/installation/gateway/development/docker-compose-consul" >}}">Run Gloo locally with Docker Compose</a>, using HashiCorp Consul for configuration and HashiCorp Vault for secret storage.
+    </td>
+  </tr>
+  <tr height="100">
+    <td width="10%">
+      <a href="{{< versioned_link_path fromRoot="/installation/gateway/development/docker-compose-file" >}}"><img src='{{< versioned_link_path fromRoot="/img/docker.png" >}}' width="60"/></a>
+    </td>
+    <td>
+     <a href="{{< versioned_link_path fromRoot="/installation/gateway/development/docker-compose-file" >}}">Run Gloo locally with Docker Compose</a>, using <code>yaml</code> files which are mounted to the Gloo container for configuration and secret storage.
+    </td>
+  </tr>
+</table>
+</div>


### PR DESCRIPTION
It appears that the tag `<div markdown=1>` is no longer respected by Hugo, so markdown included in HTML tables is not being rendered properly. I have updated two docs to use all HTML markup for the tables. The formatting available in markdown for tables doesn't really look right.

This resolves issue #2688 