### PR TITLE
Update documentation versions

### DIFF
--- a/changelog/v1.6.0-beta15/update-documentation-versions.yaml
+++ b/changelog/v1.6.0-beta15/update-documentation-versions.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/3896
+    description: >
+      The tracing documentation was incorrect in v1.5.x.
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/3900
+    description: >
+      The tracing documentation was incorrect in v1.6.x.

--- a/docs/active_versions.json
+++ b/docs/active_versions.json
@@ -1,9 +1,9 @@
 {
-  "latest": "1.5.8",
+  "latest": "1.5.12",
   "versions": [
     "master",
-    "1.6.0-beta8",
-    "1.5.8"
+    "1.6.0-beta14",
+    "1.5.12"
   ],
   "oldVersions": [
     "1.4.15",


### PR DESCRIPTION
# Description

Update the release versions used in our documentation

# Context

We have updated documentation in previous releases. To make this visible to users, we need to update which deployed versions is used for our docs.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3896
resolves https://github.com/solo-io/gloo/issues/3900