### PR TITLE
Find require ns

### DIFF
--- a/changelog/v1.4.0-beta11/solokit-upgrade.yaml
+++ b/changelog/v1.4.0-beta11/solokit-upgrade.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    description: Bumped the version of solo-kit to pick up the bug fix
+    dependencyOwner: solo-io
+    dependencyRepo: solo-kit
+    dependencyTag: v0.13.7

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/solo-io/go-utils v0.14.1
 	github.com/solo-io/protoc-gen-ext v0.0.7
 	github.com/solo-io/reporting-client v0.1.2
-	github.com/solo-io/solo-kit v0.13.6
+	github.com/solo-io/solo-kit v0.13.7
 	github.com/solo-io/wasme v0.0.13-rc1
 	github.com/spf13/afero v1.2.2
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -1016,8 +1016,8 @@ github.com/solo-io/reporting-client v0.1.2/go.mod h1:FmBDzwc1zEwayCCrlP+1w7NcpM0
 github.com/solo-io/solo-kit v0.6.3/go.mod h1:oBaQ6tOwuO97u7w+s3TeI08YLHcbiWemInx0XkDfKFw=
 github.com/solo-io/solo-kit v0.12.1/go.mod h1:oNDT3CNTgdjNh5tgkr4Wj8tj+h0VtJjfT/ZaZ8e1/js=
 github.com/solo-io/solo-kit v0.12.2/go.mod h1:oNDT3CNTgdjNh5tgkr4Wj8tj+h0VtJjfT/ZaZ8e1/js=
-github.com/solo-io/solo-kit v0.13.6 h1:krPCDawOo79lNUU6ImbLIdrcX/MPuDkhUIPyhjOHjgs=
-github.com/solo-io/solo-kit v0.13.6/go.mod h1:1cSoxO1Cgzn++03nnp5V1iGf0S45OLDTUmj70rD/+hY=
+github.com/solo-io/solo-kit v0.13.7 h1:w/M43G0O+mC7T0isZUPCC21vHdhOHmlVznbAsrJV7zY=
+github.com/solo-io/solo-kit v0.13.7/go.mod h1:1cSoxO1Cgzn++03nnp5V1iGf0S45OLDTUmj70rD/+hY=
 github.com/solo-io/wasme v0.0.1/go.mod h1:Zb85GQMTyx7NEyEINCUiofKE9KZLjQVF6obvHOHBQE8=
 github.com/solo-io/wasme v0.0.13-rc1 h1:CcfW64lH7rL/n6+zTgC/25/nfJWAsBGXAEh4X09y6V0=
 github.com/solo-io/wasme v0.0.13-rc1/go.mod h1:JwS6dxyZcWO9P7z0NmmD2pAl5PVaxJ2ASN06Owbgpd4=

