### PR TITLE
Update kind action

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -58,7 +58,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - uses: engineerd/setup-kind@v0.4.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
         name: kind
     - uses: azure/setup-kubectl@v1
@@ -105,7 +105,7 @@ jobs:
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
-    - uses: engineerd/setup-kind@v0.4.0
+    - uses: engineerd/setup-kind@v0.5.0
       with:
         name: kind
     - uses: azure/setup-kubectl@v1

--- a/changelog/v1.6.0-beta11/update-kind.yaml
+++ b/changelog/v1.6.0-beta11/update-kind.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update kind setup action


### PR DESCRIPTION
# Description

Update kind action

# Context

Fix for https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works