### PR TITLE
Remove dep references from developer guide

### DIFF
--- a/docs/content/guides/dev/setting-up-dev-environment.md
+++ b/docs/content/guides/dev/setting-up-dev-environment.md
@@ -110,10 +110,8 @@ To generate or re-generate code in Gloo, some additional dependencies are requir
 Install Solo-Kit and required go packages:
 
 ```bash
-mkdir -p ${GOPATH}/src/github.com/solo-io
-cd ${GOPATH}/src/github.com/solo-io
-git clone https://github.com/solo-io/solo-kit
-cd gloo
+cd ${GOPATH}/src/github.com/solo-io/gloo
+
 # install required go packages
 make update-deps
 ```

--- a/docs/content/guides/dev/setting-up-dev-environment.md
+++ b/docs/content/guides/dev/setting-up-dev-environment.md
@@ -13,15 +13,18 @@ Developing on Gloo requires the following to be installed on your system:
 - [`make`](https://www.gnu.org/software/make/)
 - [`git`](https://git-scm.com/)
 - [`go`](https://golang.org/)
-- [`dep`](https://github.com/golang/dep)
 - `protoc` (`solo-io` projects are built using version `3.6.1`)
 - the `github.com/gogo/protobuf` go package
+- standard development tools like `gcc`
 
 To install all the requirements, run the following:
 
 On macOS:
 
 ```bash
+# install the Command Line Tools package if not already installed
+xcode-select --install
+
 # install protoc
 curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-osx-x86_64.zip
 unzip protoc-3.6.1-osx-x86_64.zip
@@ -31,17 +34,18 @@ rm -rf bin include protoc-3.6.1-osx-x86_64.zip readme.txt
 # install go
 curl https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash
 
-# install dep
-go get -u github.com/golang/dep/cmd/dep
-
 # install gogo-proto
 go get -u github.com/gogo/protobuf/...
 
 ```
 
-On linux:
+On Debian/Ubuntu linux:
 
 ```bash
+# install make and unzip and build tools
+sudo apt install make unzip build-essential -y
+
+# install protoc
 curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
 unzip protoc-3.6.1-linux-x86_64.zip
 sudo mv bin/protoc /usr/local/bin/
@@ -49,9 +53,6 @@ rm -rf bin include protoc-3.6.1-linux-x86_64.zip readme.txt
 
 # install go
 curl https://raw.githubusercontent.com/canha/golang-tools-install-script/master/goinstall.sh | bash
-
-# install dep
-go get -u github.com/golang/dep/cmd/dep
 
 # install gogo-proto
 go get -u github.com/gogo/protobuf/...
@@ -82,14 +83,6 @@ git clone https://github.com/solo-io/gloo
 git clone git@github.com:solo-io/gloo.git
 ```
 
-Starting in 1.x, the Gloo codebase uses [Go modules](https://blog.golang.org/using-go-modules) for dependency management. However, 
-on older versions, ensure that [`dep`](https://github.com/golang/dep) is installed and run:
-
-```bash
-cd ${GOPATH}/src/github.com/solo-io/gloo
-dep ensure # add -v for more output
-```
-
 You should now be able to run any `main.go` file in the Gloo repository using:
 
 ```bash
@@ -112,8 +105,7 @@ Awesome! You're ready to start developing on Gloo! Check out the [Writing Upstre
 
 ### Enabling Code Generation
 
-To generate or re-generate code in Gloo, some additional dependencies are required. Follow these steps if you are 
-making changes to Gloo's Protobuf-based API.
+To generate or re-generate code in Gloo, some additional dependencies are required. Follow these steps if you are making changes to Gloo's Protobuf-based API.
 
 Install Solo-Kit and required go packages:
 
@@ -122,10 +114,6 @@ mkdir -p ${GOPATH}/src/github.com/solo-io
 cd ${GOPATH}/src/github.com/solo-io
 git clone https://github.com/solo-io/solo-kit
 cd gloo
-# if developing against older versions of Gloo, import all go dependencies to ./vendor
-dep ensure -v
-# pin the installed version of solo-kit
-make pin-repos
 # install required go packages
 make update-deps
 ```


### PR DESCRIPTION
# Description

Updating the setting up development environment guide to remove references to using `dep`. Also added clarity around required Linux tooling and MacOS tooling.

# Context

This is in reference to issue #2987 