### PR TITLE
Set route prefix rewrite to ingress proxy and knative proxy configs

### DIFF
--- a/changelog/v1.6.0-beta5/helm-route-prefix-rewrite-to-ingressproxy-and-knativeproxy.yaml
+++ b/changelog/v1.6.0-beta5/helm-route-prefix-rewrite-to-ingressproxy-and-knativeproxy.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/3752
+    description: >-
+      Set route prefix_rewrite in ingress proxy and knative proxy configs from `global.glooStats.routePrefixRewrite` helm value. This allows Gloo to integrate with other monitoring systems instead of just Prometheus.
+    resolvesIssue: false

--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -75,7 +75,7 @@ data:
                                 - name: ":method"
                                   exact_match: GET
                               route:
-                                prefix_rewrite: "/stats/prometheus"
+                                prefix_rewrite: {{ .Values.global.glooStats.routePrefixRewrite }}
                                 cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router

--- a/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
@@ -76,7 +76,7 @@ data:
                                 - name: ":method"
                                   exact_match: GET
                               route:
-                                prefix_rewrite: "/stats/prometheus"
+                                prefix_rewrite: {{ .Values.global.glooStats.routePrefixRewrite }}
                                 cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router

--- a/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
@@ -76,7 +76,7 @@ data:
                                 - name: ":method"
                                   exact_match: GET
                               route:
-                                prefix_rewrite: "/stats/prometheus"
+                                prefix_rewrite: {{ .Values.global.glooStats.routePrefixRewrite }}
                                 cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router

--- a/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
@@ -76,7 +76,7 @@ data:
                                 - name: ":method"
                                   exact_match: GET
                               route:
-                                prefix_rewrite: "/stats/prometheus"
+                                prefix_rewrite: {{ .Values.global.glooStats.routePrefixRewrite }}
                                 cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router


### PR DESCRIPTION
# Description

Previous commit sets route prefix rewrite in gateway-proxy-envoy-config, but there are other places that should be changed too. This commit sets the value to the other places.

# Context

ref: #3752 #3759

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# Note

I think the referred commit already cover the changelog for this. Do we need a new one?