### PR TITLE
Properly namespace ingress- and knative-mode RBAC resources

### DIFF
--- a/changelog/v1.4.0-beta16/properly-namespace-rbac.yaml
+++ b/changelog/v1.4.0-beta16/properly-namespace-rbac.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >
+      Properly suffix all cluster-scoped RBAC resources, including those only relevant to ingress- and knative-mode installations.
+      This ensures that multi-tenant Gloo installations will not experience conflicts on those RBAC resources.
+    issueLink: https://github.com/solo-io/gloo/issues/3103

--- a/install/helm/gloo/templates/21-namespace-clusterrole-ingress.yaml
+++ b/install/helm/gloo/templates/21-namespace-clusterrole-ingress.yaml
@@ -4,7 +4,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-role-ingress
+    name: gloo-role-ingress{{ include "gloo.rbacNameSuffix" . }}
     labels:
         app: gloo
         gloo: rbac

--- a/install/helm/gloo/templates/22-namespace-clusterrole-knative.yaml
+++ b/install/helm/gloo/templates/22-namespace-clusterrole-knative.yaml
@@ -4,7 +4,7 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-role-knative
+    name: gloo-role-knative{{ include "gloo.rbacNameSuffix" . }}
     labels:
         app: gloo
         gloo: rbac

--- a/install/helm/gloo/templates/24-namespace-clusterrolebinding-ingress.yaml
+++ b/install/helm/gloo/templates/24-namespace-clusterrolebinding-ingress.yaml
@@ -4,7 +4,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: gloo-role-binding-ingress-{{ .Release.Namespace }}
+  name: gloo-role-binding-ingress{{ include "gloo.rbacNameSuffix" . }}
   labels:
     app: gloo
     gloo: rbac
@@ -20,7 +20,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: gloo-role-ingress
+  name: gloo-role-ingress-{{ .Release.Namespace }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- end -}}

--- a/install/helm/gloo/templates/24-namespace-clusterrolebinding-ingress.yaml
+++ b/install/helm/gloo/templates/24-namespace-clusterrolebinding-ingress.yaml
@@ -20,7 +20,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: gloo-role-ingress-{{ .Release.Namespace }}
+  name: gloo-role-ingress{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 
 {{- end -}}

--- a/install/helm/gloo/templates/25-namespace-clusterrolebinding-knative.yaml
+++ b/install/helm/gloo/templates/25-namespace-clusterrolebinding-knative.yaml
@@ -20,7 +20,7 @@ subjects:
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: ClusterRole
-  name: gloo-role-knative
+  name: gloo-role-knative{{ include "gloo.rbacNameSuffix" . }}
   apiGroup: rbac.authorization.k8s.io
 {{- end -}}
 

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -65,7 +65,8 @@ var _ = Describe("RBAC Test", func() {
 				})
 
 				It("is all named appropriately in a non-namespaced install", func() {
-					prepareMakefile()
+					// be sure to pass these flags here so that all RBAC resources are rendered in the template
+					prepareMakefile("ingress.enabled=true", "settings.integrations.knative.enabled=true")
 					checkSuffix(namespace)
 				})
 			})


### PR DESCRIPTION
Properly suffix all cluster-scoped RBAC resources, including those only relevant to ingress- and knative-mode installations. This ensures that multi-tenant Gloo installations will not experience conflicts on those RBAC resources.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3103