### PR TITLE
Add helm value for stats prefix rewrite #3752

### DIFF
--- a/changelog/v1.6.0-beta4/helm-value-for-stats-prefix-rewrite.yaml
+++ b/changelog/v1.6.0-beta4/helm-value-for-stats-prefix-rewrite.yaml
@@ -2,4 +2,4 @@ changelog:
   - type: HELM
     issueLink: https://github.com/solo-io/gloo/issues/3752
     description: >-
-      Add a helm value for stats prefix rewrite. This allows to integrate with other monitoring system instead of just Prometheus.
+      Add a helm value for stats prefix rewrite. This allows Gloo to integrate with other monitoring systems instead of just Prometheus, by setting the `global.glooStats.routePrefixRewrite` helm value.

--- a/changelog/v1.6.0-beta4/helm-value-for-stats-prefix-rewrite.yaml
+++ b/changelog/v1.6.0-beta4/helm-value-for-stats-prefix-rewrite.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/3752
+    description: >-
+      Add a helm value for stats prefix rewrite. This allows to integrate with other monitoring system instead of just Prometheus.

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -608,7 +608,6 @@
 |global.glooRbac.create|bool|true|create rbac rules for the gloo-system service account|
 |global.glooRbac.namespaced|bool|false|use Roles instead of ClusterRoles|
 |global.glooRbac.nameSuffix|string||When nameSuffix is nonempty, append '-$nameSuffix' to the names of Gloo RBAC resources; e.g. when nameSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'|
-|global.wasm.enabled|bool|false|switch the gateway-proxy image to one which supports WASM|
 |global.glooStats.enabled|bool|true|Controls whether or not envoy stats are enabled|
 |global.glooStats.routePrefixRewrite|string|/stats/prometheus|The envoy stats endpoint to which the metrics endpoint is rewritten|
 |global.glooMtls.enabled|bool|false|Enables internal mtls authentication|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -92,7 +92,8 @@
 |gloo.deployment.xdsPort|int|9977|port where gloo serves xDS API to Envoy|
 |gloo.deployment.restXdsPort|uint32|9976|port where gloo serves REST xDS API to Envoy|
 |gloo.deployment.validationPort|int|9988|port where gloo serves gRPC Proxy Validation to Gateway|
-|gloo.deployment.stats.enabled|bool||Controls whether or not prometheus stats are enabled|
+|gloo.deployment.stats.enabled|bool||Controls whether or not envoy stats are enabled|
+|gloo.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
 |gloo.deployment.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gloo.deployment.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gloo.deployment.externalTrafficPolicy|string||Set the external traffic policy on the gloo service|
@@ -130,7 +131,8 @@
 |discovery.deployment.image.pullPolicy|string||image pull policy for the container|
 |discovery.deployment.image.pullSecret|string||image pull policy for the container |
 |discovery.deployment.image.extended|bool|false|if true, deploy an extended version of the container with additional debug tools|
-|discovery.deployment.stats.enabled|bool||Controls whether or not prometheus stats are enabled|
+|discovery.deployment.stats.enabled|bool||Controls whether or not envoy stats are enabled|
+|discovery.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
 |discovery.deployment.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |discovery.deployment.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |discovery.deployment.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
@@ -176,7 +178,8 @@
 |gateway.deployment.image.pullPolicy|string||image pull policy for the container|
 |gateway.deployment.image.pullSecret|string||image pull policy for the container |
 |gateway.deployment.image.extended|bool|false|if true, deploy an extended version of the container with additional debug tools|
-|gateway.deployment.stats.enabled|bool||Controls whether or not prometheus stats are enabled|
+|gateway.deployment.stats.enabled|bool||Controls whether or not envoy stats are enabled|
+|gateway.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
 |gateway.deployment.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gateway.deployment.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gateway.deployment.extraGatewayLabels.NAME|string||Optional extra key-value pairs to add to the spec.template.metadata.labels data of the gloo gateway deployment.|
@@ -338,7 +341,8 @@
 |gatewayProxies.NAME.extraInitContainersHelper|string|||
 |gatewayProxies.NAME.extraVolumeHelper|string|||
 |gatewayProxies.NAME.extraListenersHelper|string|||
