### PR TITLE
Use Unlock in DeleteShelf Bookstore example to prevent runtime error

### DIFF
--- a/changelog/v1.6.0-beta4/fix-bookstore-lock-oddity.yaml
+++ b/changelog/v1.6.0-beta4/fix-bookstore-lock-oddity.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Use Unlock in Bookstore gRPC-JSON transcoding example to prevent runtime error 

--- a/docs/examples/grpc-json-transcoding/bookstore/server.go
+++ b/docs/examples/grpc-json-transcoding/bookstore/server.go
@@ -77,7 +77,7 @@ func (s *bookstoreServer) GetShelf(ctx context.Context, r *GetShelfRequest) (*Sh
 // Deletes a shelf, including all books that are stored on the shelf.
 func (s *bookstoreServer) DeleteShelf(ctx context.Context, r *DeleteShelfRequest) (*empty.Empty, error) {
 	s.m.Lock()
-	defer s.m.RUnlock()
+	defer s.m.Unlock()
 	delete(s.shelves, r.Shelf)
 	return nil, nil
 }


### PR DESCRIPTION
# Description

This fixes an instance of a RWMutex.Lock() followed by a RWMutex.RUnlock() which can cause a run-time error

# Context

This bug can be experienced while running the gRPC-JSON transcoding example from the recent 1.5 release if there is no active RLock() present

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works