### PR TITLE
Fix glooctl istio inject for GlooE

### DIFF
--- a/changelog/v1.5.0-beta25/istio-inject-fix.yaml
+++ b/changelog/v1.5.0-beta25/istio-inject-fix.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3641
+    description: >
+      Fix a bug that was causing `glooctl istio inject` to use
+      the wrong version for the SDS sidecar in GlooE environments.

--- a/changelog/v1.5.0-beta25/istio-inject-fix.yaml
+++ b/changelog/v1.5.0-beta25/istio-inject-fix.yaml
@@ -4,3 +4,8 @@ changelog:
     description: >
       Fix a bug that was causing `glooctl istio inject` to use
       the wrong version for the SDS sidecar in GlooE environments.
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/3640
+    description: >
+      Update istio mTLS docs to note what YAML changes that
+      glooctl istio inject does under the hood.

--- a/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
+++ b/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
@@ -13,11 +13,11 @@ This guide was tested with Istio 1.6.6 and 1.7. For older versions of Istio, see
 
 ### Gloo versions
 
-This guide was tested with Gloo v1.5.0-beta23.
+This guide was tested with Gloo v1.5.0-beta25.
 
 {{% notice warning %}}
 
-The Gloo integration with Istio 1.6.x requires Gloo version 1.4.10, or 1.5.0-beta23 or higher.
+The Gloo integration with Istio 1.6.x requires Gloo version 1.4.10, or 1.5.0-beta25 or higher.
 
 {{% /notice %}}
 
@@ -72,7 +72,7 @@ glooctl install gateway
 ```
 or with helm:
 ```
-kubectl create ns gloo-system; helm install --namespace gloo-system --version 1.5.0-beta23 gloo gloo/gloo
+kubectl create ns gloo-system; helm install --namespace gloo-system --version 1.5.0-beta25 gloo gloo/gloo
 ```
 See the [quick start]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/" %}}) guide for more information.
 
@@ -133,7 +133,9 @@ To test this out, we need a route in Gloo:
 glooctl add route --name prodpage --namespace gloo-system --path-prefix / --dest-name default-productpage-9080 --dest-namespace gloo-system
 ```
 
-And we can curl it:
+## Step 4 - Test it
+
+We can curl the product page:
 
 ```bash
 curl -v $(glooctl proxy url)/productpage
@@ -145,3 +147,302 @@ HTTP_GW=$(glooctl proxy url)
 ## Open the ingress url in the browser:
 $([ "$(uname -s)" = "Linux" ] && echo xdg-open || echo open) $HTTP_GW/productpage
 ```
