### PR TITLE
Remove dangling ratelimit comments

### DIFF
--- a/changelog/v1.5.0-beta23/remove-dangling-comments.yaml
+++ b/changelog/v1.5.0-beta23/remove-dangling-comments.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: HELM
+    description: Remove comments from template for ratelimit value, which is no longer present.
+    issueLink: https://github.com/solo-io/gloo/issues/3467

--- a/changelog/v1.5.0-beta23/remove-dangling-comments.yaml
+++ b/changelog/v1.5.0-beta23/remove-dangling-comments.yaml
@@ -1,4 +1,3 @@
 changelog:
   - type: NON_USER_FACING
     description: Remove comments from template for ratelimit value, which is no longer present.
-    issueLink: https://github.com/solo-io/gloo/issues/3467

--- a/changelog/v1.5.0-beta23/remove-dangling-comments.yaml
+++ b/changelog/v1.5.0-beta23/remove-dangling-comments.yaml
@@ -1,4 +1,4 @@
 changelog:
-  - type: HELM
+  - type: NON_USER_FACING
     description: Remove comments from template for ratelimit value, which is no longer present.
     issueLink: https://github.com/solo-io/gloo/issues/3467

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -39,8 +39,6 @@ settings:
   # If false (default), Gloo will propagate the state of the Proxy to Envoy, resetting the listener to a clean slate with no routes.
   # If true, Gloo will keep serving the routes from the last applied valid configuration.
   disableProxyGarbageCollection: false
-  # Set this value to a an array of ratelimit descriptors to have rate limits on the gloo instance's installation namespace.
-  # For more info, see https://docs.solo.io/gloo/latest/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/ratelimit/ratelimit.proto.sk/#servicesettings
 gloo:
   deployment:
     image:


### PR DESCRIPTION
# Description

Realized that I forgot to remove the comments associated with the ratelimit value in my previous commit for this. Doing so now.

# Context

original PR: https://github.com/solo-io/gloo/pull/3539/files
Issue Link: https://github.com/solo-io/gloo/issues/3467

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3467