### PR TITLE
plugins/utils/transformation: trim spaces around parameter names

### DIFF
--- a/changelog/v1.4.0-beta14/fix-spaces-around-parameter-names.yaml
+++ b/changelog/v1.4.0-beta14/fix-spaces-around-parameter-names.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: >
+      Allow for spaces around parameter names in gRPC parameter options
+    issueLink: https://github.com/solo-io/gloo/issues/3123

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/transformation/parameters.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/transformation/parameters.proto.sk.md
@@ -35,7 +35,7 @@ weight: 5
 
 | Field | Type | Description | Default |
 | ----- | ---- | ----------- |----------- | 
-| `headers` | `map<string, string>` | headers that will be used to extract data for processing output templates Gloo will search for parameters by their name in header value strings, enclosed in single curly braces Example: extensions: parameters: headers: x-user-id: { userId }. |  |
+| `headers` | `map<string, string>` | headers that will be used to extract data for processing output templates Gloo will search for parameters by their name in header value strings, enclosed in single curly braces Example: extensions: parameters: headers: x-user-id: '{userId}'. |  |
 | `path` | [.google.protobuf.StringValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/string-value) | part of the (or the entire) path that will be used extract data for processing output templates Gloo will search for parameters by their name in header value strings, enclosed in single curly braces Example: extensions: parameters: path: /users/{ userId }. |  |
 
 