-|gatewayProxies.NAME.stats.enabled|bool||Controls whether or not prometheus stats are enabled|
+|gatewayProxies.NAME.stats.enabled|bool||Controls whether or not envoy stats are enabled|
+|gatewayProxies.NAME.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
 |gatewayProxies.NAME.readConfig|bool||expose a read-only subset of the envoy admin api|
 |gatewayProxies.NAME.extraProxyVolumeMountHelper|string||name of custom made named template allowing for extra volume mounts on the proxy container|
 |gatewayProxies.NAME.loopBackAddress|string||Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1|
@@ -463,7 +467,8 @@
 |gatewayProxies.gatewayProxy.extraInitContainersHelper|string|||
 |gatewayProxies.gatewayProxy.extraVolumeHelper|string|||
 |gatewayProxies.gatewayProxy.extraListenersHelper|string|||
-|gatewayProxies.gatewayProxy.stats.enabled|bool||Controls whether or not prometheus stats are enabled|
+|gatewayProxies.gatewayProxy.stats.enabled|bool||Controls whether or not envoy stats are enabled|
+|gatewayProxies.gatewayProxy.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
 |gatewayProxies.gatewayProxy.readConfig|bool|false|expose a read-only subset of the envoy admin api|
 |gatewayProxies.gatewayProxy.extraProxyVolumeMountHelper|string||name of custom made named template allowing for extra volume mounts on the proxy container|
 |gatewayProxies.gatewayProxy.loopBackAddress|string|127.0.0.1|Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1|
@@ -564,7 +569,8 @@
 |accessLogger.port|uint|8083||
 |accessLogger.serviceName|string|AccessLog||
 |accessLogger.enabled|bool|false||
-|accessLogger.stats.enabled|bool|true|Controls whether or not prometheus stats are enabled|
+|accessLogger.stats.enabled|bool|true|Controls whether or not envoy stats are enabled|
+|accessLogger.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
 |accessLogger.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |accessLogger.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
 |accessLogger.extraAccessLoggerLabels.NAME|string||Optional extra key-value pairs to add to the spec.template.metadata.labels data of the gloo access logger deployment.|
@@ -602,7 +608,9 @@
 |global.glooRbac.create|bool|true|create rbac rules for the gloo-system service account|
 |global.glooRbac.namespaced|bool|false|use Roles instead of ClusterRoles|
 |global.glooRbac.nameSuffix|string||When nameSuffix is nonempty, append '-$nameSuffix' to the names of Gloo RBAC resources; e.g. when nameSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'|
-|global.glooStats.enabled|bool|true|Controls whether or not prometheus stats are enabled|
+|global.wasm.enabled|bool|false|switch the gateway-proxy image to one which supports WASM|
+|global.glooStats.enabled|bool|true|Controls whether or not envoy stats are enabled|
+|global.glooStats.routePrefixRewrite|string|/stats/prometheus|The envoy stats endpoint to which the metrics endpoint is rewritten|
 |global.glooMtls.enabled|bool|false|Enables internal mtls authentication|
 |global.glooMtls.sds.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |global.glooMtls.sds.image.repository|string|sds|image name (repository) for the container.|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -93,7 +93,7 @@
 |gloo.deployment.restXdsPort|uint32|9976|port where gloo serves REST xDS API to Envoy|
 |gloo.deployment.validationPort|int|9988|port where gloo serves gRPC Proxy Validation to Gateway|
 |gloo.deployment.stats.enabled|bool||Controls whether or not envoy stats are enabled|
-|gloo.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
+|gloo.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics are written|
 |gloo.deployment.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gloo.deployment.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gloo.deployment.externalTrafficPolicy|string||Set the external traffic policy on the gloo service|
@@ -132,7 +132,7 @@
 |discovery.deployment.image.pullSecret|string||image pull policy for the container |
 |discovery.deployment.image.extended|bool|false|if true, deploy an extended version of the container with additional debug tools|
 |discovery.deployment.stats.enabled|bool||Controls whether or not envoy stats are enabled|
-|discovery.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
+|discovery.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics are written|
 |discovery.deployment.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |discovery.deployment.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |discovery.deployment.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
@@ -179,7 +179,7 @@
 |gateway.deployment.image.pullSecret|string||image pull policy for the container |
 |gateway.deployment.image.extended|bool|false|if true, deploy an extended version of the container with additional debug tools|
 |gateway.deployment.stats.enabled|bool||Controls whether or not envoy stats are enabled|
