### PR TITLE
Use set to expand cluster local service domains for Knative

### DIFF
--- a/changelog/v1.5.0-beta21/knative-ingress-local-domains.yaml
+++ b/changelog/v1.5.0-beta21/knative-ingress-local-domains.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Use Set to store expanded cluster local service domains for Knative.

--- a/projects/clusteringress/pkg/translator/translate_test.go
+++ b/projects/clusteringress/pkg/translator/translate_test.go
@@ -222,10 +222,10 @@ var _ = Describe("Translate", func() {
 								{
 									Name: "example.ing-1",
 									Domains: []string{
-										"pog.com",
-										"pog.com:80",
 										"champ.net",
 										"champ.net:80",
+										"pog.com",
+										"pog.com:80",
 										"zah.net",
 										"zah.net:80",
 									},

--- a/projects/knative/pkg/translator/translate.go
+++ b/projects/knative/pkg/translator/translate.go
@@ -10,8 +10,6 @@ import (
 
 	"knative.dev/serving/pkg/apis/networking"
 
-	"knative.dev/pkg/network"
-
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	v1 "k8s.io/api/core/v1"
 
@@ -220,7 +218,7 @@ func routingConfig(ctx context.Context, ingresses map[*core.Metadata]knativev1al
 			}
 
 			var hosts []string
-			for _, host := range expandHosts(rule.Hosts) {
+			for _, host := range rule.Hosts {
 				hosts = append(hosts, host)
 				if useTls {
 					hosts = append(hosts, fmt.Sprintf("%v:%v", host, bindPortHttps))
@@ -307,25 +305,4 @@ func getHeaderManipulation(headersToAppend map[string]string) *headers.HeaderMan
 	return &headers.HeaderManipulation{
 		RequestHeadersToAdd: headersToAdd,
 	}
-}
-
-// trim kube dns suffixes
-// undocumented requirement
-// see https://github.com/knative/serving/blob/master/pkg/reconciler/ingress/resources/virtual_service.go#L281
-func expandHosts(hosts []string) []string {
-	var expanded []string
-	allowedSuffixes := []string{
-		"",
-		"." + network.GetClusterDomainName(),
-		".svc." + network.GetClusterDomainName(),
-	}
-	for _, h := range hosts {
-		for _, suffix := range allowedSuffixes {
-			if strings.HasSuffix(h, suffix) {
-				expanded = append(expanded, strings.TrimSuffix(h, suffix))
-			}
-		}
-	}
-
-	return expanded
 }

--- a/projects/knative/pkg/translator/translate.go
+++ b/projects/knative/pkg/translator/translate.go
@@ -8,10 +8,12 @@ import (
 	"strings"
 	"time"
 
+	"knative.dev/pkg/network"
 	"knative.dev/serving/pkg/apis/networking"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1alpha1 "github.com/solo-io/gloo/projects/knative/pkg/api/external/knative"
 	"github.com/solo-io/go-utils/contextutils"
@@ -218,7 +220,7 @@ func routingConfig(ctx context.Context, ingresses map[*core.Metadata]knativev1al
 			}
 
 			var hosts []string
-			for _, host := range rule.Hosts {
+			for _, host := range expandHosts(rule.Hosts) {
 				hosts = append(hosts, host)
 				if useTls {
 					hosts = append(hosts, fmt.Sprintf("%v:%v", host, bindPortHttps))
@@ -305,4 +307,25 @@ func getHeaderManipulation(headersToAppend map[string]string) *headers.HeaderMan
 	return &headers.HeaderManipulation{
 		RequestHeadersToAdd: headersToAdd,
 	}
+}
+
+// trim kube dns suffixes
+// undocumented requirement
+// see https://github.com/knative/serving/blob/master/pkg/reconciler/ingress/resources/virtual_service.go#L281
+func expandHosts(hosts []string) []string {
+	expanded := sets.NewString()
+	allowedSuffixes := []string{
+		"",
+		"." + network.GetClusterDomainName(),
+		".svc." + network.GetClusterDomainName(),
+	}
+	for _, h := range hosts {
+		for _, suffix := range allowedSuffixes {
+			if strings.HasSuffix(h, suffix) {
+				expanded.Insert(strings.TrimSuffix(h, suffix))
+			}
+		}
+	}
+
+	return expanded.List()
 }

--- a/projects/knative/pkg/translator/translate_test.go
+++ b/projects/knative/pkg/translator/translate_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Translate", func() {
 			Spec: v1alpha1.IngressSpec{
 				Rules: []v1alpha1.IngressRule{
 					{
-						Hosts: []string{"petes.com", "zah.net", "mysvc.myns.svc.cluster.local", "mysvc.myns.svc", "mysvc.myns", "mysvc.myns.example.com"},
+						Hosts: []string{"petes.com", "zah.net", "mysvc.myns.svc.cluster.local", "mysvc.myns.example.com"},
 						HTTP: &v1alpha1.HTTPIngressRuleValue{
 							Paths: []v1alpha1.HTTPIngressPath{
 								{
@@ -162,18 +162,18 @@ var _ = Describe("Translate", func() {
 								{
 									Name: "example.ing-0",
 									Domains: []string{
-										"petes.com",
-										"petes.com:80",
-										"zah.net",
-										"zah.net:80",
-										"mysvc.myns.svc.cluster.local",
-										"mysvc.myns.svc.cluster.local:80",
-										"mysvc.myns.svc",
-										"mysvc.myns.svc:80",
 										"mysvc.myns",
 										"mysvc.myns:80",
 										"mysvc.myns.example.com",
 										"mysvc.myns.example.com:80",
+										"mysvc.myns.svc",
+										"mysvc.myns.svc:80",
+										"mysvc.myns.svc.cluster.local",
+										"mysvc.myns.svc.cluster.local:80",
+										"petes.com",
+										"petes.com:80",
+										"zah.net",
+										"zah.net:80",
 									},
 									Routes: []*gloov1.Route{
 										{
@@ -229,10 +229,10 @@ var _ = Describe("Translate", func() {
 								{
 									Name: "example.ing-1",
 									Domains: []string{
-										"pog.com",
-										"pog.com:80",
 										"champ.net",
 										"champ.net:80",
+										"pog.com",
+										"pog.com:80",
 										"zah.net",
 										"zah.net:80",
 									},

--- a/projects/knative/pkg/translator/translate_test.go
+++ b/projects/knative/pkg/translator/translate_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Translate", func() {
 			Spec: v1alpha1.IngressSpec{
 				Rules: []v1alpha1.IngressRule{
 					{
-						Hosts: []string{"petes.com", "zah.net", "mysvc.myns.svc.cluster.local", "mysvc.myns.example.com"},
+						Hosts: []string{"petes.com", "zah.net", "mysvc.myns.svc.cluster.local", "mysvc.myns.svc", "mysvc.myns", "mysvc.myns.example.com"},
 						HTTP: &v1alpha1.HTTPIngressRuleValue{
 							Paths: []v1alpha1.HTTPIngressPath{
 								{


### PR DESCRIPTION
# Description

Since Knative started expanding the cluster local domains by https://github.com/knative/serving/pull/9100, Gloo does not need to expand it anymore.
This patch stops to call `expandHosts()`.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works