### PR TITLE
Correct use of us-east-2 and us-west-2

### DIFF
--- a/docs/content/guides/integrations/service_mesh/gloo_app_mesh.md
+++ b/docs/content/guides/integrations/service_mesh/gloo_app_mesh.md
@@ -25,7 +25,7 @@ For this guide, we'll assume you want to use AWS App Mesh on Kubernetes (AWS EKS
 
 We recommend you follow this link: [Tutorial: Configure App Mesh Integration with Kubernetes] (https://docs.aws.amazon.com/app-mesh/latest/userguide/mesh-k8s-integration.html) for getting started with AWS App Mesh and setting up the examples.
 
-We will assumed that you use `color-mesh` as the name of your mesh and you deployed your EKS cluster in the `us-east-2 (Oregon)` as the AWS region.
+We will assumed that you use `color-mesh` as the name of your mesh and you deployed your EKS cluster in the `us-east-2 (Ohio)` as the AWS region.
 
 Once you have the examples installed, you should have an environment like this:
 
@@ -170,7 +170,7 @@ Now let's figure out what the right URL is to contact Gloo:
 ```bash
 glooctl proxy url
 
-http://a034a61854c2111e992a70a2a7eb7b9a-398563398.us-west-2.elb.amazonaws.com:80
+http://a034a61854c2111e992a70a2a7eb7b9a-398563398.us-east-2.elb.amazonaws.com:80
 ```
 And then call our new API:
 


### PR DESCRIPTION
The documentation mixed us-east-2 and us-west-2 and Oregon and Ohio.  This will correct that mix.  Please review to ensure that the change to the US-west-2 ELB is not impacting the intent of the documentation.

# Description

This addresses a documentation confusion around the use of us-west-2 and us-east-2 which does not directly make the documentation unusable but may confuse someone if they are not paying attention. 

There is no known bug report for this yet.

# Context

Users ran into this issue when reading the documentation. 

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works