### PR TITLE
Remove reference to Istio-Based Route Rule Discovery

### DIFF
--- a/docs/content/introduction/architecture/_index.md
+++ b/docs/content/introduction/architecture/_index.md
@@ -100,7 +100,6 @@ The following discovery methods are currently supported:
 * AWS Lambda-Based Function Discovery
 * Google Cloud Function-Based Function Discovery
 * OpenAPI-Based Function Discovery
-* Istio-Based Route Rule Discovery (Experimental)
 
 ---
 


### PR DESCRIPTION
# Description

Remove an obsolete reference to a one-time experimental feature called Istio-Based Route Rule Discovery. It is misleading to users. 
