### PR TITLE
Static upstream host header rewrite

### DIFF
--- a/changelog/v1.4.0-beta9/host-rewrite-healthcheck.yaml
+++ b/changelog/v1.4.0-beta9/host-rewrite-healthcheck.yaml
@@ -2,5 +2,7 @@ changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/2794
     description: >
-      When static upstreams are converted to Envoy clusters, add hostnames so that host headers for requests
-      and healthchecks are set properly.
+      When static upstreams are converted to Envoy clusters, add hostnames to each
+      endpoint so that host headers for requests and healthchecks are set to the endpoint
+      hostname rather than the Envoy cluster name. This change only applies if `autoHostRewrite`
+      is set to true on route routing to the static upstream.

--- a/changelog/v1.4.0-beta9/host-rewrite-healthcheck.yaml
+++ b/changelog/v1.4.0-beta9/host-rewrite-healthcheck.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/2794
+    description: >
+      When static upstreams are converted to Envoy clusters, add hostnames so that host headers for requests
+      and healthchecks are set properly.

--- a/projects/gloo/pkg/plugins/static/plugin.go
+++ b/projects/gloo/pkg/plugins/static/plugin.go
@@ -82,6 +82,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 			&envoyendpoint.LbEndpoint{
 				HostIdentifier: &envoyendpoint.LbEndpoint_Endpoint{
 					Endpoint: &envoyendpoint.Endpoint{
+						Hostname:    host.Addr,
 						Address: &envoycore.Address{
 							Address: &envoycore.Address_SocketAddress{
 								SocketAddress: &envoycore.SocketAddress{
@@ -92,6 +93,9 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 									},
 								},
 							},
+						},
+						HealthCheckConfig: &envoyendpoint.Endpoint_HealthCheckConfig{
+							Hostname: host.Addr,
 						},
 					},
 				},

