### PR TITLE
Run gateway-proxy with no root privileges by default

### DIFF
--- a/changelog/v1.4.0-beta15/reduce-gateway-proxy-default-privileges.yaml
+++ b/changelog/v1.4.0-beta15/reduce-gateway-proxy-default-privileges.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >
+      Default gateway proxy to running as non-root and
+      disabling NET_BIND_SERVICE by default.
+    issueLink: https://github.com/solo-io/gloo/issues/3084
+    resolvesIssue: false

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -307,8 +307,8 @@
 |gatewayProxies.gatewayProxy.podTemplate.resources.limits.cpu|string||amount of CPUs|
 |gatewayProxies.gatewayProxy.podTemplate.resources.requests.memory|string||amount of memory|
 |gatewayProxies.gatewayProxy.podTemplate.resources.requests.cpu|string||amount of CPUs|
-|gatewayProxies.gatewayProxy.podTemplate.disableNetBind|bool|false|don't add the NET_BIND_SERVICE capability to the pod. This means that the gateway proxy will not be able to bind to ports below 1024|
-|gatewayProxies.gatewayProxy.podTemplate.runUnprivileged|bool|false|run envoy as an unprivileged user|
+|gatewayProxies.gatewayProxy.podTemplate.disableNetBind|bool|true|don't add the NET_BIND_SERVICE capability to the pod. This means that the gateway proxy will not be able to bind to ports below 1024|
+|gatewayProxies.gatewayProxy.podTemplate.runUnprivileged|bool|true|run envoy as an unprivileged user|
 |gatewayProxies.gatewayProxy.podTemplate.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gatewayProxies.gatewayProxy.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gatewayProxies.gatewayProxy.configMap.data.NAME|string|||

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -91,6 +91,8 @@ gatewayProxies:
       httpPort: 8080
       httpsPort: 8443
       runAsUser: 10101
+      runUnprivileged: true
+      disableNetBind: true
     service:
       type: LoadBalancer
       # clusterIP: None

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -715,13 +715,15 @@ var _ = Describe("Helm Test", func() {
 						}}
 						truez := true
 						falsez := false
+						defaultUser := int64(10101)
 						deploy.Spec.Template.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
 							Capabilities: &v1.Capabilities{
-								Add:  []v1.Capability{"NET_BIND_SERVICE"},
 								Drop: []v1.Capability{"ALL"},
 							},
 							ReadOnlyRootFilesystem:   &truez,
 							AllowPrivilegeEscalation: &falsez,
+							RunAsNonRoot:             &truez,
+							RunAsUser:                &defaultUser,
 						}
 						deploy.Spec.Template.Spec.ServiceAccountName = "gateway-proxy"
 						gatewayProxyDeployment = deploy


### PR DESCRIPTION
Default to running as non-root and now giving privileges to bind to ports <1024 (we use 8080 and 8443 by default). 

There's already config here that users can override in their own values.yaml, if they need these privileges for any reason, but since our default setup doesn't need them we should run with as few privileges as possible.