### PR TITLE
add graceful shutdown

### DIFF
--- a/changelog/v1.5.0-beta14/graceful-shutdown.yaml
+++ b/changelog/v1.5.0-beta14/graceful-shutdown.yaml
@@ -1,0 +1,6 @@
+changelog:
+    - type: HELM
+      issueLink: https://github.com/solo-io/gloo/issues/3308
+      description: >
+        Support a Kubernetes `preStop` hook to enable a "graceful shutdown" when relying on external loadbalancers. This will
+        allow envoy to fail external facing healthchecks while still processing existing requests.

--- a/changelog/v1.5.0-beta14/graceful-shutdown.yaml
+++ b/changelog/v1.5.0-beta14/graceful-shutdown.yaml
@@ -3,4 +3,7 @@ changelog:
       issueLink: https://github.com/solo-io/gloo/issues/3308
       description: >
         Support a Kubernetes `preStop` hook to enable a "graceful shutdown" when relying on external loadbalancers. This will
-        allow envoy to fail external facing healthchecks while still processing existing requests.
+        allow envoy to fail external facing healthchecks while still processing existing requests. This feature is controlled
+        via a helm value, specifically the `gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown` object. You
+        can enable the hook via `gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.enabled` and control the actual time
+        of the grace period via `gatewayProxies.gatewayProxy.podTemplate.gracefulShutdownsleepTimeSeconds`

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -353,8 +353,8 @@
 |gatewayProxies.gatewayProxy.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gatewayProxies.gatewayProxy.podTemplate.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
 |gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.enabled|bool|false|Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers. *NOTE:* This will not have any effect if you have not defined health checks via the health check filter|
-|gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.sleepTimeSeconds|int|60|Time (in seconds) for the preStop hook to wait before allowing envoy to terminate|
-|gatewayProxies.gatewayProxy.podTemplate.terminationGracePeriodSeconds|int|30|Time in seconds to wait for the pod to terminate gracefully. See [kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) for more info|
+|gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.sleepTimeSeconds|int|25|Time (in seconds) for the preStop hook to wait before allowing envoy to terminate|
+|gatewayProxies.gatewayProxy.podTemplate.terminationGracePeriodSeconds|int|0|Time in seconds to wait for the pod to terminate gracefully. See [kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) for more info|
 |gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.exec.command[]|string|||
 |gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.path|string|||
 |gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.port|int64|||
@@ -368,11 +368,11 @@
 |gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.tcpSocket.port|int32|||
 |gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.tcpSocket.port|string|||
 |gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.tcpSocket.host|string|||
-|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.initialDelaySeconds|int32|||
-|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.timeoutSeconds|int32|||
-|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.periodSeconds|int32|||
-|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.successThreshold|int32|||
-|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.failureThreshold|int32|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.initialDelaySeconds|int32|0||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.timeoutSeconds|int32|0||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.periodSeconds|int32|0||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.successThreshold|int32|0||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.failureThreshold|int32|0||
 |gatewayProxies.gatewayProxy.configMap.data.NAME|string|||
 |gatewayProxies.gatewayProxy.globalDownstreamMaxConnections|uint32|250000|the number of concurrent connections needed. limit used to protect against exhausting file descriptors on host machine|
 |gatewayProxies.gatewayProxy.service.type|string|LoadBalancer|gateway [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). default is `LoadBalancer`|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -230,7 +230,7 @@
 |gatewayProxies.NAME.podTemplate.floatingUserId|bool||set to true to allow the cluster to dynamically assign a user ID|
 |gatewayProxies.NAME.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gatewayProxies.NAME.podTemplate.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
-|gatewayProxies.NAME.podTemplate.gracefulShutdown.enabled|bool||Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers|
+|gatewayProxies.NAME.podTemplate.gracefulShutdown.enabled|bool||Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers. *NOTE:* This will not have any effect if you have not defined health checks via the health check filter|
 |gatewayProxies.NAME.podTemplate.gracefulShutdown.sleepTimeSeconds|int||Time (in seconds) for the preStop hook to wait before allowing envoy to terminate|
 |gatewayProxies.NAME.podTemplate.terminationGracePeriodSeconds|int||Time in seconds to wait for the pod to terminate gracefully. See [kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) for more info|
 |gatewayProxies.NAME.podTemplate.customReadinessProbe.exec.command[]|string|||
