### PR TITLE
Wrong upstream port

### DIFF
--- a/changelog/v1.4.0-beta11/log-wrong-upstream-port.yaml
+++ b/changelog/v1.4.0-beta11/log-wrong-upstream-port.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: Gloo pod will now log a clear message when an upstream's port does not match that of its underlying kubernetes service.
+    issueLink: https://github.com/solo-io/gloo/issues/2905
+    resolvesIssue: false

--- a/projects/gloo/pkg/plugins/kubernetes/eds.go
+++ b/projects/gloo/pkg/plugins/kubernetes/eds.go
@@ -190,7 +190,10 @@ func filterEndpoints(ctx context.Context, writeNamespace string, kubeEndpoints [
 			}
 			if len(svc.Spec.Ports) == 1 {
 				singlePortService = true
-				kubeServicePort = &svc.Spec.Ports[0]
+				if spec.ServicePort == uint32(svc.Spec.Ports[0].Port) {
+					kubeServicePort = &svc.Spec.Ports[0]
+					break findServicePort
+				}
 			}
 			for _, port := range svc.Spec.Ports {
 				if spec.ServicePort == uint32(port.Port) {


### PR DESCRIPTION
Gloo pod will now log a clear message when an upstream's port does not match that of its underlying kubernetes service.

This doesn't resolve the issue because it doesn't update the status on the upstream resource. We already have an issue (https://app.asana.com/0/1148785095952953/1161331415562787/f) to resolve this that we previously put on the back burner because it was more time consuming than anticipated.