### PR TITLE
Use solo-io fork of setup-protoc

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -15,7 +15,7 @@ jobs:
         go-version: 1.14
       id: go
     - name: Install Protoc
-      uses: arduino/setup-protoc@v1.1.0
+      uses: solo-io/setup-protoc@master
       with:
         version: '3.6.1'
     - name: Check out code into the Go module directory

--- a/changelog/v1.5.0-beta14/setup-protoc.yaml
+++ b/changelog/v1.5.0-beta14/setup-protoc.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: >
+      Use the solo-io fork of the github action setup-protoc, as the upstream doesn't support
+      release pagination, meaning 3.6.1 wouldn't install.


### PR DESCRIPTION
This is needed to use older versions of protoc, which now counts
v3.6.1. This will fix the broken github actions in CI.