### PR TITLE
Stop opening PRs to homebrew-core for non-stable glooctl versions

### DIFF
--- a/changelog/v1.5.0-beta1/brew-unstable-prs.yaml
+++ b/changelog/v1.5.0-beta1/brew-unstable-prs.yaml
@@ -2,3 +2,8 @@ changelog:
   - type: NON_USER_FACING
     description: Stop opening PRs to homebrew-core for non-stable versions, which is disallowed per https://docs.brew.sh/Acceptable-Formulae#stable-versions.
     issueLink: https://github.com/solo-io/gloo/issues/3178
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: go-utils
+    dependencyTag: v0.16.1
+    description: Update go-utils to version 0.16.1, which includes non-user-facing fixes to Go package layouts and our release scripts.

--- a/changelog/v1.5.0-beta1/brew-unstable-prs.yaml
+++ b/changelog/v1.5.0-beta1/brew-unstable-prs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Stop opening PRs to homebrew-core for non-stable versions, which is disallowed per https://docs.brew.sh/Acceptable-Formulae#stable-versions.
+    issueLink: https://github.com/solo-io/gloo/issues/3178

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/sergi/go-diff v1.0.0
 	github.com/solo-io/envoy-operator v0.1.1
 	github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f
-	github.com/solo-io/go-utils v0.14.1
+	github.com/solo-io/go-utils v0.16.1
 	github.com/solo-io/protoc-gen-ext v0.0.7
 	github.com/solo-io/reporting-client v0.1.2
 	github.com/solo-io/solo-kit v0.13.8

--- a/go.sum
+++ b/go.sum
@@ -1013,8 +1013,8 @@ github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f/go.mod h1
 github.com/solo-io/go-utils v0.11.0/go.mod h1:R8lbLuLtMaTOhD+6wGpdxj60r1Vwt63fHe1UxlObHig=
 github.com/solo-io/go-utils v0.11.7/go.mod h1:D5lbi4EyIMq+T5gzjJacu0Ou4Z1brL7g2YYYYgYBJso=
 github.com/solo-io/go-utils v0.13.0/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
-github.com/solo-io/go-utils v0.14.1 h1:V61dGoFiM2XKUMl+PdQAteXAXn2Ra98Dal5qSO9uKxk=
-github.com/solo-io/go-utils v0.14.1/go.mod h1:pA8kwWDNlJueffTcC1BYddTerO8zpUUGl5/7JGeC5iU=
+github.com/solo-io/go-utils v0.16.1 h1:JXZZEjWFmYX0wa6Fu204BxJYGzh1d9rNlOk4ecADGPQ=
+github.com/solo-io/go-utils v0.16.1/go.mod h1:uIPAgEuwiEwpBaFv1uI7j4CUVaFYR5iHmTYuIUlLY2Q=
 github.com/solo-io/protoc-gen-ext v0.0.7 h1:s9uFGtAoSsXL7vukWKPgofkxzHUeje7m6+0C3rYA2fU=
 github.com/solo-io/protoc-gen-ext v0.0.7/go.mod h1:zZIFs9Ch3EU3uQgL2ZwCHlUGAtwiz4Cbw6tBcmaNsEk=
 github.com/solo-io/reporting-client v0.1.2 h1:U585Q5UlB5/UUewtgEAQz94SWuNRBxoHc4tPthhnYko=


### PR DESCRIPTION
Stop opening PRs to homebrew-core for non-stable versions, which is disallowed per https://docs.brew.sh/Acceptable-Formulae#stable-versions.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3178