### PR TITLE
Unpin curl

### DIFF
--- a/changelog/v1.6.0-beta2/unpin-curl.yaml
+++ b/changelog/v1.6.0-beta2/unpin-curl.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      unpin curl in extended docker image flow as base containers have differing requirements and can't all be
+      satisfied by the same version

--- a/ci/extended-docker/Dockerfile
+++ b/ci/extended-docker/Dockerfile
@@ -4,6 +4,6 @@ FROM $BASE_IMAGE
 
 USER root
 
-RUN apk add curl=7.67.0-r1
+RUN apk add curl
 
 USER 10101


### PR DESCRIPTION
# Description

unpin curl in extended docker image flow as base containers have differing requirements and can't all be satisfied by the same version

sample logs: https://console.cloud.google.com/cloud-build/builds/b4b7bdda-4e36-4f54-b918-35f7c9b16ce8;step=10?project=solo-public

note:
```
ERROR: unsatisfiable constraints:
  curl-7.69.1-r1:
    breaks: world[curl=7.67.0-r1]
```