### PR TITLE
Docs als headers to log

### DIFF
--- a/changelog/v1.5.0-beta1/improve-als-logs.yaml
+++ b/changelog/v1.5.0-beta1/improve-als-logs.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: Improve access logging docs
-    issueLink: https://github.com/solo-io/gloo/issues/3122

--- a/changelog/v1.5.0-beta1/improve-als-logs.yaml
+++ b/changelog/v1.5.0-beta1/improve-als-logs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Improve access logging docs
+    issueLink: https://github.com/solo-io/gloo/issues/3122

--- a/changelog/v1.5.0-beta2/improve-als-logs.yaml
+++ b/changelog/v1.5.0-beta2/improve-als-logs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Improve access logging docs
+    issueLink: https://github.com/solo-io/gloo/issues/3122

--- a/docs/content/guides/security/access_logging/_index.md
+++ b/docs/content/guides/security/access_logging/_index.md
@@ -274,9 +274,13 @@ spec:
             staticClusterName: access_log_cluster
 ```
 
+{{% notice note %}}
+You may want to add additional configuration for the {{% protobuf name="als.options.gloo.solo.io.GrpcService" display="GrpcService"%}} such as additional request headers to log so they can be accessed in the gRPC access logs.
+{{% /notice %}}
+
 This will cause requests to the HTTP port to be logged to standard out in the `gateway-proxy-access-logger` container:
 ```
-$ k logs -n gloo-system deploy/gateway-proxy-access-logger
+$ kubectl logs -n gloo-system deploy/gateway-proxy-access-logger
 ```
 
 ```


### PR DESCRIPTION
Add note to access logging docs that may have tripped up users trying to log headers in gRPC access logs.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3122