### PR TITLE
Fix regression test flake with valid/invalid virtual services

### DIFF
--- a/changelog/v1.4.0-beta12/fix-valid-invalid-regression-test-flakes.yaml
+++ b/changelog/v1.4.0-beta12/fix-valid-invalid-regression-test-flakes.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Ensure invalid resources have been deleted before enabling validation, which could fail our regression tests

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -486,12 +486,15 @@ var _ = Describe("Kube2e: gateway", func() {
 
 			})
 			AfterEach(func() {
-				UpdateAlwaysAcceptSetting(false)
 				_ = virtualServiceClient.Delete(testHelper.InstallNamespace, invalidVsName, clients.DeleteOpts{})
 				_ = virtualServiceClient.Delete(testHelper.InstallNamespace, validVsName, clients.DeleteOpts{})
 				_ = virtualServiceClient.Delete(testHelper.InstallNamespace, petstoreName, clients.DeleteOpts{})
 				_ = kubeClient.CoreV1().Services(testHelper.InstallNamespace).Delete(petstoreName, nil)
 				_ = kubeClient.AppsV1().Deployments(testHelper.InstallNamespace).Delete(petstoreName, nil)
+				// important that we update the always accept setting after removing resources, or else we can have:
+				// "validation is disabled due to an invalid resource which has been written to storage.
+				// Please correct any Rejected resources to re-enable validation."
+				UpdateAlwaysAcceptSetting(false)
 			})
 			It("propagates the valid virtual services to envoy", func() {
 				testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{


### PR DESCRIPTION
# Description

Fix regression test flakes that occurred when we enabled validation before all invalid resources had been removed

# Context

We have hit flakes in CI related to this often lately, should ease dev experience greatly.