### PR TITLE
Fix helm chart to honor `.Values.settings.replaceInvalidRoutes` value

### DIFF
--- a/changelog/v1.5.1/invalid-rts.yaml
+++ b/changelog/v1.5.1/invalid-rts.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/3619
+    description: >-
+      Fix helm chart to honor `.Values.settings.replaceInvalidRoutes` value. This change makes the default invalid
+      route behavior match what's documented (disabled by default). To enable again, set
+      `.Values.settings.replaceInvalidRoutes=true`
+    resolvesIssue: false

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -16,7 +16,7 @@ spec:
     xdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.xdsPort }}"
     restXdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.restXdsPort }}"
 {{- end }}
-{{- if .Values.settings.invalidConfigPolicy }}
+{{- if .Values.settings.replaceInvalidRoutes }}
     invalidConfigPolicy:
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}
 {{- end }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1591,7 +1591,6 @@ spec:
      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
        ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
      invalidRouteResponseCode: 404
-
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}
@@ -1599,7 +1598,11 @@ spec:
  discoveryNamespace: ` + namespace + `
 `)
 
-						prepareMakefile(namespace, helmValues{})
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"settings.replaceInvalidRoutes=true",
+							},
+						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
 
@@ -1626,11 +1629,6 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: true
    disableProxyGarbageCollection: false
-   invalidConfigPolicy:
-     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
-       ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
-     invalidRouteResponseCode: 404
-
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}
@@ -1665,11 +1663,6 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
-   invalidConfigPolicy:
-     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
-       ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
-     invalidRouteResponseCode: 404
-
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}
@@ -1709,11 +1702,6 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
-   invalidConfigPolicy:
-     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
-       ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
-     invalidRouteResponseCode: 404
-
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}
@@ -1762,11 +1750,6 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: true
-   invalidConfigPolicy:
-     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
-       ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
-     invalidRouteResponseCode: 404
-
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}
@@ -1807,11 +1790,6 @@ spec:
     disableProxyGarbageCollection: false
     awsOptions:
       enableCredentialsDiscovey: true
-    invalidConfigPolicy:
-      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
-        ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
-      invalidRouteResponseCode: 404
-
   kubernetesArtifactSource: {}
   kubernetesConfigSource: {}
   kubernetesSecretSource: {}
@@ -1854,11 +1832,6 @@ spec:
       serviceAccountCredentials:
         cluster: aws_sts_cluster
         uri: sts.us-east-2.amazonaws.com
-    invalidConfigPolicy:
-      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run
-        ` + "`" + `glooctl check` + "`" + ` to find and fix config errors.
-      invalidRouteResponseCode: 404
-
   kubernetesArtifactSource: {}
   kubernetesConfigSource: {}
   kubernetesSecretSource: {}

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -48,21 +48,24 @@ var _ = Describe("Kube2e: helm", func() {
 
 	It("uses helm to update the settings without errors", func() {
 
-		By("should start with the default settings.invalidConfigPolicy.invalidRouteResponseCode=404")
+		By("should start with the settings.invalidConfigPolicy.invalidRouteResponseCode=404")
 		client := helpers.MustSettingsClient()
 		settings, err := client.Read(testHelper.InstallNamespace, defaults.SettingsName, clients.ReadOpts{})
 		Expect(err).To(BeNil())
 		Expect(settings.GetGloo().GetInvalidConfigPolicy().GetInvalidRouteResponseCode()).To(Equal(uint32(404)))
 
+		// following logic handles chartUri for focused test
 		// update the settings with `helm upgrade` (without updating the gloo version)
 		if chartUri == "" { // hasn't yet upgraded to the chart being tested- use regular gloo/gloo chart
 			runAndCleanCommand("helm", "upgrade", "gloo", "gloo/gloo",
 				"-n", testHelper.InstallNamespace,
+				"--set", "settings.replaceInvalidRoutes=true",
 				"--set", "settings.invalidConfigPolicy.invalidRouteResponseCode=400",
 				"--version", GetGlooServerVersion(testHelper.InstallNamespace))
 		} else { // has already upgraded to the chart being tested- use it
 			runAndCleanCommand("helm", "upgrade", "gloo", chartUri,
 				"-n", testHelper.InstallNamespace,
+				"--set", "settings.replaceInvalidRoutes=true",
 				"--set", "settings.invalidConfigPolicy.invalidRouteResponseCode=400")
 		}
 

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -73,6 +73,7 @@ global:
 settings:
   singleNamespace: true
   create: true
+  replaceInvalidRoutes: true
 gloo:
   deployment:
     disableUsageStatistics: true


### PR DESCRIPTION
backport of (#3725)

# Description

Fix helm chart to honor `.Values.settings.replaceInvalidRoutes` value.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works