--- a/projects/gloo/pkg/plugins/static/plugin.go
+++ b/projects/gloo/pkg/plugins/static/plugin.go
@@ -82,7 +82,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 			&envoyendpoint.LbEndpoint{
 				HostIdentifier: &envoyendpoint.LbEndpoint_Endpoint{
 					Endpoint: &envoyendpoint.Endpoint{
-						Hostname:    host.Addr,
+						Hostname: host.Addr,
 						Address: &envoycore.Address{
 							Address: &envoycore.Address_SocketAddress{
 								SocketAddress: &envoycore.SocketAddress{

--- a/projects/gloo/pkg/plugins/static/plugin_test.go
+++ b/projects/gloo/pkg/plugins/static/plugin_test.go
@@ -1,6 +1,7 @@
 package static
 
 import (
+	envoyendpoint "github.com/envoyproxy/go-control-plane/envoy/api/v2/endpoint"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -73,6 +74,55 @@ var _ = Describe("Plugin", func() {
 
 			p.ProcessUpstream(params, upstream, out)
 			Expect(out.GetType()).To(Equal(envoyapi.Cluster_STATIC))
+			expected := []*envoyendpoint.LocalityLbEndpoints{
+				&envoyendpoint.LocalityLbEndpoints{
+					LbEndpoints: []*envoyendpoint.LbEndpoint{
+						&envoyendpoint.LbEndpoint{
+							HostIdentifier: &envoyendpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoyendpoint.Endpoint{
+									Hostname: "1.2.3.4",
+									Address: &envoycore.Address{
+										Address: &envoycore.Address_SocketAddress{
+											SocketAddress: &envoycore.SocketAddress{
+												Protocol: envoycore.SocketAddress_TCP,
+												Address:  "1.2.3.4",
+												PortSpecifier: &envoycore.SocketAddress_PortValue{
+													PortValue: 1234,
+												},
+											},
+										},
+									},
+									HealthCheckConfig: &envoyendpoint.Endpoint_HealthCheckConfig{
+										Hostname: "1.2.3.4",
+									},
+								},
+							},
+						},
+						&envoyendpoint.LbEndpoint{
+							HostIdentifier: &envoyendpoint.LbEndpoint_Endpoint{
+								Endpoint: &envoyendpoint.Endpoint{
+									Hostname: "2603:3005:b0b:1d00::b7aa",
+									Address: &envoycore.Address{
+										Address: &envoycore.Address_SocketAddress{
+											SocketAddress: &envoycore.SocketAddress{
+												Protocol: envoycore.SocketAddress_TCP,
+												Address:  "2603:3005:b0b:1d00::b7aa",
+												PortSpecifier: &envoycore.SocketAddress_PortValue{
+													PortValue: 1234,
+												},
+											},
+										},
+									},
+									HealthCheckConfig: &envoyendpoint.Endpoint_HealthCheckConfig{
+										Hostname: "2603:3005:b0b:1d00::b7aa",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(out.GetLoadAssignment().Endpoints).To(Equal(expected))
 		})
 
 		It("use dns if has mixed addresses", func() {

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Gateway", func() {
 
 		})
 
-		It("should create 2 gateway", func() {
+		It("should create 2 gateways", func() {
 			gatewaycli := testClients.GatewayClient
 			gw, err := gatewaycli.List(writeNamespace, clients.ListOpts{})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Description
When static upstreams with two or more hosts are converted to Envoy clusters, we will now add hostnames so that host headers for requests and healthchecks are set properly.

## Context
Users had a service behind each host that required the host header to be set to their own hostname.

## Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] I have added tests that prove my fix is effective or that my feature works. (**Note**: existing tests already covered the change)

## Manual test
Here is how I tested to check that our healthchecks and requests were having their host headers replaced properly:

Start up 2 services that run 'mendhak/http-https-echo', a docker image that will log and echo back all the information in the request that is sent to it:
```
kind: Deployment
apiVersion: apps/v1
metadata:
  name: headers1
  namespace: default
  labels:
    name: headers1
spec:
  replicas: 1
  selector:
    matchLabels:
      task: headers1
  template:
    metadata:
      labels:
        task: headers1
    spec:
      containers:
        - name: log-and-echo-headers
          image: mendhak/http-https-echo
          ports:
            - containerPort: 80
---
kind: Deployment
apiVersion: apps/v1
metadata:
  name: headers2
  namespace: default
  labels:
    name: headers2
spec:
  replicas: 1
  selector:
    matchLabels:
      task: headers2
  template:
    metadata:
      labels:
        task: headers2
    spec:
      containers:
        - name: log-and-echo-headers
          image: mendhak/http-https-echo
          ports:
            - containerPort: 80
---
apiVersion: v1
kind: Service
metadata:
  name: headers1
  namespace: default
spec:
  ports:
    - name: http
      port: 80
  selector:
    task: headers1
---
apiVersion: v1
kind: Service
metadata:
  name: headers2
  namespace: default
spec:
  ports:
    - name: http
      port: 80
  selector:
    task: headers2
```
look at k get service -A to get the cluster IPs of header1 and header2
change the upstream hosts:
```
apiVersion: gloo.solo.io/v1
kind: Upstream
metadata:
  name: test-upstream
  namespace: gloo-system
spec:
  healthChecks:
  - healthyThreshold: 1
    httpHealthCheck:
      path: /healthcheck
    interval: 30s
    timeout: 10s
    unhealthyThreshold: 1
  static:
    hosts:
    - addr: 10.xxxxxx ## this may be different
      port: 80
    - addr: 10.xxxxxx ## this may be different
      port: 80
---
apiVersion: gateway.solo.io/v1
kind: VirtualService
metadata:
  name: test-vs
  namespace: gloo-system
spec:
  virtualHost:
    domains:
      - 'foo'
    routes:
      - matchers:
        - prefix: /
        routeAction:
          single:
            upstream:
              name: test-upstream
              namespace: gloo-system
        options:
          autoHostRewrite: true
```
Now, look at the logs for the header1 and header2 pods. You should see that the healthcheck requests (with the /healthcheck path) have the correct headers (e.g. the IP address of that service)
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2794