### PR TITLE
Fix incorrect virtualservice to gateway assignment faq guidance

### DIFF
--- a/docs/content/introduction/faq.md
+++ b/docs/content/introduction/faq.md
@@ -142,7 +142,7 @@ If you create a VirtualService and assign it TLS/SSL configuration, it will be b
 
 In the event you have multiple Gateways/listeners or you want more fine-grained control over how a VirtualService gets associated with a Gateway, you can explicitly add the VirtualService name to the Gateway resource like this:
 
-{{< highlight yaml "hl_lines=9-11" >}}
+{{< highlight yaml "hl_lines=9-12" >}}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:
@@ -151,9 +151,10 @@ metadata:
 spec:
   bindAddress: '::'
   bindPort: 8080
-  virtualServices:
-  - name: pet-virtual-service
-    namespace: gloo-system
+  httpGateway:
+    virtualServices:
+    - name: pet-virtual-service
+      namespace: gloo-system
 status:
   reported_by: gateway
   state: 1
@@ -162,6 +163,25 @@ status:
       reported_by: gloo
       state: 1
 {{< /highlight >}}
+
+Or you can match on a map of labels that you have applied to the VirtualService:
+
+{{< highlight yaml "hl_lines=9-12" >}}
+apiVersion: gateway.solo.io/v1
+kind: Gateway
+metadata:
+  name: gateway-proxy
+  namespace: gloo-system
+spec:
+  bindAddress: '::'
+  bindPort: 8080
+  httpGateway:
+    virtualServiceSelector:
+      label-name: label-value
+      anotherlabel-name: anotherlabel-value
+{{< /highlight >}}
+
+
 
 #### How do I configure TLS for Gloo
 


### PR DESCRIPTION
# Description

Please include a summary of the changes.

This fixes the FAQ documentation guidance on how to assign a VirtualService to a specific Gateway when running multiple Gateways in parallel.

# Context
I ran into this erroneous documentation when setting up my own Gloo deployment with multiple Gateways, where I need to assign a subset of VirtualServices to one Gateway and a different subset to a different Gateway. The documentation changes have been verified in testing and were based on the [API reference](https://docs.solo.io/gloo/latest/reference/api/github.com/solo-io/gloo/projects/gateway/api/v1/gateway.proto.sk/#httpgateway) docs.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works