### PR TITLE
Basic ratelimit docs - route-level rate limits

### DIFF
--- a/changelog/v1.5.0-beta26/route-basic-ratelimit-docs.yaml
+++ b/changelog/v1.5.0-beta26/route-basic-ratelimit-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/2517/
+    description: Update the basic rate limit API page with instructions for route-level rate limits.

--- a/docs/content/guides/security/rate_limiting/simple/_index.md
+++ b/docs/content/guides/security/rate_limiting/simple/_index.md
@@ -6,13 +6,13 @@ description: Simplified rate-limit API that covers most use cases.
 
 ## Overview
 
-Gloo includes a simplified rate limiting model that allows you to specify the number of requests per configurable unit of time that can be made against all routes defined within a virtual host. You can set different limits for both authorized and anonymous users. An authorized user is one that the Gloo external authentication server has validated and their user token is included with the request. Authorized users are rate limited on a per user basis. Anonymous users are rate limited on a calling IP basis, i.e., all requests from that incoming IP count towards the requests per time limits.
+Gloo includes a simplified rate limiting model that allows you to specify the number of requests per configurable unit of time that can be made against all routes defined within a virtual host or individual routes. You can set different limits for both authorized and anonymous users. An authorized user is one that the Gloo external authentication server has validated and their user token is included with the request. Authorized users are rate limited on a per user basis. Anonymous users are rate limited on a calling IP basis, i.e., all requests from that incoming IP count towards the requests per time limits.
 
 For a more fine grained approach, take a look at using Gloo with [Envoy's native rate limiting model]({{% versioned_link_path fromRoot="/guides/security/rate_limiting/envoy/" %}})
 
 ## Rate Limit
 
-Rate limits are defined on the virtual service specification as `spec.virtualHost.options.ratelimitBasic` with the following {{% protobuf name="ratelimit.options.gloo.solo.io.IngressRateLimit" display="format"%}}. There is a full example later in this document that shows the rate limit configuration in context.
+Rate limits are defined on the virtual service or route specification as `spec.virtualHost.options.ratelimitBasic` with the following {{% protobuf name="ratelimit.options.gloo.solo.io.IngressRateLimit" display="format"%}}. There is a full example later in this document that shows the rate limit configuration in context.
 
 ```yaml
 ratelimitBasic:
@@ -32,7 +32,7 @@ ratelimitBasic:
 
 ### An example virtual service with rate limits enabled
 
-The minimum required configuration to create a new virtual service for the example petclinic application with anonymous and authorized rate limits enabled is shown below.
+The minimum required configuration to create a new virtual service for the example petclinic application with service-level anonymous and authorized rate limits enabled is shown below.
 
 First, install the petclinic application.
 
@@ -103,4 +103,37 @@ spec:
         anonymous_limits:
           requests_per_unit: 1000
           unit: HOUR
+{{< /highlight >}}
+
+### Route-level rate limits
+
+Rate limits can be specified on individual routes within a virtual host in addition to or instead of the virtual host itself. The API for specifying the rate limits is identical to the virtual host version, with one caveat. Any routes with a specified `ratelimitBasic` must also specify a `name` at the top level of the route. These names:
+* Must be non-blank.
+* Must not match other route names or the name of the virtual host, for all such resources with a `ratelimitBasic` specified.
+For example:
+{{< highlight yaml "hl_lines=14-19" >}}
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: default
+  namespace: gloo-system
+spec:
+  displayName: default
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matchers:
+      - prefix: /
+      name: example-route
+      options:
+        ratelimitBasic:
+          anonymous_limits:
+            requests_per_unit: 1000
+            unit: HOUR
+      routeAction:
+        single:
+          upstream:
+            name: default-petclinic-8080
+            namespace: gloo-system
 {{< /highlight >}}


### PR DESCRIPTION
Add docs for the route-level rate limiting feature added [here](https://github.com/solo-io/solo-projects/pull/1879).
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2517/