### PR TITLE
Use non-root filegroup when mounting volumes

### DIFF
--- a/changelog/v1.4.0-beta17/default-nonroot-volumes.yaml
+++ b/changelog/v1.4.0-beta17/default-nonroot-volumes.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >
+      Default gateway proxy to mount volumes as non-root.
+    issueLink: https://github.com/solo-io/gloo/issues/3084
+    resolvesIssue: false

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -221,6 +221,7 @@
 |gatewayProxies.NAME.podTemplate.runUnprivileged|bool||run envoy as an unprivileged user|
 |gatewayProxies.NAME.podTemplate.floatingUserId|bool||set to true to allow the cluster to dynamically assign a user ID|
 |gatewayProxies.NAME.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
+|gatewayProxies.NAME.podTemplate.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
 |gatewayProxies.NAME.configMap.data.NAME|string|||
 |gatewayProxies.NAME.service.type|string||gateway [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). default is `LoadBalancer`|
 |gatewayProxies.NAME.service.httpPort|int||HTTP port for the gateway service|
@@ -314,6 +315,7 @@
 |gatewayProxies.gatewayProxy.podTemplate.runUnprivileged|bool|true|run envoy as an unprivileged user|
 |gatewayProxies.gatewayProxy.podTemplate.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gatewayProxies.gatewayProxy.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
+|gatewayProxies.gatewayProxy.podTemplate.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
 |gatewayProxies.gatewayProxy.configMap.data.NAME|string|||
 |gatewayProxies.gatewayProxy.service.type|string|LoadBalancer|gateway [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). default is `LoadBalancer`|
 |gatewayProxies.gatewayProxy.service.httpPort|int|80|HTTP port for the gateway service|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -258,6 +258,7 @@ type GatewayProxyPodTemplate struct {
 	RunUnprivileged  bool                  `json:"runUnprivileged" desc:"run envoy as an unprivileged user"`
 	FloatingUserId   bool                  `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
 	RunAsUser        float64               `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
+	FsGroup          float64               `json:"fsGroup" desc:"Explicitly set the group ID for volume ownership. Default is 10101"`
 }
 
 type GatewayProxyService struct {

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -69,9 +69,14 @@ spec:
         readconfig-port: "8082"
 {{- end}}
     spec:
+
+{{- if $spec.podTemplate.runUnprivileged }}
       securityContext:
         fsGroup: {{ printf "%.0f" (float64 $spec.podTemplate.fsGroup) }}
+        {{- if not $spec.podTemplate.floatingUserId }}
         runAsUser: {{ printf "%.0f" (float64 $spec.podTemplate.runAsUser) -}}
+        {{- end}}
+{{- end}}
 {{- if $spec.kind.deployment }}
 {{- if $spec.antiAffinity }}
       affinity:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -70,6 +70,8 @@ spec:
 {{- end}}
     spec:
 {{- if $spec.kind.deployment }}
+      securityContext:
+        fsGroup: {{ printf "%.0f" (float64 $spec.podTemplate.fsGroup) -}}
 {{- if $spec.antiAffinity }}
       affinity:
         podAntiAffinity:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -69,9 +69,10 @@ spec:
         readconfig-port: "8082"
 {{- end}}
     spec:
-{{- if $spec.kind.deployment }}
       securityContext:
-        fsGroup: {{ printf "%.0f" (float64 $spec.podTemplate.fsGroup) -}}
+        fsGroup: {{ printf "%.0f" (float64 $spec.podTemplate.fsGroup) }}
+        runAsUser: {{ printf "%.0f" (float64 $spec.podTemplate.runAsUser) -}}
+{{- if $spec.kind.deployment }}
 {{- if $spec.antiAffinity }}
       affinity:
         podAntiAffinity:

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -92,6 +92,7 @@ gatewayProxies:
       httpPort: 8080
       httpsPort: 8443
       runAsUser: 10101
+      fsGroup: 10101
       runUnprivileged: true
       disableNetBind: true
     service:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -716,6 +716,12 @@ var _ = Describe("Helm Test", func() {
 						truez := true
 						falsez := false
 						defaultUser := int64(10101)
+
+						deploy.Spec.Template.Spec.SecurityContext = &v1.PodSecurityContext{
+							FSGroup:   &defaultUser,
+							RunAsUser: &defaultUser,
+						}
+
 						deploy.Spec.Template.Spec.Containers[0].SecurityContext = &v1.SecurityContext{
 							Capabilities: &v1.Capabilities{
 								Drop: []v1.Capability{"ALL"},
@@ -859,6 +865,7 @@ var _ = Describe("Helm Test", func() {
 						})
 						uid := int64(10102)
 						truez := true
+						gatewayProxyDeployment.Spec.Template.Spec.SecurityContext.RunAsUser = &uid
 						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser = &uid
 						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].SecurityContext.RunAsNonRoot = &truez
 						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)


### PR DESCRIPTION
Defaults mounted volumes to 10101 so that they can be used by unprivileged users.

This was preventing extauth sidecar from accessing a unix domain socket that was mounted and defaulting to root ownership.