### PR TITLE
parameters.proto: fix example in comment

### DIFF
--- a/projects/gloo/api/v1/options/transformation/parameters.proto
+++ b/projects/gloo/api/v1/options/transformation/parameters.proto
@@ -18,7 +18,7 @@ message Parameters {
     //   extensions:
     //     parameters:
     //         headers:
-    //           x-user-id: { userId }
+    //           x-user-id: '{userId}'
     map<string, string> headers = 1;
     // part of the (or the entire) path that will be used extract data for processing output templates
     // Gloo will search for parameters by their name in header value strings, enclosed in single


### PR DESCRIPTION
# Description

Before, the example made it look like you could specify

```
headers:
  foo: { bar }
```

But it seems the correct format is
```
headers:
  foo: '{bar}'
```
This change fixes the proto comment that leads to this example being included in the API docs.

I'll need a hint or two on how you generate your pb code, and your docs, from this proto file. 😃 

# Context

Users ran into this bug trying to extract headers into my grpc message.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works