### PR TITLE
ingress class, named port, partial snapshot processing

### DIFF
--- a/changelog/v1.4.0-beta12/fix-ingress-controller.yaml
+++ b/changelog/v1.4.0-beta12/fix-ingress-controller.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3051
+    description: >-
+      Fixes a bug where the Gloo Ingress Controller (`ingress` pod) would stop processing Ingress updates when a detected Ingress `backend` incorrectly referenced a service port.
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/3050
+    description: >-
+      Adds support for the use of named ports on Kubernetes Ingress objects.
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/3047
+    description: >-
+      Adds the `customIngressClass` variable to the Gloo Helm Chart, which, when set, will allow overriding the default `kubernetes.io/ingress.class` Ingress Class used by Gloo. Use in combination with `requireIngressClass` to allow multiple Gloo controllers to partition the Ingress objects within a cluster.

--- a/docs/content/guides/integrations/ingress/_index.md
+++ b/docs/content/guides/integrations/ingress/_index.md
@@ -6,13 +6,21 @@ description: Setting up Gloo to handle Kubernetes Ingress Objects.
 
 Kubernetes Ingress Controllers are for simple traffic routing in a Kubernetes cluster. Gloo supports managing Ingress objects with the `glooctl install ingress` command, Gloo will configure Envoy using [Kubernetes Ingress objects](https://kubernetes.io/docs/concepts/services-networking/ingress/) created by users.
 
-{{% notice note %}}
-Note: if running multiple ingress controllers in cluster, Gloo can be configured to only process Ingress objects annotated with `kubernetes.io/ingress.class: gloo` 
+## Ingress Class
 
-This feature can be enabled one of the following:
+By default, Gloo ignores the `kubernetes.io/ingress.class` [Ingress Class annotation](https://github.com/kubernetes/ingress-gce/blob/master/docs/faq/README.md#how-do-i-run-multiple-ingress-controllers-in-the-same-cluster) on Ingresses, meaning that Gloo will enable routing for all detected Ingresses regardless of their ingress class.
+
+To have Gloo respect the Ingress Class annotation, such that Gloo will only process Ingresses with the annotation `kubernetes.io/ingress.class: gloo`:
 
 * Setting the `Values.ingress.requireIngressClass=true` in your Helm value overrides
-* Directly setting the environment variable `REQUIRE_INGRESS_CLASS=true` on the Gloo deployment
+* Directly setting the environment variable `REQUIRE_INGRESS_CLASS=true` on the `ingress` deployment
+
+When Gloo is set to require ingress class, the value `gloo` can be customized to match any arbitrary value by doing one of the following:
+
+* Set the `Values.ingress.customIngressClass=VALUE` in your Helm value overrides
+* Directly setting the environment variable `CUSTOM_INGRESS_CLASS=VALUE` on the `ingress` deployment.
+
+This is useful when wishing to use multiple instances of the Gloo ingress controller in the same Kubernetes cluster. 
 
 {{% /notice %}}
 

--- a/docs/content/guides/integrations/ingress/_index.md
+++ b/docs/content/guides/integrations/ingress/_index.md
@@ -15,6 +15,9 @@ To have Gloo respect the Ingress Class annotation, such that Gloo will only proc
 * Setting the `Values.ingress.requireIngressClass=true` in your Helm value overrides
 * Directly setting the environment variable `REQUIRE_INGRESS_CLASS=true` on the `ingress` deployment
 
+
+{{% notice %}}
+
 When Gloo is set to require ingress class, the value `gloo` can be customized to match any arbitrary value by doing one of the following:
 
 * Set the `Values.ingress.customIngressClass=VALUE` in your Helm value overrides

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -374,7 +374,8 @@
 |ingress.deployment.resources.limits.cpu|string||amount of CPUs|
 |ingress.deployment.resources.requests.memory|string||amount of memory|
 |ingress.deployment.resources.requests.cpu|string||amount of CPUs|
-|ingress.requireIngressClass|bool||only serve traffic for Ingress objects with the annotation 'kubernetes.io/ingress.class: gloo''|
+|ingress.requireIngressClass|bool||only serve traffic for Ingress objects with the Ingress Class annotation 'kubernetes.io/ingress.class'. By default the annotation value must be set to 'gloo', however this can be overriden via customIngressClass.|
+|ingress.customIngressClass|bool||Only relevant when requireIngressClass is set to true. Setting this value will cause the Gloo Ingress Controller to process only those Ingress objects which have their ingress class set to this value (e.g. 'kubernetes.io/ingress.class=SOMEVALUE').|
 |ingressProxy.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |ingressProxy.deployment.image.repository|string|gloo-envoy-wrapper|image name (repository) for the container.|
 |ingressProxy.deployment.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -288,7 +288,8 @@ type GatewayProxyConfigMap struct {
 type Ingress struct {
 	Enabled             *bool              `json:"enabled"`
 	Deployment          *IngressDeployment `json:"deployment,omitempty"`
-	RequireIngressClass *bool              `json:"requireIngressClass" desc:"only serve traffic for Ingress objects with the annotation 'kubernetes.io/ingress.class: gloo''"`
+	RequireIngressClass *bool              `json:"requireIngressClass" desc:"only serve traffic for Ingress objects with the Ingress Class annotation 'kubernetes.io/ingress.class'. By default the annotation value must be set to 'gloo', however this can be overriden via customIngressClass."`
+	CustomIngress       *bool              `json:"customIngressClass" desc:"Only relevant when requireIngressClass is set to true. Setting this value will cause the Gloo Ingress Controller to process only those Ingress objects which have their ingress class set to this value (e.g. 'kubernetes.io/ingress.class=SOMEVALUE')."`
 }
 
 type IngressDeployment struct {

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -55,6 +55,11 @@ spec:
         - name: "REQUIRE_INGRESS_CLASS"
           value: "true"
   {{- end }}
+
+  {{- if and .Values.ingress.customIngressClass }}
+        - name: "CUSTOM_INGRESS_CLASS"
+          value: "{{ .Values.ingress.customIngressClass }}"
+  {{- end }}
 {{- end }}
 
 

--- a/projects/ingress/api/v1/solo-kit.json
+++ b/projects/ingress/api/v1/solo-kit.json
@@ -8,6 +8,10 @@
         "package": "gloo.solo.io"
       },
       {
+        "name": "KubeService",
+        "package": "ingress.solo.io"
+      },
+      {
         "name": "Ingress",
         "package": "ingress.solo.io"
       }

--- a/projects/ingress/pkg/api/v1/translator_snapshot_simple_emitter.sk.go
+++ b/projects/ingress/pkg/api/v1/translator_snapshot_simple_emitter.sk.go
@@ -92,6 +92,8 @@ func (c *translatorSimpleEmitter) Snapshots(ctx context.Context) (<-chan *Transl
 					switch typed := res.(type) {
 					case *gloo_solo_io.Upstream:
 						currentSnapshot.Upstreams = append(currentSnapshot.Upstreams, typed)
+					case *KubeService:
+						currentSnapshot.Services = append(currentSnapshot.Services, typed)
 					case *Ingress:
 						currentSnapshot.Ingresses = append(currentSnapshot.Ingresses, typed)
 					default:

--- a/projects/ingress/pkg/setup/opts.go
+++ b/projects/ingress/pkg/setup/opts.go
@@ -19,4 +19,5 @@ type Opts struct {
 	KnativeVersion              string
 	DisableKubeIngress          bool
 	RequireIngressClass         bool
+	CustomIngressClass          string
 }

--- a/projects/ingress/pkg/status/status_syncer_test.go
+++ b/projects/ingress/pkg/status/status_syncer_test.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"time"
 
+	"github.com/solo-io/gloo/projects/ingress/pkg/translator"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/ingress/pkg/api/ingress"
@@ -86,7 +88,7 @@ var _ = Describe("StatusSyncer", func() {
 				Name:      "rusty",
 				Namespace: namespace,
 				Annotations: map[string]string{
-					"kubernetes.io/ingress.class": "gloo",
+					translator.IngressClassKey: "gloo",
 				},
 			},
 			Spec: v1beta1.IngressSpec{


### PR DESCRIPTION
# Description

this pr makes 3 changes to the `ingress` controller:
- fix a bug that cause ingress controller to stop processing ingresses when a config error is detected
- add support for Ingress objects which use named ports
- add support for customizing the Ingress class used by Gloo (via helm / env var) 

# Context

https://github.com/solo-io/gloo/issues/3051
https://github.com/solo-io/gloo/issues/3050
https://github.com/solo-io/gloo/issues/3047

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3051
resolves https://github.com/solo-io/gloo/issues/3050
resolves https://github.com/solo-io/gloo/issues/3047