### PR TITLE
upgrade to gloo 1.3 docs, leveraging helm 3.2 adoption of resources

### DIFF
--- a/changelog/v1.4.0-beta9/safer-upgrade-using-helm-3-2-0.yaml
+++ b/changelog/v1.4.0-beta9/safer-upgrade-using-helm-3-2-0.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update docs for 1.3 upgrade to be safer by adopting resources instead of deleting and recreating them.
+    issueLink: https://github.com/solo-io/gloo/issues/2807

--- a/docs/content/operations/upgrading/1.3.0.md
+++ b/docs/content/operations/upgrading/1.3.0.md
@@ -110,33 +110,30 @@ curl $(glooctl proxy url)/posts
 
 Now Gloo is installed and ready for upgrade.
 
-If running Gloo 1.2.x or lower (open-source or enterprise):
-```shell script
-glooctl debug yaml > gloo-state-backup.yaml                   # backup your state of the world
-kubectl scale --replicas 0 deployment/gateway -n gloo-system  # so gateway doesn't update the proxy after we delete the gateway
-kubectl scale --replicas 0 deployment/gloo -n gloo-system          # so gloo doesn't recreate the settings
-kubectl scale --replicas 0 deployment/discovery -n gloo-system     # so discovery doesn't recreate the settings
-kubectl scale --replicas 0 deployment/observability -n gloo-system # so observability doesn't recreate the settings
-kubectl delete settings -n gloo-system --all # delete the helm-hook settings, so we can upgrade to settings managed by helm
-kubectl delete gateway -n gloo-system --all  # delete the helm-hook gateway, so we can upgrade to gateways managed by helm
-```
-
-Note that when upgrading, if you had any non-default `Gateway` or `Settings` configuration, you will want to make sure
-the generated gateways and settings match your previously configured gateways and settings by comparing the output of
-`helm template` with your `gloo-state-backup.yaml` before running `helm upgrade`.
+If running Gloo 1.2.x or lower (open-source or enterprise), label the default gateways and settings to become part of your helm release:
 
 {{% notice warning %}}
-If the gateway and settings rendered by `helm template` do not match the original ones we deleted then the differing
-configuration **MAY RESULT IN DOWNTIME**. Ensure the gateway and settings rendered by `helm template` match the
-original ones backed up in `gloo-state-backup.yaml`.
+This requires helm 3.2 or newer. If you must use helm 2, drop into our [slack](https://slack.solo.io/) for help upgrading your setup.
 {{% /notice %}}
 
-A full list of supported helm chart values in open-source gloo can be found [here]({{< versioned_link_path fromRoot="/reference/helm_chart_values/" >}}). 
-The enterprise-only list is [here]({{% versioned_link_path fromRoot="/installation/enterprise/#list-of-gloo-helm-chart-values" %}}).
+```shell script
+# adopt the old gateway into your existing helm release
+kubectl annotate gateway gateway-proxy meta.helm.sh/release-name=gloo -n gloo-system
+kubectl annotate gateway gateway-proxy meta.helm.sh/release-namespace=gloo-system -n gloo-system
+kubectl label gateway gateway-proxy app.kubernetes.io/managed-by=Helm -n gloo-system
 
-{{% notice note %}}
-If you need further customization of the Helm chart, please read our [advanced customization guide]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/helm_advanced/" %}}).
-{{% /notice %}}
+# adopt the old ssl gateway into your existing helm release
+kubectl annotate gateway gateway-proxy-ssl meta.helm.sh/release-name=gloo -n gloo-system
+kubectl annotate gateway gateway-proxy-ssl meta.helm.sh/release-namespace=gloo-system -n gloo-system
+kubectl label gateway gateway-proxy-ssl app.kubernetes.io/managed-by=Helm -n gloo-system
+
+# adopt the old settings into your existing helm release
+kubectl annotate settings default meta.helm.sh/release-name=gloo -n gloo-system
+kubectl annotate settings default meta.helm.sh/release-namespace=gloo-system -n gloo-system
+kubectl label settings default app.kubernetes.io/managed-by=Helm -n gloo-system
+```
+
+Now you're ready to upgrade!
 
 <details><summary>Upgrade to Open-Source</summary>
 


### PR DESCRIPTION
# Description

This is a safer way for teams to upgrade to Gloo 1.3 from Gloo 1.2, leveraging helm 3's new feature to adopt previously existing resources into the chart. This allows us to skip deleting and recreating some resources to get them into the release (i.e., the settings and gateways).

# Context

While the documented workflows worked, they were easy to mess up, and could cause downtime if done improperly. This approach is also easier, just requires the newest release of helm.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (I did test each of the documented upgrades, 1.2 OS -> 1.3 OS, 1.2 OS -> 1.3 Enterprise, and 1.2 Enterprise to 1.3 Enterprise)
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2807