### PR TITLE
docs/extauth/opa: add link, and note for using without OIDC

### DIFF
--- a/docs/content/guides/security/auth/extauth/opa/_index.md
+++ b/docs/content/guides/security/auth/extauth/opa/_index.md
@@ -221,10 +221,10 @@ rm policy.rego
 ```
 
 ## Validate JWTs with Open Policy Agent
-The Open Policy Agent policy language has in-built support for [JSON Web Tokens](https://jwt.io/) (JWTs), allowing you 
-to define policies based on the claims contained in a JWT. If you are using an **authentication** mechanism that conveys 
-identity information via JWTs (e.g. [OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect)), this feature makes 
-it easy to implement **authorization** for authenticated users.
+The Open Policy Agent policy language has [in-built support](https://www.openpolicyagent.org/docs/latest/policy-reference/#token-verification)
+for [JSON Web Tokens](https://jwt.io/) (JWTs), allowing you to define policies based on the claims contained in a JWT.
+If you are using an **authentication** mechanism that conveys identity information via JWTs (e.g. [OpenID Connect](https://en.wikipedia.org/wiki/OpenID_Connect)),
+this feature makes it easy to implement **authorization** for authenticated users.
 
 In this guide we will see how to use OPA to enforce policies on the JWTs produced by Gloo's **OpenID Connect** (OIDC) authentication module.
 

--- a/docs/content/guides/security/auth/extauth/opa/_index.md
+++ b/docs/content/guides/security/auth/extauth/opa/_index.md
@@ -228,6 +228,18 @@ this feature makes it easy to implement **authorization** for authenticated user
 
 In this guide we will see how to use OPA to enforce policies on the JWTs produced by Gloo's **OpenID Connect** (OIDC) authentication module.
 
+{{% notice note %}}
+It is possible to use the OPA without the OIDC authentication module.
+Each request that is passed to the OPA check contains all HTTP request headers as part of the
+[ `CheckRequest`](https://www.envoyproxy.io/docs/envoy/latest/api-v2/service/auth/v2/external_auth.proto#service-auth-v2-checkrequest)
+object provided in `input.check_request`.
+
+For example, a JWT passed via a `api-token` header could be used in a policy as
+```
+jwt := input.check_request.attributes.request.http.headers["api-token"]
+```
+{{% /notice %}}
+
 ### Deploy sample application
 {{% notice warning %}}
 The sample `petclinic` application deploys a MySql server. If you are using `minikube` v1.5 to run this guide, this 


### PR DESCRIPTION
# Description

A small docs improvement that could be helpful.

# Context

When checking the docs, it's not perhaps not as clear as it could be that the OPA stuff works well without the OIDC module.

Related: #3009 

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works