### PR TITLE
Fix for issue #2473

### DIFF
--- a/changelog/v1.4.0-beta17/fix-ingress-status.yaml
+++ b/changelog/v1.4.0-beta17/fix-ingress-status.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/2473
+  description: > 
+    Ingress: fixed updating status.loadBalancer field

--- a/install/helm/gloo/templates/21-namespace-clusterrole-ingress.yaml
+++ b/install/helm/gloo/templates/21-namespace-clusterrole-ingress.yaml
@@ -22,7 +22,7 @@ rules:
   resources: ["settings", "upstreams","upstreamgroups", "proxies","virtualservices", "routetables", "authconfigs"]
   verbs: ["*"]
 - apiGroups: ["extensions", ""]
-  resources: ["ingresses"]
+  resources: ["ingresses", "ingresses/status"]
   verbs: ["*"]
 {{- end -}}
 


### PR DESCRIPTION
# Description

In ingress mode, Gloo attempts to update Ingress resources with
`status.loadBalancer` field. However, this update is silently ignored,
per [spec-and-status]. Fixing this temporary by making a call to
`UpdateStatus` after `Update`. A proper fix potentially should include
extending ingress client with a new method `WriteStatus`. Ingress
ClusterRole has been updated to support ops for `ingresses/status`
endpoint.

Also updating a test for `status_syncer.go`: the old test worked only in
Kubernetes clusters that do not update Service status with
LoadBalancerStatus. A fixed test verified with EKS and bare-metal
cluster to make sure both modes are supported.

# Context

Updating Ingress resource with `status.loadBalancer` is required for
`external-dns`. Specifically, for AWS EKS with no ELB listed in the
status, `external-dns` has nothing to act on.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

[spec-and-status]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2473