+
+
+
+## Understanding the changes made
+
+While the `glooctl` functions we've used in this guide are great for getting started quickly, it's also useful to know what changes they've actually made to our configuration under the hood. When we ran `glooctl inject istio`, this updated two resources:
+
+##### ConfigMap changes
+First, it updates the `gateway-proxy-envoy-config` `ConfigMap` resource used by the `gateway-proxy` deployment to bootstrap our envoy server. Specifically, it adds the `gateway_proxy_sds` cluster, so that envoy can receive the secrets over SDS:
+
+{{< highlight yaml "hl_lines=20-31" >}}
+apiVersion: v1
+data:
+  envoy.yaml: |
+    (...)
+    staticResources:
+      clusters:
+      - altStatName: xds_cluster
+        connectTimeout: 5s
+        http2ProtocolOptions: {}
+        loadAssignment:
+          clusterName: gloo.gloo-system.svc.cluster.local:9977
+          endpoints:
+          - lbEndpoints:
+            - endpoint:
+                address:
+                  socketAddress:
+                    address: gloo.gloo-system.svc.cluster.local
+                    portValue: 9977
+      (...)
+      - connectTimeout: 0.250s
+            http2ProtocolOptions: {}
+            loadAssignment:
+              clusterName: gateway_proxy_sds
+              endpoints:
+              - lbEndpoints:
+                - endpoint:
+                    address:
+                      socketAddress:
+                        address: 127.0.0.1
+                        portValue: 8234
+            name: gateway_proxy_sds
+      (...)
+{{< /highlight >}}
+
+##### Deployment changes
+Next, it updates our `gateway-proxy` deployment to add two sidecars and some volume mounts. It adds an `istio-proxy` sidecar, which is used to generate the certificates used for mTLS communication. It also adds an `sds` sidecar, a running sds server which feeds any certificate changes into our `gateway-proxy` envoy whenever the certs change. For example, this will happen when the istio mTLS certificates rotate, which is every 24 hours in the default istio installation. The certs are also added to a volumeMount at `/etc/istio-certs/`
+
+{{< highlight yaml "hl_lines=65-192 202-216" >}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: gloo
+    gateway-proxy-id: gateway-proxy
+    gloo: gateway-proxy
+  name: gateway-proxy
+  namespace: gloo-system
+spec:
+  selector:
+    matchLabels:
+      gateway-proxy-id: gateway-proxy
+      gloo: gateway-proxy
+  template:
+    metadata:
+      annotations:
+        prometheus.io/path: /metrics
+        prometheus.io/port: "8081"
+        prometheus.io/scrape: "true"
+      creationTimestamp: null
+      labels:
+        gateway-proxy: live
+        gateway-proxy-id: gateway-proxy
+        gloo: gateway-proxy
+    spec:
+      containers:
+      - args:
+        - --disable-hot-restart
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        image: quay.io/solo-io/gloo-envoy-wrapper:1.5.0-beta24
+        imagePullPolicy: IfNotPresent
+        name: gateway-proxy
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        - containerPort: 8443
+          name: https
+          protocol: TCP
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          runAsUser: 10101
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/envoy
+          name: envoy-config
+      - env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: ISTIO_MTLS_SDS_ENABLED
+          value: "true"
+        image: quay.io/solo-io/sds:1.5.0-beta24
+        imagePullPolicy: IfNotPresent
+        name: sds
+        ports:
+        - containerPort: 8234
+          name: sds
+          protocol: TCP
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/istio-certs/
+          name: istio-certs
+        - mountPath: /etc/envoy
+          name: envoy-config
+      - args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - --configPath
+        - /etc/istio/proxy
+        - --binaryPath
+        - /usr/local/bin/envoy
+        - --serviceCluster
+        - istio-proxy-prometheus
+        - --drainDuration
+        - 45s
+        - --parentShutdownDuration
+        - 1m0s
+        - --discoveryAddress
+        - istio-pilot.istio-system.svc:15012
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --connectTimeout
+        - 10s
+        - --proxyAdminPort
+        - "15000"
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --dnsRefreshRate
+        - 300s
+        - --statusPort
+        - "15021"
+        - --trust-domain=cluster.local
+        - --controlPlaneBootstrap=false
+        env:
+        - name: OUTPUT_CERTS
+          value: /etc/istio-certs
+        - name: JWT_POLICY
+          value: first-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        - name: ISTIO_META_POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
+        - name: ISTIO_META_CONFIG_NAMESPACE
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.namespace
+        image: docker.io/istio/proxyv2:1.6.0
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15021
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /etc/istio-certs/
+          name: istio-certs
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext:
+        fsGroup: 10101
+        runAsUser: 10101
+      serviceAccount: gateway-proxy
+      serviceAccountName: gateway-proxy
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - configMap:
+          defaultMode: 420
+          name: gateway-proxy-envoy-config
+        name: envoy-config
+      - emptyDir:
+          medium: Memory
+        name: istio-certs
+      - configMap:
+          defaultMode: 420
+          name: istio-ca-root-cert
+        name: istiod-ca-cert
+      - emptyDir:
+          medium: Memory
+        name: istio-envoy
+status:
+(...)
+{{< /highlight >}}
+
+Finally, running `glooctl istio enable-mtls --upstream default-productpage-9080` adds the `sslConfig` to our upstream so that Envoy knows to get the certs via SDS:
+
+{{< highlight yaml "hl_lines=17-24" >}}
+apiVersion: gloo.solo.io/v1
+kind: Upstream
+metadata:
+  name: default-productpage-9080
+  namespace: gloo-system
+spec:
+  discoveryMetadata:
+    labels:
+      app: productpage
+      service: productpage
+  kube:
+    selector:
+      app: productpage
+    serviceName: productpage
+    serviceNamespace: default
+    servicePort: 9080
+  sslConfig:
+    alpnProtocols:
+    - istio
+    sds:
+      certificatesSecretName: istio_server_cert
+      clusterName: gateway_proxy_sds
+      targetUri: 127.0.01:8234
+      validationContextName: istio_validation_context
+status:
+(...)
+{{< /highlight >}}

--- a/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
+++ b/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
@@ -416,6 +416,7 @@ status:
 (...)
 {{< /highlight >}}
 
+##### Upstream changes
 Finally, running `glooctl istio enable-mtls --upstream default-productpage-9080` adds the `sslConfig` to our upstream so that Envoy knows to get the certs via SDS:
 
 {{< highlight yaml "hl_lines=17-24" >}}


### PR DESCRIPTION
# Description

To fix https://github.com/solo-io/gloo/issues/3641, use only the Gloo OS pods (gateway, ingress, discovery) to determine Gloo OS version to be used in the SDS sidecar.

# Context

Users ran into this bug using `glooctl istio inject` with GlooE.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3641
resolves https://github.com/solo-io/gloo/issues/3640