### PR TITLE
Backport: Ingress: add Envoy host with port rule

### DIFF
--- a/changelog/v1.4.2/add-ingress-envoy-host-port-rule.yaml
+++ b/changelog/v1.4.2/add-ingress-envoy-host-port-rule.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >
+      Add Envoy host with port rule for Ingress
+    issueLink: https://github.com/solo-io/gloo/issues/3244
+    resolvesIssue: false

--- a/projects/ingress/pkg/translator/translate.go
+++ b/projects/ingress/pkg/translator/translate.go
@@ -247,7 +247,7 @@ func virtualHosts(ctx context.Context, ingresses []*v1beta1.Ingress, upstreams g
 		glooutils.SortRoutesByPath(routes)
 		virtualHostsHttp = append(virtualHostsHttp, &gloov1.VirtualHost{
 			Name:    host + "-http",
-			Domains: []string{host},
+			Domains: []string{host, host + ":80"},
 			Routes:  routes,
 		})
 	}
@@ -262,7 +262,7 @@ func virtualHosts(ctx context.Context, ingresses []*v1beta1.Ingress, upstreams g
 		virtualHostsHttps = append(virtualHostsHttps, secureVirtualHost{
 			vh: &gloov1.VirtualHost{
 				Name:    host + "-https",
-				Domains: []string{host},
+				Domains: []string{host, host + ":443"},
 				Routes:  routes,
 			},
 			secret: *secret,

--- a/projects/ingress/pkg/translator/translate_test.go
+++ b/projects/ingress/pkg/translator/translate_test.go
@@ -201,6 +201,7 @@ var _ = Describe("Translate", func() {
 										Name: "wow.com-http",
 										Domains: []string{
 											"wow.com",
+											"wow.com:80",
 										},
 										Routes: []*gloov1.Route{
 											{
@@ -241,6 +242,7 @@ var _ = Describe("Translate", func() {
 										Name: "wow.com-https",
 										Domains: []string{
 											"wow.com",
+											"wow.com:443",
 										},
 										Routes: []*gloov1.Route{
 											{
@@ -298,7 +300,7 @@ var _ = Describe("Translate", func() {
 										Namespace: "example",
 									},
 								},
-								SniDomains: []string{"wow.com"},
+								SniDomains: []string{"wow.com", "wow.com:443"},
 							},
 						},
 					},
@@ -366,6 +368,7 @@ var _ = Describe("Translate", func() {
 				},
 				SniDomains: []string{
 					"api-dev.intellishift.com",
+					"api-dev.intellishift.com:443",
 				},
 			},
 			{
@@ -377,6 +380,7 @@ var _ = Describe("Translate", func() {
 				},
 				SniDomains: []string{
 					"ui-dev.intellishift.com",
+					"ui-dev.intellishift.com:443",
 				},
 			},
 		}))
@@ -405,7 +409,7 @@ var _ = Describe("Translate", func() {
 		vhosts := proxy.Listeners[0].GetHttpListener().GetVirtualHosts()
 		Expect(vhosts).To(HaveLen(1))
 		// expect only ing1 to have been translated
-		Expect(vhosts[0].Domains).To(Equal([]string{host1}))
+		Expect(vhosts[0].Domains).To(Equal([]string{host1, host1 + ":80"}))
 	})
 	It("respects a custom ingress class", func() {
 
@@ -434,7 +438,7 @@ var _ = Describe("Translate", func() {
 		vhosts := proxy.Listeners[0].GetHttpListener().GetVirtualHosts()
 		Expect(vhosts).To(HaveLen(1))
 		// expect only ing1 to have been translated
-		Expect(vhosts[0].Domains).To(Equal([]string{host1}))
+		Expect(vhosts[0].Domains).To(Equal([]string{host1, host1 + ":80"}))
 	})
 	It("supports named ports", func() {
 


### PR DESCRIPTION
# Description

Gloo in ingress mode should add two Envoy rules: first for the Ingress host, second for the Ingress port and port.
This fixes bug #3244

# Context

Gloo in ingress mode adds an Envoy rule that matches a host specified in
Ingress, but does not add a rule that matches a host and a port (80 or
443). This creates an issue for proxying GRPC services, because most of
the standard GRPC clients (grpcurl, Go, Python) use GRPC endpoint for
:authority header, if authority is not explicitly specified.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works