### PR TITLE
Fix enterprise install docs

### DIFF
--- a/changelog/v1.5.0-beta4/fix-enterprise-helm-install-command.yaml
+++ b/changelog/v1.5.0-beta4/fix-enterprise-helm-install-command.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: fix helm install command for enterprise

--- a/docs/content/installation/enterprise/_index.md
+++ b/docs/content/installation/enterprise/_index.md
@@ -61,10 +61,16 @@ helm repo add glooe http://storage.googleapis.com/gloo-ee-helm
 
 Finally, install Gloo using the following command:
 
-```shell
-helm install glooe/gloo-ee --name glooe --namespace gloo-system \
-  --set-string license_key=YOUR_LICENSE_KEY
-```
+{{< tabs >}}
+{{< tab name="Helm 2" codelang="shell">}}
+helm install glooe/gloo-ee --name gloo --namespace gloo-system \
+  --set gloo.crds.create=true --set-string license_key=YOUR_LICENSE_KEY
+{{< /tab >}}
+{{< tab name="Helm 3" codelang="shell">}}
+helm install gloo glooe/gloo-ee --namespace gloo-system \
+  --create-namespace --set-string license_key=YOUR_LICENSE_KEY
+{{< /tab >}}
+{{< /tabs >}}
 
 Once you've installed Gloo, please be sure [to verify your installation](#verify-your-installation).
 
@@ -86,9 +92,20 @@ settings:
 
 and use it to override default values in the Gloo Helm chart:
 
-```shell
-helm install gloo/gloo --name gloo-custom-0-7-6 --namespace my-namespace -f value-overrides.yaml
+```shell script
+helm install gloo glooe/gloo-ee --namespace gloo-system -f vals.yaml --create-namespace
 ```
+
+{{< tabs >}}
+{{< tab name="Helm 2" codelang="shell">}}
+helm install glooe/gloo-ee --name gloo --namespace gloo-system \
+  -f value-overrides.yaml --set gloo.crds.create=true --set-string license_key=YOUR_LICENSE_KEY
+{{< /tab >}}
+{{< tab name="Helm 3" codelang="shell">}}
+helm install gloo glooe/gloo-ee --namespace gloo-system \
+  -f value-overrides.yaml --create-namespace --set-string license_key=YOUR_LICENSE_KEY
+{{< /tab >}}
+{{< /tabs >}}
 
 #### List of Gloo Helm chart values
 

--- a/docs/content/installation/enterprise/_index.md
+++ b/docs/content/installation/enterprise/_index.md
@@ -92,10 +92,6 @@ settings:
 
 and use it to override default values in the Gloo Helm chart:
 
-```shell script
-helm install gloo glooe/gloo-ee --namespace gloo-system -f vals.yaml --create-namespace
-```
-
 {{< tabs >}}
 {{< tab name="Helm 2" codelang="shell">}}
 helm install glooe/gloo-ee --name gloo --namespace gloo-system \


### PR DESCRIPTION
# Description

The enterprise helm install docs haven't been updated since helm 3's release, so it was not immediately clear to users that in this scenario the command was for helm 2 (instead of helm 3, like the rest of our docs).

This PR updates the command to work for helm 2 and 3

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works