### PR TITLE
Fix docs typo in istio mTLS

### DIFF
--- a/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
+++ b/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
@@ -442,7 +442,7 @@ spec:
     sds:
       certificatesSecretName: istio_server_cert
       clusterName: gateway_proxy_sds
-      targetUri: 127.0.01:8234
+      targetUri: 127.0.0.1:8234
       validationContextName: istio_validation_context
 status:
 (...)


### PR DESCRIPTION
Technically it works as-written because it gets routed to 127.0.0.1 ultimately, but we should fix it to make it less confusing.