### PR TITLE
Docs replacing invalid routes

### DIFF
--- a/changelog/v1.5.0-beta4/replace-invalid-routes-doc.yaml
+++ b/changelog/v1.5.0-beta4/replace-invalid-routes-doc.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add section noting that replacing invalid routes should be enabled for production deploys in docs.
+    issueLink: https://github.com/solo-io/gloo/issues/3097
+    resolvesIssue: false

--- a/docs/content/operations/production_deployment/_index.md
+++ b/docs/content/operations/production_deployment/_index.md
@@ -19,6 +19,11 @@ For example, Gloo's data plane (the `gateway-proxy` pod) has ReadOnly file syste
 * **Disable Kubernetes destinations**
     - Gloo out of the box routes to upstreams. It can also route directly to Kubernetes destinations (bypassing upstreams). Upstreams is the recommended abstraction to which to route in VirtualServices, and you can disable the Kubernetes destinations with the `settings.gloo.disableKubernetesDestinations`. This saves on memory overhead so Gloo pod doesn't cache both upstreams and Kubernetes destinations. 
 
+## Enable replacing invalid routes
+
+* **Configure invalidConfigPolicy**
+    - In some cases, it may be desirable to update a virtual service even if its config becomes partially invalid. This is particularly useful when delegating to Route Tables as it ensures that a single Route Table will not block updates for other Route Tables which share the same Virtual Service. More information on why and how to enable this can be found [here]({{% versioned_link_path fromRoot="/traffic_management/configuration_validation/invalid_route_replacement/" %}})
+
 ## Enable health checks
 
 {{% notice warning %}}


### PR DESCRIPTION
Note replacing invalid routes on production deployment docs page, as this is common in prod deployments.