### PR TITLE
Fix zipkin v2 docs

### DIFF
--- a/changelog/v1.4.0-beta15/fix-zipkin-docs-v2.yaml
+++ b/changelog/v1.4.0-beta15/fix-zipkin-docs-v2.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix docs to use v2 endpoint of zipkin
+    issueLink: https://github.com/solo-io/gloo/issues/3089

--- a/docs/content/guides/observability/tracing.md
+++ b/docs/content/guides/observability/tracing.md
@@ -48,7 +48,7 @@ gatewayProxies:
         typed_config:
           "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig"
           collector_cluster: zipkin
-          collector_endpoint: "/api/v1/spans"
+          collector_endpoint: "/api/v2/spans"
           collector_endpoint_version: HTTP_JSON
       cluster:
         - name: zipkin
@@ -87,7 +87,7 @@ data:
         typed_config:
           "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig"
           collector_cluster: zipkin
-          collector_endpoint: "/api/v1/spans"
+          collector_endpoint: "/api/v2/spans"
           collector_endpoint_version: HTTP_JSON
     node:
       cluster: gateway


### PR DESCRIPTION
# Description

Fixes our docs on tracing to use zipkin v2 endpoints with the v2 api

# Context

The current documented flow is broken

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3089