### PR TITLE
Add optional limits for the certgen pod

### DIFF
--- a/changelog/v1.4.0-beta10/certgen-resource-limits.yaml
+++ b/changelog/v1.4.0-beta10/certgen-resource-limits.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    description: >
+      Add a helm chart value `gateway.certGenJob.resources`.
+      This allows you to add resource limits for the certgen pod that is created by the certgen job

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -36,6 +36,9 @@ spec:
             - "--secret-name={{ .Values.gateway.validation.secretName }}"
             - "--svc-name=gateway"
             - "--validating-webhook-configuration-name=gloo-gateway-validation-webhook-{{ .Release.Namespace }}"
+{{- if .Values.gateway.certGenJob.resources }}
+          resources:
+{{ toYaml .Values.gateway.certGenJob.resources | indent 10}}
       restartPolicy: {{ .Values.gateway.certGenJob.restartPolicy }}
   # this feature is still in Alpha, which means it must be manually enabled in the k8s api server
   # with --feature-gates="TTLAfterFinished=true". This flag also works with minikube start ...

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -39,6 +39,7 @@ spec:
 {{- if .Values.gateway.certGenJob.resources }}
           resources:
 {{ toYaml .Values.gateway.certGenJob.resources | indent 10}}
+{{- end }}
       restartPolicy: {{ .Values.gateway.certGenJob.restartPolicy }}
   # this feature is still in Alpha, which means it must be manually enabled in the k8s api server
   # with --feature-gates="TTLAfterFinished=true". This flag also works with minikube start ...


### PR DESCRIPTION

# Description
This new feature can be used to add resource limits to the certgen pod

# Context

Users needed this feature to install gloo in kube clusters that require resource limits on all running pods

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)