### PR TITLE
Fix validation API to support dry run

### DIFF
--- a/changelog/v1.5.0-beta14/validation-api-handle-dry-run.yaml
+++ b/changelog/v1.5.0-beta14/validation-api-handle-dry-run.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >
+      The gateway validation API now honors dry-run requests. Previously, any dry-run requests could still modify the
+      internal resource cache, making future gateway validation results incorrect.
+    issueLink: https://github.com/solo-io/gloo/issues/3437

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
@@ -316,7 +316,12 @@ func (wh *gatewayValidationWebhook) makeAdmissionResponse(ctx context.Context, r
 
 	isDelete := req.Operation == v1beta1.Delete
 
-	proxyReports, validationErr := wh.validate(ctx, gvk, ref, req.Object.Raw, isDelete)
+	var dryRun bool
+	if req.DryRun != nil {
+		dryRun = *req.DryRun
+	}
+
+	proxyReports, validationErr := wh.validate(ctx, gvk, ref, req.Object.Raw, isDelete, dryRun)
 	var proxies []*gloov1.Proxy
 	for proxy, _ := range proxyReports {
 		proxies = append(proxies, proxy)
@@ -418,35 +423,35 @@ func (wh *gatewayValidationWebhook) getFailureCauses(proxyReports validation.Pro
 	return causes
 }
 
-func (wh *gatewayValidationWebhook) validate(ctx context.Context, gvk schema.GroupVersionKind, ref core.ResourceRef, rawJson []byte, isDelete bool) (validation.ProxyReports, error) {
+func (wh *gatewayValidationWebhook) validate(ctx context.Context, gvk schema.GroupVersionKind, ref core.ResourceRef, rawJson []byte, isDelete, dryRun bool) (validation.ProxyReports, error) {
 
 	switch gvk {
 	case ListGVK:
-		return wh.validateList(ctx, rawJson)
+		return wh.validateList(ctx, rawJson, dryRun)
 	case gwv1.GatewayGVK:
 		if isDelete {
 			// we don't validate gateway deletion
 			break
 		}
-		return wh.validateGateway(ctx, rawJson)
+		return wh.validateGateway(ctx, rawJson, dryRun)
 	case gwv1.VirtualServiceGVK:
 		if isDelete {
-			return validation.ProxyReports{}, wh.validator.ValidateDeleteVirtualService(ctx, ref)
+			return validation.ProxyReports{}, wh.validator.ValidateDeleteVirtualService(ctx, ref, dryRun)
 		} else {
-			return wh.validateVirtualService(ctx, rawJson)
+			return wh.validateVirtualService(ctx, rawJson, dryRun)
 		}
 	case gwv1.RouteTableGVK:
 		if isDelete {
-			return validation.ProxyReports{}, wh.validator.ValidateDeleteRouteTable(ctx, ref)
+			return validation.ProxyReports{}, wh.validator.ValidateDeleteRouteTable(ctx, ref, dryRun)
 		} else {
-			return wh.validateRouteTable(ctx, rawJson)
+			return wh.validateRouteTable(ctx, rawJson, dryRun)
 		}
 	}
 	return validation.ProxyReports{}, nil
 
 }
 
-func (wh *gatewayValidationWebhook) validateList(ctx context.Context, rawJson []byte) (validation.ProxyReports, error) {
+func (wh *gatewayValidationWebhook) validateList(ctx context.Context, rawJson []byte, dryRun bool) (validation.ProxyReports, error) {
 	var (
 		ul           unstructured.UnstructuredList
 		proxyReports validation.ProxyReports
@@ -456,13 +461,13 @@ func (wh *gatewayValidationWebhook) validateList(ctx context.Context, rawJson []
 	if err := ul.UnmarshalJSON(rawJson); err != nil {
 		return nil, WrappedUnmarshalErr(err)
 	}
-	if proxyReports, err = wh.validator.ValidateList(ctx, &ul); err != nil {
+	if proxyReports, err = wh.validator.ValidateList(ctx, &ul, dryRun); err != nil {
 		return proxyReports, errors.Wrapf(err, "Validating %T failed", ul)
 	}
 	return proxyReports, nil
 }
 
-func (wh *gatewayValidationWebhook) validateGateway(ctx context.Context, rawJson []byte) (validation.ProxyReports, error) {
+func (wh *gatewayValidationWebhook) validateGateway(ctx context.Context, rawJson []byte, dryRun bool) (validation.ProxyReports, error) {
 	var (
 		gw           gwv1.Gateway
 		proxyReports validation.ProxyReports
@@ -474,13 +479,13 @@ func (wh *gatewayValidationWebhook) validateGateway(ctx context.Context, rawJson
 	if skipValidationCheck(gw.Metadata.Annotations) {
 		return nil, nil
 	}
-	if proxyReports, err = wh.validator.ValidateGateway(ctx, &gw); err != nil {
+	if proxyReports, err = wh.validator.ValidateGateway(ctx, &gw, dryRun); err != nil {
 		return proxyReports, errors.Wrapf(err, "Validating %T failed", gw)
 	}
 	return proxyReports, nil
 }
 
-func (wh *gatewayValidationWebhook) validateVirtualService(ctx context.Context, rawJson []byte) (validation.ProxyReports, error) {
+func (wh *gatewayValidationWebhook) validateVirtualService(ctx context.Context, rawJson []byte, dryRun bool) (validation.ProxyReports, error) {
 	var (
 		vs           gwv1.VirtualService
 		proxyReports validation.ProxyReports
@@ -492,13 +497,13 @@ func (wh *gatewayValidationWebhook) validateVirtualService(ctx context.Context, 
 	if skipValidationCheck(vs.Metadata.Annotations) {
 		return nil, nil
 	}
-	if proxyReports, err = wh.validator.ValidateVirtualService(ctx, &vs); err != nil {
+	if proxyReports, err = wh.validator.ValidateVirtualService(ctx, &vs, dryRun); err != nil {
 		return proxyReports, errors.Wrapf(err, "Validating %T failed", vs)
 	}
 	return proxyReports, nil
 }
 
-func (wh *gatewayValidationWebhook) validateRouteTable(ctx context.Context, rawJson []byte) (validation.ProxyReports, error) {
+func (wh *gatewayValidationWebhook) validateRouteTable(ctx context.Context, rawJson []byte, dryRun bool) (validation.ProxyReports, error) {
 	var (
 		rt           gwv1.RouteTable
 		proxyReports validation.ProxyReports
@@ -510,7 +515,7 @@ func (wh *gatewayValidationWebhook) validateRouteTable(ctx context.Context, rawJ
 	if skipValidationCheck(rt.Metadata.Annotations) {
 		return nil, nil
 	}
-	if proxyReports, err = wh.validator.ValidateRouteTable(ctx, &rt); err != nil {
+	if proxyReports, err = wh.validator.ValidateRouteTable(ctx, &rt, dryRun); err != nil {
 		return proxyReports, errors.Wrapf(err, "Validating %T failed", rt)
 	}
 	return proxyReports, nil

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/ghodss/yaml"
 
-	"github.com/hashicorp/go-multierror"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -423,7 +422,7 @@ func (wh *gatewayValidationWebhook) validate(ctx context.Context, gvk schema.Gro
 
 	switch gvk {
 	case ListGVK:
-		return wh.validateList(ctx, rawJson, isDelete)
+		return wh.validateList(ctx, rawJson)
 	case gwv1.GatewayGVK:
 		if isDelete {
 			// we don't validate gateway deletion
@@ -447,51 +446,20 @@ func (wh *gatewayValidationWebhook) validate(ctx context.Context, gvk schema.Gro
 
 }
 
-func (wh *gatewayValidationWebhook) validateList(ctx context.Context, rawJson []byte, isDelete bool) (validation.ProxyReports, error) {
+func (wh *gatewayValidationWebhook) validateList(ctx context.Context, rawJson []byte) (validation.ProxyReports, error) {
 	var (
 		ul           unstructured.UnstructuredList
-		proxyReports = validation.ProxyReports{}
-		errs         = &multierror.Error{}
+		proxyReports validation.ProxyReports
+		err          error
 	)
 
 	if err := ul.UnmarshalJSON(rawJson); err != nil {
 		return nil, WrappedUnmarshalErr(err)
 	}
-
-	for _, item := range ul.Items {
-
-		gv, err := schema.ParseGroupVersion(item.GetAPIVersion())
-		if err != nil {
-			return validation.ProxyReports{}, err
-		}
-
-		itemGvk := schema.GroupVersionKind{
-			Version: gv.Version,
-			Group:   gv.Group,
-			Kind:    item.GetKind(),
-		}
-
-		jsonBytes, err := item.MarshalJSON()
-		if err != nil {
-			return validation.ProxyReports{}, err
-		}
-
-		itemRef := core.ResourceRef{
-			Namespace: item.GetNamespace(),
-			Name:      item.GetName(),
-		}
-
-		itemProxyReports, err := wh.validate(ctx, itemGvk, itemRef, jsonBytes, isDelete)
-
-		errs = multierror.Append(errs, err)
-		for proxy, report := range itemProxyReports {
-			// ok to return final proxy reports as the latest result includes latest proxy calculated
-			// for each resource, as we process incrementally, storing new state in memory as we go
-			proxyReports[proxy] = report
-		}
+	if proxyReports, err = wh.validator.ValidateList(ctx, &ul); err != nil {
+		return proxyReports, errors.Wrapf(err, "Validating %T failed", ul)
 	}
-
-	return proxyReports, errs.ErrorOrNil()
+	return proxyReports, nil
 }
 
 func (wh *gatewayValidationWebhook) validateGateway(ctx context.Context, rawJson []byte) (validation.ProxyReports, error) {

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -259,7 +259,7 @@ func (v *validator) ValidateList(ctx context.Context, ul *unstructured.Unstructu
 	// TODO(kdorosh) we need some kind of lock
 	//v.lock.Lock()
 	//defer v.lock.Unlock()
-	origSnapshot := v.latestSnapshot
+	snap := v.latestSnapshot.Clone()
 
 	for _, item := range ul.Items {
 
@@ -315,7 +315,9 @@ func (v *validator) ValidateList(ctx context.Context, ul *unstructured.Unstructu
 		}
 	}
 
-	v.latestSnapshot = origSnapshot
+	if dryRun {
+		v.latestSnapshot = &snap
+	}
 
 	return proxyReports, errs.ErrorOrNil()
 }


### PR DESCRIPTION
# Description

The gateway validation API and webhook indicated that the API had no side-effects (see [here](https://github.com/solo-io/gloo/blob/v1.5.0-beta13/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml#L25)), when in actuality, the API would modify its internal cache regardless of the dry-run value in the admission request.

This PR updates the validation API to handle dry-run requests and only modify the internal cache when necessary.

# Context

To accomplish this, a minor refactor was required and some logic was moved from the admission webhook code into the validator. The first commit (https://github.com/solo-io/gloo/commit/93992c5a2b3c24e5cd692e7ac89c06f3ed9ae600) only has the refactor, so reviewing that first and then the following commits may help the reviewer.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3437