### PR TITLE
Upgrade the upgrade docs

### DIFF
--- a/changelog/v1.4.0-beta11/upgrade-the-upgrade-docs.yaml
+++ b/changelog/v1.4.0-beta11/upgrade-the-upgrade-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: upgrade the upgrade docs with newest recommendations
+    issueLink: https://github.com/solo-io/gloo/issues/2902

--- a/docs/content/operations/upgrading/0.18.1.md
+++ b/docs/content/operations/upgrading/0.18.1.md
@@ -69,13 +69,13 @@ Once all of the traffic is being routed through `gateway-proxy-v2`, the Gateway 
 * Remove the v1 to v2 Gateway upgrade job with:
 `kubectl delete job -n gloo-system gateway-conversion`
 
-## Notes
+# Notes
 
-### Upgrading Gateway CRDs in Git
+##### Upgrading Gateway CRDs in Git
 If you are doing a GitOps workflow and have Gateway v1 CRDs in a git repository, those will need to be updated. Once upgraded to 0.18.1, the Gateway v2 CRDs can be saved to the Git repository, replacing the Gateway v1 CRDs. Alternative, the Gateway CRDs in git can be manually fixed and the group updated. Please contact us in Slack if you'd like help with this. 
 
-### Kubernetes CRD upgrade support
+##### Kubernetes CRD upgrade support
 In the future, we intend to utilize Kubernetes schemas and conversion webhooks, first introduced in Kubernetes 1.13, to facilitate better support around CRD versioning. However, at this time we must support older versions of Kubernetes, and so our upgrade process does not rely on those features. 
 
-### More sophisticated traffic shifting
+##### More sophisticated traffic shifting
 It may not be desirable to shift traffic 0 -> 50/50 -> 100% -- a more sophisticated approach may be preferred. We don't currently have support for this as part of this upgrade, but it is an area we'd like to improve and please contact us in slack if you'd like to explore that. 

--- a/docs/content/operations/upgrading/1.0.0.md
+++ b/docs/content/operations/upgrading/1.0.0.md
@@ -19,12 +19,12 @@ description: Migrating from Gloo 0.x to Gloo 1.0.0
 We have officially released Gloo 1.0.0! This major version bump comes with a number of breaking changes
 that you will have to keep in mind as you upgrade from Gloo 0.x to 1.0.0+. While the easiest upgrade 
 process is to just start with a totally fresh installation of Gloo, many users are running Gloo in 
-production in older versions; this guide is provided for users like them who would like to update to our 
+production on older versions; this guide is provided for users like them who would like to update to our 
 latest and greatest Gloo without any downtime.
 
-## Breaking Changes From 0.x to 1.0.0
+# Breaking Changes From 0.x to 1.0.0
 
-### Breaking Changes Commonly Requiring Manual Action
+##### Breaking Changes Commonly Requiring Manual Action
 
 These breaking changes are common pain points that most users will have to address, and which we specifically
 would like to draw attention to. For a complete list of all breaking changes,
