### PR TITLE
Homebrew update docs

### DIFF
--- a/changelog/v1.6.0-beta3/homebrew-doc-update.yaml
+++ b/changelog/v1.6.0-beta3/homebrew-doc-update.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: update brew command to use native instead of tap

--- a/docs/content/installation/glooctl_setup.md
+++ b/docs/content/installation/glooctl_setup.md
@@ -5,7 +5,7 @@ The `glooctl` command line provides useful functions to install, configure, and 
 * To install `glooctl` using the [Homebrew](https://brew.sh) package manager, run the following.
 
   ```shell
-  brew install solo-io/tap/glooctl
+  brew install glooctl
   ```
 
 * To install on most platforms you can use the install script. Python is required for installation to execute properly.


### PR DESCRIPTION
# Description

Update the glooctl install doc to remove tap reference for homebrew install. Reference issue: #3707 

# Context

The homebrew install now uses the native brew command instead of a tap.
