### PR TITLE
Enable bulldozer keep pr updated

### DIFF
--- a/.github/workflows/add-pr-label.yaml
+++ b/.github/workflows/add-pr-label.yaml
@@ -1,0 +1,17 @@
+name: PR Auto Labeling
+on:
+  pull_request:
+    types:
+      - opened
+jobs:
+  add-label:
+    name: Add `keep pr updated` Label
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: christianvuerings/add-labels@v1
+        with:
+          labels: |
+            keep pr updated
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog/v1.5.0-beta21/add-pr-label-adder.yaml
+++ b/changelog/v1.5.0-beta21/add-pr-label-adder.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add GH action that adds label to opt-in to bulldozer feature that keeps our PRs up to date with base branch


### PR DESCRIPTION
# Description

adds GH action to add label titled "keep pr updated", which signals to bulldozer to keep our PRs up to date