### PR TITLE
fix: update Gloo image version in Nomad/Vagrant demo

### DIFF
--- a/install/nomad/demo-vagrant.sh
+++ b/install/nomad/demo-vagrant.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-GLOO_VERSION='1.3.1'
+GLOO_VERSION='1.4.13'
 
 # Will exit script if we would use an uninitialised variable (nounset) or when a
 # simple command (not a control structure) fails (errexit)


### PR DESCRIPTION
# Description

This PR updates the pinned Gloo versions running in the Nomad / Vagrant demo to `1.4.13`

# Context

Running the demo at `/install/nomad/demo-vagrant.sh`, I consistently ran into issues where the Nomad job specifications couldn't complete their placement of all of the Gloo tasks because `gateway-proxy` wouldn't stay healthy:

![image](https://user-images.githubusercontent.com/19556538/95138081-3d12fd00-071e-11eb-8d3e-3b0399a215e4.png)


MAY be related to solo-io/gloo#2404

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works