### PR TITLE
Silence usage for glooctl with error

### DIFF
--- a/changelog/v1.4.0-beta12/supress-glooctl-usage.yaml
+++ b/changelog/v1.4.0-beta12/supress-glooctl-usage.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: >
+      Suppress the usage message for glooctl on error. This makes error messages easier to find.
+    issueLink: https://github.com/solo-io/gloo/issues/2880

--- a/projects/gloo/cli/pkg/cmd/get/root_test.go
+++ b/projects/gloo/cli/pkg/cmd/get/root_test.go
@@ -1,6 +1,8 @@
 package get_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/get"
@@ -12,6 +14,8 @@ import (
 )
 
 var _ = Describe("Root", func() {
+
+	emptyFlagsMsg := fmt.Sprintf("Error: %s", get.EmptyGetError.Error())
 
 	BeforeEach(func() {
 		helpers.UseMemoryClients()
@@ -25,8 +29,8 @@ var _ = Describe("Root", func() {
 
 	Context("Empty args and flags", func() {
 		It("should give clear error message", func() {
-			// Ignore the output message since it changes whenever we add flags and it is tested via the cobra lib.
-			_, err := testutils.GlooctlOut("get")
+			msg, err := testutils.GlooctlOut("get")
+			Expect(msg).To(Equal(emptyFlagsMsg))
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(get.EmptyGetError))
 		})

--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -43,6 +43,7 @@ func App(opts *options.Options, preRunFuncs []PreRunFunc, optionsFunc ...cliutil
 			}
 			return nil
 		},
+		SilenceUsage: true,
 	}
 
 	flagutils.AddKubeConfigFlag(app.PersistentFlags(), &opts.Top.KubeConfig)


### PR DESCRIPTION
Use Cobra's `SilenceUsage` property to suppress the usage message when
an error has occurred. This allows the error to be found easier in the
output.

Added a check to the "should give clear error message" test to verify,
as this should no longer differ between builds based on flags changes.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2880