### PR TITLE
Use failover.enabled helm value in gloo fed demo

### DIFF
--- a/changelog/v1.5.0-beta20/fix-demo.yaml
+++ b/changelog/v1.5.0-beta20/fix-demo.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Use the gateway_proxy.GATEWAY_PROXY_NAME.failover.enabled helm value in the 
+      `glooctl demo federation` script.


### PR DESCRIPTION
# Description

Now that we have the `gateway_proxy.GATEWAY_PROXY_NAME.failover.enabled` helm value, we can use that in the gloo fed demo script.

It effectively replaces this operation:
```
# Apply failover gateway and service
kubectl apply -f - <<EOF
apiVersion: gateway.solo.io/v1
kind: Gateway
metadata:
  name: failover-gateway
  namespace: gloo-system
  labels:
    app: gloo
spec:
  bindAddress: "::"
  bindPort: 15443
  tcpGateway:
    tcpHosts:
    - name: failover
      sslConfig:
        secretRef:
          name: failover-downstream
          namespace: gloo-system
      destination:
        forwardSniClusterName: {}
---
apiVersion: v1
kind: Service
metadata:
  labels:
    app: gloo
    gateway-proxy-id: gateway-proxy
    gloo: gateway-proxy
  name: failover
  namespace: gloo-system
spec:
  ports:
  - name: failover
    nodePort: 32000
    port: 15443
    protocol: TCP
    targetPort: 15443
  selector:
    gateway-proxy: live
    gateway-proxy-id: gateway-proxy
  sessionAffinity: None
  type: NodePort
EOF
```

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works