### PR TITLE
Faster ci

### DIFF
--- a/changelog/v1.5.0-beta25/no-cleanup-gloo-in-ci.yaml
+++ b/changelog/v1.5.0-beta25/no-cleanup-gloo-in-ci.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Gate cleanup logic so it doesn't run in CI since uninstall is slow and ci clusters are ephemeral

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -71,9 +71,11 @@ func StartTestHelper() {
 }
 
 func TearDownTestHelper() {
-	Expect(testHelper).ToNot(BeNil())
-	err := testHelper.UninstallGloo()
-	Expect(err).NotTo(HaveOccurred())
-	_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(testHelper.InstallNamespace, metav1.GetOptions{})
-	Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	if os.Getenv("TEAR_DOWN") == "true" {
+		Expect(testHelper).ToNot(BeNil())
+		err := testHelper.UninstallGloo()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(testHelper.InstallNamespace, metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	}
 }

--- a/test/kube2e/gloo-mtls/gloo_mtls_suite_test.go
+++ b/test/kube2e/gloo-mtls/gloo_mtls_suite_test.go
@@ -13,10 +13,8 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/check"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/test/helpers"
-	"github.com/solo-io/gloo/test/kube2e"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/testutils"
-	"github.com/solo-io/go-utils/testutils/clusterlock"
 	"github.com/solo-io/go-utils/testutils/exec"
 	"github.com/solo-io/go-utils/testutils/helper"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
@@ -25,13 +23,10 @@ import (
 	. "github.com/onsi/gomega"
 	errors "github.com/rotisserie/eris"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
-
-	"github.com/avast/retry-go"
 )
 
 var (
 	testHelper       *helper.SoloTestHelper
-	locker           *clusterlock.TestClusterLocker
 	installNamespace = "gloo-system"
 )
 
@@ -65,10 +60,6 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
-
-	locker, err = clusterlock.NewKubeClusterLocker(kube2e.MustKubeClient(), clusterlock.Options{})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(locker.AcquireLock(retry.Attempts(40))).NotTo(HaveOccurred())
 
 	// Install Gloo
 	values, cleanup := getHelmOverrides()
@@ -105,18 +96,18 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	defer locker.ReleaseLock()
+	if os.Getenv("TEAR_DOWN") == "true" {
+		err := testHelper.UninstallGloo()
+		Expect(err).NotTo(HaveOccurred())
 
-	err := testHelper.UninstallGloo()
-	Expect(err).NotTo(HaveOccurred())
+		// glooctl should delete the namespace. we do it again just in case it failed
+		// ignore errors
+		_ = testutils.Kubectl("delete", "namespace", testHelper.InstallNamespace)
 
-	// glooctl should delete the namespace. we do it again just in case it failed
-	// ignore errors
-	_ = testutils.Kubectl("delete", "namespace", testHelper.InstallNamespace)
-
-	EventuallyWithOffset(1, func() error {
-		return testutils.Kubectl("get", "namespace", testHelper.InstallNamespace)
-	}, "60s", "1s").Should(HaveOccurred())
+		EventuallyWithOffset(1, func() error {
+			return testutils.Kubectl("get", "namespace", testHelper.InstallNamespace)
+		}, "60s", "1s").Should(HaveOccurred())
+	}
 })
 
 func getHelmOverrides() (filename string, cleanup func()) {

--- a/test/kube2e/helm/helm_suite_test.go
+++ b/test/kube2e/helm/helm_suite_test.go
@@ -73,11 +73,13 @@ func StartTestHelper() {
 }
 
 func TearDownTestHelper() {
-	Expect(testHelper).ToNot(BeNil())
-	err := testHelper.UninstallGloo()
-	Expect(err).NotTo(HaveOccurred())
-	_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(testHelper.InstallNamespace, metav1.GetOptions{})
-	Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	if os.Getenv("TEAR_DOWN") == "true" {
+		Expect(testHelper).ToNot(BeNil())
+		err := testHelper.UninstallGloo()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(testHelper.InstallNamespace, metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	}
 }
 
 func runAndCleanCommand(name string, arg ...string) []byte {

--- a/test/kube2e/ingress/ingress_suite_test.go
+++ b/test/kube2e/ingress/ingress_suite_test.go
@@ -11,10 +11,6 @@ import (
 
 	"github.com/solo-io/gloo/test/helpers"
 
-	"github.com/avast/retry-go"
-	"github.com/solo-io/gloo/test/kube2e"
-	"github.com/solo-io/go-utils/testutils/clusterlock"
-
 	"github.com/solo-io/go-utils/testutils"
 	"github.com/solo-io/go-utils/testutils/helper"
 
@@ -36,7 +32,6 @@ func TestIngress(t *testing.T) {
 }
 
 var testHelper *helper.SoloTestHelper
-var locker *clusterlock.TestClusterLocker
 
 var _ = BeforeSuite(func() {
 	cwd, err := os.Getwd()
@@ -54,24 +49,21 @@ var _ = BeforeSuite(func() {
 	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
 	testHelper.Verbose = true
 
-	locker, err = clusterlock.NewTestClusterLocker(kube2e.MustKubeClient(), clusterlock.Options{})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(locker.AcquireLock(retry.Attempts(40))).NotTo(HaveOccurred())
-
 	// Install Gloo
 	err = testHelper.InstallGloo(helper.INGRESS, 5*time.Minute)
 	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
-	defer locker.ReleaseLock()
-	err := testHelper.UninstallGlooAll()
-	Expect(err).NotTo(HaveOccurred())
+	if os.Getenv("TEAR_DOWN") == "true" {
+		err := testHelper.UninstallGlooAll()
+		Expect(err).NotTo(HaveOccurred())
 
-	// TODO go-utils should expose `glooctl uninstall --delete-namespace`
-	testutils.Kubectl("delete", "namespace", testHelper.InstallNamespace)
+		// TODO go-utils should expose `glooctl uninstall --delete-namespace`
+		testutils.Kubectl("delete", "namespace", testHelper.InstallNamespace)
 
-	Eventually(func() error {
-		return testutils.Kubectl("get", "namespace", testHelper.InstallNamespace)
-	}, "60s", "1s").Should(HaveOccurred())
+		Eventually(func() error {
+			return testutils.Kubectl("get", "namespace", testHelper.InstallNamespace)
+		}, "60s", "1s").Should(HaveOccurred())
+	}
 })

--- a/test/kube2e/wasm/wasm_suite_test.go
+++ b/test/kube2e/wasm/wasm_suite_test.go
@@ -104,9 +104,11 @@ gloo:
 }
 
 func TearDownTestHelper() {
-	Expect(testHelper).ToNot(BeNil())
-	err := testHelper.UninstallGloo()
-	Expect(err).NotTo(HaveOccurred())
-	_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(testHelper.InstallNamespace, metav1.GetOptions{})
-	Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	if os.Getenv("TEAR_DOWN") == "true" {
+		Expect(testHelper).ToNot(BeNil())
+		err := testHelper.UninstallGloo()
+		Expect(err).NotTo(HaveOccurred())
+		_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(testHelper.InstallNamespace, metav1.GetOptions{})
+		Expect(apierrors.IsNotFound(err)).To(BeTrue())
+	}
 }


### PR DESCRIPTION
# Description

Gate cleanup logic so it doesn't run in CI since uninstall is slow and ci clusters are ephemeral