### PR TITLE
Docs CLI Fix (#3969)

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -36,10 +36,18 @@ jobs:
       uses: peaceiris/actions-hugo@v2
       with:
         hugo-version: '0.69.2'
+    - name: Detect Communinty PR
+      id: community-pr-check
+      if: ${{ github.event.pull_request.head.repo.full_name != 'solo-io/gloo' }}
+      shell: bash
+      run: |
+          echo "Pull Request is from a fork. Setting IS_COMMUNITY_PR to true"
+          echo "::set-output name=IS_COMMUNITY_PR::true"
     - name: Generate versioned docs site
       run: make -C docs build-site
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        SKIP_CHANGELOG_GENERATION: ${{ steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
   regression_tests:
     name: k8s regression tests
     runs-on: ubuntu-18.04

--- a/changelog/v1.6.0-beta18/disable-community-docs-deploy.yaml
+++ b/changelog/v1.6.0-beta18/disable-community-docs-deploy.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Disable enterprise docs gen for community PRs


### PR DESCRIPTION
# Description

PR to fix current bug in CI preventing community users from passing codegen due to some sensitive enterprise-related docsgen permissions.

# Context

Users ran into this recently after we updated our docs CI.

You can see this PR's fix working in an example PR from a fork here - https://github.com/solo-io/gloo/pull/3969

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works