### PR TITLE
Support yaml in the gateway validation API

### DIFF
--- a/changelog/v1.5.0-beta14/validation-api-handles-yaml.yaml
+++ b/changelog/v1.5.0-beta14/validation-api-handles-yaml.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    description: >
+      The gateway validation API now handles yaml admission requests if sent with the `application/x-yaml` header.
+    issueLink: https://github.com/solo-io/gloo/issues/3256

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,6 @@ require (
 	google.golang.org/grpc v1.28.1
 	gopkg.in/AlecAivazis/survey.v1 v1.8.7
 	gopkg.in/yaml.v2 v2.3.0
-	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	helm.sh/helm/v3 v3.1.2
 	k8s.io/api v0.17.4
 	k8s.io/apiextensions-apiserver v0.18.2

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	google.golang.org/grpc v1.28.1
 	gopkg.in/AlecAivazis/survey.v1 v1.8.7
 	gopkg.in/yaml.v2 v2.3.0
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 	helm.sh/helm/v3 v3.1.2
 	k8s.io/api v0.17.4
 	k8s.io/apiextensions-apiserver v0.18.2

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
@@ -69,6 +69,11 @@ var (
 	}
 )
 
+const (
+	ApplicationJson = "application/json"
+	ApplicationYaml = "application/x-yaml"
+)
+
 func incrementMetric(ctx context.Context, resource string, ref core.ResourceRef, m *stats.Int64Measure) {
 	utils.MeasureOne(
 		ctx,
@@ -192,7 +197,7 @@ func (wh *gatewayValidationWebhook) ServeHTTP(w http.ResponseWriter, r *http.Req
 
 	// Verify the content type is accurate
 	contentType := r.Header.Get("Content-Type")
-	if contentType != "application/json" && contentType != "application/x-yaml" {
+	if contentType != ApplicationJson && contentType != ApplicationYaml {
 		logger.Errorf("contentType=%s, expecting application/json or application/x-yaml", contentType)
 		http.Error(w, "empty body", http.StatusBadRequest)
 		return
@@ -217,7 +222,7 @@ func (wh *gatewayValidationWebhook) ServeHTTP(w http.ResponseWriter, r *http.Req
 		err               error
 	)
 
-	if contentType == "application/x-yaml" {
+	if contentType == ApplicationYaml {
 		if err = yaml.Unmarshal(body, &review); err == nil {
 			admissionResponse = wh.makeAdmissionResponse(wh.ctx, &review)
 		}

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
@@ -96,8 +96,9 @@ type WebhookConfig struct {
 	webhookNamespace              string
 }
 
-func NewWebhookConfig(ctx context.Context, validator validation.Validator, watchNamespaces []string, port int, serverCertPath string, serverKeyPath string, alwaysAccept bool, readGatewaysFromAllNamespaces bool, webhookNamespace string) WebhookConfig {
-	return WebhookConfig{ctx: ctx,
+func NewWebhookConfig(ctx context.Context, validator validation.Validator, watchNamespaces []string, port int, serverCertPath, serverKeyPath string, alwaysAccept, readGatewaysFromAllNamespaces bool, webhookNamespace string) WebhookConfig {
+	return WebhookConfig{
+		ctx:                           ctx,
 		validator:                     validator,
 		watchNamespaces:               watchNamespaces,
 		port:                          port,

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook_test.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook_test.go
@@ -260,10 +260,10 @@ func makeReviewRequestRaw(url string, gvk schema.GroupVersionKind, operation v1b
 		err         error
 	)
 	if useYamlEncoding {
-		contentType = "application/x-yaml"
+		contentType = ApplicationYaml
 		body, err = yaml.Marshal(review)
 	} else {
-		contentType = "application/json"
+		contentType = ApplicationJson
 		body, err = json.Marshal(review)
 	}
 	if err != nil {

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook_test.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook_test.go
@@ -164,7 +164,7 @@ var _ = Describe("ValidatingAdmissionWebhook", func() {
 	})
 
 	Context("namespace scoping", func() {
-		It("Does not process the resource if it's not whitelisted by watchNamespaces", func() {
+		It("does not process the resource if it's not whitelisted by watchNamespaces", func() {
 			wh.alwaysAccept = false
 			wh.watchNamespaces = []string{routeTable.Metadata.Namespace}
 			wh.webhookNamespace = routeTable.Metadata.Namespace
@@ -183,7 +183,7 @@ var _ = Describe("ValidatingAdmissionWebhook", func() {
 			Expect(review.Response.Result).To(BeNil())
 		})
 
-		It("Does not process other-namespace gateway resources if readGatewaysFromAllNamespaces is false, even if they're from whitelisted namespaces", func() {
+		It("does not process other-namespace gateway resources if readGatewaysFromAllNamespaces is false, even if they're from whitelisted namespaces", func() {
 			otherNamespace := routeTable.Metadata.Namespace + "other"
 			wh.alwaysAccept = false
 			wh.watchNamespaces = []string{routeTable.Metadata.Namespace, otherNamespace}

--- a/projects/gateway/pkg/translator/opts.go
+++ b/projects/gateway/pkg/translator/opts.go
@@ -6,6 +6,7 @@ import (
 )
 
 type Opts struct {
+	GlooNamespace                 string
 	WriteNamespace                string
 	WatchNamespaces               []string
 	Gateways                      factory.ResourceClientFactory

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -135,7 +135,7 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 	// gloo is dependency of gateway, needs to run second if we want to test validation
 	if !runOptions.WhatToRun.DisableGateway {
 		opts := defaultTestConstructOpts(ctx, runOptions)
-		go gatewaysyncer.RunGateway(opts, glooOpts.Settings.Metadata.Namespace)
+		go gatewaysyncer.RunGateway(opts)
 	}
 
 	if !runOptions.WhatToRun.DisableFds {
@@ -191,6 +191,7 @@ func defaultTestConstructOpts(ctx context.Context, runOptions *RunOptions) trans
 	}
 
 	return translator.Opts{
+		GlooNamespace:   runOptions.Settings.Metadata.Namespace,
 		WriteNamespace:  runOptions.NsToWrite,
 		WatchNamespaces: runOptions.NsToWatch,
 		Gateways:        f,

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -190,8 +190,9 @@ func defaultTestConstructOpts(ctx context.Context, runOptions *RunOptions) trans
 		Cache: runOptions.Cache,
 	}
 
+	meta := runOptions.Settings.GetMetadata()
 	return translator.Opts{
-		GlooNamespace:   runOptions.Settings.Metadata.Namespace,
+		GlooNamespace:   meta.GetNamespace(),
 		WriteNamespace:  runOptions.NsToWrite,
 		WatchNamespaces: runOptions.NsToWatch,
 		Gateways:        f,


### PR DESCRIPTION
# Description

Validation endpoint API now supports yaml encoding. e.g.:

```yaml
request:
  kind:
    group: gateway.solo.io
    kind: VirtualService
    version: v1
  name: vs
  namespace: namespace
  object:
    apiVersion: gateway.solo.io/v1
    kind: VirtualService
    metadata:
      creationTimestamp: null
      name: vs
      namespace: namespace
    spec:
      virtualHost:
        domains:
        - '*'
        routes:
        - directResponseAction:
            body: "Gloo and Envoy are configured correctly!\n\nDelete the 'vs Virtual Service to get started. \t\n"
            status: 200
          matchers:
          - prefix: /
    status: {}
  oldObject: null
  operation: CREATE
  options: null
  resource:
    group: ""
    resource: ""
    version: ""
  uid: "1234"
  userInfo: {}
```

sent in body of request with `application/x-yaml` for the content-type header.

# Context

Users wanted this as a convenience since the config they are validating is already yaml.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3256