### PR TITLE
Fix misleading message in `glooctl install` output

### DIFF
--- a/changelog/v1.6.0-beta1/fix-glooctl-install-output.yaml
+++ b/changelog/v1.6.0-beta1/fix-glooctl-install-output.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/3704
+  description: Fix misleading message in `glooctl install` output when the install namespace already exists.

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -192,6 +192,8 @@ func (i *installer) createNamespace(namespace string) {
 		} else {
 			fmt.Printf("Done.\n")
 		}
+	} else if apierrors.IsAlreadyExists(err) {
+		fmt.Printf("\nNamespace %s already exists. Continuing...\n", namespace)
 	} else {
 		fmt.Printf("\nUnable to check if namespace %s exists. Continuing...\n", namespace)
 	}


### PR DESCRIPTION
Fix misleading message in `glooctl install` output when the install namespace already exists.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3704