### PR TITLE
Support LoadBalancerSourceRanges

### DIFF
--- a/changelog/v1.4.0-beta12/add-loadbalancersourceranges.yaml
+++ b/changelog/v1.4.0-beta12/add-loadbalancersourceranges.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: HELM
+    description: >
+      Support for specifying the IP ranges that are allowed to access the load
+      balancer via loadBalancerSourceRanges. Refer to [Restrict Access For LoadBalancer Service]
+      (https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service)
+    issueLink: https://github.com/solo-io/gloo/issues/2358

--- a/changelog/v1.4.0-beta12/add-loadbalancersourceranges.yaml
+++ b/changelog/v1.4.0-beta12/add-loadbalancersourceranges.yaml
@@ -2,6 +2,6 @@ changelog:
   - type: HELM
     description: >
       Support for specifying the IP ranges that are allowed to access the load
-      balancer via loadBalancerSourceRanges. Refer to [Restrict Access For LoadBalancer Service]
-      (https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service)
+      balancer via loadBalancerSourceRanges. Refer to
+      [Restrict Access For LoadBalancer Service](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service)
     issueLink: https://github.com/solo-io/gloo/issues/2358

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -225,8 +225,10 @@
 |gatewayProxies.NAME.service.clusterIP|string||static clusterIP (or `None`) when `gatewayProxies[].gatewayProxy.service.type` is `ClusterIP`|
 |gatewayProxies.NAME.service.extraAnnotations.NAME|string|||
 |gatewayProxies.NAME.service.externalTrafficPolicy|string|||
-|gatewayProxies.NAME.service.name|string|||
-|gatewayProxies.NAME.service.httpsFirst|bool|||
+|gatewayProxies.NAME.service.name|string||Custom name override for the service resource of the proxy|
+|gatewayProxies.NAME.service.httpsFirst|bool||List HTTPS port before HTTP|
+|gatewayProxies.NAME.service.loadBalancerIP|string||IP address of the load balancer|
+|gatewayProxies.NAME.service.loadBalancerSourceRanges[]|string||List of IP CIDR ranges that are allowed to access the load balancer|
 |gatewayProxies.NAME.antiAffinity|bool||configure anti affinity such that pods are prefferably not co-located|
 |gatewayProxies.NAME.tracing.provider|string|||
 |gatewayProxies.NAME.tracing.cluster|string|||
@@ -312,8 +314,10 @@
 |gatewayProxies.gatewayProxy.service.clusterIP|string||static clusterIP (or `None`) when `gatewayProxies[].gatewayProxy.service.type` is `ClusterIP`|
 |gatewayProxies.gatewayProxy.service.extraAnnotations.NAME|string|||
 |gatewayProxies.gatewayProxy.service.externalTrafficPolicy|string|||