@@ -352,7 +352,7 @@
 |gatewayProxies.gatewayProxy.podTemplate.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gatewayProxies.gatewayProxy.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gatewayProxies.gatewayProxy.podTemplate.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
-|gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.enabled|bool|false|Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers|
+|gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.enabled|bool|false|Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers. *NOTE:* This will not have any effect if you have not defined health checks via the health check filter|
 |gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.sleepTimeSeconds|int|60|Time (in seconds) for the preStop hook to wait before allowing envoy to terminate|
 |gatewayProxies.gatewayProxy.podTemplate.terminationGracePeriodSeconds|int|30|Time in seconds to wait for the pod to terminate gracefully. See [kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) for more info|
 |gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.exec.command[]|string|||

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -230,6 +230,27 @@
 |gatewayProxies.NAME.podTemplate.floatingUserId|bool||set to true to allow the cluster to dynamically assign a user ID|
 |gatewayProxies.NAME.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gatewayProxies.NAME.podTemplate.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
+|gatewayProxies.NAME.podTemplate.gracefulShutdown.enabled|bool||Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers|
+|gatewayProxies.NAME.podTemplate.gracefulShutdown.sleepTimeSeconds|int||Time (in seconds) for the preStop hook to wait before allowing envoy to terminate|
+|gatewayProxies.NAME.podTemplate.terminationGracePeriodSeconds|int||Time in seconds to wait for the pod to terminate gracefully. See [kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) for more info|
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.exec.command[]|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.path|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.port|int64|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.port|int32|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.port|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.host|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.scheme|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.httpHeaders[].name|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.httpGet.httpHeaders[].value|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.tcpSocket.port|int64|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.tcpSocket.port|int32|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.tcpSocket.port|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.tcpSocket.host|string|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.initialDelaySeconds|int32|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.timeoutSeconds|int32|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.periodSeconds|int32|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.successThreshold|int32|||
+|gatewayProxies.NAME.podTemplate.customReadinessProbe.failureThreshold|int32|||
 |gatewayProxies.NAME.configMap.data.NAME|string|||
 |gatewayProxies.NAME.globalDownstreamMaxConnections|uint32||the number of concurrent connections needed. limit used to protect against exhausting file descriptors on host machine|
 |gatewayProxies.NAME.service.type|string||gateway [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). default is `LoadBalancer`|
@@ -331,6 +352,27 @@
 |gatewayProxies.gatewayProxy.podTemplate.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gatewayProxies.gatewayProxy.podTemplate.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gatewayProxies.gatewayProxy.podTemplate.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
