### PR TITLE
Fix setting custom runAsUser during helm install via --set

### DIFF
--- a/changelog/v1.4.0-beta15/fix-helm-run-as-user.yaml
+++ b/changelog/v1.4.0-beta15/fix-helm-run-as-user.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix setting custom runAsUser during helm install via --set
+    issueLink: https://github.com/solo-io/gloo/issues/3152

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -98,7 +98,7 @@ spec:
           {{- /* see https://github.com/helm/helm/issues/1707#issuecomment-520357573 */ -}}
           {{- /* the user id may be set quite high -- openshift wants userids that may get printed as scientific notation */}}
           {{- if not .Values.gloo.deployment.floatingUserId }}
-          runAsUser: {{ printf "%.0f" .Values.gloo.deployment.runAsUser -}}
+          runAsUser: {{ printf "%.0f" (float64 .Values.gloo.deployment.runAsUser) -}}
           {{- end }}
           capabilities:
             drop:

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -42,7 +42,7 @@ spec:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if not .Values.discovery.deployment.floatingUserId }}
-          runAsUser: {{ printf "%.0f" .Values.discovery.deployment.runAsUser -}}
+          runAsUser: {{ printf "%.0f" (float64 .Values.discovery.deployment.runAsUser) -}}
           {{- end }}
           capabilities:
             drop:

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -50,7 +50,7 @@ spec:
           allowPrivilegeEscalation: false
           runAsNonRoot: true
           {{- if not .Values.gateway.deployment.floatingUserId }}
-          runAsUser: {{ printf "%.0f" .Values.gateway.deployment.runAsUser -}}
+          runAsUser: {{ printf "%.0f" (float64 .Values.gateway.deployment.runAsUser) -}}
           {{- end }}
           capabilities:
             drop:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -122,7 +122,7 @@ spec:
           {{- if $spec.podTemplate.runUnprivileged }}
           runAsNonRoot: true
           {{- if not $spec.podTemplate.floatingUserId }}
-          runAsUser: {{ printf "%.0f" $spec.podTemplate.runAsUser -}}
+          runAsUser: {{ printf "%.0f" (float64 $spec.podTemplate.runAsUser) -}}
           {{- end }}
           {{- end}}
           capabilities:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -848,6 +848,20 @@ var _ = Describe("Helm Test", func() {
 						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
 					})
 
+					It("allows setting custom runAsUser", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"gatewayProxies.gatewayProxy.podTemplate.runAsUser=10102",
+								"gatewayProxies.gatewayProxy.podTemplate.runUnprivileged=true",
+							},
+						})
+						uid := int64(10102)
+						truez := true
+						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = &uid
+						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot = &truez
+						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
+					})
+
 					It("enables anti affinity ", func() {
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{"gatewayProxies.gatewayProxy.antiAffinity=true"},
@@ -1526,6 +1540,15 @@ metadata:
 						testManifest.ExpectDeploymentAppsV1(glooDeployment)
 					})
 
+					It("should allow overriding runAsUser", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gloo.deployment.runAsUser=10102"},
+						})
+						uid := int64(10102)
+						glooDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = &uid
+						testManifest.ExpectDeploymentAppsV1(glooDeployment)
+					})
+
 					It("should disable usage stats collection when appropriate", func() {
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{"gloo.deployment.disableUsageStatistics=true"},
@@ -1731,6 +1754,15 @@ metadata:
 						})
 						testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
 					})
+
+					It("allows setting custom runAsUser", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gateway.deployment.runAsUser=10102"},
+						})
+						uid := int64(10102)
+						gatewayDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = &uid
+						testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
+					})
 				})
 
 				Context("discovery deployment", func() {
@@ -1834,6 +1866,15 @@ metadata:
 								"discovery.deployment.customEnv[0].Value=test",
 							},
 						})
+						testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
+					})
+
+					It("allows setting custom runAsUser", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"discovery.deployment.runAsUser=10102"},
+						})
+						uid := int64(10102)
+						discoveryDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = &uid
 						testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
 					})
 				})


### PR DESCRIPTION
Setting this value currently only works via a values.yaml file, not using the --set arg. This PR fixes that & adds some tests.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3152