--- a/projects/gloo/api/v1/options/transformation/parameters.proto
+++ b/projects/gloo/api/v1/options/transformation/parameters.proto
@@ -18,7 +18,7 @@ message Parameters {
     //   extensions:
     //     parameters:
     //         headers:
-    //           x-user-id: { userId }
+    //           x-user-id: '{userId}'
     map<string, string> headers = 1;
     // part of the (or the entire) path that will be used extract data for processing output templates
     // Gloo will search for parameters by their name in header value strings, enclosed in single

--- a/projects/gloo/pkg/api/v1/options/transformation/parameters.pb.go
+++ b/projects/gloo/pkg/api/v1/options/transformation/parameters.pb.go
@@ -33,7 +33,7 @@ type Parameters struct {
 	//   extensions:
 	//     parameters:
 	//         headers:
-	//           x-user-id: { userId }
+	//           x-user-id: '{userId}'
 	Headers map[string]string `protobuf:"bytes,1,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// part of the (or the entire) path that will be used extract data for processing output templates
 	// Gloo will search for parameters by their name in header value strings, enclosed in single

--- a/projects/gloo/pkg/plugins/grpc/plugin_test.go
+++ b/projects/gloo/pkg/plugins/grpc/plugin_test.go
@@ -5,15 +5,20 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/solo-io/gloo/pkg/utils"
+	envoy_transform "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/transformation"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	pluginsv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
 	v1grpc "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc"
 	v1static "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
+	transformapi "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/transformation"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
 	envoyroute "github.com/envoyproxy/go-control-plane/envoy/api/v2/route"
+	"github.com/envoyproxy/go-control-plane/pkg/conversion"
+	"github.com/gogo/protobuf/types"
 )
 
 var _ = Describe("Plugin", func() {
@@ -24,7 +29,7 @@ var _ = Describe("Plugin", func() {
 		upstream     *v1.Upstream
 		upstreamSpec *v1static.UpstreamSpec
 		out          *envoyapi.Cluster
-		grpcSepc     *pluginsv1.ServiceSpec_Grpc
+		grpcSpec     *pluginsv1.ServiceSpec_Grpc
 	)
 
 	BeforeEach(func() {
@@ -32,7 +37,7 @@ var _ = Describe("Plugin", func() {
 		p = NewPlugin(&b)
 		out = new(envoyapi.Cluster)
 
-		grpcSepc = &pluginsv1.ServiceSpec_Grpc{
+		grpcSpec = &pluginsv1.ServiceSpec_Grpc{
 			Grpc: &v1grpc.ServiceSpec{
 				GrpcServices: []*v1grpc.ServiceSpec_GrpcService{{
 					PackageName:   "foo",
@@ -45,7 +50,7 @@ var _ = Describe("Plugin", func() {
 		p.Init(plugins.InitParams{})
 		upstreamSpec = &v1static.UpstreamSpec{
 			ServiceSpec: &pluginsv1.ServiceSpec{
-				PluginType: grpcSepc,
+				PluginType: grpcSpec,
 			},
 			Hosts: []*v1static.Host{{
 				Addr: "localhost",
@@ -64,7 +69,7 @@ var _ = Describe("Plugin", func() {
 
 	})
 	Context("upstream", func() {
-		It("should not mark none grpc upstreams as http2", func() {
+		It("should not mark non-grpc upstreams as http2", func() {
 			upstreamSpec.ServiceSpec.PluginType = nil
 			err := p.ProcessUpstream(params, upstream, out)
 			Expect(err).NotTo(HaveOccurred())
@@ -79,6 +84,16 @@ var _ = Describe("Plugin", func() {
 	})
 
 	Context("route", func() {
+
+		ps := &transformapi.Parameters{
+			Path: &types.StringValue{Value: "/{what}/{ ever }/{nested.field}/too"},
+			Headers: map[string]string{
+				"header-simple":            "{simple}",
+				"header-simple-with-space": "{ simple_with_space }",
+				"header-nested":            "{something.nested}",
+			},
+		}
+
 		It("should process route", func() {
 
 			var routeParams plugins.RouteParams
@@ -89,7 +104,12 @@ var _ = Describe("Plugin", func() {
 							Single: &v1.Destination{
 								DestinationSpec: &v1.DestinationSpec{
 									DestinationType: &v1.DestinationSpec_Grpc{
-										Grpc: &v1grpc.DestinationSpec{},
+										Grpc: &v1grpc.DestinationSpec{
+											Package:    "foo",
+											Service:    "bar",
+											Function:   "func",
+											Parameters: ps,
+										},
 									},
 								},
 								DestinationType: &v1.Destination_Upstream{
@@ -113,7 +133,32 @@ var _ = Describe("Plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 			err = p.ProcessRoute(routeParams, routeIn, routeOut)
 			Expect(err).NotTo(HaveOccurred())
-		})
 
+			var cfg envoy_transform.RouteTransformations
+			err = conversion.StructToMessage(routeOut.GetPerFilterConfig()[transformation.FilterName], &cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			tt := cfg.GetRequestTransformation().GetTransformationTemplate()
+			Expect(tt.GetMergeExtractorsToBody()).NotTo(Equal(nil))
+
+			extrs := tt.GetExtractors()
+			Expect(extrs["what"].GetHeader()).To(Equal(":path"))
+			Expect(extrs["what"].GetSubgroup()).To(Equal(uint32(1)))
+
+			Expect(extrs["ever"].GetHeader()).To(Equal(":path"))
+			Expect(extrs["ever"].GetSubgroup()).To(Equal(uint32(2)))
+
+			Expect(extrs["nested.field"].GetHeader()).To(Equal(":path"))
+			Expect(extrs["nested.field"].GetSubgroup()).To(Equal(uint32(3)))
+
+			Expect(extrs["simple"].GetHeader()).To(Equal("header-simple"))
+			Expect(extrs["simple"].GetSubgroup()).To(Equal(uint32(1)))
+
+			Expect(extrs["simple_with_space"].GetHeader()).To(Equal("header-simple-with-space"))
+			Expect(extrs["simple_with_space"].GetSubgroup()).To(Equal(uint32(1)))
+
+			Expect(extrs["something.nested"].GetHeader()).To(Equal("header-nested"))
+			Expect(extrs["something.nested"].GetSubgroup()).To(Equal(uint32(1)))
+		})
 	})
 })

--- a/projects/gloo/pkg/plugins/grpc/plugin_test.go
+++ b/projects/gloo/pkg/plugins/grpc/plugin_test.go
@@ -139,7 +139,7 @@ var _ = Describe("Plugin", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			tt := cfg.GetRequestTransformation().GetTransformationTemplate()
-			Expect(tt.GetMergeExtractorsToBody()).NotTo(Equal(nil))
+			Expect(tt.GetMergeExtractorsToBody()).NotTo(BeNil())
 
 			extrs := tt.GetExtractors()
 			Expect(extrs["what"].GetHeader()).To(Equal(":path"))

--- a/projects/gloo/pkg/plugins/utils/transformation/extractors.go
+++ b/projects/gloo/pkg/plugins/utils/transformation/extractors.go
@@ -86,14 +86,14 @@ func addHeaderExtractorFromParam(ctx context.Context, header, parameter string, 
 	return nil
 }
 
-var rxp = regexp.MustCompile(`\{([\.\-_[:word:]]+)\}`)
+var rxp = regexp.MustCompile(`\{\s*([\.\-_[:word:]]+)\s*\}`)
 
 func getNamesAndRegexFromParamString(paramString string) ([]string, string) {
 	// escape regex
 	// TODO: make sure all envoy regex is being escaped here
 	parameterNames := rxp.FindAllString(paramString, -1)
 	for i, name := range parameterNames {
-		parameterNames[i] = strings.TrimSuffix(strings.TrimPrefix(name, "{"), "}")
+		parameterNames[i] = strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(name, "{"), "}"))
 	}
 
 	return parameterNames, buildRegexString(rxp, paramString)


### PR DESCRIPTION
# Description

The gRPC header extraction settings

    parameters:
      headers:
        foo: '{ bar }'

would fail with

    reason: "1 error occurred:\n\t* Route Error: ProcessingError. Reason: *grpc.plugin:
       error processing parameter: { bar } is not valid syntax. {} braces must be
       closed and variable names must satisfy regex ([\\-._[:alnum:]]+)\n\n"

With this change, it should pass and work the same as if it was '{bar}'.

❓If you find this acceptable, I'll happily add a changelog item. I could use a hint on where this is tested, so that I can add a case or two. 😃 

# Context

This is an alternative to the docs fix attempted in #3112.
# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3123