### PR TITLE
feat: configuration of settings.extauth via helm values

### DIFF
--- a/changelog/v1.6.0-beta18/helm-value-for-settings-extauth.yaml
+++ b/changelog/v1.6.0-beta18/helm-value-for-settings-extauth.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/1892
+    description: >-
+      Add a helm value for setting extauth field for gloo.solo.io.Settings. This allows to configure custom external auth server while installing Helm chart, without need to post-render or patch Settings object after helm chart was installed or upgraded.

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f
-	github.com/solo-io/go-utils v0.20.0
+	github.com/solo-io/go-utils v0.20.1
 	github.com/solo-io/k8s-utils v0.0.2
 	github.com/solo-io/protoc-gen-ext v0.0.9
 	github.com/solo-io/reporting-client v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1362,6 +1362,8 @@ github.com/solo-io/go-utils v0.19.0 h1:MoXeilk74K32iPKgfnfftQk4iz6mGRqz7c3liNLiz
 github.com/solo-io/go-utils v0.19.0/go.mod h1:If8NiehXROCFU65PGeDTrrZCNA5gJXvbcVoXI8Fqjko=
 github.com/solo-io/go-utils v0.20.0 h1:R6NYnFw+SOi1ThTMIlJbFnB3W0vnu8exu+raaUE26jI=
 github.com/solo-io/go-utils v0.20.0/go.mod h1:wy4um9xnqPNlASld4eSuQQqjNCXRBtDjVRLJsoGqkdE=
+github.com/solo-io/go-utils v0.20.1 h1:Mze8hnruTQYuIMIZJwkb4dKeCbPW2WlZJo3SpoD30FM=
+github.com/solo-io/go-utils v0.20.1/go.mod h1:wy4um9xnqPNlASld4eSuQQqjNCXRBtDjVRLJsoGqkdE=
 github.com/solo-io/k8s-utils v0.0.1 h1:e2alFsqTT7GU10d6cFDX2y+86J142DrsRwy5itvvZOI=
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
 github.com/solo-io/k8s-utils v0.0.2 h1:2g5ypM9mJKHt4+VpGhXYyg8xT+DkkQQcOhPf+KP2K60=

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -93,6 +93,11 @@ spec:
 {{- toYaml .Values.settings.rateLimit | nindent 4 }}
 {{- end }}
 
+{{- if .Values.global.extensions.extAuth }}
+  extauth:
+{{- toYaml .Values.global.extensions.extAuth | nindent 4 }}
+{{- end }}
+
 {{- if .Values.settings.singleNamespace }}
   watchNamespaces:
   - {{ .Release.Namespace }}


### PR DESCRIPTION
# Description

Resolves #1892

# Context

Users needed this feature to .configure custom extauth server ref withoun need to post-render or kubectl patch steps.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1892