### PR TITLE
Use recommended way of pinning go tools

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,7 +11,7 @@ Users ran into this bug doing ... \ Users needed this feature to ...
 # Checklist:
 
 - [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
-- [ ] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
+- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
 - [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
 - [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
 - [ ] I have performed a self-review of my own code

--- a/BUILD.md
+++ b/BUILD.md
@@ -39,7 +39,7 @@ unzip protoc-3.6.1-osx-x86_64.zip
 sudo mv bin/protoc /usr/local/bin/
 rm -rf bin include protoc-3.6.1-osx-x86_64.zip readme.txt
 # download other codegen deps
-make update-deps
+make install-go-tools
 ```
 
 Then run:

--- a/Makefile
+++ b/Makefile
@@ -79,11 +79,16 @@ init:
 fmt-changed:
 	git diff --name-only | grep '.*.go$$' | xargs -- goimports -w
 
+# must be a seperate target so that make waits for it to complete before moving on
+.PHONY: mod-download
+mod-download:
+	go mod download
+
 DEPSGOBIN=$(shell pwd)/_output/.bin
 
 # https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md
 .PHONY: install-go-tools
-install-go-tools:
+install-go-tools: mod-download
 	mkdir -p $(DEPSGOBIN)
 	chmod +x $(shell go list -f '{{ .Dir }}' -m k8s.io/code-generator)/generate-groups.sh
 	GOBIN=$(DEPSGOBIN) go install github.com/solo-io/protoc-gen-ext

--- a/Makefile
+++ b/Makefile
@@ -79,25 +79,20 @@ init:
 fmt-changed:
 	git diff --name-only | grep '.*.go$$' | xargs -- goimports -w
 
-
-# must be a seperate target so that make waits for it to complete before moving on
-.PHONY: mod-download
-mod-download:
-	go mod download
-
 DEPSGOBIN=$(shell pwd)/_output/.bin
 
-.PHONY: update-deps
-update-deps: mod-download
-	mkdir $(DEPSGOBIN)
-	$(shell cd $(shell go list -f '{{ .Dir }}' -m github.com/solo-io/protoc-gen-ext); make install)
+# https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md
+.PHONY: install-go-tools
+install-go-tools:
+	mkdir -p $(DEPSGOBIN)
 	chmod +x $(shell go list -f '{{ .Dir }}' -m k8s.io/code-generator)/generate-groups.sh
-	GOBIN=$(DEPSGOBIN) go get -v golang.org/x/tools/cmd/goimports@v0.0.0-20200423205358-59e73619c742
-	GOBIN=$(DEPSGOBIN) go get -v github.com/gogo/protobuf/protoc-gen-gogo@v1.3.1
-	GOBIN=$(DEPSGOBIN) go get -v github.com/cratonica/2goarray@514510793eaa1ae2cc2217a9a743104312412f35
-	GOBIN=$(DEPSGOBIN) go get -v -u github.com/golang/mock/gomock@v1.4.3
-	GOBIN=$(DEPSGOBIN) go get -v github.com/golang/mock/mockgen@v1.4.3
-	GOBIN=$(DEPSGOBIN) go get -v github.com/gogo/protobuf/gogoproto@v1.3.1
+	GOBIN=$(DEPSGOBIN) go install github.com/solo-io/protoc-gen-ext
+	GOBIN=$(DEPSGOBIN) go install golang.org/x/tools/cmd/goimports
+	GOBIN=$(DEPSGOBIN) go install github.com/gogo/protobuf/protoc-gen-gogo
+	GOBIN=$(DEPSGOBIN) go install github.com/cratonica/2goarray
+	GOBIN=$(DEPSGOBIN) go install github.com/golang/mock/gomock
+	GOBIN=$(DEPSGOBIN) go install github.com/golang/mock/mockgen
+	GOBIN=$(DEPSGOBIN) go install github.com/gogo/protobuf/gogoproto
 
 
 .PHONY: check-format
@@ -177,7 +172,7 @@ MOCK_RESOURCE_INFO := \
 generate-client-mocks:
 	@$(foreach INFO, $(MOCK_RESOURCE_INFO), \
 		echo Generating mock for $(word 3,$(subst :, , $(INFO)))...; \
-		mockgen -destination=projects/$(word 1,$(subst :, , $(INFO)))/pkg/mocks/mock_$(word 2,$(subst :, , $(INFO)))_client.go \
+		GOBIN=$(DEPSGOBIN) mockgen -destination=projects/$(word 1,$(subst :, , $(INFO)))/pkg/mocks/mock_$(word 2,$(subst :, , $(INFO)))_client.go \
      		-package=mocks \
      		github.com/solo-io/gloo/projects/$(word 1,$(subst :, , $(INFO)))/pkg/api/v1 \
      		$(word 3,$(subst :, , $(INFO))) \

--- a/changelog/v1.5.0-beta9/fix-go-tool-versioning.yaml
+++ b/changelog/v1.5.0-beta9/fix-go-tool-versioning.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+    Follow the [recommended approach](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module)
+    for go tool versioning.

--- a/ci/check-code-and-docs-gen.sh
+++ b/ci/check-code-and-docs-gen.sh
@@ -8,7 +8,7 @@ if [ ! -f .gitignore ]; then
   echo "_output" > .gitignore
 fi
 
-make update-deps
+make install-go-tools
 
 set +e
 
@@ -19,7 +19,7 @@ if [[ $? -ne 0 ]]; then
 fi
 if [[ $(git status --porcelain | wc -l) -ne 0 ]]; then
   echo "Generating code produced a non-empty diff"
-  echo "Try running 'make update-deps generated-code -B' then re-pushing."
+  echo "Try running 'make install-go-tools generated-code -B' then re-pushing."
   git status --porcelain
   git diff | cat
   exit 1;

--- a/ci/tools.go
+++ b/ci/tools.go
@@ -17,9 +17,12 @@ limitations under the License.
 package tools
 
 import (
+	_ "github.com/cratonica/2goarray"
 	_ "github.com/envoyproxy/protoc-gen-validate"
 	_ "github.com/gogo/protobuf/gogoproto"
+	_ "github.com/golang/mock/mockgen"
 	_ "github.com/solo-io/protoc-gen-ext"
 	_ "github.com/solo-io/solo-apis"
+	_ "golang.org/x/tools/cmd/goimports"
 	_ "k8s.io/code-generator"
 )

--- a/docs/content/guides/dev/setting-up-dev-environment.md
+++ b/docs/content/guides/dev/setting-up-dev-environment.md
@@ -113,7 +113,7 @@ Install Solo-Kit and required go packages:
 cd ${GOPATH}/src/github.com/solo-io/gloo
 
 # install required go packages
-make update-deps
+make install-go-tools
 ```
 
 You can test that code generation works with Gloo:

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/avast/retry-go v2.4.3+incompatible
 	github.com/aws/aws-sdk-go v1.30.15
 	github.com/cncf/udpa/go v0.0.0-20200313221541-5f7e5dd04533
+	github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/envoyproxy/go-control-plane v0.9.6-0.20200529035633-fc42e08917e9
 	github.com/envoyproxy/protoc-gen-validate v0.1.0
@@ -66,6 +67,7 @@ require (
 	golang.org/x/mod v0.3.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+	golang.org/x/tools v0.0.0-20200427205912-352a5409fae0
 	google.golang.org/genproto v0.0.0-20191115221424-83cc0476cb11
 	google.golang.org/grpc v1.27.0
 	gopkg.in/AlecAivazis/survey.v1 v1.8.7

--- a/go.sum
+++ b/go.sum
@@ -241,6 +241,8 @@ github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfc
 github.com/coreos/rkt v1.30.0/go.mod h1:O634mlH6U7qk87poQifK6M2rsFNt+FyUTWNMnP1hF1U=
 github.com/cpuguy83/go-md2man v1.0.10 h1:BSKMNlYxDvnunlTymqtgONjNnaRV1sTpcovwwjF22jk=
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa h1:Wg+722vs7a2zQH5lR9QWYsVbplKeffaQFIs5FTdfNNo=
+github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa/go.mod h1:6Arca19mRx58CA7OWEd7Wu1NpC1rd3uDnNs6s1pj/DI=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=


### PR DESCRIPTION
# Description

Prior to this change, we were installing the `go` tools we require during builds by `go get`ting a specific version of executable packages, e.g.:

```
go get -v golang.org/x/tools/cmd/goimports@v0.0.0-20200423205358-59e73619c742
``` 

The problem with this approach is that it creates an alternative source of truth for go library versions (the main one being the `go.mod` file). When there is drift between the two, these commands can impose unintended version constraints, which would break our build process.

The solution is to have the `go.mod` file determine the versions of the `go` tools to install, as described [here](https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module).

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make update-deps generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
~~- [ ] I have made corresponding changes to the documentation~~ N/A
~~- [ ] I have added tests that prove my fix is effective or that my feature works~~ N/A