### PR TITLE
Missing authConfig should validate a VS, not a Gateway

### DIFF
--- a/changelog/v1.6.0-beta10/invalid-vs-gateway.yaml
+++ b/changelog/v1.6.0-beta10/invalid-vs-gateway.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3538
+    description: >- 
+      Fixed a bug where a bad authconfig which should invalidate
+      a single vs was incorrectly invalidating the entire gateway

--- a/changelog/v1.6.0-beta10/invalid-vs-gateway.yaml
+++ b/changelog/v1.6.0-beta10/invalid-vs-gateway.yaml
@@ -3,4 +3,4 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/3538
     description: >- 
       Fixed a bug where a bad authconfig which should invalidate
-      a single vs was incorrectly invalidating the entire gateway
+      a single virtual service was incorrectly invalidating the entire gateway 

--- a/projects/gloo/pkg/translator/listener.go
+++ b/projects/gloo/pkg/translator/listener.go
@@ -121,13 +121,11 @@ func (t *translatorInstance) computeListenerFilters(params plugins.Params, liste
 	}
 
 	// Check that we don't refer to nonexistent auth config
-	for _, vHost := range httpListener.HttpListener.GetVirtualHosts() {
+	for i, vHost := range httpListener.HttpListener.GetVirtualHosts() {
 		acRef := vHost.GetOptions().GetExtauth().GetConfigRef()
 		if acRef != nil {
 			if _, err := params.Snapshot.AuthConfigs.Find(acRef.GetNamespace(), acRef.GetName()); err != nil {
-				validation.AppendHTTPListenerError(
-					httpListenerReport, validationapi.HttpListenerReport_Error_ProcessingError,
-					"auth config not found: "+acRef.String())
+				validation.AppendVirtualHostError(httpListenerReport.VirtualHostReports[i], validationapi.VirtualHostReport_Error_ProcessingError, "auth config not found: "+acRef.String())
 			}
 		}
 	}

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Translator", func() {
 
 			Expect(err).To(BeNil())
 			Expect(errs.Validate()).To(HaveOccurred())
-			Expect(errs.Validate().Error()).To(ContainSubstring("HttpListener Error: ProcessingError. Reason: auth config not found:"))
+			Expect(errs.Validate().Error()).To(ContainSubstring("VirtualHost Error: ProcessingError. Reason: auth config not found:"))
 		})
 	})
 

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -192,6 +192,23 @@ func defaultTestConstructOpts(ctx context.Context, runOptions *RunOptions) trans
 	}
 
 	meta := runOptions.Settings.GetMetadata()
+
+	var validation *translator.ValidationOpts
+	if runOptions.Settings != nil && runOptions.Settings.Gateway != nil && runOptions.Settings.Gateway.Validation != nil {
+		validation = &translator.ValidationOpts{}
+		if runOptions.Settings.Gateway.Validation.ProxyValidationServerAddr != "" {
+			validation.ProxyValidationServerAddress = runOptions.Settings.Gateway.Validation.ProxyValidationServerAddr
+		}
+		if runOptions.Settings.Gateway.Validation.AllowWarnings != nil {
+			validation.AllowWarnings = runOptions.Settings.Gateway.Validation.AllowWarnings.Value
+
+		}
+		if runOptions.Settings.Gateway.Validation.AlwaysAccept != nil {
+			validation.AlwaysAcceptResources = runOptions.Settings.Gateway.Validation.AlwaysAccept.Value
+		}
+
+	}
+
 	return translator.Opts{
 		GlooNamespace:   meta.GetNamespace(),
 		WriteNamespace:  runOptions.NsToWrite,
@@ -204,7 +221,8 @@ func defaultTestConstructOpts(ctx context.Context, runOptions *RunOptions) trans
 			Ctx:         ctx,
 			RefreshRate: time.Minute,
 		},
-		DevMode: false,
+		Validation: validation,
+		DevMode:    false,
 	}
 }
 


### PR DESCRIPTION
# Description

VS was being accepted when it had an invalid authconfig. This had the knock-on effect of the vs making it into the gateway, but since it was invalid, it invalidated the entire gateway.

This fix changes it so that the vs with the bad authconfig is itself marked invalid, does _not_ make it into the gateway, and does not block updates of the other, well-configured virtualservices.

# Context

Users ran into this when creating a virtualservice that pointed to an authconfig which didn't exist.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo [contribution guide](https://docs.solo.io/gloo/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3538