--- a/projects/clusteringress/pkg/api/external/knative/cluster_ingress.sk.go
+++ b/projects/clusteringress/pkg/api/external/knative/cluster_ingress.sk.go
@@ -73,13 +73,10 @@ func (r *ClusterIngress) GroupVersionKind() schema.GroupVersionKind {
 
 type ClusterIngressList []*ClusterIngress
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list ClusterIngressList) Find(namespace, name string) (*ClusterIngress, error) {
 	for _, clusterIngress := range list {
-		if clusterIngress.GetMetadata().Name == name {
-			if namespace == "" || clusterIngress.GetMetadata().Namespace == namespace {
-				return clusterIngress, nil
-			}
+		if clusterIngress.GetMetadata().Name == name && clusterIngress.GetMetadata().Namespace == namespace {
+			return clusterIngress, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find clusterIngress %v.%v", namespace, name)

--- a/projects/gateway/pkg/api/v1/gateway.sk.go
+++ b/projects/gateway/pkg/api/v1/gateway.sk.go
@@ -45,13 +45,10 @@ func (r *Gateway) GroupVersionKind() schema.GroupVersionKind {
 
 type GatewayList []*Gateway
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list GatewayList) Find(namespace, name string) (*Gateway, error) {
 	for _, gateway := range list {
-		if gateway.GetMetadata().Name == name {
-			if namespace == "" || gateway.GetMetadata().Namespace == namespace {
-				return gateway, nil
-			}
+		if gateway.GetMetadata().Name == name && gateway.GetMetadata().Namespace == namespace {
+			return gateway, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find gateway %v.%v", namespace, name)

--- a/projects/gateway/pkg/api/v1/route_table.sk.go
+++ b/projects/gateway/pkg/api/v1/route_table.sk.go
@@ -45,13 +45,10 @@ func (r *RouteTable) GroupVersionKind() schema.GroupVersionKind {
 
 type RouteTableList []*RouteTable
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list RouteTableList) Find(namespace, name string) (*RouteTable, error) {
 	for _, routeTable := range list {
-		if routeTable.GetMetadata().Name == name {
-			if namespace == "" || routeTable.GetMetadata().Namespace == namespace {
-				return routeTable, nil
-			}
+		if routeTable.GetMetadata().Name == name && routeTable.GetMetadata().Namespace == namespace {
+			return routeTable, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find routeTable %v.%v", namespace, name)

--- a/projects/gateway/pkg/api/v1/virtual_service.sk.go
+++ b/projects/gateway/pkg/api/v1/virtual_service.sk.go
@@ -45,13 +45,10 @@ func (r *VirtualService) GroupVersionKind() schema.GroupVersionKind {
 
 type VirtualServiceList []*VirtualService
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list VirtualServiceList) Find(namespace, name string) (*VirtualService, error) {
 	for _, virtualService := range list {
-		if virtualService.GetMetadata().Name == name {
-			if namespace == "" || virtualService.GetMetadata().Namespace == namespace {
-				return virtualService, nil
-			}
+		if virtualService.GetMetadata().Name == name && virtualService.GetMetadata().Namespace == namespace {
+			return virtualService, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find virtualService %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/artifact.sk.go
+++ b/projects/gloo/pkg/api/v1/artifact.sk.go
@@ -41,13 +41,10 @@ func (r *Artifact) GroupVersionKind() schema.GroupVersionKind {
 
 type ArtifactList []*Artifact
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list ArtifactList) Find(namespace, name string) (*Artifact, error) {
 	for _, artifact := range list {
-		if artifact.GetMetadata().Name == name {
-			if namespace == "" || artifact.GetMetadata().Namespace == namespace {
-				return artifact, nil
-			}
+		if artifact.GetMetadata().Name == name && artifact.GetMetadata().Namespace == namespace {
+			return artifact, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find artifact %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/endpoint.sk.go
+++ b/projects/gloo/pkg/api/v1/endpoint.sk.go
@@ -41,13 +41,10 @@ func (r *Endpoint) GroupVersionKind() schema.GroupVersionKind {
 
 type EndpointList []*Endpoint
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list EndpointList) Find(namespace, name string) (*Endpoint, error) {
 	for _, endpoint := range list {
-		if endpoint.GetMetadata().Name == name {
-			if namespace == "" || endpoint.GetMetadata().Namespace == namespace {
-				return endpoint, nil
-			}
+		if endpoint.GetMetadata().Name == name && endpoint.GetMetadata().Namespace == namespace {
+			return endpoint, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find endpoint %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/auth_config.sk.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/auth_config.sk.go
@@ -45,13 +45,10 @@ func (r *AuthConfig) GroupVersionKind() schema.GroupVersionKind {
 
 type AuthConfigList []*AuthConfig
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list AuthConfigList) Find(namespace, name string) (*AuthConfig, error) {
 	for _, authConfig := range list {
-		if authConfig.GetMetadata().Name == name {
-			if namespace == "" || authConfig.GetMetadata().Namespace == namespace {
-				return authConfig, nil
-			}
+		if authConfig.GetMetadata().Name == name && authConfig.GetMetadata().Namespace == namespace {
+			return authConfig, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find authConfig %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/proxy.sk.go
+++ b/projects/gloo/pkg/api/v1/proxy.sk.go
@@ -45,13 +45,10 @@ func (r *Proxy) GroupVersionKind() schema.GroupVersionKind {
 
 type ProxyList []*Proxy
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list ProxyList) Find(namespace, name string) (*Proxy, error) {
 	for _, proxy := range list {
-		if proxy.GetMetadata().Name == name {
-			if namespace == "" || proxy.GetMetadata().Namespace == namespace {
-				return proxy, nil
-			}
+		if proxy.GetMetadata().Name == name && proxy.GetMetadata().Namespace == namespace {
+			return proxy, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find proxy %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/secret.sk.go
+++ b/projects/gloo/pkg/api/v1/secret.sk.go
@@ -41,13 +41,10 @@ func (r *Secret) GroupVersionKind() schema.GroupVersionKind {
 
 type SecretList []*Secret
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list SecretList) Find(namespace, name string) (*Secret, error) {
 	for _, secret := range list {
-		if secret.GetMetadata().Name == name {
-			if namespace == "" || secret.GetMetadata().Namespace == namespace {
-				return secret, nil
-			}
+		if secret.GetMetadata().Name == name && secret.GetMetadata().Namespace == namespace {
+			return secret, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find secret %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/settings.sk.go
+++ b/projects/gloo/pkg/api/v1/settings.sk.go
@@ -45,13 +45,10 @@ func (r *Settings) GroupVersionKind() schema.GroupVersionKind {
 
 type SettingsList []*Settings
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list SettingsList) Find(namespace, name string) (*Settings, error) {
 	for _, settings := range list {
-		if settings.GetMetadata().Name == name {
-			if namespace == "" || settings.GetMetadata().Namespace == namespace {
-				return settings, nil
-			}
+		if settings.GetMetadata().Name == name && settings.GetMetadata().Namespace == namespace {
+			return settings, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find settings %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/upstream.sk.go
+++ b/projects/gloo/pkg/api/v1/upstream.sk.go
@@ -45,13 +45,10 @@ func (r *Upstream) GroupVersionKind() schema.GroupVersionKind {
 
 type UpstreamList []*Upstream
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list UpstreamList) Find(namespace, name string) (*Upstream, error) {
 	for _, upstream := range list {
-		if upstream.GetMetadata().Name == name {
-			if namespace == "" || upstream.GetMetadata().Namespace == namespace {
-				return upstream, nil
-			}
+		if upstream.GetMetadata().Name == name && upstream.GetMetadata().Namespace == namespace {
+			return upstream, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find upstream %v.%v", namespace, name)

--- a/projects/gloo/pkg/api/v1/upstream_group.sk.go
+++ b/projects/gloo/pkg/api/v1/upstream_group.sk.go
@@ -45,13 +45,10 @@ func (r *UpstreamGroup) GroupVersionKind() schema.GroupVersionKind {
 
 type UpstreamGroupList []*UpstreamGroup
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list UpstreamGroupList) Find(namespace, name string) (*UpstreamGroup, error) {
 	for _, upstreamGroup := range list {
-		if upstreamGroup.GetMetadata().Name == name {
-			if namespace == "" || upstreamGroup.GetMetadata().Namespace == namespace {
-				return upstreamGroup, nil
-			}
+		if upstreamGroup.GetMetadata().Name == name && upstreamGroup.GetMetadata().Namespace == namespace {
+			return upstreamGroup, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find upstreamGroup %v.%v", namespace, name)

--- a/projects/ingress/pkg/api/v1/ingress.sk.go
+++ b/projects/ingress/pkg/api/v1/ingress.sk.go
@@ -41,13 +41,10 @@ func (r *Ingress) GroupVersionKind() schema.GroupVersionKind {
 
 type IngressList []*Ingress
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list IngressList) Find(namespace, name string) (*Ingress, error) {
 	for _, ingress := range list {
-		if ingress.GetMetadata().Name == name {
-			if namespace == "" || ingress.GetMetadata().Namespace == namespace {
-				return ingress, nil
-			}
+		if ingress.GetMetadata().Name == name && ingress.GetMetadata().Namespace == namespace {
+			return ingress, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find ingress %v.%v", namespace, name)

--- a/projects/ingress/pkg/api/v1/kube_service.sk.go
+++ b/projects/ingress/pkg/api/v1/kube_service.sk.go
@@ -41,13 +41,10 @@ func (r *KubeService) GroupVersionKind() schema.GroupVersionKind {
 
 type KubeServiceList []*KubeService
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list KubeServiceList) Find(namespace, name string) (*KubeService, error) {
 	for _, kubeService := range list {
-		if kubeService.GetMetadata().Name == name {
-			if namespace == "" || kubeService.GetMetadata().Namespace == namespace {
-				return kubeService, nil
-			}
+		if kubeService.GetMetadata().Name == name && kubeService.GetMetadata().Namespace == namespace {
+			return kubeService, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find kubeService %v.%v", namespace, name)

--- a/projects/knative/pkg/api/external/knative/ingress.sk.go
+++ b/projects/knative/pkg/api/external/knative/ingress.sk.go
@@ -73,13 +73,10 @@ func (r *Ingress) GroupVersionKind() schema.GroupVersionKind {
 
 type IngressList []*Ingress
 
-// namespace is optional, if left empty, names can collide if the list contains more than one with the same name
 func (list IngressList) Find(namespace, name string) (*Ingress, error) {
 	for _, ingress := range list {
-		if ingress.GetMetadata().Name == name {
-			if namespace == "" || ingress.GetMetadata().Namespace == namespace {
-				return ingress, nil
-			}
+		if ingress.GetMetadata().Name == name && ingress.GetMetadata().Namespace == namespace {
+			return ingress, nil
 		}
 	}
 	return nil, errors.Errorf("list did not find ingress %v.%v", namespace, name)


### PR DESCRIPTION
# Description

This pulls in the fix in solo-kit that does not allow `Find` to accept resources without a namespace.

# Context

This bug was discovered with regard to upstreams while fixing https://github.com/solo-io/gloo/issues/2730.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works