### PR TITLE
Fix docs typo

### DIFF
--- a/docs/content/guides/security/rate_limiting/crds/_index.md
+++ b/docs/content/guides/security/rate_limiting/crds/_index.md
@@ -55,7 +55,7 @@ spec:
     rateLimits:
     - actions:
       - genericKey:
-          descriptorValue: counters
+          descriptorValue: counter
 ```
 
 Once an `RateLimitConfig` is created, it can be used to enforce rate limits on your `VirtualService`s (or on the 


### PR DESCRIPTION
# Description

Fix a typo in the rate limit docs

# Context

Ran into this debugging tests written based off the guide

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works