### PR TITLE
fix panic by checking that the auth config ref is not nil

### DIFF
--- a/changelog/v1.5.0-beta14/fix-glooctl-panic.yaml
+++ b/changelog/v1.5.0-beta14/fix-glooctl-panic.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix for panic when inspecting no-auth virtual services in glooctl check.
+    issueLink: https://github.com/solo-io/gloo/issues/3391

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -417,7 +417,8 @@ func checkVirtualServices(namespaces, knownUpstreams, knownAuthConfigs, knownRat
 
 			// Check references to auth configs
 			isAuthConfigRefValid := func(knownConfigs []string, ref *core.ResourceRef) bool {
-				if !cliutils.Contains(knownConfigs, renderRef(ref)) {
+				// If the virtual service points to a specific, non-existent authconfig, it is not valid.
+				if ref != nil && !cliutils.Contains(knownConfigs, renderRef(ref)) {
 					fmt.Printf("Virtual service references unknown auth config:\n")
 					fmt.Printf("  Virtual service: %s\n", renderMetadata(virtualService.GetMetadata()))
 					fmt.Printf("  Auth Config: %s\n", renderRef(ref))


### PR DESCRIPTION
# Description

This change fixes a bug in glooctl check which caused a panic for users with virtual services that do not use extauth auth config refs.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works 😳 
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3391