### PR TITLE
Fix broken kind links in gloo docs

### DIFF
--- a/docs/content/installation/enterprise/_index.md
+++ b/docs/content/installation/enterprise/_index.md
@@ -39,7 +39,7 @@ glooctl install gateway enterprise --license-key YOUR_LICENSE_KEY
 
 <details>
 <summary>Special Instructions to Install Gloo Enterprise on Kind</summary>
-If you followed the cluster setup instructions for Kind [here]({{< versioned_link_path fromRoot="/installation/platform_configuration/cluster_setup/#kind-kubernetes-in-docker" >}}), then you should have exposed custom ports 31500 (for http) and 32500 (https) from your cluster's Docker container to its host machine. The purpose of this is to make it easier to access your service endpoints from your host workstation.  Use the following custom installation for Gloo to publish those same ports from the proxy as well.
+If you followed the cluster setup instructions for Kind [here]({{< versioned_link_path fromRoot="/installation/platform_configuration/cluster_setup/#kind" >}}), then you should have exposed custom ports 31500 (for http) and 32500 (https) from your cluster's Docker container to its host machine. The purpose of this is to make it easier to access your service endpoints from your host workstation.  Use the following custom installation for Gloo to publish those same ports from the proxy as well.
 
 ```bash
 cat <<EOF | glooctl install gateway enterprise --license-key YOUR_LICENSE_KEY --values -

--- a/docs/content/installation/gateway/kubernetes/_index.md
+++ b/docs/content/installation/gateway/kubernetes/_index.md
@@ -34,7 +34,7 @@ glooctl install gateway
 
 <details>
 <summary>Special Instructions to Install Gloo on Kind</summary>
-If you followed the cluster setup instructions for Kind [here]({{< versioned_link_path fromRoot="/installation/platform_configuration/cluster_setup/#kind-kubernetes-in-docker" >}}), then you should have exposed custom ports 31500 (for http) and 32500 (https) from your cluster's Docker container to its host machine. The purpose of this is to make it easier to access your service endpoints from your host workstation.  Use the following custom installation for Gloo to publish those same ports from the proxy as well.
+If you followed the cluster setup instructions for Kind [here]({{< versioned_link_path fromRoot="/installation/platform_configuration/cluster_setup/#kind" >}}), then you should have exposed custom ports 31500 (for http) and 32500 (https) from your cluster's Docker container to its host machine. The purpose of this is to make it easier to access your service endpoints from your host workstation.  Use the following custom installation for Gloo to publish those same ports from the proxy as well.
 
 ```bash
 cat <<EOF | glooctl install gateway --values -

--- a/docs/content/installation/platform_configuration/cluster_setup.md
+++ b/docs/content/installation/platform_configuration/cluster_setup.md
@@ -142,7 +142,7 @@ kubectl cluster-info --context kind-kind
 Thanks for using kind! 😊
 ```
 
-It will also be necessary for you to customize Gloo installation to use these same ports.  See the special Kind instructions for both [open source]({{< versioned_link_path fromRoot="/installation/gateway/kubernetes/#installing-on-kubernetes-with-glooctl" >}}) and [enterprise]({{< versioned_link_path fromRoot="installation/enterprise/#installing-on-kubernetes-with-glooctl" >}}) versions.
+It will also be necessary for you to customize Gloo installation to use these same ports.  See the special Kind instructions for both [open source]({{< versioned_link_path fromRoot="/installation/gateway/kubernetes/#installing-on-kubernetes-with-glooctl" >}}) and [enterprise]({{< versioned_link_path fromRoot="/installation/enterprise/#installing-on-kubernetes-with-glooctl" >}}) versions.
 
 Note also that the url to invoke services published through Gloo will be slightly different with Kind-hosted clusters.  Much of the Gloo documentation instructs you to use `$(glooctl proxy url)` as the header for your service url.  This will not work with kind.  For example, instead of using curl commands like this:
 


### PR DESCRIPTION
# Description

I was going through the kind installation process recently and ran across some broken links in the docs.  This PR fixes those.
