### PR TITLE
Issue 3124 - make 'glooctl debug logs -f' actually save to file

### DIFF
--- a/changelog/v1.5.0-beta4/glooctl-debug-logs-text-file-output.yaml
+++ b/changelog/v1.5.0-beta4/glooctl-debug-logs-text-file-output.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Make glooctl debug command respect -f flag for unzipped log output
+    issueLink: https://github.com/solo-io/gloo/issues/3124

--- a/projects/gloo/cli/pkg/cmd/debug/debug_test.go
+++ b/projects/gloo/cli/pkg/cmd/debug/debug_test.go
@@ -50,6 +50,21 @@ var _ = Describe("Debug", func() {
 			err = os.RemoveAll(opts.Top.File)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("should create a text file at location specified in --file when --zip is not enabled", func() {
+			opts := options.Options{}
+			opts.Metadata.Namespace = "gloo-system"
+			opts.Top.File = "/tmp/log.txt"
+			opts.Top.Zip = false
+			err := DebugLogs(&opts, ioutil.Discard)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = os.Stat(opts.Top.File)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = os.RemoveAll(opts.Top.File)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 
 	Context("yaml dumper", func() {

--- a/projects/gloo/cli/pkg/cmd/debug/debug_test.go
+++ b/projects/gloo/cli/pkg/cmd/debug/debug_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strings"
 
 	installcmd "github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
@@ -39,9 +40,14 @@ var _ = Describe("Debug", func() {
 		It("should create a tar file at location specified in --file when --zip is enabled", func() {
 			opts := options.Options{}
 			opts.Metadata.Namespace = "gloo-system"
-			opts.Top.File = "/tmp/log.tgz"
 			opts.Top.Zip = true
-			err := DebugLogs(&opts, ioutil.Discard)
+
+			dir, err := ioutil.TempDir("", "testDir")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(dir)
+			opts.Top.File = filepath.Join(dir, "log.tgz")
+
+			err = DebugLogs(&opts, ioutil.Discard)
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = os.Stat(opts.Top.File)
@@ -54,9 +60,14 @@ var _ = Describe("Debug", func() {
 		It("should create a text file at location specified in --file when --zip is not enabled", func() {
 			opts := options.Options{}
 			opts.Metadata.Namespace = "gloo-system"
-			opts.Top.File = "/tmp/log.txt"
 			opts.Top.Zip = false
-			err := DebugLogs(&opts, ioutil.Discard)
+
+			dir, err := ioutil.TempDir("", "testDir")
+			Expect(err).NotTo(HaveOccurred())
+			defer os.RemoveAll(dir)
+			opts.Top.File = filepath.Join(dir, "log.txt")
+
+			err = DebugLogs(&opts, ioutil.Discard)
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = os.Stat(opts.Top.File)


### PR DESCRIPTION
# Description

This fixes a small bug in the glooctl debug command, in which the logs sub-command only respected the -f flag when --zip was also included. The command's functionality now matches the behavior specified in the docs by outputting logs to a text file when -f <filename> is included without --zip.

# Context

See https://github.com/solo-io/gloo/issues/3124

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3124