-|gateway.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
+|gateway.deployment.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics are written|
 |gateway.deployment.floatingUserId|bool|false|set to true to allow the cluster to dynamically assign a user ID|
 |gateway.deployment.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |gateway.deployment.extraGatewayLabels.NAME|string||Optional extra key-value pairs to add to the spec.template.metadata.labels data of the gloo gateway deployment.|
@@ -342,7 +342,7 @@
 |gatewayProxies.NAME.extraVolumeHelper|string|||
 |gatewayProxies.NAME.extraListenersHelper|string|||
 |gatewayProxies.NAME.stats.enabled|bool||Controls whether or not envoy stats are enabled|
-|gatewayProxies.NAME.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
+|gatewayProxies.NAME.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics are written|
 |gatewayProxies.NAME.readConfig|bool||expose a read-only subset of the envoy admin api|
 |gatewayProxies.NAME.extraProxyVolumeMountHelper|string||name of custom made named template allowing for extra volume mounts on the proxy container|
 |gatewayProxies.NAME.loopBackAddress|string||Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1|
@@ -468,7 +468,7 @@
 |gatewayProxies.gatewayProxy.extraVolumeHelper|string|||
 |gatewayProxies.gatewayProxy.extraListenersHelper|string|||
 |gatewayProxies.gatewayProxy.stats.enabled|bool||Controls whether or not envoy stats are enabled|
-|gatewayProxies.gatewayProxy.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
+|gatewayProxies.gatewayProxy.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics are written|
 |gatewayProxies.gatewayProxy.readConfig|bool|false|expose a read-only subset of the envoy admin api|
 |gatewayProxies.gatewayProxy.extraProxyVolumeMountHelper|string||name of custom made named template allowing for extra volume mounts on the proxy container|
 |gatewayProxies.gatewayProxy.loopBackAddress|string|127.0.0.1|Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1|
@@ -570,7 +570,7 @@
 |accessLogger.serviceName|string|AccessLog||
 |accessLogger.enabled|bool|false||
 |accessLogger.stats.enabled|bool|true|Controls whether or not envoy stats are enabled|
-|accessLogger.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics endpoint is rewritten|
+|accessLogger.stats.routePrefixRewrite|string||The envoy stats endpoint to which the metrics are written|
 |accessLogger.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
 |accessLogger.fsGroup|float64||Explicitly set the group ID for volume ownership. Default is 10101|
 |accessLogger.extraAccessLoggerLabels.NAME|string||Optional extra key-value pairs to add to the spec.template.metadata.labels data of the gloo access logger deployment.|
@@ -609,7 +609,7 @@
 |global.glooRbac.namespaced|bool|false|use Roles instead of ClusterRoles|
 |global.glooRbac.nameSuffix|string||When nameSuffix is nonempty, append '-$nameSuffix' to the names of Gloo RBAC resources; e.g. when nameSuffix is 'foo', the role 'gloo-resource-reader' will become 'gloo-resource-reader-foo'|
 |global.glooStats.enabled|bool|true|Controls whether or not envoy stats are enabled|
