### PR TITLE
Fix sed CI flake

### DIFF
--- a/changelog/v1.6.0-beta18/fix-sed-ci.yaml
+++ b/changelog/v1.6.0-beta18/fix-sed-ci.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix a flake in CI caused by invisible formatting characters interfering with the sed regex.

--- a/ci/kind.sh
+++ b/ci/kind.sh
@@ -15,7 +15,7 @@ trap "cleanup" EXIT SIGINT
 echo ">> Temporary output file ${TEMP_FILE}"
 
 # grab the image names out of the `make docker` output
-sed -nE 's|Successfully tagged (.*$)|\1|p' ${TEMP_FILE} | while read f; do kind load docker-image --name kind $f; done
+sed -nE 's|(\\x1b\[0m)?Successfully tagged (.*$)|\2|p' ${TEMP_FILE} | while read f; do kind load docker-image --name kind $f; done
 
 VERSION=kind make build-test-chart
 make glooctl-linux-amd64


### PR DESCRIPTION
Fixes a subtle bug in our CI, where formatting on the previous line can interfere with our parsing of that log line - which we currently do to pull out the docker images built in this build run.

For example:

This currently works fine:
![image](https://user-images.githubusercontent.com/1928125/101523401-9124a280-3956-11eb-8eb5-b15bab847701.png)

But if the previous line (493) has formatting, it causes a CI build issue:
![image](https://user-images.githubusercontent.com/1928125/101523273-61759a80-3956-11eb-8791-a01f26251483.png)
