### PR TITLE
Use helm's built-in --create-namespace over separate kubectl

### DIFF
--- a/docs/content/installation/advanced_configuration/wasm.md
+++ b/docs/content/installation/advanced_configuration/wasm.md
@@ -23,8 +23,8 @@ The easiest way to install with this value is using helm 3 as follows:
 helm repo add gloo https://storage.googleapis.com/solo-public-helm
 
 helm repo update
-kubectl create ns gloo-system
-helm install --namespace gloo-system --set global.wasm.enabled=true gloo gloo/gloo
+
+helm install --namespace gloo-system --create-namespace --set global.wasm.enabled=true gloo gloo/gloo
 {{< /tab >}}
 {{< /tabs >}}
 


### PR DESCRIPTION
I had previously added the `kubectl create ns gloo-system ` step as this was something I ran into trying to run these instructions against a brand new cluster. Helm has a built-in way to handle this via the --create-namespace flag. This way saves the user a setup command and doesn't care if the namespace already exists.

Tested against a brand new kind cluster and everything works as expected.