@@ -36,8 +36,7 @@ in 0.21.1) changed to `matchers` (see [here](https://github.com/solo-io/gloo/blo
 in 1.0.0) to support an array of multiple matchers. https://github.com/solo-io/gloo/pull/1353
    - Upstreams have been flattened, entirely removing the `UpstreamSpec` proto message (see
 [here](https://github.com/solo-io/gloo/blob/v0.21.1/projects/gloo/api/v1/plugins.proto#L196) in 0.21.1) and moving
-all the associated fields into the top-level Upstream (see [here]
-(https://github.com/solo-io/gloo/blob/v1.0.0/projects/gloo/api/v1/upstream.proto#L34) in 1.0.0).
+all the associated fields into the top-level Upstream (see [here](https://github.com/solo-io/gloo/blob/v1.0.0/projects/gloo/api/v1/upstream.proto#L34) in 1.0.0).
 https://github.com/solo-io/gloo/pull/1697
    - The suffix `v2` has been dropped from the `gateway-v2` and `gateway-proxy-v2` deployments, and the Gateway
 CRD has had the `.v2` dropped from its name and API group; the
@@ -56,7 +55,7 @@ in Gloo 1.2.0.
    - All instances of `...plugins` in our API have been renamed to `options` (e.g., `virtualHostPlugins` -> `options`, `routePlugins` -> `options`).
    - Update ExtAuth secret API to use strongly-typed configuration. OAuth and ApiKey secrets are no longer configured in the opaque extensions block, the same configuration lives at the top level in the api_key and oauth blocks. (https://github.com/solo-io/gloo/issues/1171)
 
-### All Breaking Changes
+##### All Breaking Changes
 
 {{% expand "Click to see the complete list of breaking changes from 0.x to 1.0.0" %}}
 - Rename the Gateway field tcpGateway.destinations to tcpGateway.tcpHosts in order to eliminate the duplicated field names (i.e., tcpGateway.destinations[].destination) (https://github.com/solo-io/gloo/issues/1171)
@@ -354,8 +353,8 @@ Gloo was successfully uninstalled.
 
 #### Removing Cluster-Scoped RBAC
 
-`glooctl uninstall` will not remove cluster-scoped RBAC. Since we set `globals.glooRbac.nameSuffix` in our
-1.0.0 installation values file, you may remove any ClusterRole or ClusterRoleBinding that DOES have the label
+Older versions of `glooctl uninstall` will not remove cluster-scoped RBAC. Since we set `globals.glooRbac.nameSuffix`
+in our 1.0.0 installation values file, you may remove any ClusterRole or ClusterRoleBinding that DOES have the label
 `app=gloo` and whose name does NOT have the suffix we set in that Helm value.
 
 ## Helm Compatibility
@@ -363,14 +362,13 @@ Gloo was successfully uninstalled.
 There are several points to consider about Helm compatibility if you are upgrading Gloo (open source or enterprise)
 across the 0.x to 1.x boundary:
 
-* Using Helm 2 with open source Gloo v1.2.3 and later or Gloo Enterprise v1.2.0 and later requires explicitly setting `crds.create=true`, as this is how we are managing compatibility between Helm 2 and 3.
 * Helm 2 **IS NOT** compatible with the Open Source Gloo chart in Gloo versions v1.2.0 through v1.2.2.
 * However, Helm 2 **IS** compatible with all stable versions of the Gloo Enterprise chart.
 * `glooctl` prior to v1.2.0 cannot be used to install open source Gloo v1.2.0 and later or Gloo Enterprise v1.2.0 and later.
 
 ## Gloo Enterprise
 
-Gloo Enterprise has also had a 1.x.y major release! If you are a Gloo Enterprise user, please consult both this section
+Gloo Enterprise also had a 1.x.y major release! If you are a Gloo Enterprise user, please consult both this section
 and the rest of the document (covering open source features), as the entire document will be relevant to you.
 
 ### Enterprise Versioning
@@ -387,9 +385,9 @@ Gloo if you are upgrading Enterprise from 0.x to >=1.2.0.
 In addition to the open source breaking changes, Gloo Enterprise 1.2.0 also includes the following breaking changes:
 
 - Remove some deprecated APIs:
-    - weighed_destination_plugins on WeightedDestinations, prefer weighted_destination_plugins
-    - gateway_proxy_name on Gateway, prefer proxy_names
-    - role_arns on UpstreamSpec, prefer role_arn
-    - Extauth's VhostExtension and RouteExtension, among other minor removals. Prefer configuring Gloo Enterprise ExtAuth 
-using AuthConfig Custom Resources, and configure Virtual Services via ExtAuthExtension to either reference these AuthConfigs
-or reference your own custom auth implementation using CustomAuth. (https://github.com/solo-io/gloo/issues/1171)
+    - `weighed_destination_plugins` on `WeightedDestinations`, prefer `weighted_destination_options`
+    - `gateway_proxy_name` on `Gateway`, prefer `proxy_names`
+    - `role_arns` on UpstreamSpec, prefer `role_arn`
+    - Extauth's `VhostExtension` and `RouteExtension`, among other minor removals. Prefer configuring Gloo Enterprise ExtAuth 
+using AuthConfig Custom Resources, and configure Virtual Services via `ExtAuthExtension` to either reference these `AuthConfig`s
+or reference your own custom auth implementation using `CustomAuth`. (https://github.com/solo-io/gloo/issues/1171)

--- a/docs/content/operations/upgrading/faq.md
+++ b/docs/content/operations/upgrading/faq.md
@@ -12,13 +12,13 @@ Use `glooctl uninstall --all` followed by the normal installation procedure for 
  
 - **What is the recommended way to upgrade if I'm running Gloo in a production environment, where downtime is unacceptable?**
 
-We are still working on an exact recommendation in this case, but enterprise customers have found success
-in performing a blue/green deployment using two simultaneous deployments of Gloo. There are still questions
-outstanding about, for example, how to maintain Gloo state (virtual services, settings, etc.) across the
-different deployments, if the blue/green deployment is happening across datacenters.
+In Gloo 1.2 and newer, we recommend `helm upgrade` with the proper readiness probes and healthchecks configured (see
+the [1.3.0+ upgrade guide]({{< versioned_link_path fromRoot="/operations/upgrading/1.3.0" >}})). For versions prior
+to Gloo 1.2, enterprise customers have found success performing a blue/green deployment using two simultaneous deployments
+of Gloo. For a brief example, see the
+[1.0.0 example upgrade]({{< versioned_link_path fromRoot="/operations/upgrading/1.0.0#example-upgrade-process" >}}).
 
-We will be providing more docs on this soon, but in the meantime, reach out to us on our 
-[public Slack](https://slack.solo.io/).
+If you have concerns not addressed in the docs here, reach out to us on our [public Slack](https://slack.solo.io/).
 
 - **What will happen to my upstreams, virtual services, settings, and Gloo state in general?**
 
@@ -29,7 +29,7 @@ adjustment must be made to perform the upgrade.
 As of open-source Gloo version 0.21.1, there is a command available in `glooctl` that can help mitigate
 some concern about Gloo state: `glooctl debug yaml` can be used to dump the current Gloo state to one
 large YAML manifest. While this command is not yet really suitable as a robust backup tool, it is
-a very useful debug tool to have available.
+a useful debug tool to have available.
 
 - **How do I handle upgrading across a breaking change?**
 

--- a/docs/content/operations/upgrading/upgrade_steps.md
+++ b/docs/content/operations/upgrading/upgrade_steps.md
@@ -5,14 +5,18 @@ description: Steps for upgrading Gloo components
 ---
 
 {{% notice warning %}}
-This upgrade process is not suitable in environments where downtime is unacceptable. This is mainly for upgrading Gloo while experimenting in dev or staging environments. For zero-downtime upgrades, users have found success in performing Gloo upgrades through blue-green deployments across different namespaces.
+This upgrade process is not suitable in environments where downtime is unacceptable. Depending on your Gloo version, 
+configured probes, and external infrastructure (e.g. external load-balancer to Gloo) additional steps may need to be
+taken. This guide is targeted toward users that are upgrading Gloo while experimenting in dev or staging environments.
 {{% /notice %}}
 
 {{% notice note %}}
-This guide will largely assume that you are running Gloo in Kubernetes.
+This guide assumes that you are running open source Gloo in Kubernetes.
 {{% /notice %}}
 
-In this guide, we'll walk you through how to upgrade Gloo. First you'll want to familiarize yourself with our various [Changelog entry types]({{% versioned_link_path fromRoot="/reference/changelog/changelog_types/" %}}) so that you can review the changes that have been made in the release you are upgrading to. 
+In this guide, we'll walk you through how to upgrade Gloo. First you'll want to familiarize yourself with our various 
+[Changelog entry types]({{% versioned_link_path fromRoot="/reference/changelog/changelog_types/" %}}) so that you can
+review the changes that have been made in the release you are upgrading to. 
 
 Once you have reviewed the changes in the new release, there are two components to upgrade:
 
@@ -20,17 +24,28 @@ Once you have reviewed the changes in the new release, there are two components 
     * [Using `glooctl` itself](#using-glooctl-itself)
     * [Download release asset](#download-release-asset)
 * [Gloo (server components)](#upgrading-the-server-components)
-    * [Updating Gloo using `glooctl`](#using-glooctl)
-    * [Updating Gloo using Helm](#using-helm)
-        * [Helm 3](#helm-3)
-        * [Helm 2](#helm-2)
+    * [Helm 3](#helm-3)
+    * [Helm 2](#helm-2)
 
-Before upgrading, always make sure to check our changelogs (refer to our [open-source]({{% versioned_link_path fromRoot="/reference/changelog/open_source/" %}}) or [enterprise]({{% versioned_link_path fromRoot="/reference/changelog/enterprise/" %}}) changelogs) for any mention of breaking changes. In some cases, a breaking change may mean a slightly different upgrade procedure; if this is the case, then we will take care to explain what ust be done in the changelog notes.
+Before upgrading, always make sure to check our changelogs (refer to our 
+[open-source]({{% versioned_link_path fromRoot="/reference/changelog/open_source/" %}}) or 
+[enterprise]({{% versioned_link_path fromRoot="/reference/changelog/enterprise/" %}}) changelogs) for any mention of
+breaking changes. In some cases, a breaking change may mean a slightly different upgrade procedure; if this is the
+case, then we will take care to explain what must be done in the changelog notes and an upgrade notice in the docs.
 
-You may also want to scan our [frequently-asked questions]({{% versioned_link_path fromRoot="/operations/upgrading/faq/" %}}) to see if any of those cases apply to you. Also feel free to post in the `#gloo` or `#gloo-enterprise` rooms of our [public Slack](https://slack.solo.io/) if your use case doesn't quite fit the standard upgrade path. 
+You may also want to scan our 
+[frequently-asked questions]({{% versioned_link_path fromRoot="/operations/upgrading/faq/" %}}) to see if any of
+those cases apply to you. Also feel free to post in the `#gloo` or `#gloo-enterprise` rooms of our
+[public Slack](https://slack.solo.io/) if your use case doesn't quite fit the standard upgrade path. 
 
 {{% notice note %}}
-We version open-source Gloo separately from Gloo Enterprise. This is because Gloo Enterprise pulls in open-source Gloo as a dependency. While the patch versions of Gloo and Gloo Enterprise may drift apart from each other, we will maintain the same major/minor versions across the two projects. So for example, we may be at version `x.y.a` in open-source Gloo and `x.y.b` in Gloo Enterprise. `x` and `y` will always be the same, but `a` and `b` will often not be the same. This is why, if you are a Gloo Enterprise user, you may see different versions reported by `glooctl version`. We will try to ensure that open-source Gloo and Gloo Enterprise will be compatible each other across patch versions, but make no guarantees about compatibility between minor or major versions.
+We version open-source Gloo separately from Gloo Enterprise. This is because Gloo Enterprise pulls in open-source
+Gloo as a dependency. While the patch versions of Gloo and Gloo Enterprise may drift apart from each other, we will
+maintain the same major/minor versions across the two projects. So for example, we may be at version `x.y.a` in
+open-source Gloo and `x.y.b` in Gloo Enterprise. `x` and `y` will always be the same, but `a` and `b` will often not
+be the same. This is why, if you are a Gloo Enterprise user, you may see different versions reported by
+`glooctl version`. We will try to ensure that open-source Gloo and Gloo Enterprise will be compatible each other
+across patch versions, but make no guarantees about compatibility between minor or major versions.
 
 <br> 
 
@@ -49,24 +64,40 @@ Server: {"type":"Gateway","enterprise":true,"kubernetes":...,{"Tag":"0.20.8","Na
 
 <br>
 
-If you are an open-source user of Gloo, you will only need to be aware of open-source versions found [in our open-source changelogs]({{% versioned_link_path fromRoot="/reference/changelog/open_source/" %}}). If you are an enterprise user of Gloo, you will be selecting versions of Gloo Enterprise from [our Enterprise changelogs]({{% versioned_link_path fromRoot="/reference/changelog/enterprise/" %}}). However, you may need to be aware of the version of open-source Gloo included as a dependency in Gloo Enterprise, as most of our proto definitions are open-source. Changes to the open-source version will be listed as "Dependency Bumps", and significant changes may be listed as "Breaking Changes" in our [changelog entries]({{% versioned_link_path fromRoot="/reference/changelog/changelog_types/" %}}).
+If you are an open-source user of Gloo, you will only need to be aware of open-source versions found 
+[in our open-source changelogs]({{% versioned_link_path fromRoot="/reference/changelog/open_source/" %}}). If you are
+an enterprise user of Gloo, you will be selecting versions of Gloo Enterprise from 
+[our Enterprise changelogs]({{% versioned_link_path fromRoot="/reference/changelog/enterprise/" %}}). However, you may
+need to be aware of the version of open-source Gloo included as a dependency in Gloo Enterprise, as most of our proto
+definitions are open-source. Changes to the open-source version will be listed as "Dependency Bumps", and significant
+changes may be listed as "Breaking Changes" in our 
+[changelog entries]({{% versioned_link_path fromRoot="/reference/changelog/changelog_types/" %}}).
 {{% /notice %}}
 
 ## Upgrading Components
 
-After upgrading a component, you should be sure to run `glooctl check` immediately afterwards. `glooctl check` will scan Gloo for problems and report them back to you. A problem reported by `glooctl check` means that Gloo is not working properly and that Envoy may not be receiving updated configuration.
+After upgrading a component, you should be sure to run `glooctl check` immediately afterwards. `glooctl check` will
+scan Gloo for problems and report them back to you. A problem reported by `glooctl check` means that Gloo is not
+working properly and that Envoy may not be receiving updated configuration.
 
 ### Upgrading `glooctl`
 
 {{% notice note %}}
-It is important to try to keep the version of `glooctl` in alignment with the version of the Gloo server components running in your cluster. Because `glooctl` can create resources in your cluster (for example, with `glooctl add route`), you may see errors in Gloo if you create resources from a version of `glooctl` that is incompatible with the version of the server components.
+It is important to try to keep the version of `glooctl` in alignment with the version of the Gloo server components
+running in your cluster. Because `glooctl` can create resources in your cluster (for example, with 
+`glooctl add route`), you may see errors in Gloo if you create resources from a version of `glooctl` that is
+incompatible with the version of the server components.
 {{% /notice %}}
 
 #### Using `glooctl` Itself
 
-The easiest way to upgrade `glooctl` is to simply run `glooctl upgrade`, which will attempt to download the latest binary. There are more fine-grained options available; those can be viewed by running `glooctl upgrade --help`. One in particular to make note of is `glooctl upgrade --release`, which can be useful in maintaining careful control over what version you are running.
+The easiest way to upgrade `glooctl` is to simply run `glooctl upgrade`, which will attempt to download the latest
+binary. There are more fine-grained options available; those can be viewed by running `glooctl upgrade --help`. One in
+particular to make note of is `glooctl upgrade --release`, which can be useful in maintaining careful control over
+what version you are running.
 
-Here is an example where we notice we have a version mismatch between `glooctl` and the version of Gloo running in our minikube cluster (1.2.0 and 1.2.1 respectively), and we correct it:
+Here is an example where we notice we have a version mismatch between `glooctl` and the version of Gloo running in our
+minikube cluster (1.2.0 and 1.2.1 respectively), and we correct it:
 
 ```bash
 ~ > glooctl version
@@ -101,104 +132,35 @@ No problems detected.
 
 #### Download Release Asset
 
-You can find `glooctl` built for every platform in our release artifacts. For example, see our release assets for v1.0.0: https://github.com/solo-io/gloo/releases/tag/v1.0.0
+You can find `glooctl` built for every platform in our release artifacts. For example, see our release assets for
+v1.0.0: https://github.com/solo-io/gloo/releases/tag/v1.0.0
 
 ### Upgrading the Server Components
 
-There are two options for how to perform the server upgrade. Note that these options are not mutually-exclusive; if you have used one in the past, you can freely choose to use a different one in the future.
-
-Both installation methods allow you to provide overrides for the default chart values; however, installing through Helm may give you more flexibility as you are working directly with Helm rather than `glooctl`, which, for installation, is essentially just a wrapper around Helm. See our [open-source installation docs]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/#list-of-gloo-helm-chart-values" %}}) and our [enterprise installation docs]({{% versioned_link_path fromRoot="/installation/enterprise/#list-of-gloo-helm-chart-values" %}}) for a complete list of Helm values that can be overridden.
-
-{{% notice note %}}
-We create a Kubernetes Job named `gateway-certgen` to generate a cert for the validation webhook. We attempt to put a `ttlSecondsAfterFinished` value on the job so that it gets cleaned up automatically, but as this setting is still in Alpha, your cluster may ignore this value. If that is the case, you may run into an issue while upgrading where the upgrade attempts to change the `gateway-certgen` job, but the update fails because the job is immutable. If you run into this, simply delete the job, which should have completed long before, and re-apply the upgrade.
-{{% /notice %}}
-
-#### Using `glooctl`
-
-You'll want to use the `glooctl install` command tree, the most common path in which is `glooctl install gateway`. A good way to proceed in a simple case is a two-step process, which will ensure that `glooctl`'s version is left matching the server components:
-
-1. Upgrade the `glooctl` binary as described above
-1. Run `glooctl install gateway`, which will pull down image versions matching `glooctl`'s version.
-
-All `glooctl` commands can have `--help` appended to them to view helpful usage information. Some useful flags to be aware of in particular:
-
-* `--dry-run` (`-d`): lets you preview the YAML of the release manifest
-* `--namespace` (`-n`): lets you customize the namespace being installed to, which defaults to `gloo-system`
-* `--values`: provide a path to a values override file to use when rendering the Helm chart
-
-Here we perform an upgrade from Gloo 1.2.0 to 1.2.1 in our minikube cluster, confirming along the way (just as a demonstration) that the new images `glooctl` is referencing match its own version. Along the way you may need to delete the completed `gateway-certgen` job.
+Note that you may encounter downtime without the proper probes and healthchecks setup before attempting the upgrade.
+For more detailed upgrade instructions for production setup, we recommend looking at the upgrade guide associated for
+your version (for example, the [1.3.0+ upgrade guide]({{< versioned_link_path fromRoot="/operations/upgrading/1.3.0" >}})).
 
 {{% notice note %}}
-For Enterprise users of Gloo, this process is largely the same. You'll just need to change your `glooctl`
-invocation to
-
-```bash
-glooctl install gateway enterprise --license-key ${license}
-```
-Get a trial Enterprise license at https://www.solo.io/gloo-trial.
+We create a Kubernetes Job named `gateway-certgen` to generate a cert for the validation webhook. We attempt to put a
+`ttlSecondsAfterFinished` value on the job so that it gets cleaned up automatically, but as this setting is still in
+Alpha, your cluster may ignore this value. If that is the case, you may run into an issue while upgrading where the
+upgrade attempts to change the `gateway-certgen` job, but the update fails because the job is immutable. If you run
+into this, simply delete the job, which should have completed long before, and re-apply the upgrade.
 {{% /notice %}}
-
-```bash
-~ > glooctl version
-Client: {"version":"1.2.0"}
-Server: {"type":"Gateway","kubernetes":{"containers":[{"Tag":"1.2.0","Name":"discovery","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gateway","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gloo-envoy-wrapper","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gloo","Registry":"quay.io/solo-io"}],"namespace":"gloo-system"}}
-```
-
-```bash
-~ > glooctl upgrade --release v1.2.1
-downloading glooctl-darwin-amd64 from release tag v1.2.1
-successfully downloaded and installed glooctl version v1.2.1 to /usr/local/bin/glooctl
-```
-
-```bash
-~ > glooctl version
-Client: {"version":"1.2.1"}
-Server: {"type":"Gateway","kubernetes":{"containers":[{"Tag":"1.2.0","Name":"discovery","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gateway","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gloo-envoy-wrapper","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gloo","Registry":"quay.io/solo-io"}],"namespace":"gloo-system"}}
-```
-
-```bash
-~ > glooctl install gateway --dry-run | grep -o 'quay.*$'
-quay.io/solo-io/certgen:1.2.1
-quay.io/solo-io/gloo:1.2.1
-quay.io/solo-io/discovery:1.2.1
-quay.io/solo-io/gateway:1.2.1
-quay.io/solo-io/gloo-envoy-wrapper:1.2.1
-```
-
-```bash
-~ > glooctl install gateway --dry-run | kubectl apply -f - -n gloo-system
-# output snipped for brevity
-# you may see warnings along the lines of "kubectl apply should be used on resource created by either kubectl create or kubectl apply..."
-# these lines are harmless
-```
-
-```bash
-~ > kubectl -n gloo-system get pod -l gloo=gloo -ojsonpath='{.items[0].spec.containers[0].image}'
-quay.io/solo-io/gloo:1.2.1
-```
-
-```bash
-~ > glooctl check
-Checking deployments... OK
-Checking pods... OK
-Checking upstreams... OK
-Checking upstream groups... OK
-Checking secrets... OK
-Checking virtual services... OK
-Checking gateways... OK
-Checking proxies... OK
-No problems detected.
-```
 
 #### Using Helm
 
-{{% notice note %}}
-Upgrading through Helm only (i.e., not through `glooctl`) will not ensure that the version of `glooctl` matches the server components. You may encounter errors in this state. Be sure to follow the ["upgrading `glooctl`"](#upgrading-glooctl) steps above to match `glooctl`'s version to the server components. 
-{{% /notice %}}
-
-For Enterprise users of Gloo, the process with either Helm 2 or 3 is the same. You'll just need to set your license key during installation by using `--set license_key="$license"` (or include the line `license_key: LICENSE-KEY` in your values file).
+For Enterprise users of Gloo, the process with either Helm 2 or 3 is the same. You'll just need to set your license
+key during installation by using `--set license_key="$license"` (or include the line `license_key: $LICENSE-KEY` in
+your values file).
 
 Get a trial Enterprise license at https://www.solo.io/gloo-trial.
+
+{{% notice note %}}
+While it is possible to upgrade from open source Gloo to enterprise Gloo using helm upgrade, you may have to take
+additional steps to ensure there is no downtime because the charts do not have the exact same helm values.
+{{% /notice %}}
 
 ##### Helm 3
 
@@ -225,46 +187,23 @@ quay.io/solo-io/gloo:1.2.1
 ##### Helm 2
 
 {{% notice warning %}}
-Using Helm 2 with open source Gloo v1.2.3 and later or Gloo Enterprise v1.2.0 and later requires explicitly setting `crds.create=true`, as this is how we are managing compatibility between Helm 2 and 3.
+Using Helm 2 with open source Gloo v1.2.3 and later or Gloo Enterprise v1.2.0 and later requires explicitly setting
+`crds.create=true` on the first install, as this is how we are managing compatibility between Helm 2 and 3.
 {{% /notice %}}
 
-At the time of writing, Helm v2 [does not support managing CRDs](https://github.com/helm/helm/issues/5871#issuecomment-522096388). As a result, if you try to upgrade through `helm install` or `helm upgrade`, you may encounter an error stating that a CRD already exists.
+Helm upgrade command should just work:
+```bash
+~ > helm upgrade gloo gloo/gloo --namespace gloo-system
+```
+
+If you'd rather delete and reinstall to get a clean slate, take care to manage your CRDs as Helm v2 
+[does not support managing CRDs](https://github.com/helm/helm/issues/5871#issuecomment-522096388). As a result, if you
+try to upgrade through deleting a helm release (`helm delete --purge gloo`) and reinstalling via `helm install`, you
+may encounter an error stating that a CRD already exists.
 
 ```bash
-~ > helm install gloo/gloo
+~ > helm install gloo/gloo --name gloo --namespace gloo-system --set crds.create=true
 Error: customresourcedefinitions.apiextensions.k8s.io "authconfigs.enterprise.gloo.solo.io" already exists
 ```
 
-There are two options for resolving this problem. If there have not been changes to the CRDs (such a change would be mentioned in our changelogs), then you can simply set the Helm value `global.glooRbac.create` to `false` and skip CRD creation altogether. If there have been changes to the CRDs, then you could either delete the CRDs yourself, or you could render the chart yourself and then directly `kubectl apply` it. The rest of this section will assume the latter.
-
-```bash
-namespace=gloo-system # customize to your namespace
-helm repo add gloo https://storage.googleapis.com/solo-public-helm
-helm fetch gloo/gloo --version "1.2.1"
-```
-
-We will perform the same upgrade of Gloo v1.2.0 to v1.2.1:
-
-```bash
-~ > glooctl version
-Client: {"version":"1.2.0"}
-Server: {"type":"Gateway","kubernetes":{"containers":[{"Tag":"1.2.0","Name":"discovery","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gloo-envoy-wrapper","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gateway","Registry":"quay.io/solo-io"},{"Tag":"1.2.0","Name":"gloo","Registry":"quay.io/solo-io"}],"namespace":"gloo-system"}}
-~ > kubectl delete job gateway-certgen # if the job has not already been removed by its TTL expiration
-job.batch "gateway-certgen" deleted
-```
-
-```bash
-~ > helm template ./gloo-1.2.1.tgz --namespace gloo-system --set crds.create=true | kubectl apply -f -
-configmap/gloo-usage configured
-configmap/gateway-proxy-envoy-config unchanged
-serviceaccount/gloo unchanged
-... # snipped for brevity
-gateway.gateway.solo.io/gateway-proxy-ssl unchanged
-settings.gloo.solo.io/default unchanged
-validatingwebhookconfiguration.admissionregistration.k8s.io/gloo-gateway-validation-webhook-gloo-system configured
-```
-
-```bash
-~ > kubectl get pod -l gloo=gloo -ojsonpath='{.items[0].spec.containers[0].image}'
-quay.io/solo-io/gloo:1.2.1
-```
+To successfully reinstall, run the same install command with `crds.create=false`.


### PR DESCRIPTION
# Description

Polish the upgrade docs with our up to date recommendations for upgrading Gloo. In particular, this removes recommendations of `helm template | kubectl apply` \ `glooctl install --dry-run | kubectl apply`, as we don't recommend this as an upgrade path.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff (N.A, docs only PR)
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works (docs only PR, tested the new upgrade flows)
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2902