### PR TITLE
Prepend TlsInspector Listener filter when no ServerName matches are present in Tcp Proxy

### DIFF
--- a/changelog/v1.5.0-beta5/no-tls-inspector.yaml
+++ b/changelog/v1.5.0-beta5/no-tls-inspector.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/3288
+  description: >
+    Prepend the TlsInspector filter when no SNI domains are available to match on, as without the ServerName match
+    envoy does not automatically prepend it

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk.md
@@ -169,7 +169,7 @@ Note: the destination spec and subsets are not supported in this context and wil
 | `single` | [.gloo.solo.io.Destination](../proxy.proto.sk/#destination) | Use SingleDestination to route to a single upstream. Only one of `single`, `multi`, or `forwardSniClusterName` can be set. |  |
 | `multi` | [.gloo.solo.io.MultiDestination](../proxy.proto.sk/#multidestination) | Use MultiDestination to load balance requests between multiple upstreams (by weight). Only one of `multi`, `single`, or `forwardSniClusterName` can be set. |  |
 | `upstreamGroup` | [.core.solo.io.ResourceRef](../../../../../../solo-kit/api/v1/ref.proto.sk/#resourceref) | Use a reference to an upstream group for routing. Only one of `upstreamGroup`, `single`, or `forwardSniClusterName` can be set. |  |
-| `forwardSniClusterName` | [.google.protobuf.Empty](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/empty) | Forwards the SNI name into the destination cluster https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/sni_cluster/empty/sni_cluster. Only one of `forwardSniClusterName`, `single`, or `upstreamGroup` can be set. |  |
+| `forwardSniClusterName` | [.google.protobuf.Empty](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/empty) | Forwards the SNI name into the destination cluster https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/sni_cluster/empty/sni_cluster Note: This filter will only work properly with TLS connections in which the upstream SNI domain is specified. Only one of `forwardSniClusterName`, `single`, or `upstreamGroup` can be set. |  |
 
 
 

--- a/projects/gloo/api/v1/proxy.proto
+++ b/projects/gloo/api/v1/proxy.proto
@@ -134,6 +134,7 @@ message TcpHost {
 
             // Forwards the SNI name into the destination cluster
             // https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/network/sni_cluster/empty/sni_cluster
+            // Note: This filter will only work properly with TLS connections in which the upstream SNI domain is specified
             google.protobuf.Empty forward_sni_cluster_name = 4;
         };
     }

--- a/projects/gloo/pkg/plugins/registry/registry.go
+++ b/projects/gloo/pkg/plugins/registry/registry.go
@@ -36,6 +36,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/upstreamssl"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/virtualhost"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/wasm"
+	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 )
 
 type registry struct {
@@ -57,7 +58,7 @@ var globalRegistry = func(opts bootstrap.Opts, pluginExtensions ...func() plugin
 		hcmPlugin,
 		als.NewPlugin(),
 		pipe.NewPlugin(),
-		tcp.NewPlugin(),
+		tcp.NewPlugin(utils.NewSslConfigTranslator()),
 		static.NewPlugin(),
 		transformationPlugin,
 		grpcweb.NewPlugin(),

--- a/projects/gloo/pkg/plugins/tcp/plugin.go
+++ b/projects/gloo/pkg/plugins/tcp/plugin.go
@@ -42,8 +42,6 @@ var (
 	InvalidSecretsError = func(err error, name string) error {
 		return eris.Wrapf(err, "invalid secrets for listener %v", name)
 	}
-
-	NoSslConfigFoundError = eris.New("SslConfig required when using forward_sni_cluster_name")
 )
 
 type Plugin struct {
@@ -170,11 +168,6 @@ func (p *Plugin) tcpProxyFilters(
 			WeightedClusters: wc,
 		}
 	case *v1.TcpHost_TcpAction_ForwardSniClusterName:
-		// The ForwardSniClusterName filter receives the cluster name to route to via the Server Name which can only
-		// be retrieved from TLS connections. Therefore, if there is no SslConfig, this type of host is invalid.
-		if host.GetSslConfig() == nil {
-			return nil, NoSslConfigFoundError
-		}
 		// Pass an empty cluster as it will be overwritten by SNI Cluster
 		cfg.ClusterSpecifier = &envoytcp.TcpProxy_Cluster{
 			Cluster: "",

--- a/projects/gloo/pkg/plugins/tcp/plugin_test.go
+++ b/projects/gloo/pkg/plugins/tcp/plugin_test.go
@@ -233,21 +233,6 @@ var _ = Describe("Plugin", func() {
 			Expect(clusters.Clusters[1].Weight).To(Equal(uint32(1)))
 		})
 
-		It("will error when forward sni is specified with no SslConfig", func() {
-			tcpListener.TcpHosts = append(tcpListener.TcpHosts, &v1.TcpHost{
-				Name: "one",
-				Destination: &v1.TcpHost_TcpAction{
-					Destination: &v1.TcpHost_TcpAction_ForwardSniClusterName{
-						ForwardSniClusterName: &types.Empty{},
-					},
-				},
-			})
-			p := NewPlugin(sslTranslator)
-			_, err := p.ProcessListenerFilterChain(plugins.Params{Snapshot: snap}, in)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring(NoSslConfigFoundError.Error()))
-		})
-
 		It("can add the forward sni cluster name filter", func() {
 			sslConfig := &v1.SslConfig{
 				SslSecrets: &v1.SslConfig_SecretRef{

--- a/projects/gloo/pkg/plugins/tcp/plugin_test.go
+++ b/projects/gloo/pkg/plugins/tcp/plugin_test.go
@@ -4,23 +4,21 @@ import (
 	"time"
 
 	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
-	envoy_api_v2_auth "github.com/envoyproxy/go-control-plane/envoy/api/v2/auth"
+	envoytcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
+	envoyauth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/pkg/utils/gogoutils"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/tcp"
-	mock_utils "github.com/solo-io/gloo/projects/gloo/pkg/utils/mocks"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	. "github.com/solo-io/gloo/projects/gloo/pkg/plugins/tcp"
 	translatorutil "github.com/solo-io/gloo/projects/gloo/pkg/translator"
-
-	envoytcp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/tcp_proxy/v3"
-	"github.com/gogo/protobuf/types"
-	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
-	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	mock_utils "github.com/solo-io/gloo/projects/gloo/pkg/utils/mocks"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 var _ = Describe("Plugin", func() {
@@ -272,7 +270,7 @@ var _ = Describe("Plugin", func() {
 
 			sslTranslator.EXPECT().
 				ResolveDownstreamSslConfig(snap.Secrets, sslConfig).
-				Return(&envoy_api_v2_auth.DownstreamTlsContext{}, nil)
+				Return(&envoyauth.DownstreamTlsContext{}, nil)
 
 			p := NewPlugin(sslTranslator)
 			filterChains, err := p.ProcessListenerFilterChain(plugins.Params{Snapshot: snap}, in)

--- a/projects/gloo/pkg/plugins/tcp/tcp_suite_test.go
+++ b/projects/gloo/pkg/plugins/tcp/tcp_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestHcm(t *testing.T) {
+func TestTcp(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "tcp Suite")
 }

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -863,8 +863,10 @@ var _ = Describe("Kube2e: gateway", func() {
 				tcpGateway := defaultGateway.GetTcpGateway()
 				Expect(tcpGateway).NotTo(BeNil())
 				tcpGateway.TcpHosts = []*gloov1.TcpHost{host}
-				_, err := gatewayClient.Write(defaultGateway, clients.WriteOpts{})
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					_, err := gatewayClient.Write(defaultGateway, clients.WriteOpts{})
+					return err
+				}, "5s", "0.5s").ShouldNot(HaveOccurred())
 			}
 		)
 


### PR DESCRIPTION
# Description

This PR fixes the bug which was causing the forward sni cluster name tcp proxy feature to not work properly.
When a ServerName match is present, envoy automatically adds the TlsInspector filter, which is how the SniCluster gets the cluster name to route too. However, with no Server Name match, this filter doesn't get appended and causes the routing to fail.

# Context

I ran into this bug while creating a TCP proxy with the forward sni cluster name host type, and an Ssl Config with no SniDomains.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3288