### PR TITLE
I3250 helm upgrade docs fix

### DIFF
--- a/changelog/v1.5.0-beta5/glooe-helm-upgrade-docs-correction.yaml
+++ b/changelog/v1.5.0-beta5/glooe-helm-upgrade-docs-correction.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add note to 1.3.0+ docs to delete apiserver-ui service when upgrading to glooE 1.4.0+
+    issueLink: https://github.com/solo-io/gloo/issues/3250

--- a/docs/content/operations/upgrading/1.3.0.md
+++ b/docs/content/operations/upgrading/1.3.0.md
@@ -160,6 +160,12 @@ kubectl delete deployment -n gloo-system glooe-grafana
 kubectl delete service -n gloo-system glooe-grafana
 ```
 
+Additionally, if upgrading from any version of Gloo Enterprise prior to 1.4.0 to Gloo Enterprise 1.4.0 or later, 
+you must delete the apiserver-ui service to avoid more breaking changes:
+```
+kubectl delete service -n gloo-system apiserver-ui
+```
+
 Upgrade to Gloo Enterprise 1.3.0 (helm 2 or helm 3):
 
 {{% notice note %}}


### PR DESCRIPTION
# Description

The apiserver-ui service's type was changed in the 1.4.0 upgrade. This change can't be automatically managed by helm, and causes attempts to upgrade GlooE via helm to fail. The easy solution is to delete the apiserver-ui service just before upgrading GlooE. This is safe because the apiserver-ui service just manages the GlooE dashboard, which can be briefly down with no major consequences.

# Context

https://github.com/solo-io/gloo/issues/3250

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [X] I have performed a self-review of my own code
- [X] I have made corresponding changes to the documentation
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3250