### PR TITLE
Fix gateway-level extauth to allow it to be overriden by virtualhost, route, and weighted destination config

### DIFF
--- a/changelog/v1.5.0-beta6/fix-gateway-extauth-overrides.yaml
+++ b/changelog/v1.5.0-beta6/fix-gateway-extauth-overrides.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >-
+      Fix issue where gateway-level extauth could not be overriden by lower-level virtualhost, route, and weighted
+      destination extauth config.
+    issueLink: https://github.com/solo-io/gloo/issues/3270

--- a/projects/gloo/pkg/plugins/extauth/filter.go
+++ b/projects/gloo/pkg/plugins/extauth/filter.go
@@ -30,10 +30,14 @@ var (
 	}
 )
 
-func BuildHttpFilters(settings *extauthv1.Settings, upstreams v1.UpstreamList) ([]plugins.StagedHttpFilter, error) {
+func BuildHttpFilters(globalSettings *extauthv1.Settings, listener *v1.HttpListener, upstreams v1.UpstreamList) ([]plugins.StagedHttpFilter, error) {
 	var filters []plugins.StagedHttpFilter
 
 	// If no extauth settings are provided, don't configure the ext_authz filter
+	settings := listener.GetOptions().GetExtauth()
+	if settings == nil {
+		settings = globalSettings
+	}
 	if settings == nil {
 		return filters, nil
 	}

--- a/projects/gloo/pkg/plugins/extauth/filter_test.go
+++ b/projects/gloo/pkg/plugins/extauth/filter_test.go
@@ -25,9 +25,9 @@ import (
 
 var _ = Describe("Extauth Http filter builder function", func() {
 
-	When("no extauth settings are provided", func() {
+	When("no global extauth settings are provided", func() {
 		It("does not return any filter", func() {
-			filters, err := BuildHttpFilters(nil, nil)
+			filters, err := BuildHttpFilters(nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(filters).To(HaveLen(0))
 		})
@@ -35,7 +35,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 
 	When("settings do not contain ext auth server ref", func() {
 		It("returns an error", func() {
-			_, err := BuildHttpFilters(&extauthv1.Settings{}, nil)
+			_, err := BuildHttpFilters(&extauthv1.Settings{}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(NoServerRefErr))
 		})
@@ -47,7 +47,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 				Name:      "non",
 				Namespace: "existent",
 			}
-			_, err := BuildHttpFilters(&extauthv1.Settings{ExtauthzServerRef: invalidUs}, nil)
+			_, err := BuildHttpFilters(&extauthv1.Settings{ExtauthzServerRef: invalidUs}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(HaveInErrorChain(ServerNotFound(invalidUs)))
 		})
@@ -174,7 +174,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("uses the expected defaults", func() {
-				filters, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				filters, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(filters).To(HaveLen(1))
 
@@ -226,7 +226,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("generates the expected configuration", func() {
-				filters, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				filters, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(filters).To(HaveLen(1))
 
@@ -248,7 +248,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				_, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(HaveInErrorChain(InvalidStatusOnErrorErr(999)))
 			})
@@ -314,7 +314,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("uses the expected defaults", func() {
-				filters, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				filters, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(filters).To(HaveLen(1))
 

--- a/projects/gloo/pkg/plugins/extauth/plugin.go
+++ b/projects/gloo/pkg/plugins/extauth/plugin.go
@@ -36,11 +36,7 @@ func (p *Plugin) Init(params plugins.InitParams) error {
 
 func (p *Plugin) HttpFilters(params plugins.Params, listener *v1.HttpListener) ([]plugins.StagedHttpFilter, error) {
 	// Delegate to a function with a simpler signature, will make it easier to reuse
-	settings := listener.GetOptions().GetExtauth()
-	if settings == nil {
-		settings = p.extAuthSettings
-	}
-	return BuildHttpFilters(settings, params.Snapshot.Upstreams)
+	return BuildHttpFilters(listener.GetOptions().GetExtauth(), listener, params.Snapshot.Upstreams)
 }
 
 // This function generates the ext_authz TypedPerFilterConfig for this virtual host. If the ext_authz filter was not
@@ -51,7 +47,7 @@ func (p *Plugin) HttpFilters(params plugins.Params, listener *v1.HttpListener) (
 func (p *Plugin) ProcessVirtualHost(params plugins.VirtualHostParams, in *v1.VirtualHost, out *envoyroute.VirtualHost) error {
 
 	// Ext_authz filter is not configured on listener, do nothing
-	if !p.isExtAuthzFilterConfigured(params.Snapshot.Upstreams) {
+	if !p.isExtAuthzFilterConfigured(params.Listener.GetHttpListener(), params.Snapshot.Upstreams) {
 		return nil
 	}
 
@@ -84,8 +80,8 @@ func (p *Plugin) ProcessVirtualHost(params plugins.VirtualHostParams, in *v1.Vir
 // - else, do nothing (will inherit config from parent virtual host).
 func (p *Plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *envoyroute.Route) error {
 
-	// Ext_authz is not configured, do nothing
-	if !p.isExtAuthzFilterConfigured(params.Snapshot.Upstreams) {
+	// Ext_authz filter is not configured on listener, do nothing
+	if !p.isExtAuthzFilterConfigured(params.Listener.GetHttpListener(), params.Snapshot.Upstreams) {
 		return nil
 	}
 
@@ -118,8 +114,8 @@ func (p *Plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *env
 // - else, do nothing (will inherit config from parent virtual host and/or route).
 func (p *Plugin) ProcessWeightedDestination(params plugins.RouteParams, in *v1.WeightedDestination, out *envoyroute.WeightedCluster_ClusterWeight) error {
 
-	// Ext_authz is not configured, do nothing
-	if !p.isExtAuthzFilterConfigured(params.Snapshot.Upstreams) {
+	// Ext_authz filter is not configured on listener, do nothing
+	if !p.isExtAuthzFilterConfigured(params.Listener.GetHttpListener(), params.Snapshot.Upstreams) {
 		return nil
 	}
 
@@ -146,9 +142,10 @@ func (p *Plugin) ProcessWeightedDestination(params plugins.RouteParams, in *v1.W
 	return pluginutils.SetWeightedClusterPerFilterConfig(out, wellknown.HTTPExternalAuthorization, config)
 }
 
-func (p *Plugin) isExtAuthzFilterConfigured(upstreams v1.UpstreamList) bool {
+func (p *Plugin) isExtAuthzFilterConfigured(listener *v1.HttpListener, upstreams v1.UpstreamList) bool {
+
 	// Call the same function called by HttpFilters to verify whether the filter was created
-	filters, err := BuildHttpFilters(p.extAuthSettings, upstreams)
+	filters, err := BuildHttpFilters(p.extAuthSettings, listener, upstreams)
 	if err != nil {
 		// If it returned an error, the filter was not configured
 		return false

--- a/projects/gloo/pkg/plugins/extauth/plugin.go
+++ b/projects/gloo/pkg/plugins/extauth/plugin.go
@@ -36,7 +36,7 @@ func (p *Plugin) Init(params plugins.InitParams) error {
 
 func (p *Plugin) HttpFilters(params plugins.Params, listener *v1.HttpListener) ([]plugins.StagedHttpFilter, error) {
 	// Delegate to a function with a simpler signature, will make it easier to reuse
-	return BuildHttpFilters(listener.GetOptions().GetExtauth(), listener, params.Snapshot.Upstreams)
+	return BuildHttpFilters(p.extAuthSettings, listener, params.Snapshot.Upstreams)
 }
 
 // This function generates the ext_authz TypedPerFilterConfig for this virtual host. If the ext_authz filter was not

--- a/projects/gloo/pkg/plugins/extauth/plugin_test.go
+++ b/projects/gloo/pkg/plugins/extauth/plugin_test.go
@@ -55,47 +55,57 @@ var validationFuncForConfigValue = map[ConfigState]func(e envoyTypedPerFilterCon
 // combinations of resources and input types), should the need ever arise in the future.
 var _ = Describe("Process Custom Extauth configuration", func() {
 
-	DescribeTable("virtual host extauth filter configuration",
-		func(input, expected ConfigState) {
-			pluginContext := getPluginContext(input, Undefined, Undefined)
+	allTests := func(globalSettings bool) {
+		DescribeTable("virtual host extauth filter configuration",
+			func(input, expected ConfigState) {
+				pluginContext := getPluginContext(globalSettings, input, Undefined, Undefined)
 
-			var out envoyv2.VirtualHost
-			err := pluginContext.PluginInstance.ProcessVirtualHost(pluginContext.VirtualHostParams, pluginContext.VirtualHost, &out)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
-		},
-		Entry("undefined -> disable", Undefined, Disabled), // This is a special case for virtual hosts
-		Entry("disabled -> disable", Disabled, Disabled),
-		Entry("enabled -> enable", Enabled, Enabled),
-	)
+				var out envoyv2.VirtualHost
+				err := pluginContext.PluginInstance.ProcessVirtualHost(pluginContext.VirtualHostParams, pluginContext.VirtualHost, &out)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
+			},
+			Entry("undefined -> disable", Undefined, Disabled), // This is a special case for virtual hosts
+			Entry("disabled -> disable", Disabled, Disabled),
+			Entry("enabled -> enable", Enabled, Enabled),
+		)
 
-	DescribeTable("route extauth filter configuration",
-		func(input, expected ConfigState) {
-			pluginContext := getPluginContext(Undefined, input, Undefined)
+		DescribeTable("route extauth filter configuration",
+			func(input, expected ConfigState) {
+				pluginContext := getPluginContext(globalSettings, Undefined, input, Undefined)
 
-			var out envoyv2.Route
-			err := pluginContext.PluginInstance.ProcessRoute(pluginContext.RouteParams, pluginContext.Route, &out)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
-		},
-		Entry("undefined -> don't set", Undefined, Undefined),
-		Entry("disabled -> disable", Disabled, Disabled),
-		Entry("enabled -> enable", Enabled, Enabled),
-	)
+				var out envoyv2.Route
+				err := pluginContext.PluginInstance.ProcessRoute(pluginContext.RouteParams, pluginContext.Route, &out)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
+			},
+			Entry("undefined -> don't set", Undefined, Undefined),
+			Entry("disabled -> disable", Disabled, Disabled),
+			Entry("enabled -> enable", Enabled, Enabled),
+		)
 
-	DescribeTable("weighted destination extauth filter configuration",
-		func(input, expected ConfigState) {
-			pluginContext := getPluginContext(Undefined, Undefined, input)
+		DescribeTable("weighted destination extauth filter configuration",
+			func(input, expected ConfigState) {
+				pluginContext := getPluginContext(globalSettings, Undefined, Undefined, input)
 
-			var out envoyv2.WeightedCluster_ClusterWeight
-			err := pluginContext.PluginInstance.ProcessWeightedDestination(pluginContext.RouteParams, pluginContext.WeightedDestination, &out)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
-		},
-		Entry("undefined -> don't set", Undefined, Undefined),
-		Entry("disabled -> disable", Disabled, Disabled),
-		Entry("enabled -> enable", Enabled, Enabled),
-	)
+				var out envoyv2.WeightedCluster_ClusterWeight
+				err := pluginContext.PluginInstance.ProcessWeightedDestination(pluginContext.RouteParams, pluginContext.WeightedDestination, &out)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(validationFuncForConfigValue[expected](&out)).To(BeTrue())
+			},
+			Entry("undefined -> don't set", Undefined, Undefined),
+			Entry("disabled -> disable", Disabled, Disabled),
+			Entry("enabled -> enable", Enabled, Enabled),
+		)
+	}
+
+	Context("with global extauth settings", func() {
+		allTests(true)
+	})
+
+	Context("with gateway-level extauth settings", func() {
+		allTests(false)
+	})
 })
 
 type pluginContext struct {
@@ -107,7 +117,7 @@ type pluginContext struct {
 	WeightedDestination *gloov1.WeightedDestination
 }
 
-func getPluginContext(authOnVirtualHost, authOnRoute, authOnWeightedDest ConfigState) *pluginContext {
+func getPluginContext(globalSettings bool, authOnVirtualHost, authOnRoute, authOnWeightedDest ConfigState) *pluginContext {
 	ctx := context.TODO()
 
 	extAuthServerUpstream := &gloov1.Upstream{
@@ -214,6 +224,10 @@ func getPluginContext(authOnVirtualHost, authOnRoute, authOnWeightedDest ConfigS
 		virtualHost.Options.Extauth = disableAuth
 	}
 
+	usRef := extAuthServerUpstream.Metadata.Ref()
+	settings := &extauthv1.Settings{
+		ExtauthzServerRef: &usRef,
+	}
 	// ----------------------------------------------------------------------------
 	// Proxy
 	// ----------------------------------------------------------------------------
@@ -226,10 +240,16 @@ func getPluginContext(authOnVirtualHost, authOnRoute, authOnWeightedDest ConfigS
 			Name: "default",
 			ListenerType: &gloov1.Listener_HttpListener{
 				HttpListener: &gloov1.HttpListener{
+					Options:      &gloov1.HttpListenerOptions{},
 					VirtualHosts: []*gloov1.VirtualHost{virtualHost},
 				},
 			},
 		}},
+	}
+
+	if !globalSettings {
+		httpListener := proxy.Listeners[0].GetHttpListener()
+		httpListener.Options.Extauth = settings
 	}
 
 	// ----------------------------------------------------------------------------
@@ -255,13 +275,12 @@ func getPluginContext(authOnVirtualHost, authOnRoute, authOnWeightedDest ConfigS
 
 	plugin := NewCustomAuthPlugin()
 	initParams := plugins.InitParams{Ctx: ctx}
+	initParams.Settings = &gloov1.Settings{}
 
-	usRef := extAuthServerUpstream.Metadata.Ref()
-	settings := &extauthv1.Settings{
-		ExtauthzServerRef: &usRef,
+	if globalSettings {
+		initParams.Settings.Extauth = settings
 	}
 
-	initParams.Settings = &gloov1.Settings{Extauth: settings}
 	err := plugin.Init(initParams)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
# Description

Virtualhost, route, and weighted destination configuration is lower level, and if provided, intended to override higher level configuration.

This behavior works for extauth settings configured in Gloo `Settings`, our global settings store. In Gloo 1.4, we added support for listener-level configuration of the envoy extauth filter (e.g., allowing for multiple extauth servers, one for each listener). In the added listener-level config (exposed on the Gloo `Gateway` object), these lower-level overrides were not working.

# Context

Users ran into this bug trying to disable extauth on a route while inheriting configuration from gateway-level extauth.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3270