### PR TITLE
fixed listener config code blocks to clarify and fix copy-paste errors

### DIFF
--- a/docs/content/guides/traffic_management/listener_configuration/_index.md
+++ b/docs/content/guides/traffic_management/listener_configuration/_index.md
@@ -15,18 +15,23 @@ For demonstration purposes, let's edit the default gateways that are installed w
 
 ```bash
 kubectl get gateway --all-namespaces
+```
+
+```bash
 NAMESPACE     NAME                AGE
 gloo-system   gateway-proxy       2d
 gloo-system   gateway-proxy-ssl   2d
 ```
 
-`kubectl edit gateway -n gloo-system gateway-proxy`
+```bash
+kubectl edit gateway -n gloo-system gateway-proxy
+```
 
 ### Plugin summary
 
 The listener plugin portion of the gateway Custom Resource (CR) is shown below.
 
-{{< highlight yaml "hl_lines=7-11" >}}
+{{< highlight yaml "hl_lines=7-12" >}}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata: # collapsed for brevity


### PR DESCRIPTION
# Description

Fixed https://docs.solo.io/gloo/latest/guides/traffic_management/listener_configuration/ to correct command blocks that didn't copy-paste properly, plus a yaml highlighting fix.

