### PR TITLE
Fix glooctl new lines on failed deployments check

### DIFF
--- a/changelog/v1.6.0-beta9/glooctl-check-fix-newlines.yaml
+++ b/changelog/v1.6.0-beta9/glooctl-check-fix-newlines.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: fixes glooctl check error messages that are displayed when deployments checks have failed
+    issueLink: https://github.com/solo-io/gloo/issues/2952

--- a/changelog/v1.6.0-beta9/glooctl-check-fix-newlines.yaml
+++ b/changelog/v1.6.0-beta9/glooctl-check-fix-newlines.yaml
@@ -1,4 +1,4 @@
 changelog:
-  - type: NON_USER_FACING
+  - type: FIX
     description: fixes glooctl check error messages that are displayed when deployments checks have failed
     issueLink: https://github.com/solo-io/gloo/issues/2952

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
@@ -66,7 +66,7 @@ func RateLimitIsConnected(stats string) bool {
 func checkXdsMetrics(ctx context.Context, glooNamespace string, deployments *v1.DeploymentList) error {
 	errMessage := "Problem while checking for gloo xds errors"
 	if deployments == nil {
-		fmt.Printf("Skipping due to an error in checking deployments")
+		fmt.Println("Skipping due to an error in checking deployments")
 		return fmt.Errorf("xds metrics check was skipped due to an error in checking deployments")
 	}
 	// port-forward proxy deployment and get prometheus metrics

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -574,7 +574,7 @@ func checkGateways(namespaces []string) error {
 func checkProxies(ctx context.Context, namespaces []string, glooNamespace string, deployments *appsv1.DeploymentList) error {
 	fmt.Printf("Checking proxies... ")
 	if deployments == nil {
-		fmt.Printf("Skipping due to an error in checking deployments")
+		fmt.Println("Skipping due to an error in checking deployments")
 		return fmt.Errorf("proxy check was skipped due to an error in checking deployments")
 	}
 	var multiErr *multierror.Error


### PR DESCRIPTION
# Description

Changed the deployments error message to use `Println` rather than `Printf`, for cleaner error messages.

![image](https://user-images.githubusercontent.com/1731122/98389413-00d70300-2022-11eb-8ced-2700993268d6.png)

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2952