### PR TITLE
fix glooctl linux federation demo

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -15,7 +15,7 @@ jobs:
         go-version: 1.14
       id: go
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1.1.0
+      uses: solo-io/setup-protoc@master
       with:
         version: '3.6.1'
     - name: Check out code into the Go module directory

--- a/changelog/v1.5.0-beta14/fix-glooctl-linux-federation-demo.yaml
+++ b/changelog/v1.5.0-beta14/fix-glooctl-linux-federation-demo.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo-fed/issues/239
+    description: Fix glooctl demo federation command for linux.

--- a/projects/gloo/cli/pkg/cmd/demo/federation.go
+++ b/projects/gloo/cli/pkg/cmd/demo/federation.go
@@ -200,8 +200,8 @@ case $(uname) in
   } ;;
   "Linux")
   {
-      CLUSTER_DOMAIN_MGMT=$(docker exec $managementPlane-control-plane ip addr show dev eth0 | sed -nE 's|\s*inet\s+([0-9.]+).*|\1|p'):6443
-      CLUSTER_DOMAIN_REMOTE=$(docker exec $remoteCluster-control-plane ip addr show dev eth0 | sed -nE 's|\s*inet\s+([0-9.]+).*|\1|p'):6443
+      CLUSTER_DOMAIN_MGMT=$(docker exec $1-control-plane ip addr show dev eth0 | sed -nE 's|\s*inet\s+([0-9.]+).*|\1|p'):6443
+      CLUSTER_DOMAIN_REMOTE=$(docker exec $2-control-plane ip addr show dev eth0 | sed -nE 's|\s*inet\s+([0-9.]+).*|\1|p'):6443
   } ;;
   *)
   {


### PR DESCRIPTION
# Description

Fix glooctl linux federation demo. Previously, $managementPlane and $controlPlane were not defined in the script, so these commands fail to retrieve the IP address needed for cluster registration. This has been fixed.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo-fed/issues/239