### PR TITLE
bump envoy-operator + styfle/cancel-workflow-action versions, revert …

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -6,9 +6,8 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - name: Cancel Previous Actions
-      uses: styfle/cancel-workflow-action@0.3.1
+      uses: styfle/cancel-workflow-action@0.4.1
       with:
-        workflow_id: 1442930
         access_token: ${{ github.token }}
     - name: Set up Go 1.14
       uses: actions/setup-go@v1
@@ -40,9 +39,8 @@ jobs:
         kube-e2e-test-type: ['gateway', 'ingress', 'knative', 'helm', 'wasm']
     steps:
     - name: Cancel Previous Actions
-      uses: styfle/cancel-workflow-action@0.3.1
+      uses: styfle/cancel-workflow-action@0.4.1
       with:
-        workflow_id: 1442930
         access_token: ${{ github.token }}
     - name: Set up Go 1.14
       uses: actions/setup-go@v1

--- a/changelog/v1.5.0-beta11/clean-up-versions.yaml
+++ b/changelog/v1.5.0-beta11/clean-up-versions.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-operator
+  dependencyTag: v0.1.4
+- type: NON_USER_FACING
+  description: Downgraded protobuf version to 1.3.5 to avoid upgrade to v2, upgraded styfle/cancel-workflow-action version to 0.4.1 to remove outdated workflow_id.

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/gogo/googleapis v1.3.1
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/mock v1.4.4-0.20200406172829-6d816de489c1
-	github.com/golang/protobuf v1.4.2
+	github.com/golang/protobuf v1.3.5
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-github/v31 v31.0.0
 	github.com/gorilla/mux v1.7.3
@@ -51,7 +51,7 @@ require (
 	github.com/prometheus/prometheus v2.5.0+incompatible
 	github.com/rotisserie/eris v0.1.1
 	github.com/sergi/go-diff v1.0.0
-	github.com/solo-io/envoy-operator v0.1.3
+	github.com/solo-io/envoy-operator v0.1.4
 	github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f
 	github.com/solo-io/go-utils v0.16.4
 	github.com/solo-io/protoc-gen-ext v0.0.9
@@ -97,7 +97,6 @@ replace (
 	github.com/docker/docker => github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309
 
 	github.com/golang/mock => github.com/golang/mock v1.4.3
-	github.com/golang/protobuf => github.com/golang/protobuf v1.3.3
 
 	// kube 1.17
 	k8s.io/api => k8s.io/api v0.17.1

--- a/go.sum
+++ b/go.sum
@@ -483,8 +483,15 @@ github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4er
 github.com/golang/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:tluoj9z5200jBnyusfRPU2LqT6J+DAorxEvtC7LHB+E=
 github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
+github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
 github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
+github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
+github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golangplus/bytes v0.0.0-20160111154220-45c989fe5450/go.mod h1:Bk6SMAONeMXrxql8uvOKuAZSu8aM5RUGv+1C6IJaEho=
@@ -1007,8 +1014,8 @@ github.com/solo-io/anyvendor v0.0.1/go.mod h1:SLucIeU8qBOYI82BveNVn2LzZFcMWJSCf8
 github.com/solo-io/autopilot v0.1.1-0.20200211163026-f295a102fd94/go.mod h1:ChONxgEh+B2WxCOiX79u+gd2+5sABOwD3EG4cKtR6KA=
 github.com/solo-io/envoy-operator v0.1.1 h1:fiUN3lqvR9OwmMuktX0MjLSNwGdya+1ObvxXqQGZwsQ=
 github.com/solo-io/envoy-operator v0.1.1/go.mod h1:ZP5hB+khljAFCROj/yDjVPXCPHntdewy6mqYybcCneQ=
-github.com/solo-io/envoy-operator v0.1.3 h1:YIidO1Jar/eiix9vaErhv3WQsnkx2TQe/Ec2UzwzDik=
-github.com/solo-io/envoy-operator v0.1.3/go.mod h1:Yy+X1PjxxizebbuNBO0qOX4AqAvM/sAoIfy8FWidrNE=
+github.com/solo-io/envoy-operator v0.1.4 h1:haffsWSfiDtQrOHVaAuTL48LUVBvSYsv9nqJeNgF8kg=
+github.com/solo-io/envoy-operator v0.1.4/go.mod h1:RX7+5zmyZs0SM4K9q9bkaqPMx4XzoQJVi/zBl3NNsG0=
 github.com/solo-io/gloo v1.3.1/go.mod h1:08u6J9vpfFGRDsZybTQ65UX7UuJr+EBsZz++J1wtKkQ=
 github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f h1:CHgAq6eqV0JkJJifAEQ3f80YYmsxqTmhJfg6UnGVrCA=
 github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f/go.mod h1:lojsKFoQQH0O/ElLmagtWINB9zAaq04E8z0xIVS/gLU=


### PR DESCRIPTION
- upgrade styfle/cancel-workflow-action version to 0.4.1 to remove outdated workflow_id
- bump envoy-operator version so that we can...
- downgrade protobuf version back to v1.3.5 (v1.4.2 is apparently v2)