### PR TITLE
Validation API now handles list of gateway resources (#3434)

### DIFF
--- a/changelog/v1.4.7/validation-api-handles-lists.yaml
+++ b/changelog/v1.4.7/validation-api-handles-lists.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >
+      Gateway validation API (the API that backs the validating webhook) now handles lists of gateway resources.
+    issueLink: https://github.com/solo-io/gloo/issues/3261


### PR DESCRIPTION
backport of https://github.com/solo-io/gloo/pull/3434

# Description

This updates the gateway validation API to handle a list of gateway resources and validate them together against the current gateway snapshot (the gateway controller's view of the world).

# Context

Users wanted this feature to validate large change-sets against our validation API (that backs the validation webhook) before committing them to git (e.g., gitops approach)

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3261