-|global.glooStats.routePrefixRewrite|string|/stats/prometheus|The envoy stats endpoint to which the metrics endpoint is rewritten|
+|global.glooStats.routePrefixRewrite|string|/stats/prometheus|The envoy stats endpoint to which the metrics are written|
 |global.glooMtls.enabled|bool|false|Enables internal mtls authentication|
 |global.glooMtls.sds.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |global.glooMtls.sds.image.repository|string|sds|image name (repository) for the container.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -437,7 +437,7 @@ type K8s struct {
 }
 
 type Stats struct {
-	Enabled bool `json:"enabled,omitempty" desc:"Controls whether or not envoy stats are enabled"`
+	Enabled            bool    `json:"enabled,omitempty" desc:"Controls whether or not envoy stats are enabled"`
 	RoutePrefixRewrite *string `json:"routePrefixRewrite,omitempty" desc:"The envoy stats endpoint to which the metrics endpoint is rewritten"`
 }
 

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -438,7 +438,7 @@ type K8s struct {
 
 type Stats struct {
 	Enabled            bool    `json:"enabled,omitempty" desc:"Controls whether or not envoy stats are enabled"`
-	RoutePrefixRewrite *string `json:"routePrefixRewrite,omitempty" desc:"The envoy stats endpoint to which the metrics endpoint is rewritten"`
+	RoutePrefixRewrite *string `json:"routePrefixRewrite,omitempty" desc:"The envoy stats endpoint to which the metrics are written"`
 }
 
 type Mtls struct {

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -437,7 +437,8 @@ type K8s struct {
 }
 
 type Stats struct {
-	Enabled bool `json:"enabled,omitempty" desc:"Controls whether or not prometheus stats are enabled"`
+	Enabled bool `json:"enabled,omitempty" desc:"Controls whether or not envoy stats are enabled"`
+	RoutePrefixRewrite *string `json:"routePrefixRewrite,omitempty" desc:"The envoy stats endpoint to which the metrics endpoint is rewritten"`
 }
 
 type Mtls struct {

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -79,7 +79,7 @@ data:
                                 - name: ":method"
                                   exact_match: GET
                               route:
-                                prefix_rewrite: "/stats/prometheus"
+                                prefix_rewrite: {{ $statsConfig.routePrefixRewrite }}
                                 cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -169,6 +169,7 @@ global:
     create: true
   glooStats:
     enabled: true
+    routePrefixRewrite: /stats/prometheus
   glooMtls:
     enabled: false
     sds:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -538,6 +538,50 @@ spec:
 						}
 					})
 				})
+
+				It("should set route prefix_rewrite in gateway-proxy-envoy-config from global.glooStats", func() {
+					prepareMakefile(namespace, helmValues{
+						valuesArgs: []string{
+							"global.glooStats.enabled=true",
+							"global.glooStats.routePrefixRewrite=/stats?format=json"},
+					})
+
+					testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+						return resource.GetKind() == "ConfigMap"
+					}).ExpectAll(func(configMap *unstructured.Unstructured) {
+						configMapObject, err := kuberesource.ConvertUnstructured(configMap)
+						Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("ConfigMap %+v should be able to convert from unstructured", configMap))
+						structuredConfigMap, ok := configMapObject.(*v1.ConfigMap)
+						Expect(ok).To(BeTrue(), fmt.Sprintf("ConfigMap %+v should be able to cast to a structured config map", configMap))
+
+						if structuredConfigMap.GetName() == "gateway-proxy-envoy-config" {
+							expectedPrefixRewrite := "prefix_rewrite: /stats?format=json"
+							Expect(structuredConfigMap.Data["envoy.yaml"]).To(ContainSubstring(expectedPrefixRewrite))
+						}
+					})
+				})
+
+				It("should set route prefix_rewrite in gateway-proxy-envoy-config from gatewayProxies.gatewayProxy", func() {
+					prepareMakefile(namespace, helmValues{
+						valuesArgs: []string{
+							"gatewayProxies.gatewayProxy.stats.enabled=true",
+							"gatewayProxies.gatewayProxy.stats.routePrefixRewrite=/stats?format=json"},
+					})
+
+					testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+						return resource.GetKind() == "ConfigMap"
+					}).ExpectAll(func(configMap *unstructured.Unstructured) {
+						configMapObject, err := kuberesource.ConvertUnstructured(configMap)
+						Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("ConfigMap %+v should be able to convert from unstructured", configMap))
+						structuredConfigMap, ok := configMapObject.(*v1.ConfigMap)
+						Expect(ok).To(BeTrue(), fmt.Sprintf("ConfigMap %+v should be able to cast to a structured config map", configMap))
+
+						if structuredConfigMap.GetName() == "gateway-proxy-envoy-config" {
+							expectedPrefixRewrite := "prefix_rewrite: /stats?format=json"
+							Expect(structuredConfigMap.Data["envoy.yaml"]).To(ContainSubstring(expectedPrefixRewrite))
+						}
+					})
+				})
 			})
 
 			Context("gloo with istio sds settings", func() {


### PR DESCRIPTION
# Description

This PR adds a helm value for stats prefix rewrite

Currently it's hard-coded to `/stats/prometheus`. To integrate with
Datadog, or other monitoring system, we need to be able to change
the envoy stats endpoint.

# Context

I want to setup Datadog integration to monitor envoy as described in the docs https://docs.solo.io/gloo/latest/guides/integrations/datadog/. But there is a manual step to update the configmap.
I want to eliminate the manual step so that I can automate it.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

fixes #3752 
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3752