### PR TITLE
Githook fix

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,7 +2,7 @@
 
 echo "Checking commit for JSON web tokens..."
 echo "Note: This fails without python3. Comment out .githooks/pre-commit to disable this hook."
-if test -f /dev/tty ; then
+if test -e /dev/tty ; then
 exec < /dev/tty ./.githooks/pre-commit-python.py
 fi
 

--- a/.githooks/pre-commit-python.py
+++ b/.githooks/pre-commit-python.py
@@ -47,7 +47,7 @@ def contains_jwt(lines):
 
 def main():
     #get git diff lines
-    lines = subprocess.check_output(['git', 'diff', 'HEAD~1']).decode("utf-8").split('\n')
+    lines = subprocess.check_output(['git', 'diff', '--staged']).decode("utf-8").split('\n')
 
     # filter out short lines and lines that don't begin with a '+' to only
     # test longer, newly added text

--- a/changelog/v1.5.0-beta22/githook-mac-fix.yaml
+++ b/changelog/v1.5.0-beta22/githook-mac-fix.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Correct JWT githook to work when warning mac users, and to actually check the correct diffs

--- a/hook-test
+++ b/hook-test
@@ -1,0 +1,1 @@
+eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ

--- a/hook-test
+++ b/hook-test
@@ -1,1 +1,0 @@
-eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ


### PR DESCRIPTION
# Description

Please include a summary of the changes.

Fixes a mac bug in the JWT githook introduced by the linux fix, and changes the git command used to get recent changes to the correct command.


# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/) 
- [X] I have performed a self-review of my own code   