-|gatewayProxies.gatewayProxy.service.name|string|||
-|gatewayProxies.gatewayProxy.service.httpsFirst|bool|false||
+|gatewayProxies.gatewayProxy.service.name|string||Custom name override for the service resource of the proxy|
+|gatewayProxies.gatewayProxy.service.httpsFirst|bool|false|List HTTPS port before HTTP|
+|gatewayProxies.gatewayProxy.service.loadBalancerIP|string||IP address of the load balancer|
+|gatewayProxies.gatewayProxy.service.loadBalancerSourceRanges[]|string||List of IP CIDR ranges that are allowed to access the load balancer|
 |gatewayProxies.gatewayProxy.antiAffinity|bool|false|configure anti affinity such that pods are prefferably not co-located|
 |gatewayProxies.gatewayProxy.tracing.provider|string|||
 |gatewayProxies.gatewayProxy.tracing.cluster|string|||

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -258,14 +258,16 @@ type GatewayProxyPodTemplate struct {
 }
 
 type GatewayProxyService struct {
-	Type                  string            "json:\"type,omitempty\" desc:\"gateway [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). default is `LoadBalancer`\""
-	HttpPort              int               `json:"httpPort,omitempty" desc:"HTTP port for the gateway service"`
-	HttpsPort             int               `json:"httpsPort,omitempty" desc:"HTTPS port for the gateway service"`
-	ClusterIP             string            "json:\"clusterIP,omitempty\" desc:\"static clusterIP (or `None`) when `gatewayProxies[].gatewayProxy.service.type` is `ClusterIP`\""
-	ExtraAnnotations      map[string]string `json:"extraAnnotations,omitempty"`
-	ExternalTrafficPolicy string            `json:"externalTrafficPolicy,omitempty"`
-	Name                  string            `json:"name,omitempty", desc:"Custom name override for the service resource of the proxy"`
-	HttpsFirst            bool              `json:"httpsFirst", desc:"List HTTPS port before HTTP"`
+	Type                     string            "json:\"type,omitempty\" desc:\"gateway [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). default is `LoadBalancer`\""
+	HttpPort                 int               `json:"httpPort,omitempty" desc:"HTTP port for the gateway service"`
+	HttpsPort                int               `json:"httpsPort,omitempty" desc:"HTTPS port for the gateway service"`
+	ClusterIP                string            "json:\"clusterIP,omitempty\" desc:\"static clusterIP (or `None`) when `gatewayProxies[].gatewayProxy.service.type` is `ClusterIP`\""
+	ExtraAnnotations         map[string]string `json:"extraAnnotations,omitempty"`
+	ExternalTrafficPolicy    string            `json:"externalTrafficPolicy,omitempty"`
+	Name                     string            `json:"name,omitempty" desc:"Custom name override for the service resource of the proxy"`
+	HttpsFirst               bool              `json:"httpsFirst" desc:"List HTTPS port before HTTP"`
+	LoadBalancerIP           string            `json:"loadBalancerIP,omitempty" desc:"IP address of the load balancer"`
+	LoadBalancerSourceRanges []string          `json:"loadBalancerSourceRanges,omitempty" desc:"List of IP CIDR ranges that are allowed to access the load balancer"`
 }
 
 type Tracing struct {

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -60,8 +60,18 @@ spec:
   {{- if and (eq $spec.service.type "ClusterIP") $spec.service.clusterIP }}
   clusterIP: {{ $spec.service.clusterIP }}
   {{- end }}
-  {{- if and (eq $spec.service.type "LoadBalancer") $spec.service.loadBalancerIP }}
+  {{- if eq $spec.service.type "LoadBalancer" }}
+  {{- if $spec.service.loadBalancerIP }}
   loadBalancerIP: {{ $spec.service.loadBalancerIP }}
-  {{- end }}
+  {{- end }} # $spec.service.loadBalancerIP
+  {{- if $spec.service.loadBalancerSourceRanges }}
+  {{- with $spec.service.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+    {{- range . }}
+    - {{ . }}
+    {{- end }}
+  {{- end }} # with spec.service.loadBalancerSourceRanges
+  {{- end }} # $spec.service.loadBalancerSourceRanges
+  {{- end }} # $spec.service.type "LoadBalancer"
 {{- end }}
 {{ end }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -630,6 +630,14 @@ var _ = Describe("Helm Test", func() {
 						testManifest.ExpectService(gatewayProxyService)
 					})
 
+					It("sets load balancer source ranges", func() {
+						gatewayProxyService.Spec.Type = v1.ServiceTypeLoadBalancer
+						gatewayProxyService.Spec.LoadBalancerSourceRanges = []string{"130.211.204.1/32", "130.211.204.2/32"}
+						gatewayProxyService.Annotations = map[string]string{"test": "test"}
+						prepareMakefileFromValuesFile("val_lb_source_ranges.yaml")
+						testManifest.ExpectService(gatewayProxyService)
+					})
+
 					It("sets custom service name", func() {
 						gatewayProxyService.ObjectMeta.Name = "gateway-proxy-custom"
 						prepareMakefile(namespace, helmValues{

--- a/install/test/val_lb_source_ranges.yaml
+++ b/install/test/val_lb_source_ranges.yaml
@@ -1,0 +1,7 @@
+gatewayProxies:
+  gatewayProxy:
+    service:
+      type: LoadBalancer
+      loadBalancerSourceRanges:
+        - 130.211.204.1/32
+        - 130.211.204.2/32


### PR DESCRIPTION
Refer to [k8s docs](https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service) for loadBalancerSourceRanges feature.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2358