### PR TITLE
fix auth config update

### DIFF
--- a/changelog/v1.4.0-beta10/fix-auth-config-update.yaml
+++ b/changelog/v1.4.0-beta10/fix-auth-config-update.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: When AuthConfigs are updated, gloo resyncs, which should trigger a gateway resync as well.
+    issueLink: https://github.com/solo-io/gloo/issues/2920

--- a/projects/gloo/pkg/validation/server.go
+++ b/projects/gloo/pkg/validation/server.go
@@ -50,6 +50,7 @@ func (s *validator) shouldNotify(snap *v1.ApiSnapshot) bool {
 		toHash := append([]interface{}{}, snap.Upstreams.AsInterfaces()...)
 		toHash = append(toHash, snap.UpstreamGroups.AsInterfaces()...)
 		toHash = append(toHash, snap.Secrets.AsInterfaces()...)
+		toHash = append(toHash, snap.AuthConfigs.AsInterfaces()...)
 		// we also include proxies as this will help
 		// the gateway to resync in case the proxy was deleted
 		toHash = append(toHash, snap.Proxies.AsInterfaces()...)

--- a/projects/gloo/pkg/validation/server_test.go
+++ b/projects/gloo/pkg/validation/server_test.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	enterprise_gloo_solo_io "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 	mock_consul "github.com/solo-io/gloo/projects/gloo/pkg/upstreams/consul/mocks"
 	"google.golang.org/grpc"
 
@@ -163,11 +164,18 @@ var _ = Describe("Validation Server", func() {
 
 			Eventually(getNotifications, time.Second).Should(HaveLen(2))
 
+			// add an auth config
+			err = v.Sync(ctx, &v1.ApiSnapshot{
+				AuthConfigs: enterprise_gloo_solo_io.AuthConfigList{{}}},
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(getNotifications, time.Second).Should(HaveLen(3))
+
 			// create jitter by changing upstreams
 			err = v.Sync(ctx, &v1.ApiSnapshot{Upstreams: v1.UpstreamList{{}}})
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(getNotifications, time.Second).Should(HaveLen(3))
+			Eventually(getNotifications, time.Second).Should(HaveLen(4))
 
 			// test close
 			desiredErr = "transport is closing"
@@ -177,7 +185,7 @@ var _ = Describe("Validation Server", func() {
 			err = v.Sync(ctx, &v1.ApiSnapshot{Upstreams: v1.UpstreamList{{}, {}}})
 			Expect(err).NotTo(HaveOccurred())
 
-			Consistently(getNotifications, time.Second).Should(HaveLen(3))
+			Consistently(getNotifications, time.Second).Should(HaveLen(4))
 		})
 	})
 })


### PR DESCRIPTION
# Description

When AuthConfigs are updated, gloo resyncs, which should trigger a gateway resync as well. Previously, we weren't adding AuthConfigs into the hash that decided whether the gloo snapshot changed or not. That has been fixed here.

# Context

Users ran into this bug when deploying an auth config after a virtual service.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2920