### PR TITLE
Add Istio 1.8.x support to glooctl integrations

### DIFF
--- a/changelog/v1.6.0-beta10/istio-1-8.yaml
+++ b/changelog/v1.6.0-beta10/istio-1-8.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/3855
+    description: Add Istio 1.8.x support to the existing glooctl istio integrations.

--- a/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
+++ b/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
@@ -9,7 +9,7 @@ Serving as the Ingress for an Istio cluster -- without compromising on security 
 
 ### Istio versions
 
-This guide was tested with Istio 1.6.6 and 1.7. For older versions of Istio, see [here]({{% versioned_link_path fromRoot="/guides/integrations/service_mesh/gloo_istio_mtls/older_istio_versions/" %}}).
+This guide was tested with Istio 1.6.6, 1.7.2, and 1.8.0. For older versions of Istio, see [here]({{% versioned_link_path fromRoot="/guides/integrations/service_mesh/gloo_istio_mtls/older_istio_versions/" %}}).
 
 ### Gloo Edge versions
 

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7-1.8.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7-1.8.go
@@ -5,7 +5,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func generateIstio17Sidecar(version, jwtPolicy string) *corev1.Container {
+// Sidecar for Istio 1.7.x releases, also works for Istio 1.8.x releases
+func generateIstio17or18Sidecar(version, jwtPolicy string) *corev1.Container {
 	sidecar := &corev1.Container{
 		Name:  "istio-proxy",
 		Image: "docker.io/istio/proxyv2:" + version,

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/matcher.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/matcher.go
@@ -14,8 +14,8 @@ var ErrNoSupportedSidecar = errors.New("no valid istio sidecar found for this is
 // version of Istio, with the given jwtPolicy, to run
 // in the gateway-proxy pod
 func GetIstioSidecar(istioVersion, jwtPolicy string) (*corev1.Container, error) {
-	if strings.HasPrefix(istioVersion, "1.7.") {
-		return generateIstio17Sidecar(istioVersion, jwtPolicy), nil
+	if strings.HasPrefix(istioVersion, "1.7.") || strings.HasPrefix(istioVersion, "1.8.") {
+		return generateIstio17or18Sidecar(istioVersion, jwtPolicy), nil
 	} else if strings.HasPrefix(istioVersion, "1.6.") {
 		return generateIstio16Sidecar(istioVersion, jwtPolicy), nil
 	}


### PR DESCRIPTION
# Description

Add Istio 1.8.x support to Glooctl istio integrations

# Context

Istio 1.8.x is just about to be released to GA.

Istio sidecar configuration (args + env vars) from 1.7.x also works with 1.8.x with no changes required.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3855