### PR TITLE
Add ISTIO_META_CLUSTER_ID to helm install

### DIFF
--- a/changelog/v1.6.0-beta14/add-istio-clusterid-to-helm-chart.yaml
+++ b/changelog/v1.6.0-beta14/add-istio-clusterid-to-helm-chart.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/3881
+    description: >
+      When doing a helm install where `istioSDS.enabled` is set to `true`, the `ISTIO_META_CLUSTER_ID` environment variable is now initialized to "Kubernetes".

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -339,6 +339,8 @@ spec:
             value: istiod.istio-system.svc:15012
           - name: ISTIO_META_MESH_ID
             value: cluster.local
+          - name: ISTIO_META_CLUSTER_ID
+            value: Kubernetes
           - name: POD_NAME
             valueFrom:
               fieldRef:


### PR DESCRIPTION
# Description

This PR adds the `ISTIO_META_CLUSTER_ID` environment variable with the default value of `Kubernetes` to the helm install when `istiosds.enabled` is true

# Context

Users previously added the environment variable retroactively after using the helm install, this now includes the env var in the helm install, similar to `glooctl istio inject`

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3881