### PR TITLE
Fix validation API to support dry run (#3455)

### DIFF
--- a/changelog/v1.4.8/validation-api-handle-dry-run.yaml
+++ b/changelog/v1.4.8/validation-api-handle-dry-run.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >
+      The gateway validation API now honors dry-run requests. Previously, any dry-run requests could still modify the
+      internal resource cache, making future gateway validation results incorrect.
+    issueLink: https://github.com/solo-io/gloo/issues/3437

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook_test.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook_test.go
@@ -12,11 +12,9 @@ import (
 	"net/http/httptest"
 
 	"github.com/rotisserie/eris"
+	"github.com/solo-io/gloo/projects/gateway/pkg/validation"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	k8syamlutil "sigs.k8s.io/yaml"
-
-	"github.com/solo-io/gloo/projects/gateway/pkg/validation"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -50,31 +48,10 @@ var _ = Describe("ValidatingAdmissionWebhook", func() {
 	gateway := defaults.DefaultGateway("namespace")
 	vs := defaults.DefaultVirtualService("namespace", "vs")
 
-	kubeRes := v1.VirtualServiceCrd.KubeResource(vs)
-	bytes, err := json.Marshal(kubeRes)
-	if err != nil {
-		panic(err)
-	}
-
-	mapFromVs := map[string]interface{}{}
-
-	// NOTE: This is not the default golang yaml.Unmarshal, because that implementation
-	// does not unmarshal into a map[string]interface{}; it unmarshals the file into a map[interface{}]interface{}
-	// https://github.com/go-yaml/yaml/issues/139
-	err = k8syamlutil.Unmarshal(bytes, &mapFromVs)
-	if err != nil {
-		panic(err)
-	}
-
-	vsList := unstructured.UnstructuredList{
+	unstructuredList := unstructured.UnstructuredList{
 		Object: map[string]interface{}{
 			"kind":    "List",
 			"version": "v1",
-		},
-		Items: []unstructured.Unstructured{
-			{
-				Object: mapFromVs,
-			},
 		},
 	}
 
@@ -87,16 +64,16 @@ var _ = Describe("ValidatingAdmissionWebhook", func() {
 		wh.webhookNamespace = routeTable.Metadata.Namespace
 
 		if !valid {
-			mv.fValidateList = func(ctx context.Context, ul *unstructured.UnstructuredList) (validation.ProxyReports, error) {
+			mv.fValidateList = func(ctx context.Context, ul *unstructured.UnstructuredList, dryRun bool) (validation.ProxyReports, error) {
 				return proxyReports(), fmt.Errorf(errMsg)
 			}
-			mv.fValidateGateway = func(ctx context.Context, gw *v1.Gateway) (validation.ProxyReports, error) {
+			mv.fValidateGateway = func(ctx context.Context, gw *v1.Gateway, dryRun bool) (validation.ProxyReports, error) {
 				return proxyReports(), fmt.Errorf(errMsg)
 			}
-			mv.fValidateVirtualService = func(ctx context.Context, vs *v1.VirtualService) (validation.ProxyReports, error) {
+			mv.fValidateVirtualService = func(ctx context.Context, vs *v1.VirtualService, dryRun bool) (validation.ProxyReports, error) {
 				return proxyReports(), fmt.Errorf(errMsg)
 			}
-			mv.fValidateRouteTable = func(ctx context.Context, rt *v1.RouteTable) (validation.ProxyReports, error) {
+			mv.fValidateRouteTable = func(ctx context.Context, rt *v1.RouteTable, dryRun bool) (validation.ProxyReports, error) {
 				return proxyReports(), fmt.Errorf(errMsg)
 			}
 		}
@@ -127,8 +104,8 @@ var _ = Describe("ValidatingAdmissionWebhook", func() {
 		Entry("invalid virtual service", false, v1.VirtualServiceCrd, v1.VirtualServiceCrd.GroupVersionKind(), vs),
 		Entry("valid route table", true, v1.RouteTableCrd, v1.RouteTableCrd.GroupVersionKind(), routeTable),
 		Entry("invalid route table", false, v1.RouteTableCrd, v1.RouteTableCrd.GroupVersionKind(), routeTable),
-		Entry("valid single vs list", true, nil, ListGVK, vsList),
-		Entry("invalid single vs list", false, nil, ListGVK, vsList),
+		Entry("valid unstructured list", true, nil, ListGVK, unstructuredList),
+		Entry("invalid unstructured list", false, nil, ListGVK, unstructuredList),
 	)
 
 	Context("invalid yaml", func() {
@@ -286,12 +263,12 @@ func parseReviewResponse(resp *http.Response) (*AdmissionReviewWithProxies, erro
 
 type mockValidator struct {
 	fSync                         func(context.Context, *v1.ApiSnapshot) error
-	fValidateList                 func(ctx context.Context, ul *unstructured.UnstructuredList) (validation.ProxyReports, error)
-	fValidateGateway              func(ctx context.Context, gw *v1.Gateway) (validation.ProxyReports, error)
-	fValidateVirtualService       func(ctx context.Context, vs *v1.VirtualService) (validation.ProxyReports, error)
-	fValidateDeleteVirtualService func(ctx context.Context, vs core.ResourceRef) error
-	fValidateRouteTable           func(ctx context.Context, rt *v1.RouteTable) (validation.ProxyReports, error)
-	fValidateDeleteRouteTable     func(ctx context.Context, rt core.ResourceRef) error
+	fValidateList                 func(ctx context.Context, ul *unstructured.UnstructuredList, dryRun bool) (validation.ProxyReports, error)
+	fValidateGateway              func(ctx context.Context, gw *v1.Gateway, dryRun bool) (validation.ProxyReports, error)
+	fValidateVirtualService       func(ctx context.Context, vs *v1.VirtualService, dryRun bool) (validation.ProxyReports, error)
+	fValidateDeleteVirtualService func(ctx context.Context, vs core.ResourceRef, dryRun bool) error
+	fValidateRouteTable           func(ctx context.Context, rt *v1.RouteTable, dryRun bool) (validation.ProxyReports, error)
+	fValidateDeleteRouteTable     func(ctx context.Context, rt core.ResourceRef, dryRun bool) error
 }
 
 func (v *mockValidator) Sync(ctx context.Context, snap *v1.ApiSnapshot) error {
@@ -301,46 +278,46 @@ func (v *mockValidator) Sync(ctx context.Context, snap *v1.ApiSnapshot) error {
 	return v.fSync(ctx, snap)
 }
 
-func (v *mockValidator) ValidateList(ctx context.Context, ul *unstructured.UnstructuredList) (validation.ProxyReports, error) {
+func (v *mockValidator) ValidateList(ctx context.Context, ul *unstructured.UnstructuredList, dryRun bool) (validation.ProxyReports, error) {
 	if v.fValidateList == nil {
 		return proxyReports(), nil
 	}
-	return v.fValidateList(ctx, ul)
+	return v.fValidateList(ctx, ul, dryRun)
 }
 
-func (v *mockValidator) ValidateGateway(ctx context.Context, gw *v1.Gateway) (validation.ProxyReports, error) {
+func (v *mockValidator) ValidateGateway(ctx context.Context, gw *v1.Gateway, dryRun bool) (validation.ProxyReports, error) {
 	if v.fValidateGateway == nil {
 		return proxyReports(), nil
 	}
-	return v.fValidateGateway(ctx, gw)
+	return v.fValidateGateway(ctx, gw, dryRun)
 }
 
-func (v *mockValidator) ValidateVirtualService(ctx context.Context, vs *v1.VirtualService) (validation.ProxyReports, error) {
+func (v *mockValidator) ValidateVirtualService(ctx context.Context, vs *v1.VirtualService, dryRun bool) (validation.ProxyReports, error) {
 	if v.fValidateVirtualService == nil {
 		return proxyReports(), nil
 	}
-	return v.fValidateVirtualService(ctx, vs)
+	return v.fValidateVirtualService(ctx, vs, dryRun)
 }
 
-func (v *mockValidator) ValidateDeleteVirtualService(ctx context.Context, vs core.ResourceRef) error {
+func (v *mockValidator) ValidateDeleteVirtualService(ctx context.Context, vs core.ResourceRef, dryRun bool) error {
 	if v.fValidateDeleteVirtualService == nil {
 		return nil
 	}
-	return v.fValidateDeleteVirtualService(ctx, vs)
+	return v.fValidateDeleteVirtualService(ctx, vs, dryRun)
 }
 
-func (v *mockValidator) ValidateRouteTable(ctx context.Context, rt *v1.RouteTable) (validation.ProxyReports, error) {
+func (v *mockValidator) ValidateRouteTable(ctx context.Context, rt *v1.RouteTable, dryRun bool) (validation.ProxyReports, error) {
 	if v.fValidateRouteTable == nil {
 		return proxyReports(), nil
 	}
-	return v.fValidateRouteTable(ctx, rt)
+	return v.fValidateRouteTable(ctx, rt, dryRun)
 }
 
-func (v *mockValidator) ValidateDeleteRouteTable(ctx context.Context, rt core.ResourceRef) error {
+func (v *mockValidator) ValidateDeleteRouteTable(ctx context.Context, rt core.ResourceRef, dryRun bool) error {
 	if v.fValidateDeleteRouteTable == nil {
 		return nil
 	}
-	return v.fValidateDeleteRouteTable(ctx, rt)
+	return v.fValidateDeleteRouteTable(ctx, rt, dryRun)
 }
 
 func proxyReports() validation.ProxyReports {

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -6,7 +6,12 @@ import (
 	"sync"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	skprotoutils "github.com/solo-io/solo-kit/pkg/utils/protoutils"
 
 	"github.com/avast/retry-go"
 	"github.com/solo-io/go-utils/protoutils"
@@ -36,6 +41,10 @@ var (
 	VirtualServiceDeleteErr = func(parentGateways []core.ResourceRef) error {
 		return errors.Errorf("Deletion blocked because active Gateways reference this Virtual Service. Remove refs to this virtual service from the gateways: %v, then try again", parentGateways)
 	}
+	unmarshalErrMsg     = "could not unmarshal raw object"
+	WrappedUnmarshalErr = func(err error) error {
+		return errors.Wrapf(err, unmarshalErrMsg)
+	}
 )
 
 const (
@@ -45,11 +54,12 @@ const (
 
 type Validator interface {
 	v1.ApiSyncer
-	ValidateGateway(ctx context.Context, gw *v1.Gateway) (ProxyReports, error)
-	ValidateVirtualService(ctx context.Context, vs *v1.VirtualService) (ProxyReports, error)
-	ValidateDeleteVirtualService(ctx context.Context, vs core.ResourceRef) error
-	ValidateRouteTable(ctx context.Context, rt *v1.RouteTable) (ProxyReports, error)
-	ValidateDeleteRouteTable(ctx context.Context, rt core.ResourceRef) error
+	ValidateList(ctx context.Context, ul *unstructured.UnstructuredList, dryRun bool) (ProxyReports, error)
+	ValidateGateway(ctx context.Context, gw *v1.Gateway, dryRun bool) (ProxyReports, error)
+	ValidateVirtualService(ctx context.Context, vs *v1.VirtualService, dryRun bool) (ProxyReports, error)
+	ValidateDeleteVirtualService(ctx context.Context, vs core.ResourceRef, dryRun bool) error
+	ValidateRouteTable(ctx context.Context, rt *v1.RouteTable, dryRun bool) (ProxyReports, error)
+	ValidateDeleteRouteTable(ctx context.Context, rt core.ResourceRef, dryRun bool) error
 }
 
 type validator struct {
@@ -143,16 +153,14 @@ func (v *validator) deleteFromLocalSnapshot(resource resources.Resource) {
 	}
 }
 
-func (v *validator) validateSnapshot(ctx context.Context, apply applyResource) (ProxyReports, error) {
+func (v *validator) validateSnapshot(ctx context.Context, apply applyResource, dryRun, acquireLock bool) (ProxyReports, error) {
 	if !v.ready() {
 		return nil, NotReadyErr
 	}
 
 	ctx = contextutils.WithLogger(ctx, "gateway-validator")
 
-	v.lock.RLock()
 	snap := v.latestSnapshot.Clone()
-	v.lock.RUnlock()
 
 	if v.latestSnapshotErr != nil {
 		contextutils.LoggerFrom(ctx).Errorw(InvalidSnapshotErrMessage, zap.Error(v.latestSnapshotErr))
@@ -230,15 +238,96 @@ func (v *validator) validateSnapshot(ctx context.Context, apply applyResource) (
 
 	contextutils.LoggerFrom(ctx).Debugw("Accepted %T %v", resource, ref)
 
-	// update internal snapshot to handle race where a lot of resources may be applied at once, before syncer updates
-	v.lock.Lock()
-	apply(v.latestSnapshot)
-	v.lock.Unlock()
+	if !dryRun {
+		// update internal snapshot to handle race where a lot of resources may be applied at once, before syncer updates
+		if acquireLock {
+			v.lock.Lock()
+		}
+		apply(v.latestSnapshot)
+		if acquireLock {
+			v.lock.Unlock()
+		}
+	}
 
 	return proxyReports, nil
 }
 
-func (v *validator) ValidateVirtualService(ctx context.Context, vs *v1.VirtualService) (ProxyReports, error) {
+func (v *validator) ValidateList(ctx context.Context, ul *unstructured.UnstructuredList, dryRun bool) (ProxyReports, error) {
+	var (
+		proxyReports = ProxyReports{}
+		errs         = &multierror.Error{}
+	)
+
+	v.lock.Lock()
+	defer v.lock.Unlock()
+	snap := v.latestSnapshot.Clone()
+
+	for _, item := range ul.Items {
+
+		gv, err := schema.ParseGroupVersion(item.GetAPIVersion())
+		if err != nil {
+			return ProxyReports{}, err
+		}
+
+		itemGvk := schema.GroupVersionKind{
+			Version: gv.Version,
+			Group:   gv.Group,
+			Kind:    item.GetKind(),
+		}
+
+		jsonBytes, err := item.MarshalJSON()
+		if err != nil {
+			return ProxyReports{}, err
+		}
+
+		var itemProxyReports ProxyReports
+		switch itemGvk {
+		case v1.GatewayGVK:
+			var (
+				gw v1.Gateway
+			)
+			if err := skprotoutils.UnmarshalResource(jsonBytes, &gw); err != nil {
+				return nil, WrappedUnmarshalErr(err)
+			}
+			itemProxyReports, err = v.validateGatewayInternal(ctx, &gw, false, false)
+		case v1.VirtualServiceGVK:
+			var (
+				vs v1.VirtualService
+			)
+			if err := skprotoutils.UnmarshalResource(jsonBytes, &vs); err != nil {
+				return nil, WrappedUnmarshalErr(err)
+			}
+			itemProxyReports, err = v.validateVirtualServiceInternal(ctx, &vs, false, false)
+		case v1.RouteTableGVK:
+			var (
+				rt v1.RouteTable
+			)
+			if err := skprotoutils.UnmarshalResource(jsonBytes, &rt); err != nil {
+				return nil, WrappedUnmarshalErr(err)
+			}
+			itemProxyReports, err = v.validateRouteTableInternal(ctx, &rt, false, false)
+		}
+
+		errs = multierror.Append(errs, err)
+		for proxy, report := range itemProxyReports {
+			// ok to return final proxy reports as the latest result includes latest proxy calculated
+			// for each resource, as we process incrementally, storing new state in memory as we go
+			proxyReports[proxy] = report
+		}
+	}
+
+	if dryRun {
+		v.latestSnapshot = &snap
+	}
+
+	return proxyReports, errs.ErrorOrNil()
+}
+
+func (v *validator) ValidateVirtualService(ctx context.Context, vs *v1.VirtualService, dryRun bool) (ProxyReports, error) {
+	return v.validateVirtualServiceInternal(ctx, vs, dryRun, true)
+}
+
+func (v *validator) validateVirtualServiceInternal(ctx context.Context, vs *v1.VirtualService, dryRun, acquireLock bool) (ProxyReports, error) {
 	apply := func(snap *v1.ApiSnapshot) ([]string, resources.Resource, core.ResourceRef) {
 		vsRef := vs.GetMetadata().Ref()
 
@@ -260,10 +349,10 @@ func (v *validator) ValidateVirtualService(ctx context.Context, vs *v1.VirtualSe
 		return proxiesForVirtualService(snap.Gateways, vs), vs, vsRef
 	}
 
-	return v.validateSnapshot(ctx, apply)
+	return v.validateSnapshot(ctx, apply, dryRun, acquireLock)
 }
 
-func (v *validator) ValidateDeleteVirtualService(ctx context.Context, vsRef core.ResourceRef) error {
+func (v *validator) ValidateDeleteVirtualService(ctx context.Context, vsRef core.ResourceRef, dryRun bool) error {
 	if !v.ready() {
 		return errors.Errorf("Gateway validation is yet not available. Waiting for first snapshot")
 	}
@@ -304,12 +393,17 @@ func (v *validator) ValidateDeleteVirtualService(ctx context.Context, vsRef core
 		contextutils.LoggerFrom(ctx).Debugw("Accepted deletion of Virtual Service %v", vsRef)
 	}
 
-	v.deleteFromLocalSnapshot(vs)
-
+	if !dryRun {
+		v.deleteFromLocalSnapshot(vs)
+	}
 	return nil
 }
 
-func (v *validator) ValidateRouteTable(ctx context.Context, rt *v1.RouteTable) (ProxyReports, error) {
+func (v *validator) ValidateRouteTable(ctx context.Context, rt *v1.RouteTable, dryRun bool) (ProxyReports, error) {
+	return v.validateRouteTableInternal(ctx, rt, dryRun, true)
+}
+
+func (v *validator) validateRouteTableInternal(ctx context.Context, rt *v1.RouteTable, dryRun, acquireLock bool) (ProxyReports, error) {
 	apply := func(snap *v1.ApiSnapshot) ([]string, resources.Resource, core.ResourceRef) {
 		rtRef := rt.GetMetadata().Ref()
 
@@ -333,10 +427,10 @@ func (v *validator) ValidateRouteTable(ctx context.Context, rt *v1.RouteTable) (
 		return proxiesToConsider, rt, rtRef
 	}
 
-	return v.validateSnapshot(ctx, apply)
+	return v.validateSnapshot(ctx, apply, dryRun, acquireLock)
 }
 
-func (v *validator) ValidateDeleteRouteTable(ctx context.Context, rtRef core.ResourceRef) error {
+func (v *validator) ValidateDeleteRouteTable(ctx context.Context, rtRef core.ResourceRef, dryRun bool) error {
 	if !v.ready() {
 		return errors.Errorf("Gateway validation is yet not available. Waiting for first snapshot")
 	}
@@ -377,12 +471,17 @@ func (v *validator) ValidateDeleteRouteTable(ctx context.Context, rtRef core.Res
 		contextutils.LoggerFrom(ctx).Debugw("Accepted Route Table deletion %v", rtRef)
 	}
 
-	v.deleteFromLocalSnapshot(rt)
-
+	if !dryRun {
+		v.deleteFromLocalSnapshot(rt)
+	}
 	return nil
 }
 
-func (v *validator) ValidateGateway(ctx context.Context, gw *v1.Gateway) (ProxyReports, error) {
+func (v *validator) ValidateGateway(ctx context.Context, gw *v1.Gateway, dryRun bool) (ProxyReports, error) {
+	return v.validateGatewayInternal(ctx, gw, dryRun, true)
+}
+
+func (v *validator) validateGatewayInternal(ctx context.Context, gw *v1.Gateway, dryRun, acquireLock bool) (ProxyReports, error) {
 	apply := func(snap *v1.ApiSnapshot) ([]string, resources.Resource, core.ResourceRef) {
 		gwRef := gw.GetMetadata().Ref()
 
@@ -406,7 +505,7 @@ func (v *validator) ValidateGateway(ctx context.Context, gw *v1.Gateway) (ProxyR
 		return proxiesToConsider, gw, gwRef
 	}
 
-	return v.validateSnapshot(ctx, apply)
+	return v.validateSnapshot(ctx, apply, dryRun, acquireLock)
 }
 
 func proxiesForVirtualService(gwList v1.GatewayList, vs *v1.VirtualService) []string {

--- a/projects/gateway/pkg/validation/validator_test.go
+++ b/projects/gateway/pkg/validation/validator_test.go
@@ -2,7 +2,11 @@ package validation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syamlutil "sigs.k8s.io/yaml"
 
 	"github.com/solo-io/go-utils/testutils"
 
@@ -35,7 +39,7 @@ var _ = Describe("Validator", func() {
 		v = NewValidator(NewValidatorConfig(t, vc, ns, false, false))
 	})
 	It("returns error before sync called", func() {
-		_, err := v.ValidateVirtualService(nil, nil)
+		_, err := v.ValidateVirtualService(nil, nil, false)
 		Expect(err).To(testutils.HaveInErrorChain(NotReadyErr))
 		err = v.Sync(nil, &gatewayv1.ApiSnapshot{})
 		Expect(err).NotTo(HaveOccurred())
@@ -49,7 +53,7 @@ var _ = Describe("Validator", func() {
 				snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
+				proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 			})
@@ -60,13 +64,13 @@ var _ = Describe("Validator", func() {
 				snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
+				proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
 
 				// repeat to ensure any hashing doesn't short circuit returning the proxies
-				proxyReports, err = v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
+				proxyReports, err = v.ValidateRouteTable(context.TODO(), snap.RouteTables[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
@@ -84,7 +88,7 @@ var _ = Describe("Validator", func() {
 				// change something to change the hash
 				snap.RouteTables[0].Metadata.Labels = map[string]string{"change": "my mind"}
 
-				proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
+				proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0], false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))
 				Expect(proxyReports).To(HaveLen(1))
@@ -103,7 +107,7 @@ var _ = Describe("Validator", func() {
 					// change something to change the hash
 					snap.RouteTables[0].Metadata.Labels = map[string]string{"change": "my mind"}
 
-					proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
+					proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0], false)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(ContainSubstring("failed to communicate with Gloo Proxy validation server"))
 					Expect(proxyReports).To(BeEmpty())
@@ -117,7 +121,7 @@ var _ = Describe("Validator", func() {
 					snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
 					err := v.Sync(context.TODO(), snap)
 					Expect(err).NotTo(HaveOccurred())
-					proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0])
+					proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0], false)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(proxyReports).To(HaveLen(0))
 				})
@@ -131,7 +135,7 @@ var _ = Describe("Validator", func() {
 					err := v.Sync(context.TODO(), &gatewayv1.ApiSnapshot{})
 					Expect(err).NotTo(HaveOccurred())
 					vs, _ := samples.LinkedRouteTablesWithVirtualService("vs", "ns")
-					proxyReports, err := v.ValidateVirtualService(context.TODO(), vs)
+					proxyReports, err := v.ValidateVirtualService(context.TODO(), vs, false)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(proxyReports).To(HaveLen(0))
 				})
@@ -140,7 +144,7 @@ var _ = Describe("Validator", func() {
 					err := v.Sync(context.TODO(), &gatewayv1.ApiSnapshot{})
 					Expect(err).NotTo(HaveOccurred())
 					_, rts := samples.LinkedRouteTablesWithVirtualService("vs", "ns")
-					proxyReports, err := v.ValidateRouteTable(context.TODO(), rts[1])
+					proxyReports, err := v.ValidateRouteTable(context.TODO(), rts[1], false)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(proxyReports).To(HaveLen(0))
 				})
@@ -153,7 +157,7 @@ var _ = Describe("Validator", func() {
 
 					ref := snap.RouteTables[len(snap.RouteTables)-1].Metadata.Ref()
 
-					err = v.ValidateDeleteRouteTable(context.TODO(), ref)
+					err = v.ValidateDeleteRouteTable(context.TODO(), ref, false)
 					Expect(err).NotTo(HaveOccurred())
 				})
 			})
@@ -182,7 +186,7 @@ var _ = Describe("Validator", func() {
 				rt.Routes = append(rt.Routes, badRoute)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateRouteTable(context.TODO(), rt)
+				proxyReports, err := v.ValidateRouteTable(context.TODO(), rt, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("could not render proxy"))
 				Expect(proxyReports).To(HaveLen(0))
@@ -198,7 +202,7 @@ var _ = Describe("Validator", func() {
 				snap := samples.GatewaySnapshotWithDelegateChain(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				err = v.ValidateDeleteRouteTable(context.TODO(), snap.RouteTables[1].Metadata.Ref())
+				err = v.ValidateDeleteRouteTable(context.TODO(), snap.RouteTables[1].Metadata.Ref(), false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("Deletion blocked because active Routes delegate to this Route Table. " +
 					"Remove delegate actions to this route table from the virtual services: [] and the route tables: [{node-0 my-namespace}], then try again"))
@@ -214,7 +218,7 @@ var _ = Describe("Validator", func() {
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
 				ref := snap.RouteTables[2].Metadata.Ref()
-				err = v.ValidateDeleteRouteTable(context.TODO(), ref)
+				err = v.ValidateDeleteRouteTable(context.TODO(), ref, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// ensure route table was removed from validator internal snapshot
@@ -237,7 +241,7 @@ var _ = Describe("Validator", func() {
 				// change something to change the hash
 				snap.VirtualServices[0].Metadata.Labels = map[string]string{"change": "my mind"}
 
-				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0])
+				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0], false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))
 				Expect(proxyReports).To(HaveLen(1))
@@ -251,7 +255,7 @@ var _ = Describe("Validator", func() {
 				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0])
+				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 			})
@@ -262,13 +266,13 @@ var _ = Describe("Validator", func() {
 				snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0])
+				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
 
 				// repeat to ensure any hashing doesn't short circuit returning the proxies
-				proxyReports, err = v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0])
+				proxyReports, err = v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
@@ -289,7 +293,7 @@ var _ = Describe("Validator", func() {
 				})
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0])
+				proxyReports, err := v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(0))
 			})
@@ -319,10 +323,72 @@ var _ = Describe("Validator", func() {
 
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateVirtualService(context.TODO(), vs)
+				proxyReports, err := v.ValidateVirtualService(context.TODO(), vs, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("could not render proxy"))
 				Expect(proxyReports).To(HaveLen(0))
+			})
+		})
+
+		Context("dry-run", func() {
+			It("accepts the vs and rejects the second", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+
+				// create a virtual service to validate, should pass validation as a prior one should
+				// already be in the validation snapshot cache with a different domain
+				samples.AddVsToSnap(snap, us.GetMetadata().Ref(), "ns")
+				vs2 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs2)
+				vs2.Metadata.Name = "vs2"
+
+				proxyReports, err := v.ValidateVirtualService(context.TODO(), vs2, false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+
+				// create another virtual service to validate, should fail validation as a prior one should
+				// already be in the validation snapshot cache with the same domain (as dry-run before was false)
+				vs3 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs3)
+				vs3.Metadata.Name = "vs3"
+
+				proxyReports, err = v.ValidateVirtualService(context.TODO(), vs3, false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not render proxy"))
+				Expect(err.Error()).To(ContainSubstring("domain conflict: the following"))
+				Expect(proxyReports).To(HaveLen(0))
+			})
+
+			It("accepts the vs and accepts the second because of dry-run", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+
+				samples.AddVsToSnap(snap, us.GetMetadata().Ref(), "ns")
+				// create a virtual service to validate, should pass validation as a prior one should
+				// already be in the validation snapshot cache with a different domain
+				vs2 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs2)
+				vs2.Metadata.Name = "vs2"
+
+				proxyReports, err := v.ValidateVirtualService(context.TODO(), vs2, true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+
+				// create another virtual service to validate, should pass validation as a prior one should not
+				// already be in the validation snapshot cache (as dry-run was true)
+				vs3 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs3)
+				vs3.Metadata.Name = "vs3"
+
+				proxyReports, err = v.ValidateVirtualService(context.TODO(), vs3, true)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
 			})
 		})
 	})
@@ -343,7 +409,7 @@ var _ = Describe("Validator", func() {
 				})
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				err = v.ValidateDeleteVirtualService(context.TODO(), ref)
+				err = v.ValidateDeleteVirtualService(context.TODO(), ref, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Deletion blocked because active Gateways reference this Virtual Service. "+
 					"Remove refs to this virtual service from the gateways: [{%s my-namespace} {%s-ssl my-namespace}], "+
@@ -358,7 +424,7 @@ var _ = Describe("Validator", func() {
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
 				ref := snap.VirtualServices[0].Metadata.Ref()
-				err = v.ValidateDeleteVirtualService(context.TODO(), ref)
+				err = v.ValidateDeleteVirtualService(context.TODO(), ref, false)
 				Expect(err).NotTo(HaveOccurred())
 
 				// ensure vs was removed from validator internal snapshot
@@ -381,7 +447,7 @@ var _ = Describe("Validator", func() {
 				// change something to change the hash
 				snap.Gateways[0].Metadata.Labels = map[string]string{"change": "my mind"}
 
-				proxyReports, err := v.ValidateGateway(context.TODO(), snap.Gateways[0])
+				proxyReports, err := v.ValidateGateway(context.TODO(), snap.Gateways[0], false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))
 				Expect(proxyReports).To(HaveLen(1))
@@ -394,7 +460,7 @@ var _ = Describe("Validator", func() {
 				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateGateway(context.TODO(), snap.Gateways[0])
+				proxyReports, err := v.ValidateGateway(context.TODO(), snap.Gateways[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 			})
@@ -405,13 +471,13 @@ var _ = Describe("Validator", func() {
 				snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateGateway(context.TODO(), snap.Gateways[0])
+				proxyReports, err := v.ValidateGateway(context.TODO(), snap.Gateways[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
 
 				// repeat to ensure any hashing doesn't short circuit returning the proxies
-				proxyReports, err = v.ValidateGateway(context.TODO(), snap.Gateways[0])
+				proxyReports, err = v.ValidateGateway(context.TODO(), snap.Gateways[0], false)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(proxyReports).To(HaveLen(1))
 				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
@@ -430,12 +496,235 @@ var _ = Describe("Validator", func() {
 				gw.GatewayType.(*gatewayv1.Gateway_HttpGateway).HttpGateway.VirtualServices = append(gw.GatewayType.(*gatewayv1.Gateway_HttpGateway).HttpGateway.VirtualServices, badRef)
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
-				proxyReports, err := v.ValidateGateway(context.TODO(), gw)
+				proxyReports, err := v.ValidateGateway(context.TODO(), gw, false)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("could not render proxy"))
 				Expect(proxyReports).To(HaveLen(0))
 			})
 		})
+	})
+
+	Context("validating a list of virtual services", func() {
+
+		toUnstructuredList := func(vss ...*gatewayv1.VirtualService) *unstructured.UnstructuredList {
+
+			var objs []unstructured.Unstructured
+			for _, vs := range vss {
+				kubeRes, _ := gatewayv1.VirtualServiceCrd.KubeResource(vs)
+				bytes, err := json.Marshal(kubeRes)
+				Expect(err).ToNot(HaveOccurred())
+				mapFromVs := map[string]interface{}{}
+
+				// NOTE: This is not the default golang yaml.Unmarshal, because that implementation
+				// does not unmarshal into a map[string]interface{}; it unmarshals the file into a map[interface{}]interface{}
+				// https://github.com/go-yaml/yaml/issues/139
+				err = k8syamlutil.Unmarshal(bytes, &mapFromVs)
+				Expect(err).ToNot(HaveOccurred())
+
+				obj := unstructured.Unstructured{Object: mapFromVs}
+				objs = append(objs, obj)
+			}
+
+			return &unstructured.UnstructuredList{
+				Object: map[string]interface{}{
+					"kind":    "List",
+					"version": "v1",
+				},
+				Items: objs,
+			}
+		}
+
+		Context("proxy validation returns error", func() {
+			It("rejects the vs list", func() {
+				vc.validateProxy = failProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+
+				// change something to change the hash
+				snap.VirtualServices[0].Metadata.Labels = map[string]string{"change": "my mind"}
+				vsList := toUnstructuredList(snap.VirtualServices[0])
+
+				proxyReports, err := v.ValidateList(context.TODO(), vsList, false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))
+				Expect(proxyReports).To(HaveLen(1))
+
+			})
+		})
+
+		Context("proxy validation accepted", func() {
+
+			It("accepts the vs list", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+				proxyReports, err := v.ValidateList(context.TODO(), toUnstructuredList(snap.VirtualServices[0]), false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+			})
+
+			It("accepts the multi vs list", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+				vs1 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[0].DeepCopyInto(vs1)
+				vs1.Metadata.Name = "vs1"
+				vs1.VirtualHost.Domains = []string{"example.vs1.com"}
+				vs2 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[0].DeepCopyInto(vs2)
+				vs2.Metadata.Name = "vs2"
+				vs2.VirtualHost.Domains = []string{"example.vs2.com"}
+
+				proxyReports, err := v.ValidateList(context.TODO(), toUnstructuredList(vs1, vs2), false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(2))
+			})
+
+			It("rejects the multi vs list with overlapping domains", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+
+				vs1 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[0].DeepCopyInto(vs1)
+				vs1.Metadata.Name = "vs1"
+
+				vs2 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[0].DeepCopyInto(vs2)
+				vs2.Metadata.Name = "vs2"
+
+				proxyReports, err := v.ValidateList(context.TODO(), toUnstructuredList(vs1, vs2), false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not render proxy"))
+				Expect(err.Error()).To(ContainSubstring("domain conflict: the following"))
+				Expect(proxyReports).To(HaveLen(0))
+			})
+
+			It("accepts the vs list and returns proxies each time", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+				proxyReports, err := v.ValidateList(context.TODO(), toUnstructuredList(snap.VirtualServices[0]), false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
+
+				// repeat to ensure any hashing doesn't short circuit returning the proxies
+				proxyReports, err = v.ValidateList(context.TODO(), toUnstructuredList(snap.VirtualServices[0]), false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+				Expect(proxyReports).To(HaveKey(ContainSubstring("listener-::-8080")))
+			})
+		})
+
+		Context("virtual service list rejected", func() {
+			It("rejects the vs list", func() {
+				badRoute := &gatewayv1.Route{
+					Action: &gatewayv1.Route_DelegateAction{
+
+						DelegateAction: &gatewayv1.DelegateAction{
+							DelegationType: &gatewayv1.DelegateAction_Ref{
+								Ref: &core.ResourceRef{
+									Name:      "invalid",
+									Namespace: "name",
+								},
+							},
+						},
+					},
+				}
+
+				// validate proxy should never be called
+				vc.validateProxy = nil
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				vs := snap.VirtualServices[0].DeepCopyObject().(*gatewayv1.VirtualService)
+				vs.VirtualHost.Routes = append(vs.VirtualHost.Routes, badRoute)
+				vsList := toUnstructuredList(vs)
+
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+				proxyReports, err := v.ValidateList(context.TODO(), vsList, false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not render proxy"))
+				Expect(proxyReports).To(HaveLen(0))
+			})
+		})
+
+		Context("dry-run", func() {
+			It("accepts the vs and rejects the second", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+
+				// create a virtual service to validate, should pass validation as a prior one should
+				// already be in the validation snapshot cache with a different domain
+				samples.AddVsToSnap(snap, us.GetMetadata().Ref(), "ns")
+
+				vs2 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs2)
+				vs2.Metadata.Name = "vs2"
+
+				proxyReports, err := v.ValidateList(context.TODO(), toUnstructuredList(vs2), false)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+
+				// create another virtual service to validate, should fail validation as a prior one should
+				// already be in the validation snapshot cache with the same domain (as dry-run before was false)
+				vs3 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs3)
+				vs3.Metadata.Name = "vs3"
+
+				proxyReports, err = v.ValidateList(context.TODO(), toUnstructuredList(vs3), false)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("could not render proxy"))
+				Expect(err.Error()).To(ContainSubstring("domain conflict: the following"))
+				Expect(proxyReports).To(HaveLen(0))
+			})
+
+			It("accepts the vs and accepts the second because of dry-run", func() {
+				vc.validateProxy = acceptProxy
+				us := samples.SimpleUpstream()
+				snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+				err := v.Sync(context.TODO(), snap)
+				Expect(err).NotTo(HaveOccurred())
+
+				samples.AddVsToSnap(snap, us.GetMetadata().Ref(), "ns")
+				// create a virtual service to validate, should pass validation as a prior one should
+				// already be in the validation snapshot cache with a different domain
+				vs2 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs2)
+				vs2.Metadata.Name = "vs2"
+
+				proxyReports, err := v.ValidateList(context.TODO(), toUnstructuredList(vs2), true)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+
+				// create another virtual service to validate, should pass validation as a prior one should not
+				// already be in the validation snapshot cache (as dry-run was true)
+				vs3 := &gatewayv1.VirtualService{}
+				snap.VirtualServices[1].DeepCopyInto(vs3)
+				vs3.Metadata.Name = "vs3"
+
+				proxyReports, err = v.ValidateList(context.TODO(), toUnstructuredList(vs3), true)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(proxyReports).To(HaveLen(1))
+			})
+
+		})
+
 	})
 
 })

--- a/projects/gateway/pkg/validation/validator_test.go
+++ b/projects/gateway/pkg/validation/validator_test.go
@@ -510,7 +510,7 @@ var _ = Describe("Validator", func() {
 
 			var objs []unstructured.Unstructured
 			for _, vs := range vss {
-				kubeRes, _ := gatewayv1.VirtualServiceCrd.KubeResource(vs)
+				kubeRes := gatewayv1.VirtualServiceCrd.KubeResource(vs)
 				bytes, err := json.Marshal(kubeRes)
 				Expect(err).ToNot(HaveOccurred())
 				mapFromVs := map[string]interface{}{}


### PR DESCRIPTION
backport of https://github.com/solo-io/gloo/pull/3455

# Description

The gateway validation API and webhook indicated that the API had no side-effects (see [here](https://github.com/solo-io/gloo/blob/v1.5.0-beta13/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml#L25)), when in actuality, the API would modify its internal cache regardless of the dry-run value in the admission request.

This PR updates the validation API to handle dry-run requests and only modify the internal cache when necessary.

# Context

To accomplish this, a minor refactor was required and some logic was moved from the admission webhook code into the validator. The first commit (https://github.com/solo-io/gloo/commit/93992c5a2b3c24e5cd692e7ac89c06f3ed9ae600) only has the refactor, so reviewing that first and then the following commits may help the reviewer.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3437