### PR TITLE
Backport gw level fixes

### DIFF
--- a/changelog/v1.4.3/fix-gateway-extauth-overrides.yaml
+++ b/changelog/v1.4.3/fix-gateway-extauth-overrides.yaml
@@ -4,3 +4,4 @@ changelog:
       Fix issue where gateway-level extauth could not be overriden by lower-level virtualhost, route, and weighted
       destination extauth config.
     issueLink: https://github.com/solo-io/gloo/issues/3270
+    resolvesIssue: false

--- a/changelog/v1.5.0-beta6/fix-gateway-extauth-overrides.yaml
+++ b/changelog/v1.5.0-beta6/fix-gateway-extauth-overrides.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >-
+      Fix issue where gateway-level extauth could not be overriden by lower-level virtualhost, route, and weighted
+      destination extauth config.
+    issueLink: https://github.com/solo-io/gloo/issues/3270

--- a/projects/gloo/pkg/plugins/extauth/filter.go
+++ b/projects/gloo/pkg/plugins/extauth/filter.go
@@ -28,10 +28,14 @@ var (
 	}
 )
 
-func BuildHttpFilters(settings *extauthv1.Settings, upstreams v1.UpstreamList) ([]plugins.StagedHttpFilter, error) {
+func BuildHttpFilters(globalSettings *extauthv1.Settings, listener *v1.HttpListener, upstreams v1.UpstreamList) ([]plugins.StagedHttpFilter, error) {
 	var filters []plugins.StagedHttpFilter
 
 	// If no extauth settings are provided, don't configure the ext_authz filter
+	settings := listener.GetOptions().GetExtauth()
+	if settings == nil {
+		settings = globalSettings
+	}
 	if settings == nil {
 		return filters, nil
 	}

--- a/projects/gloo/pkg/plugins/extauth/filter_test.go
+++ b/projects/gloo/pkg/plugins/extauth/filter_test.go
@@ -23,9 +23,9 @@ import (
 
 var _ = Describe("Extauth Http filter builder function", func() {
 
-	When("no extauth settings are provided", func() {
+	When("no global extauth settings are provided", func() {
 		It("does not return any filter", func() {
-			filters, err := BuildHttpFilters(nil, nil)
+			filters, err := BuildHttpFilters(nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(filters).To(HaveLen(0))
 		})
@@ -33,7 +33,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 
 	When("settings do not contain ext auth server ref", func() {
 		It("returns an error", func() {
-			_, err := BuildHttpFilters(&extauthv1.Settings{}, nil)
+			_, err := BuildHttpFilters(&extauthv1.Settings{}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(Equal(NoServerRefErr))
 		})
@@ -45,7 +45,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 				Name:      "non",
 				Namespace: "existent",
 			}
-			_, err := BuildHttpFilters(&extauthv1.Settings{ExtauthzServerRef: invalidUs}, nil)
+			_, err := BuildHttpFilters(&extauthv1.Settings{ExtauthzServerRef: invalidUs}, nil, nil)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(HaveInErrorChain(ServerNotFound(invalidUs)))
 		})
@@ -172,7 +172,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("uses the expected defaults", func() {
-				filters, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				filters, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(filters).To(HaveLen(1))
 
@@ -224,7 +224,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("generates the expected configuration", func() {
-				filters, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				filters, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(filters).To(HaveLen(1))
 
@@ -246,7 +246,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("returns an error", func() {
-				_, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				_, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(HaveInErrorChain(InvalidStatusOnErrorErr(999)))
 			})
@@ -312,7 +312,7 @@ var _ = Describe("Extauth Http filter builder function", func() {
 			})
 
 			It("uses the expected defaults", func() {
-				filters, err := BuildHttpFilters(settings, gloov1.UpstreamList{upstream})
+				filters, err := BuildHttpFilters(settings, nil, gloov1.UpstreamList{upstream})
 				Expect(err).NotTo(HaveOccurred())
 				Expect(filters).To(HaveLen(1))
 


### PR DESCRIPTION
backport of https://github.com/solo-io/gloo/pull/3300

# Description

Virtualhost, route, and weighted destination configuration is lower level, and if provided, intended to override higher level configuration.

This behavior works for extauth settings configured in Gloo `Settings`, our global settings store. In Gloo 1.4, we added support for listener-level configuration of the envoy extauth filter (e.g., allowing for multiple extauth servers, one for each listener). In the added listener-level config (exposed on the Gloo `Gateway` object), these lower-level overrides were not working.

# Context

Users ran into this bug trying to disable extauth on a route while inheriting configuration from gateway-level extauth.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

