### PR TITLE
Allow changing ingress proxy label

### DIFF
--- a/changelog/v1.5.0-beta21/ingress-proxy-label.yaml
+++ b/changelog/v1.5.0-beta21/ingress-proxy-label.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX 
+    description: >
+      Allow changing a label value for ingress proxy to enable multiple ingress proxy instances in
+      the same cluster.
+    issueLink: https://github.com/solo-io/gloo/issues/3587

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -514,6 +514,7 @@
 |ingressProxy.configMap.data.NAME|string|||
 |ingressProxy.tracing|string|||
 |ingressProxy.loopBackAddress|string|127.0.0.1|Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1|
+|ingressProxy.label|string|ingress-proxy|Value for label gloo. Use a unique value to use several ingress proxy instances in the same cluster. Default is ingress-proxy|
 |ingressProxy.service.type|string|LoadBalancer|K8s service type|
 |ingressProxy.service.extraAnnotations.NAME|string||extra annotations to add to the service|
 |ingressProxy.service.loadBalancerIP|string||IP address of the load balancer|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -357,6 +357,7 @@ type IngressProxy struct {
 	ConfigMap       *IngressProxyConfigMap  `json:"configMap,omitempty"`
 	Tracing         *string                 `json:"tracing,omitempty"`
 	LoopBackAddress string                  `json:"loopBackAddress,omitempty" desc:"Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1"`
+	Label           string                  `json:"label" desc:"Value for label gloo. Use a unique value to use several ingress proxy instances in the same cluster. Default is ingress-proxy"`
 	*ServiceSpec
 }
 

--- a/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
@@ -8,7 +8,7 @@ kind: Deployment
 metadata:
   labels:
     app: gloo
-    gloo: ingress-proxy
+    gloo: {{ .Values.ingressProxy.label }}
   name: ingress-proxy
   namespace: {{ .Release.Namespace }}
 spec:
@@ -19,7 +19,7 @@ spec:
   template:
     metadata:
       labels:
-        gloo: ingress-proxy
+        gloo: {{ .Values.ingressProxy.label }}
         {{- if .Values.ingressProxy.deployment.extraIngressProxyLabels }}
         {{- range $key, $value := .Values.ingressProxy.deployment.extraIngressProxyLabels }}
         {{ $key }}: {{ $value | quote }}
@@ -46,6 +46,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: INGRESS_PROXY_LABEL
+          value: {{ .Values.ingressProxy.label }}
         image: {{template "gloo.image" $image}}
         imagePullPolicy: {{ $image.pullPolicy }}
         name: ingress-proxy

--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     app: gloo
-    gloo: ingress-proxy
+    gloo: {{ .Values.ingressProxy.label }}
 data:
 {{ if (empty .Values.ingressProxy.configMap.data) }}
   envoy.yaml: |

--- a/install/helm/gloo/templates/13-ingress-proxy-service.yaml
+++ b/install/helm/gloo/templates/13-ingress-proxy-service.yaml
@@ -4,7 +4,7 @@ kind: Service
 metadata:
   labels:
     app: gloo
-    gloo: ingress-proxy
+    gloo: {{ .Values.ingressProxy.label }}
   name: ingress-proxy
   namespace: {{ .Release.Namespace }}
 {{- if .Values.ingressProxy.service }}

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -143,6 +143,8 @@ ingress:
     replicas: 1
     runAsUser: 10101
 ingressProxy:
+  # Set to a unique value to allow using several ingress proxy instances in the same cluster.
+  label: ingress-proxy
   loopBackAddress: 127.0.0.1
   deployment:
     image:

--- a/projects/ingress/pkg/setup/opts.go
+++ b/projects/ingress/pkg/setup/opts.go
@@ -20,4 +20,5 @@ type Opts struct {
 	DisableKubeIngress          bool
 	RequireIngressClass         bool
 	CustomIngressClass          string
+	IngressProxyLabel           string
 }


### PR DESCRIPTION
# Description

Added a new Helm value for ingress proxy label. A unique value for the label is required if one wants to have several ingress proxy instances in the same cluster.

This fixes #3587.

# Context

When a user want to install more than one Gloo Ingress instance to the same cluster, they need to use a unique value for label "gloo" for ingress proxy Service.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3587