### PR TITLE
Add Open source release notes to chronological ordering of enterprise changelog

### DIFF
--- a/changelog/v1.6.0-beta17/fix-enterprise-changelog-docs.yaml
+++ b/changelog/v1.6.0-beta17/fix-enterprise-changelog-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix for broken OSS links in enterprise changelog docs. In addition, users can now see OSS releases merged into chronologically ordered enterprise docs.
+    issueLink: https://github.com/solo-io/gloo/issues/3953

--- a/docs/cmd/changelogutils/changelog_utils.go
+++ b/docs/cmd/changelogutils/changelog_utils.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Fetches releases for repo from github
-func GetAllReleases(client *github.Client, repo string, sortedByVersion bool) ([]*github.RepositoryRelease, error) {
+func GetAllReleases(client *github.Client, repo string) ([]*github.RepositoryRelease, error) {
 	allReleases, _, err := client.Repositories.ListReleases(context.Background(), "solo-io", repo,
 		&github.ListOptions{
 			Page:    0,
@@ -28,20 +28,6 @@ func GetAllReleases(client *github.Client, repo string, sortedByVersion bool) ([
 		return nil, err
 	}
 
-	if sortedByVersion {
-		sort.Slice(allReleases, func(i, j int) bool {
-			releaseA, releaseB := allReleases[i], allReleases[j]
-			versionA, err := ParseVersion(releaseA.GetTagName())
-			if err != nil {
-				return false
-			}
-			versionB, err := ParseVersion(releaseB.GetTagName())
-			if err != nil {
-				return false
-			}
-			return versionA.MustIsGreaterThan(*versionB)
-		})
-	}
 	return allReleases, nil
 }
 
@@ -71,12 +57,24 @@ func ParseReleases(releases []*github.RepositoryRelease, byMinorVersion bool) (m
 // This also pulls in open source gloo edge release notes and merges them with enterprise release notes
 // The returned map will be a mapping of minor releases (v1.5, v1.6) to their body, which will contain the release notes
 // for all the patches under the minor releases
-func MergeEnterpriseOSSReleases(enterpriseReleasesSorted, osReleases []*github.RepositoryRelease) (map[Version]string, error) {
+func MergeEnterpriseOSSReleases(enterpriseReleases, osReleasesSorted []*github.RepositoryRelease, sortedByVersion bool) (map[Version]string, []Version, error) {
 	var minorReleaseMap = make(map[Version]string)
+	var versionOrder []Version
 
-	openSourceReleases, err := ParseReleases(osReleases, false)
+	enterpriseReleasesSorted := SortReleases(enterpriseReleases)
+	// if we don't want to sort it by version, preserve original chronological ordering
+	if !sortedByVersion {
+		for _, release := range enterpriseReleases {
+			version, err := ParseVersion(release.GetTagName())
+			if err != nil {
+				return nil, nil, err
+			}
+			versionOrder = append(versionOrder, *version)
+		}
+	}
+	openSourceReleases, err := ParseReleases(osReleasesSorted, false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	for index, release := range enterpriseReleasesSorted {
@@ -84,7 +82,7 @@ func MergeEnterpriseOSSReleases(enterpriseReleasesSorted, osReleases []*github.R
 
 		version, err := ParseVersion(releaseTag)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
 		previousEnterprisePatch := GetPreviousEnterprisePatchVersion(enterpriseReleasesSorted, index)
@@ -102,18 +100,22 @@ func MergeEnterpriseOSSReleases(enterpriseReleasesSorted, osReleases []*github.R
 		var depVersions []Version
 		// Get all intermediate versions of Gloo OSS that this Gloo enterprise relies on
 		if depVersion != nil && previousDepVersion != nil {
-			depVersions = GetAllOSSDependenciesBetweenEnterpriseVersions(depVersion, previousDepVersion, osReleases)
+			depVersions = GetAllOSSDependenciesBetweenEnterpriseVersions(depVersion, previousDepVersion, osReleasesSorted)
 		}
 		// Get release notes of the dependent open source gloo release version
 		body := AccumulateNotes(release.GetBody(), openSourceReleases, depVersions)
-		// We only want the minor version (not patch number or label) for the resulting map
-		minorVersion := Version{
-			Major: version.Major,
-			Minor: version.Minor,
+		if sortedByVersion {
+			// If sorting by minor version, we only want the minor version (not patch number or label) for the resulting map
+			minorVersion := Version{
+				Major: version.Major,
+				Minor: version.Minor,
+			}
+			minorReleaseMap[minorVersion] = minorReleaseMap[minorVersion] + fmt.Sprintf("\n##### %s %s\n ", version.String(), OSSDescription) + body
+		} else {
+			minorReleaseMap[*version] = fmt.Sprintf("\n\n### %s %s\n", version.String(), OSSDescription) + body
 		}
-		minorReleaseMap[minorVersion] = minorReleaseMap[minorVersion] + fmt.Sprintf("\n##### %s %s\n ", version.String(), OSSDescription) + body
 	}
-	return minorReleaseMap, nil
+	return minorReleaseMap, versionOrder, nil
 }
 
 // Parses the enterprise release notes, then inserts open source release notes for each of the dependent versions
@@ -200,8 +202,9 @@ func GetOSDependencyPrefix(openSourceVersion Version, isHeader bool) string {
 	if isHeader {
 		prefix = " (Uses Gloo Edge"
 	}
-	osReleaseURL := strings.ReplaceAll(openSourceVersion.String(), ".", "")
-	osPrefix := fmt.Sprintf("%s [OSS %s](/reference/changelog/open_source/#%s)) ", prefix, openSourceVersion.String(), osReleaseURL)
+	// Links are broken in markdown rendered by readfile, commenting out for now
+	//osReleaseURL := strings.ReplaceAll(openSourceVersion.String(), ".", "")
+	osPrefix := fmt.Sprintf("%s OSS %s) ", prefix, openSourceVersion.String())
 	return osPrefix
 }
 
@@ -288,8 +291,29 @@ func GetOSSDependencyForEnterpriseVersion(enterpriseVersion *Version) (*Version,
 }
 
 // Sorts a slice of versions in descending order by version e.g. v1.6.1, v1.6.0, v1.6.0-beta9
-func SortReleaseVersions(versions []Version) {
-	sort.Slice(versions, func(i, j int) bool {
-		return versions[i].MustIsGreaterThanOrEqualTo(versions[j])
+func SortReleaseVersions(versions []Version) []Version {
+	versionsCopy := make([]Version, len(versions))
+	copy(versionsCopy, versions)
+	sort.Slice(versionsCopy, func(i, j int) bool {
+		return versionsCopy[i].MustIsGreaterThanOrEqualTo(versionsCopy[j])
 	})
+	return versionsCopy
+}
+
+func SortReleases(releases []*github.RepositoryRelease) []*github.RepositoryRelease {
+	releasesCopy := make([]*github.RepositoryRelease, len(releases))
+	copy(releasesCopy, releases)
+	sort.Slice(releasesCopy, func(i, j int) bool {
+		releaseA, releaseB := releasesCopy[i], releasesCopy[j]
+		versionA, err := ParseVersion(releaseA.GetTagName())
+		if err != nil {
+			return false
+		}
+		versionB, err := ParseVersion(releaseB.GetTagName())
+		if err != nil {
+			return false
+		}
+		return versionA.MustIsGreaterThan(*versionB)
+	})
+	return releasesCopy
 }

--- a/docs/cmd/changelogutils/changelog_utils.go
+++ b/docs/cmd/changelogutils/changelog_utils.go
@@ -202,9 +202,8 @@ func GetOSDependencyPrefix(openSourceVersion Version, isHeader bool) string {
 	if isHeader {
 		prefix = " (Uses Gloo Edge"
 	}
-	// Links are broken in markdown rendered by readfile, commenting out for now
-	//osReleaseURL := strings.ReplaceAll(openSourceVersion.String(), ".", "")
-	osPrefix := fmt.Sprintf("%s OSS %s) ", prefix, openSourceVersion.String())
+	osReleaseURL := strings.ReplaceAll(openSourceVersion.String(), ".", "")
+	osPrefix := fmt.Sprintf("%s [OSS %s](../../../reference/changelog/open_source/#%s)) ", prefix, openSourceVersion.String(), osReleaseURL)
 	return osPrefix
 }
 

--- a/docs/cmd/changelogutils/changelog_utils.go
+++ b/docs/cmd/changelogutils/changelog_utils.go
@@ -56,7 +56,7 @@ func ParseReleases(releases []*github.RepositoryRelease, byMinorVersion bool) (m
 // Performs processing to generate a map of release version to the release notes
 // This also pulls in open source gloo edge release notes and merges them with enterprise release notes
 // The returned map will be a mapping of minor releases (v1.5, v1.6) to their body, which will contain the release notes
-// for all the patches under the minor releases
+// for all the patches under the minor releases. It also returns a list of versions, sorted by version if the sortedByVersion param is true.
 func MergeEnterpriseOSSReleases(enterpriseReleases, osReleasesSorted []*github.RepositoryRelease, sortedByVersion bool) (map[Version]string, []Version, error) {
 	var minorReleaseMap = make(map[Version]string)
 	var versionOrder []Version

--- a/docs/cmd/test/generate_changelog_doc_test.go
+++ b/docs/cmd/test/generate_changelog_doc_test.go
@@ -80,12 +80,12 @@ var _ = Describe("Generate Changelog Test", func() {
 			osVersion := Version{Major: 1, Minor: 5, Patch: 9, Label: "beta", LabelVersion: 3}
 			useHeaderPrefix := false
 			bulletPointPrefix := changelogutils.GetOSDependencyPrefix(osVersion, useHeaderPrefix)
-			expectedBulletPrefix := "\n- (From OSS v1.5.9-beta3) "
+			expectedBulletPrefix := "\n- (From OSS v1.5.9-beta3(../../../reference/changelog/open_source/#v159-beta3)) "
 			Expect(bulletPointPrefix).To(Equal(expectedBulletPrefix))
 
 			useHeaderPrefix = true
 			headerPrefix := changelogutils.GetOSDependencyPrefix(osVersion, useHeaderPrefix)
-			expectedHeaderPrefix := " (Uses Gloo Edge OSS v1.5.9-beta3) "
+			expectedHeaderPrefix := " (Uses Gloo Edge [OSS v1.5.9-beta3](../../../reference/changelog/open_source/#v159-beta3)) "
 			Expect(headerPrefix).To(Equal(expectedHeaderPrefix))
 		})
 	})

--- a/docs/cmd/test/generate_changelog_doc_test.go
+++ b/docs/cmd/test/generate_changelog_doc_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Generate Changelog Test", func() {
 			osVersion := Version{Major: 1, Minor: 5, Patch: 9, Label: "beta", LabelVersion: 3}
 			useHeaderPrefix := false
 			bulletPointPrefix := changelogutils.GetOSDependencyPrefix(osVersion, useHeaderPrefix)
-			expectedBulletPrefix := "\n- (From OSS v1.5.9-beta3(../../../reference/changelog/open_source/#v159-beta3)) "
+			expectedBulletPrefix := "\n- (From [OSS v1.5.9-beta3](../../../reference/changelog/open_source/#v159-beta3)) "
 			Expect(bulletPointPrefix).To(Equal(expectedBulletPrefix))
 
 			useHeaderPrefix = true

--- a/docs/cmd/test/generate_changelog_doc_test.go
+++ b/docs/cmd/test/generate_changelog_doc_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Generate Changelog Test", func() {
 			versions := []Version{
 				v1_5_0_beta9, v1_5_5, v1_5_0, v1_6_3, v1_6_5, v1_5_0_beta8,
 			}
-			changelogutils.SortReleaseVersions(versions)
+			versions = changelogutils.SortReleaseVersions(versions)
 			Expect(versions).To(HaveLen(len(sortedVersionsArray)))
 			Expect(versions).To(Equal(sortedVersionsArray))
 		})
@@ -80,12 +80,12 @@ var _ = Describe("Generate Changelog Test", func() {
 			osVersion := Version{Major: 1, Minor: 5, Patch: 9, Label: "beta", LabelVersion: 3}
 			useHeaderPrefix := false
 			bulletPointPrefix := changelogutils.GetOSDependencyPrefix(osVersion, useHeaderPrefix)
-			expectedBulletPrefix := "\n- (From [OSS v1.5.9-beta3](/reference/changelog/open_source/#v159-beta3)) "
+			expectedBulletPrefix := "\n- (From OSS v1.5.9-beta3) "
 			Expect(bulletPointPrefix).To(Equal(expectedBulletPrefix))
 
 			useHeaderPrefix = true
 			headerPrefix := changelogutils.GetOSDependencyPrefix(osVersion, useHeaderPrefix)
-			expectedHeaderPrefix := " (Uses Gloo Edge [OSS v1.5.9-beta3](/reference/changelog/open_source/#v159-beta3)) "
+			expectedHeaderPrefix := " (Uses Gloo Edge OSS v1.5.9-beta3) "
 			Expect(headerPrefix).To(Equal(expectedHeaderPrefix))
 		})
 	})


### PR DESCRIPTION
Currently, open source release notes only show up in the release version ordering of the enterprise changelogs. This PR adds the OS release notes to the chronological ordering of the enterprise releases (accessible if you choose "Chronological Order" on the enterprise changelogs page).

In addition, links to the open source docs of gloo from the enterprise docs are currently broken, this PR seeks to fix that.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3953