### PR TITLE
Remove conflicting doc file

### DIFF
--- a/SITE.md
+++ b/SITE.md
@@ -1,3 +1,0 @@
-# Documentation
-
-Docs are no longer published from this repo. Go to https://github.com/solo-io/gloo-docs

--- a/changelog/v1.6.0-beta4/remove-conflicting-doc-file.yaml
+++ b/changelog/v1.6.0-beta4/remove-conflicting-doc-file.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Remove conflicting top-level markdown document claiming that documentation is not maintained in this repo


### PR DESCRIPTION
# Description

Remove conflicting top-level markdown document (SITE.md) claiming that documentation is not maintained in this repo 

# Context

When looking through GitHub repositories, my eye is usually first drawn to any top-level markdown files (README.md, CONTRIBUTING.md, BUILD.md, etc.) and SITE.md is one such file, although it appears to be outdated. Luckily the linked repository is well marked as deprecated and any reference in the README is using the proper doc directory in this repo, so it's a tiny problem.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works