### PR TITLE
Docs CLI

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -36,10 +36,18 @@ jobs:
       uses: peaceiris/actions-hugo@v2
       with:
         hugo-version: '0.69.2'
+    - name: Check if community PR
+      id: community-pr-check
+      shell: bash
+      env:
+        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+      run: |
+        if [-z ${GITHUB_TOKEN}]; then ::set-output name=SKIP_CHANGELOG::true; fi
     - name: Generate versioned docs site
       run: make -C docs build-site
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        SKIP_CHANGELOG: ${{ steps.community-per-check.outputs.SKIP_CHANGELOG }}
   regression_tests:
     name: k8s regression tests
     runs-on: ubuntu-18.04

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -42,12 +42,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
-        if [-z ${GITHUB_TOKEN}]
+        if [-n ${GITHUB_TOKEN}]
         then
-          echo "GITHUB_TOKEN not set, setting SKIP_CHANGELOG_GENERATION to true"
+          echo "GITHUB_TOKEN not empty, setting SKIP_CHANGELOG_GENERATION to true"
           ::set-output name=SKIP_CHANGELOG_GENERATION::true
         else
-          echo "GITHUB_TOKEN is set, changelog generation will NOT be skipped"
+          echo "GITHUB_TOKEN is empty, changelog generation will NOT be skipped"
         fi
     - name: Generate versioned docs site
       run: make -C docs build-site

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -36,24 +36,20 @@ jobs:
       uses: peaceiris/actions-hugo@v2
       with:
         hugo-version: '0.69.2'
-    - name: Check if community PR
+    - name: Detect Communinty PR
       id: community-pr-check
+      if: ${{ github.event.pull_request.head.repo.full_name != 'solo-io/gloo' }}
       shell: bash
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
-        if [-n ${GITHUB_TOKEN}]
-        then
-          echo "GITHUB_TOKEN not empty, setting SKIP_CHANGELOG_GENERATION to true"
-          ::set-output name=SKIP_CHANGELOG_GENERATION::true
-        else
-          echo "GITHUB_TOKEN is empty, changelog generation will NOT be skipped"
-        fi
+          echo "Pull Request is from a fork. Setting IS_COMMUNITY_PR to true"
+          ::set-output name=IS_COMMUNITY_PR::true
     - name: Generate versioned docs site
       run: make -C docs build-site
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        SKIP_CHANGELOG_GENERATION: ${{ steps.community-per-check.outputs.SKIP_CHANGELOG_GENERATION }}
+        SKIP_CHANGELOG_GENERATION: ${{ steps.community-per-check.outputs.IS_COMMUNITY_PR }}
   regression_tests:
     name: k8s regression tests
     runs-on: ubuntu-18.04

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -44,7 +44,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
           echo "Pull Request is from a fork. Setting IS_COMMUNITY_PR to true"
-          ::set-output name=IS_COMMUNITY_PR::true
+          echo "::set-output name=IS_COMMUNITY_PR::true"
     - name: Generate versioned docs site
       run: make -C docs build-site
       env:

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -49,7 +49,7 @@ jobs:
       run: make -C docs build-site
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        SKIP_CHANGELOG_GENERATION: ${{ steps.community-per-check.outputs.IS_COMMUNITY_PR }}
+        SKIP_CHANGELOG_GENERATION: ${{ steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
   regression_tests:
     name: k8s regression tests
     runs-on: ubuntu-18.04

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -40,8 +40,6 @@ jobs:
       id: community-pr-check
       if: ${{ github.event.pull_request.head.repo.full_name != 'solo-io/gloo' }}
       shell: bash
-      env:
-        GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
           echo "Pull Request is from a fork. Setting IS_COMMUNITY_PR to true"
           echo "::set-output name=IS_COMMUNITY_PR::true"

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -42,7 +42,13 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
-        if [-z ${GITHUB_TOKEN}]; then ::set-output name=SKIP_CHANGELOG_GENERATION::true; fi
+        if [-z ${GITHUB_TOKEN}]
+        then
+          echo "GITHUB_TOKEN not set, setting SKIP_CHANGELOG_GENERATION to true"
+          ::set-output name=SKIP_CHANGELOG_GENERATION::true
+        else
+          echo "GITHUB_TOKEN is set, changelog generation will NOT be skipped"
+        fi
     - name: Generate versioned docs site
       run: make -C docs build-site
       env:

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -42,12 +42,12 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       run: |
-        if [-z ${GITHUB_TOKEN}]; then ::set-output name=SKIP_CHANGELOG::true; fi
+        if [-z ${GITHUB_TOKEN}]; then ::set-output name=SKIP_CHANGELOG_GENERATION::true; fi
     - name: Generate versioned docs site
       run: make -C docs build-site
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        SKIP_CHANGELOG: ${{ steps.community-per-check.outputs.SKIP_CHANGELOG }}
+        SKIP_CHANGELOG_GENERATION: ${{ steps.community-per-check.outputs.SKIP_CHANGELOG_GENERATION }}
   regression_tests:
     name: k8s regression tests
     runs-on: ubuntu-18.04

--- a/changelog/v1.6.0-beta18/disable-community-docs-deploy.yaml
+++ b/changelog/v1.6.0-beta18/disable-community-docs-deploy.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Disable enterprise docs gen for community PRs


### PR DESCRIPTION
# Description

PR to fix current bug in CI preventing community users from passing codegen due to some sensitive enterprise-related docsgen permissions.

I am using this PR from a fork as a test case.

# Context

Users ran into this recently after we updated our docs CI

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works