### PR TITLE
Fix multi proxy status reporting

### DIFF
--- a/changelog/v1.6.0-beta15/fix-multi-proxy-status.yaml
+++ b/changelog/v1.6.0-beta15/fix-multi-proxy-status.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3935
+    description: >-
+      In multi-proxy environments, resources that were invalid on one proxy (error or warning) but valid on another may
+      have a status written of accepted, despite internally calculating (and logging) a warning. This is now fixed.

--- a/projects/gateway/pkg/syncer/setup_syncer.go
+++ b/projects/gateway/pkg/syncer/setup_syncer.go
@@ -206,8 +206,6 @@ func RunGateway(opts translator.Opts) error {
 	// this tells Gateway that the validation snapshot has changed
 	notifications := make(<-chan struct{})
 
-	opts.Validation = nil
-
 	if opts.Validation != nil {
 		validationClient, err = gatewayvalidation.NewConnectionRefreshingValidationClient(
 			gatewayvalidation.RetryOnUnavailableClientConstructor(ctx, opts.Validation.ProxyValidationServerAddress),

--- a/projects/gateway/pkg/syncer/setup_syncer.go
+++ b/projects/gateway/pkg/syncer/setup_syncer.go
@@ -206,6 +206,8 @@ func RunGateway(opts translator.Opts) error {
 	// this tells Gateway that the validation snapshot has changed
 	notifications := make(<-chan struct{})
 
+	opts.Validation = nil
+
 	if opts.Validation != nil {
 		validationClient, err = gatewayvalidation.NewConnectionRefreshingValidationClient(
 			gatewayvalidation.RetryOnUnavailableClientConstructor(ctx, opts.Validation.ProxyValidationServerAddress),

--- a/projects/gateway/pkg/syncer/translator_syncer.go
+++ b/projects/gateway/pkg/syncer/translator_syncer.go
@@ -314,6 +314,8 @@ func (s *statusSyncer) syncStatus(ctx context.Context) error {
 					if subresourceStatuses.Warnings != nil {
 						report.Warnings = append(report.Warnings, subresourceStatuses.Warnings...)
 					}
+					allReports[inputResource] = report // necessary since it was not a pointer
+					fmt.Println(report)
 				} else {
 					allReports[inputResource] = subresourceStatuses
 				}

--- a/projects/gateway/pkg/syncer/translator_syncer.go
+++ b/projects/gateway/pkg/syncer/translator_syncer.go
@@ -314,8 +314,7 @@ func (s *statusSyncer) syncStatus(ctx context.Context) error {
 					if subresourceStatuses.Warnings != nil {
 						report.Warnings = append(report.Warnings, subresourceStatuses.Warnings...)
 					}
-					allReports[inputResource] = report // necessary since it was not a pointer
-					fmt.Println(report)
+					allReports[inputResource] = report
 				} else {
 					allReports[inputResource] = subresourceStatuses
 				}


### PR DESCRIPTION
# Description

In multi-proxy environments, resources that were invalid on one proxy (error or warning) but valid on another may have a status written of accepted, despite internally calculating (and logging) a warning. This PR fixes that, by ensuring that the map of status to write is updated internally.

# Context

It appears the code was written with the assumption that the `report` indexed from `allReports` was a pointer itself, when it was not.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3935