### PR TITLE
Fix mismatched Sprintf preventing compiles

### DIFF
--- a/changelog/v1.6.0-beta4/fix-wrong-typed-sprintf.yaml
+++ b/changelog/v1.6.0-beta4/fix-wrong-typed-sprintf.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix mismatched Sprintf verb in /pkg/utils/usage/usage_readers.go preventing compiling of that file

--- a/pkg/utils/usage/usage_readers.go
+++ b/pkg/utils/usage/usage_readers.go
@@ -58,10 +58,10 @@ func (d *DefaultUsageReader) GetPayload() (map[string]string, error) {
 	payload[numEnvoys] = fmt.Sprintf("%d", envoys)
 
 	if requestsCount > 0 {
-		payload[totalRequests] = fmt.Sprintf("%d", requestsCount)
+		payload[totalRequests] = fmt.Sprintf("%.0f", requestsCount)
 	}
 	if connectionsCount > 0 {
-		payload[totalConnections] = fmt.Sprintf("%d", connectionsCount)
+		payload[totalConnections] = fmt.Sprintf("%.0f", connectionsCount)
 	}
 
 	return payload, nil


### PR DESCRIPTION
# Description

Fix mismatched Sprintf verb in /pkg/utils/usage/usage_readers.go preventing the compilation of that file. The variable itself is a float64, but the Sprintf verb was for an integer. The "%.0f" verb was used in attempt to best replicate the written behavior.

# Context

While attempting to run `go test ./...` to lazily run all gloo tests at once, the following error would pollute the output, as the file would appear to not compile:

> ./usage_readers.go:61:28: Sprintf format %d has arg requestsCount of wrong type float64
> ./usage_readers.go:64:31: Sprintf format %d has arg connectionsCount of wrong type float64

I am unsure of what else this effects, however the closest test, /pkg/utils/utils_suite_test.go, passes both before and after the change.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works