+|gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.enabled|bool|false|Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers|
+|gatewayProxies.gatewayProxy.podTemplate.gracefulShutdown.sleepTimeSeconds|int|60|Time (in seconds) for the preStop hook to wait before allowing envoy to terminate|
+|gatewayProxies.gatewayProxy.podTemplate.terminationGracePeriodSeconds|int|30|Time in seconds to wait for the pod to terminate gracefully. See [kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) for more info|
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.exec.command[]|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.path|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.port|int64|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.port|int32|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.port|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.host|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.scheme|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.httpHeaders[].name|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.httpGet.httpHeaders[].value|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.tcpSocket.port|int64|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.tcpSocket.port|int32|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.tcpSocket.port|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.tcpSocket.host|string|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.initialDelaySeconds|int32|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.timeoutSeconds|int32|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.periodSeconds|int32|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.successThreshold|int32|||
+|gatewayProxies.gatewayProxy.podTemplate.customReadinessProbe.failureThreshold|int32|||
 |gatewayProxies.gatewayProxy.configMap.data.NAME|string|||
 |gatewayProxies.gatewayProxy.globalDownstreamMaxConnections|uint32|250000|the number of concurrent connections needed. limit used to protect against exhausting file descriptors on host machine|
 |gatewayProxies.gatewayProxy.service.type|string|LoadBalancer|gateway [service type](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types). default is `LoadBalancer`|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -252,21 +252,29 @@ type DaemonSetSpec struct {
 }
 
 type GatewayProxyPodTemplate struct {
-	Image            *Image                `json:"image,omitempty"`
-	HttpPort         int                   `json:"httpPort,omitempty" desc:"HTTP port for the gateway service target port"`
-	HttpsPort        int                   `json:"httpsPort,omitempty" desc:"HTTPS port for the gateway service target port"`
-	ExtraPorts       []interface{}         `json:"extraPorts,omitempty" desc:"extra ports for the gateway pod"`
-	ExtraAnnotations map[string]string     `json:"extraAnnotations,omitempty" desc:"extra annotations to add to the pod"`
-	NodeName         string                `json:"nodeName,omitempty" desc:"name of node to run on"`
-	NodeSelector     map[string]string     `json:"nodeSelector,omitempty" desc:"label selector for nodes"`
-	Tolerations      []*appsv1.Toleration  `json:"tolerations,omitEmpty"`
-	Probes           bool                  `json:"probes" desc:"enable liveness and readiness probes"`
-	Resources        *ResourceRequirements `json:"resources,omitempty"`
-	DisableNetBind   bool                  `json:"disableNetBind" desc:"don't add the NET_BIND_SERVICE capability to the pod. This means that the gateway proxy will not be able to bind to ports below 1024"`
-	RunUnprivileged  bool                  `json:"runUnprivileged" desc:"run envoy as an unprivileged user"`
-	FloatingUserId   bool                  `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
-	RunAsUser        float64               `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
-	FsGroup          float64               `json:"fsGroup" desc:"Explicitly set the group ID for volume ownership. Default is 10101"`
+	Image                         *Image                `json:"image,omitempty"`
+	HttpPort                      int                   `json:"httpPort,omitempty" desc:"HTTP port for the gateway service target port"`
+	HttpsPort                     int                   `json:"httpsPort,omitempty" desc:"HTTPS port for the gateway service target port"`
+	ExtraPorts                    []interface{}         `json:"extraPorts,omitempty" desc:"extra ports for the gateway pod"`
+	ExtraAnnotations              map[string]string     `json:"extraAnnotations,omitempty" desc:"extra annotations to add to the pod"`
+	NodeName                      string                `json:"nodeName,omitempty" desc:"name of node to run on"`
+	NodeSelector                  map[string]string     `json:"nodeSelector,omitempty" desc:"label selector for nodes"`
+	Tolerations                   []*appsv1.Toleration  `json:"tolerations,omitEmpty"`
+	Probes                        bool                  `json:"probes" desc:"enable liveness and readiness probes"`
+	Resources                     *ResourceRequirements `json:"resources,omitempty"`
+	DisableNetBind                bool                  `json:"disableNetBind" desc:"don't add the NET_BIND_SERVICE capability to the pod. This means that the gateway proxy will not be able to bind to ports below 1024"`
+	RunUnprivileged               bool                  `json:"runUnprivileged" desc:"run envoy as an unprivileged user"`
+	FloatingUserId                bool                  `json:"floatingUserId" desc:"set to true to allow the cluster to dynamically assign a user ID"`
+	RunAsUser                     float64               `json:"runAsUser" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
+	FsGroup                       float64               `json:"fsGroup" desc:"Explicitly set the group ID for volume ownership. Default is 10101"`
+	GracefulShutdown              *GracefulShutdownSpec `json:"gracefulShutdown,omitempty"`
+	TerminationGracePeriodSeconds int                   `json:"terminationGracePeriodSeconds" desc:"Time in seconds to wait for the pod to terminate gracefully. See [kubernetes docs](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) for more info"`
+	CustomReadinessProbe          *appsv1.Probe         `json:"customReadinessProbe,omitEmpty"`
+}
+
+type GracefulShutdownSpec struct {
+	Enabled          bool `json:"enabled" desc:"Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers"`
+	SleepTimeSeconds int  `json:"sleepTimeSeconds" desc:"Time (in seconds) for the preStop hook to wait before allowing envoy to terminate"`
 }
 
 type GatewayProxyService struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -273,7 +273,7 @@ type GatewayProxyPodTemplate struct {
 }
 
 type GracefulShutdownSpec struct {
-	Enabled          bool `json:"enabled" desc:"Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers"`
+	Enabled          bool `json:"enabled" desc:"Enable grace period before shutdown to finish current requests while envoy health checks fail to e.g. notify external load balancers. *NOTE:* This will not have any effect if you have not defined health checks via the health check filter"`
 	SleepTimeSeconds int  `json:"sleepTimeSeconds" desc:"Time (in seconds) for the preStop hook to wait before allowing envoy to terminate"`
 }
 

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -124,6 +124,18 @@ spec:
         image: {{ template "gloo.wasmImage" $image }}
         {{- end}}
         imagePullPolicy: {{ $image.pullPolicy }}
+        {{- if $spec.podTemplate.gracefulShutdown }}
+        {{- if $spec.podTemplate.gracefulShutdown.enabled }}
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - wget --post-data "" -O /dev/null {{ $spec.loopBackAddress }}:19000/healthcheck/fail;
+                sleep {{ $spec.podTemplate.gracefulShutdown.sleepTimeSeconds }}
+        {{- end}}
+        {{- end}}
         name: {{ $name | kebabcase }}
         securityContext:
           readOnlyRootFilesystem: true
@@ -166,6 +178,9 @@ spec:
 {{- end}}
 {{- if $spec.podTemplate.probes }}
         readinessProbe:
+{{- if $spec.podTemplate.customReadinessProbe }}
+{{ toYaml $spec.podTemplate.customReadinessProbe | indent 10}}
+{{- else }}
           exec:
             command:
             - wget
@@ -175,6 +190,7 @@ spec:
           initialDelaySeconds: 1
           periodSeconds: 10
           failureThreshold: 10
+{{- end}}
         livenessProbe:
           exec:
             command:
@@ -234,6 +250,9 @@ spec:
       {{- if $image.pullSecret }}
       imagePullSecrets:
         - name: {{ $image.pullSecret }}{{end}}
+      {{- if $spec.podTemplate.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $spec.podTemplate.terminationGracePeriodSeconds }}
+      {{- end }}
       volumes:
       - configMap:
           name: {{ $name | kebabcase }}-envoy-config

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -103,6 +103,10 @@ gatewayProxies:
       fsGroup: 10101
       runUnprivileged: true
       disableNetBind: true
+      gracefulShutdown:
+        enabled: false
+        sleepTimeSeconds: 60
+      terminationGracePeriodSeconds: 30
     service:
       customPorts: []
       type: LoadBalancer

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -105,8 +105,8 @@ gatewayProxies:
       disableNetBind: true
       gracefulShutdown:
         enabled: false
-        sleepTimeSeconds: 60
-      terminationGracePeriodSeconds: 30
+        sleepTimeSeconds: 25
+      customReadinessProbe: {}
     service:
       customPorts: []
       type: LoadBalancer


### PR DESCRIPTION
# Description

Add a set of helm options to support performing a "graceful shutdown" of envoy when gloo is sitting behind external loadbalancers that are outside of the Kubernetes context.

The main functionality is provided via a k8s `preStop` hook which will be called prior to the envoy pod being terminated. This hook will first call the envoy admin interface to explicitly begin failing healthchecks (that have been configured via the health check filter), and then sleep for a certain, customized amount of time.

This sleep period will allow for envoy to fail the healthchecks that the external loadbalancers are relying on, causing the envoy instance to be removed as a healthy endpoint, while still able to handle existing requests, etc.

# Context

For example, when using an AWS ALB with target groups of envoy proxies running inside an EKS cluster, there is no way to remove/drain an envoy instance for the ALB without abruptly killing the instance and eventually letting the ALB figure this out via failing healthchecks.

This feature allows users to do the following:

- define a health check via the healthcheck filter
- associate the health check with the ALB target groups
- on termination request of the envoy pod, begin failing health checks
- sleep for the specified amount of time
- allow the ALB to see enough failing health checks to remove this envoy instance as a healthy endpoint (which prevents new requests/connections being sent)
- allow currently processed requests to finish

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3308