### PR TITLE
move code to a different place to avoid race

### DIFF
--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -317,6 +317,7 @@ func (t *translatorInstance) setAction(params plugins.RouteParams, routeReport *
 	}
 }
 
+
 func (t *translatorInstance) setRouteAction(params plugins.RouteParams, in *v1.RouteAction, out *envoyroute.RouteAction, routeReport *validationapi.RouteReport) error {
 	switch dest := in.Destination.(type) {
 	case *v1.RouteAction_Single:
@@ -342,6 +343,7 @@ func (t *translatorInstance) setRouteAction(params plugins.RouteParams, in *v1.R
 		md := &v1.MultiDestination{
 			Destinations: upstreamGroup.Destinations,
 		}
+		t.fixUpstreamGroups(upstreamGroup)
 		return t.setWeightedClusters(params, md, out, routeReport)
 	}
 	return errors.Errorf("unknown upstream destination type")

--- a/projects/gloo/pkg/translator/upstream_groups.go
+++ b/projects/gloo/pkg/translator/upstream_groups.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	errors "github.com/rotisserie/eris"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	usconversions "github.com/solo-io/gloo/projects/gloo/pkg/upstreams"
 	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
@@ -19,11 +20,6 @@ func (t *translatorInstance) verifyUpstreamGroups(params plugins.Params, reports
 				continue
 			}
 
-			if upstream := dest.GetDestination().GetUpstream(); upstream != nil && upstream.GetNamespace() == "" {
-				parentMetadata := ug.GetMetadata()
-				upstream.Namespace = parentMetadata.GetNamespace()
-			}
-
 			upRef, err := usconversions.DestinationToUpstreamRef(dest.Destination)
 			if err != nil {
 				reports.AddError(ug, err)
@@ -38,4 +34,13 @@ func (t *translatorInstance) verifyUpstreamGroups(params plugins.Params, reports
 
 	}
 
+}
+
+func (t *translatorInstance) fixUpstreamGroups(ug *v1.UpstreamGroup) {
+	for _, dest := range ug.Destinations {
+		if upstream := dest.GetDestination().GetUpstream(); upstream != nil && upstream.GetNamespace() == "" {
+			parentMetadata := ug.GetMetadata()
+			upstream.Namespace = parentMetadata.GetNamespace()
+		}
+	}
 }

--- a/projects/gloo/pkg/translator/upstream_groups.go
+++ b/projects/gloo/pkg/translator/upstream_groups.go
@@ -26,7 +26,13 @@ func (t *translatorInstance) verifyUpstreamGroups(params plugins.Params, reports
 				continue
 			}
 
-			if _, err := upstreams.Find(upRef.Namespace, upRef.Name); err != nil {
+			ns := upRef.Namespace
+			if upRef.Namespace == "" {
+				parentMetadata := ug.GetMetadata()
+				ns = parentMetadata.GetNamespace()
+			}
+
+			if _, err := upstreams.Find(ns, upRef.Name); err != nil {
 				reports.AddError(ug, errors.Wrapf(err, "destination # %d: upstream not found", i+1))
 				continue
 			}


### PR DESCRIPTION
This is a proposed fix for https://github.com/solo-io/gloo/issues/2954

Getting into design stuff a little bit:

- I don't think it's a good idea to overwrite the upstream group from:
```
apiVersion: gloo.solo.io/v1
kind: UpstreamGroup
metadata:
  name: us-group 
  namespace: gloo-system
spec:
  destinations:
  - destination:
      upstream:
        name: static-pet 
        #namespace: gloo-system # this error shows up when the namespace is not specified here
    weight: 1
```
to
```
apiVersion: gloo.solo.io/v1
kind: UpstreamGroup
metadata:
  name: us-group 
  namespace: gloo-system
spec:
  destinations:
  - destination:
      upstream:
        name: static-pet 
        namespace: gloo-system
    weight: 1
```

This is currently what's happening (due to the following section of code):
```
if upstream := dest.GetDestination().GetUpstream(); upstream != nil && upstream.GetNamespace() == "" {
			parentMetadata := ug.GetMetadata()
			upstream.Namespace = parentMetadata.GetNamespace()
		}
```

This code modifies our 'snapshot' or our view of the system. Then, it gets written back as we report on the upstream group (setting it to 'Accepted'). This is causing a lot of weird behavior/inconsistencies.


What we _actually_ should do is - we should be fine with `glooctl get ug` outputting something like
```

+----------------+----------+--------------+----------------------------+
| UPSTREAM GROUP |  STATUS  | TOTAL WEIGHT |          DETAILS           |
+----------------+----------+--------------+----------------------------+
| us-group       | Accepted | 1            | destination type: Upstream |
|                |          |              | namespace:                 |
|                |          |              | name: static-pet           |
|                |          |              | weight: 1   % total: 1.00  |
+----------------+----------+--------------+----------------------------+
```
and we should be fine not touching the UpstreamGroup kubernetes object. The only thing we actually care about is setting the envoy cluster and route config correctly.