### PR TITLE
Fix dev portal docs

### DIFF
--- a/changelog/v1.4.0-beta9/fix-dev-portal-docs.yaml
+++ b/changelog/v1.4.0-beta9/fix-dev-portal-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/2963
+  description: Add `securityDefinitions` to OpenAPI spec in dev portal docs.

--- a/docs/content/guides/dev_portal/_index.md
+++ b/docs/content/guides/dev_portal/_index.md
@@ -743,6 +743,18 @@ save the changes by clicking "Publish Changes".
   "produces": [
     "application/json"
   ],
+  "securityDefinitions": {
+    "petStoreApiKey": {
+      "type": "apiKey",
+      "name": "api-key",
+      "in": "header"
+    }
+  },
+  "security": [
+    {
+      "petStoreApiKey": []
+    }
+  ],
   "paths": {
     "/pets": {
       "get": {


### PR DESCRIPTION
## Description
Add `securityDefinitions` to OpenAPI spec in dev portal docs.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2963