### PR TITLE
Improve checks on delegated routes

### DIFF
--- a/changelog/v1.5.0-beta5/route-table-errors.yaml
+++ b/changelog/v1.5.0-beta5/route-table-errors.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  description: >
+    Report delegation cycle errors on the offending `RouteTable`, not only on `VirtualServices` that use the table.
+  issueLink: https://github.com/solo-io/gloo/issues/3144
+  resolvesIssue: false

--- a/changelog/v1.5.0-beta5/route-table-errors.yaml
+++ b/changelog/v1.5.0-beta5/route-table-errors.yaml
@@ -1,6 +1,12 @@
 changelog:
 - type: FIX
   description: >
+    Properly validate `RouteTable` routes without matchers. Like with regular `VirtualService` routes, these routes will
+    be assigned the default `/` prefix matcher. Consequently, the route is valid only if the parent route also has a
+    `\` prefix matcher (either explicitly defined, or by default).
+  issueLink: https://github.com/solo-io/gloo/issues/3291
+- type: FIX
+  description: >
     Report delegation cycle errors on the offending `RouteTable`, not only on `VirtualServices` that use the table.
   issueLink: https://github.com/solo-io/gloo/issues/3144
   resolvesIssue: false

--- a/projects/gateway/pkg/translator/converter.go
+++ b/projects/gateway/pkg/translator/converter.go
@@ -83,8 +83,6 @@ func (v *visitableRouteTable) InputResource() resources.InputResource {
 
 // Implements Converter interface by recursively visiting a routing resource
 type routeVisitor struct {
-	// Used to store errors and warnings for the visited virtual services and route tables.
-	//reports reporter.ResourceReports
 	// Used to select route tables for delegated routes.
 	routeTableSelector RouteTableSelector
 	// Used to sort route tables when multiple ones are matched by a selector.

--- a/projects/gateway/pkg/translator/converter.go
+++ b/projects/gateway/pkg/translator/converter.go
@@ -173,6 +173,9 @@ func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInf
 
 					// Check for delegation cycles
 					if err := checkForCycles(routeTable, visitedRouteTables); err != nil {
+						// Report the error on the route table. `resource` will never be a VS if we got here,
+						// as `visitedRouteTables` will be empty on the first on the first call of this function.
+						rv.reports.AddError(resource.InputResource(), err)
 						return nil, err
 					}
 

--- a/projects/gateway/pkg/translator/converter.go
+++ b/projects/gateway/pkg/translator/converter.go
@@ -110,7 +110,7 @@ type reporterHelper struct {
 func (r *reporterHelper) addError(resource resources.InputResource, err error) {
 	r.reports.AddError(resource, err)
 
-	// If the resource is a Route Table, also add the warning to the top level virtual service.
+	// If the resource is a Route Table, also add the error to the top level virtual service.
 	if rt, ok := resource.(*gatewayv1.RouteTable); ok {
 		r.reports.AddError(r.topLevelVirtualService, TopLevelVirtualResourceErr(rt.GetMetadata(), err))
 	}
@@ -119,7 +119,7 @@ func (r *reporterHelper) addError(resource resources.InputResource, err error) {
 func (r *reporterHelper) addWarning(resource resources.InputResource, err error) {
 	r.reports.AddWarning(resource, err.Error())
 
-	// If the resource is a Route Table, also add the error to the top level virtual service.
+	// If the resource is a Route Table, also add the warning to the top level virtual service.
 	if rt, ok := resource.(*gatewayv1.RouteTable); ok {
 		r.reports.AddWarning(r.topLevelVirtualService, TopLevelVirtualResourceErr(rt.GetMetadata(), err).Error())
 	}

--- a/projects/gateway/pkg/translator/converter.go
+++ b/projects/gateway/pkg/translator/converter.go
@@ -38,18 +38,18 @@ var (
 		return errors.Wrapf(InvalidPrefixErr, "required prefix: %v, path: %v", delegatePrefix, pathString)
 	}
 	TopLevelVirtualResourceErr = func(rtRef core.Metadata, err error) error {
-		return errors.Wrapf(err, "on sub route table %v.%v", rtRef.Name, rtRef.Namespace)
+		return errors.Wrapf(err, "on sub route table %s", rtRef.Ref().Key())
 	}
 )
 
 type RouteConverter interface {
 	// Converts a VirtualService to a set of Gloo API routes (i.e. routes on a Proxy resource).
-	ConvertVirtualService(virtualService *gatewayv1.VirtualService) ([]*gloov1.Route, error)
+	// A non-nil error indicates an unexpected internal failure, all configuration errors are added to the given report object.
+	ConvertVirtualService(virtualService *gatewayv1.VirtualService, reports reporter.ResourceReports) ([]*gloov1.Route, error)
 }
 
-func NewRouteConverter(selector RouteTableSelector, indexer RouteTableIndexer, reports reporter.ResourceReports) RouteConverter {
+func NewRouteConverter(selector RouteTableSelector, indexer RouteTableIndexer) RouteConverter {
 	return &routeVisitor{
-		reports:            reports,
 		routeTableSelector: selector,
 		routeTableIndexer:  indexer,
 	}
@@ -84,7 +84,7 @@ func (v *visitableRouteTable) InputResource() resources.InputResource {
 // Implements Converter interface by recursively visiting a routing resource
 type routeVisitor struct {
 	// Used to store errors and warnings for the visited virtual services and route tables.
-	reports reporter.ResourceReports
+	//reports reporter.ResourceReports
 	// Used to select route tables for delegated routes.
 	routeTableSelector RouteTableSelector
 	// Used to sort route tables when multiple ones are matched by a selector.
@@ -103,15 +103,51 @@ type routeInfo struct {
 	hasName bool
 }
 
-func (rv *routeVisitor) ConvertVirtualService(virtualService *gatewayv1.VirtualService) ([]*gloov1.Route, error) {
+// Helper object for reporting errors and warnings
+type reporterHelper struct {
+	reports                reporter.ResourceReports
+	topLevelVirtualService *gatewayv1.VirtualService
+}
+
+func (r *reporterHelper) addError(resource resources.InputResource, err error) {
+	r.reports.AddError(resource, err)
+
+	// If the resource is a Route Table, also add the warning to the top level virtual service.
+	if rt, ok := resource.(*gatewayv1.RouteTable); ok {
+		r.reports.AddError(r.topLevelVirtualService, TopLevelVirtualResourceErr(rt.GetMetadata(), err))
+	}
+}
+
+func (r *reporterHelper) addWarning(resource resources.InputResource, err error) {
+	r.reports.AddWarning(resource, err.Error())
+
+	// If the resource is a Route Table, also add the error to the top level virtual service.
+	if rt, ok := resource.(*gatewayv1.RouteTable); ok {
+		r.reports.AddWarning(r.topLevelVirtualService, TopLevelVirtualResourceErr(rt.GetMetadata(), err).Error())
+	}
+}
+
+func (rv *routeVisitor) ConvertVirtualService(virtualService *gatewayv1.VirtualService, reports reporter.ResourceReports) ([]*gloov1.Route, error) {
 	wrapper := &visitableVirtualService{VirtualService: virtualService}
-	return rv.visit(wrapper, nil, nil, virtualService)
+	return rv.visit(
+		wrapper,
+		nil,
+		nil,
+		&reporterHelper{
+			reports:                reports,
+			topLevelVirtualService: virtualService,
+		},
+	)
 }
 
 // Performs a depth-first, in-order traversal of a route tree rooted at the given resource.
 // The additional arguments are used to store the state of the traversal of the current branch of the route tree.
-func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInfo, visitedRouteTables gatewayv1.RouteTableList,
-	topLevelVirtualService *gatewayv1.VirtualService) ([]*gloov1.Route, error) {
+func (rv *routeVisitor) visit(
+	resource resourceWithRoutes,
+	parentRoute *routeInfo,
+	visitedRouteTables gatewayv1.RouteTableList,
+	reporterHelper *reporterHelper,
+) ([]*gloov1.Route, error) {
 	var routes []*gloov1.Route
 
 	for _, gatewayRoute := range resource.GetRoutes() {
@@ -128,9 +164,7 @@ func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInf
 			var err error
 			routeClone, err = validateAndMergeParentRoute(routeClone, parentRoute)
 			if err != nil {
-				rv.reports.AddError(resource.InputResource(), err)
-				rv.reports.AddError(topLevelVirtualService,
-					TopLevelVirtualResourceErr(resource.InputResource().GetMetadata(), err))
+				reporterHelper.addError(resource.InputResource(), err)
 				continue
 			}
 		}
@@ -141,17 +175,14 @@ func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInf
 			// Validate the matcher of the delegate route
 			prefix, err := getDelegateRoutePrefix(routeClone)
 			if err != nil {
-				return nil, err
+				reporterHelper.addError(resource.InputResource(), err)
+				continue
 			}
 
 			// Determine the route tables to delegate to
 			routeTables, err := rv.routeTableSelector.SelectRouteTables(action.DelegateAction, resource.InputResource().GetMetadata().Namespace)
 			if err != nil {
-				rv.reports.AddWarning(resource.InputResource(), err.Error())
-				if parentRoute != nil { // surface error
-					rv.reports.AddWarning(topLevelVirtualService,
-						TopLevelVirtualResourceErr(resource.InputResource().GetMetadata(), err).Error())
-				}
+				reporterHelper.addWarning(resource.InputResource(), err)
 				continue
 			}
 
@@ -173,10 +204,10 @@ func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInf
 
 					// Check for delegation cycles
 					if err := checkForCycles(routeTable, visitedRouteTables); err != nil {
-						// Report the error on the route table. `resource` will never be a VS if we got here,
-						// as `visitedRouteTables` will be empty on the first on the first call of this function.
-						rv.reports.AddError(resource.InputResource(), err)
-						return nil, err
+						// Note that we do not report the error on the table we are currently visiting, but on the
+						// one we are about to visit, since that is the one that started the cycle.
+						reporterHelper.addError(routeTable, err)
+						continue
 					}
 
 					// Collect information about this route that are relevant when visiting the delegated route table
@@ -192,7 +223,12 @@ func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInf
 					visitedRtCopy := append(append([]*gatewayv1.RouteTable{}, visitedRouteTables...), routeTable)
 
 					// Recursive call
-					subRoutes, err := rv.visit(&visitableRouteTable{routeTable}, currentRouteInfo, visitedRtCopy, topLevelVirtualService)
+					subRoutes, err := rv.visit(
+						&visitableRouteTable{routeTable},
+						currentRouteInfo,
+						visitedRtCopy,
+						reporterHelper,
+					)
 					if err != nil {
 						return nil, err
 					}
@@ -232,7 +268,8 @@ func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInf
 			}
 			glooRoute, err := convertSimpleAction(routeClone)
 			if err != nil {
-				return nil, err
+				reporterHelper.addError(resource.InputResource(), err)
+				continue
 			}
 			routes = append(routes, glooRoute)
 		}

--- a/projects/gateway/pkg/translator/converter.go
+++ b/projects/gateway/pkg/translator/converter.go
@@ -184,8 +184,8 @@ func (rv *routeVisitor) visit(resource resourceWithRoutes, parentRoute *routeInf
 						hasName: routeHasName,
 					}
 
-					// Make a copy of the existing set of visited route tables and pass that into the recursive call.
-					// We do NOT want it to be modified.
+					// Make a copy of the existing set of visited route tables. We need to pass this information into
+					// the recursive call and we do NOT want the original slice to be modified.
 					visitedRtCopy := append(append([]*gatewayv1.RouteTable{}, visitedRouteTables...), routeTable)
 
 					// Recursive call

--- a/projects/gateway/pkg/translator/converter_test.go
+++ b/projects/gateway/pkg/translator/converter_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Route converter", func() {
 			Expect(reports).To(HaveLen(1))
 			_, vsReport := reports.Find("*v1.VirtualService", vs.Metadata.Ref())
 			Expect(vsReport.Errors).To(HaveOccurred())
-			Expect(vsReport.Errors.Error()).To(ContainSubstring(expectedErr.Error()))
+			Expect(vsReport.Errors).To(MatchError(ContainSubstring(expectedErr.Error())))
 		},
 
 		Entry("route has a regex matcher",
@@ -485,10 +485,10 @@ var _ = Describe("Route converter", func() {
 				expectedErr := translator.InvalidRouteTableForDelegateErr("/foo", "/invalid").Error()
 
 				_, vsReport := rpt.Find("*v1.VirtualService", vs.Metadata.Ref())
-				Expect(vsReport.Errors.Error()).To(ContainSubstring(expectedErr))
+				Expect(vsReport.Errors).To(MatchError(ContainSubstring(expectedErr)))
 
 				_, rtReport := rpt.Find("*v1.RouteTable", rt.Metadata.Ref())
-				Expect(rtReport.Errors.Error()).To(ContainSubstring(expectedErr))
+				Expect(rtReport.Errors).To(MatchError(ContainSubstring(expectedErr)))
 			})
 		})
 
@@ -503,10 +503,10 @@ var _ = Describe("Route converter", func() {
 				expectedErr := translator.InvalidRouteTableForDelegateErr("/foo", "/").Error()
 
 				_, vsReport := rpt.Find("*v1.VirtualService", vs.Metadata.Ref())
-				Expect(vsReport.Errors.Error()).To(ContainSubstring(expectedErr))
+				Expect(vsReport.Errors).To(MatchError(ContainSubstring(expectedErr)))
 
 				_, rtReport := rpt.Find("*v1.RouteTable", rt.Metadata.Ref())
-				Expect(rtReport.Errors.Error()).To(ContainSubstring(expectedErr))
+				Expect(rtReport.Errors).To(MatchError(ContainSubstring(expectedErr)))
 			})
 		})
 
@@ -764,10 +764,10 @@ var _ = Describe("Route converter", func() {
 						Expect(reports).To(HaveLen(2))
 						_, rtReport := reports.Find("*v1.RouteTable", offendingTable.Ref())
 						Expect(rtReport.Errors).To(HaveOccurred())
-						Expect(rtReport.Errors.Error()).To(ContainSubstring(expectedErrStr))
+						Expect(rtReport.Errors).To(MatchError(ContainSubstring(expectedErrStr)))
 						_, vsReport := reports.Find("*v1.VirtualService", vs.Metadata.Ref())
 						Expect(vsReport.Errors).To(HaveOccurred())
-						Expect(vsReport.Errors.Error()).To(ContainSubstring(expectedErrStr))
+						Expect(vsReport.Errors).To(MatchError(ContainSubstring(expectedErrStr)))
 					},
 
 					Entry("a route table selects itself",
@@ -824,10 +824,10 @@ var _ = Describe("Route converter", func() {
 						// Verify that error is reported on Route Table and VS
 						_, rtReport := reports.Find("*v1.RouteTable", offendingTable.Ref())
 						Expect(rtReport.Errors).To(HaveOccurred())
-						Expect(rtReport.Errors.Error()).To(ContainSubstring(expectedErrStr))
+						Expect(rtReport.Errors).To(MatchError(ContainSubstring(expectedErrStr)))
 						_, vsReport := reports.Find("*v1.VirtualService", vs.Metadata.Ref())
 						Expect(vsReport.Errors).To(HaveOccurred())
-						Expect(vsReport.Errors.Error()).To(ContainSubstring(expectedErrStr))
+						Expect(vsReport.Errors).To(MatchError(ContainSubstring(expectedErrStr)))
 					},
 
 					Entry("using the new ref format",

--- a/projects/gateway/pkg/translator/http.go
+++ b/projects/gateway/pkg/translator/http.go
@@ -222,9 +222,10 @@ func desiredListenerForHttp(gateway *v1.Gateway, virtualServicesForGateway v1.Vi
 }
 
 func virtualServiceToVirtualHost(vs *v1.VirtualService, tables v1.RouteTableList, reports reporter.ResourceReports) (*gloov1.VirtualHost, error) {
-	converter := NewRouteConverter(NewRouteTableSelector(tables), NewRouteTableIndexer(), reports)
-	routes, err := converter.ConvertVirtualService(vs)
+	converter := NewRouteConverter(NewRouteTableSelector(tables), NewRouteTableIndexer())
+	routes, err := converter.ConvertVirtualService(vs, reports)
 	if err != nil {
+		// internal error, should never happen
 		return nil, err
 	}
 

--- a/projects/gateway/pkg/translator/route_table_selector_test.go
+++ b/projects/gateway/pkg/translator/route_table_selector_test.go
@@ -77,7 +77,7 @@ var _ = Describe("RouteTableSelector", func() {
 			rt2 = buildRouteTableWithSimpleAction("rt-2", "ns-1", "/foo/2", map[string]string{"foo": "bar", "team": "dev"})
 			rt3 = buildRouteTableWithSimpleAction("rt-3", "ns-2", "/foo/3", map[string]string{"foo": "bar"})
 			rt4 = buildRouteTableWithSimpleAction("rt-4", "ns-3", "/foo/4", map[string]string{"foo": "baz"})
-			rt5 = buildRouteTableWithDelegateAction("rt-5", "ns-4", "/foo", nil,
+			rt5 = buildRouteTableWithSelector("rt-5", "ns-4", "/foo", nil,
 				&v1.RouteTableSelector{
 					Labels:     map[string]string{"team": "dev"},
 					Namespaces: []string{"ns-1", "ns-5"},


### PR DESCRIPTION
# Description

Properly validate `RouteTable` routes without matchers. Like with regular `VirtualService` routes, these routes will be assigned the default `/` prefix matcher. Consequently, the route is valid only if the parent route also has a `\` prefix matcher (either explicitly defined, or by default).

This also adds a change so that delegation cycle errors are reported on the offending `RouteTable`, not only on `VirtualServices` that use the table.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3291