### PR TITLE
Fix Istio 1.7.1+ and Istio 1.6.9+

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -117,8 +117,8 @@ jobs:
     - name: Setup test env
       run: |
         ./ci/kind.sh
-        curl -sSL https://github.com/istio/istio/releases/download/1.6.8/istio-1.6.8-linux-amd64.tar.gz | tar -xzf - istio-1.6.8/bin/istioctl
-        ./istio-1.6.8/bin/istioctl install --set profile=minimal
+        curl -sSL https://github.com/istio/istio/releases/download/1.7.2/istio-1.7.2-linux-amd64.tar.gz | tar -xzf - istio-1.7.2/bin/istioctl
+        ./istio-1.7.2/bin/istioctl install --set profile=minimal
     - name: Testing - kube e2e regression tests
       env:
         KUBE2E_TESTS: glooctl

--- a/changelog/v1.5.0-beta26/istio-1-7-1-fix.yaml
+++ b/changelog/v1.5.0-beta26/istio-1-7-1-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3650
+    description: >
+      Fix for Istio mTLS integration for Istio versions 1.6.9+ and Istio 1.7.1+

--- a/projects/gloo/cli/pkg/cmd/istio/enable_mtls.go
+++ b/projects/gloo/cli/pkg/cmd/istio/enable_mtls.go
@@ -18,7 +18,7 @@ import (
 const (
 	istioCertSecret        = "istio_server_cert"
 	istioValidationContext = "istio_validation_context"
-	sdsTargetURI           = "127.0.01:8234"
+	sdsTargetURI           = "127.0.0.1:8234"
 )
 
 // EnableMTLS adds an sslConfig to the given upstream which will

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.6.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.6.go
@@ -63,6 +63,10 @@ func generateIstio16Sidecar(version, jwtPolicy string) *corev1.Container {
 				Value: "cluster.local",
 			},
 			{
+				Name:  "ISTIO_META_CLUSTER_ID",
+				Value: "Kubernetes",
+			},
+			{
 				Name: "POD_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7.go
@@ -63,6 +63,10 @@ func generateIstio17Sidecar(version, jwtPolicy string) *corev1.Container {
 				Value: "cluster.local",
 			},
 			{
+				Name:  "ISTIO_META_CLUSTER_ID",
+				Value: "Kubernetes",
+			},
+			{
 				Name: "POD_NAME",
 				ValueFrom: &corev1.EnvVarSource{
 					FieldRef: &corev1.ObjectFieldSelector{


### PR DESCRIPTION
Added ISTIO_META_CLUSTER_ID, which is now required by these versions.

# Description

Istio v1.6.9 and 1.7.1 were throwing errors when we tried to install them with the [glooctl Istio mTLS integration](https://docs.solo.io/gloo/latest/guides/integrations/service_mesh/gloo_istio_mtls/). Versions 1.6.8 and 1.7.0 were still working fine.

These new versions need "ISTIO_META_CLUSTER_ID" explicitly set, which is what this PR does.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3650