### PR TITLE
Log opa version docs

### DIFF
--- a/changelog/v1.5.0-beta4/opa-version-logging-doc.yaml
+++ b/changelog/v1.5.0-beta4/opa-version-logging-doc.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add note about OPA version logging to docs
+    issueLink: https://github.com/solo-io/gloo/issues/3136

--- a/changelog/v1.5.0-beta4/opa-version-logging-doc.yaml
+++ b/changelog/v1.5.0-beta4/opa-version-logging-doc.yaml
@@ -2,3 +2,4 @@ changelog:
   - type: NON_USER_FACING
     description: Add note about OPA version logging to docs
     issueLink: https://github.com/solo-io/gloo/issues/3136
+    resolvesIssue: false

--- a/docs/content/guides/security/auth/extauth/opa/_index.md
+++ b/docs/content/guides/security/auth/extauth/opa/_index.md
@@ -12,6 +12,10 @@ The [Open Policy Agent](https://www.openpolicyagent.org/) (OPA) is an open sourc
 
 Be sure to check the external auth [configuration overview]({{% versioned_link_path fromRoot="/guides/security/auth/extauth/#auth-configuration-overview" %}}) for detailed information about how authentication is configured on Virtual Services.
 
+{{% notice note %}}
+As of **Gloo Enterprise** release 1.5.0-beta1, you can see Gloo's version of OPA in the extauth service logs.
+{{% /notice %}}
+
 ## Table of Contents
 - [Setup](#setup)
 - [OPA policy overview](#opa-policy-overview)


### PR DESCRIPTION
Update docs to note OPA version logging added for https://github.com/solo-io/gloo/issues/3136