### PR TITLE
replace deprecated Cluster.hosts

### DIFF
--- a/changelog/v1.5.0-beta14/envoy-v3-minor-addition.yaml
+++ b/changelog/v1.5.0-beta14/envoy-v3-minor-addition.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/2815
+  resolvesIssue: false 
+  description: This is part of the upgrade to v3 of the Envoy xDS API. It replaces the deprecated field Cluster.hosts.

--- a/projects/gloo/hack/envoy.yaml
+++ b/projects/gloo/hack/envoy.yaml
@@ -7,10 +7,15 @@ static_resources:
 
   - name: xds_cluster
     connect_timeout: 5.000s
-    hosts:
-    - socket_address:
-        address: 127.0.0.1
-        port_value: 8080
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: 127.0.0.1
+                    port_value: 8080
     http2_protocol_options: {}
     type: STATIC
 

--- a/projects/gloo/hack/run-gloo.sh
+++ b/projects/gloo/hack/run-gloo.sh
@@ -13,10 +13,15 @@ static_resources:
 
   - name: xds_cluster
     connect_timeout: 5.000s
-    hosts:
-    - socket_address:
-        address: ${GLOO_IP}
-        port_value: 8080
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: ${GLOO_IP}
+                    port_value: 8080
     http2_protocol_options: {}
     type: STATIC
 

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -70,39 +70,59 @@ static_resources:
   clusters:
   - name: xds_cluster
     connect_timeout: 5.000s
-    hosts:
-    - socket_address:
-        address: {{.GlooAddr}}
-        port_value: {{.Port}}
+    load_assignment:
+      cluster_name: xds_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{.GlooAddr}}
+                    port_value: {{.Port}}
     http2_protocol_options: {}
     type: STATIC
 {{if .RatelimitAddr}}
   - name: ratelimit_cluster
     connect_timeout: 5.000s
-    hosts:
-    - socket_address:
-        address: {{.RatelimitAddr}}
-        port_value: {{.RatelimitPort}}
+    load_assignment:
+      cluster_name: ratelimit_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{.RatelimitAddr}}
+                    port_value: {{.RatelimitPort}}
     http2_protocol_options: {}
     type: STATIC
 {{end}}
 {{if .AccessLogAddr}}
   - name: access_log_cluster
     connect_timeout: 5.000s
-    hosts:
-    - socket_address:
-        address: {{.AccessLogAddr}}
-        port_value: {{.AccessLogPort}}
+    load_assignment:
+      cluster_name: access_log_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{.AccessLogAddr}}
+                    port_value: {{.AccessLogPort}}
     http2_protocol_options: {}
     type: STATIC
 {{end}}
 {{if .MetricsAddr}}
   - name: metrics_cluster
     connect_timeout: 5.000s
-    hosts:
-    - socket_address:
-        address: {{.MetricsAddr}}
-        port_value: {{.MetricsPort}}
+    load_assignment:
+      cluster_name: metrics_cluster
+      endpoints:
+        - lb_endpoints:
+            - endpoint:
+                address:
+                  socket_address:
+                    address: {{.MetricsAddr}}
+                    port_value: {{.MetricsPort}}
     http2_protocol_options: {}
     type: STATIC
 {{end}}


### PR DESCRIPTION
One more set of changes I missed for the first section of the envoy v3 upgrade