### PR TITLE
Helm extauth

### DIFF
--- a/changelog/v1.6.0-beta18/helm-value-for-settings-extauth.yaml
+++ b/changelog/v1.6.0-beta18/helm-value-for-settings-extauth.yaml
@@ -3,3 +3,10 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/1892
     description: >-
       Add a helm value for setting extauth field for gloo.solo.io.Settings. This allows to configure custom external auth server while installing Helm chart, without need to post-render or patch Settings object after helm chart was installed or upgraded.
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: go-utils
+    dependencyTag: v0.20.1
+    description: Update go-utils to version v0.20.1, allows for windows builds of the helm tests.
+    issueLink: https://github.com/solo-io/gloo/issues/1892
+

--- a/changelog/v1.6.0-beta18/helm-value-for-settings-extauth.yaml
+++ b/changelog/v1.6.0-beta18/helm-value-for-settings-extauth.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/1892
+    description: >-
+      Add a helm value for setting extauth field for gloo.solo.io.Settings. This allows to configure custom external auth server while installing Helm chart, without need to post-render or patch Settings object after helm chart was installed or upgraded.

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0 // indirect
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/solo-io/go-list-licenses v0.0.0-20191023220251-171e4740d00f
-	github.com/solo-io/go-utils v0.20.0
+	github.com/solo-io/go-utils v0.20.1
 	github.com/solo-io/k8s-utils v0.0.2
 	github.com/solo-io/protoc-gen-ext v0.0.9
 	github.com/solo-io/reporting-client v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1362,6 +1362,8 @@ github.com/solo-io/go-utils v0.19.0 h1:MoXeilk74K32iPKgfnfftQk4iz6mGRqz7c3liNLiz
 github.com/solo-io/go-utils v0.19.0/go.mod h1:If8NiehXROCFU65PGeDTrrZCNA5gJXvbcVoXI8Fqjko=
 github.com/solo-io/go-utils v0.20.0 h1:R6NYnFw+SOi1ThTMIlJbFnB3W0vnu8exu+raaUE26jI=
 github.com/solo-io/go-utils v0.20.0/go.mod h1:wy4um9xnqPNlASld4eSuQQqjNCXRBtDjVRLJsoGqkdE=
+github.com/solo-io/go-utils v0.20.1 h1:Mze8hnruTQYuIMIZJwkb4dKeCbPW2WlZJo3SpoD30FM=
+github.com/solo-io/go-utils v0.20.1/go.mod h1:wy4um9xnqPNlASld4eSuQQqjNCXRBtDjVRLJsoGqkdE=
 github.com/solo-io/k8s-utils v0.0.1 h1:e2alFsqTT7GU10d6cFDX2y+86J142DrsRwy5itvvZOI=
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
 github.com/solo-io/k8s-utils v0.0.2 h1:2g5ypM9mJKHt4+VpGhXYyg8xT+DkkQQcOhPf+KP2K60=

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -93,9 +93,11 @@ spec:
 {{- toYaml .Values.settings.rateLimit | nindent 4 }}
 {{- end }}
 
+{{- if .Values.global.extensions }}
 {{- if .Values.global.extensions.extAuth }}
   extauth:
 {{- toYaml .Values.global.extensions.extAuth | nindent 4 }}
+{{- end }}
 {{- end }}
 
 {{- if .Values.settings.singleNamespace }}

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -93,6 +93,11 @@ spec:
 {{- toYaml .Values.settings.rateLimit | nindent 4 }}
 {{- end }}
 
+{{- if .Values.global.extensions.extAuth }}
+  extauth:
+{{- toYaml .Values.global.extensions.extAuth | nindent 4 }}
+{{- end }}
+
 {{- if .Values.settings.singleNamespace }}
   watchNamespaces:
   - {{ .Release.Namespace }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1801,6 +1801,52 @@ spec:
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
 
+					It("allows setting extauth", func() {
+						expectedYaml := makeUnstructured(`
+apiVersion: gloo.solo.io/v1
+kind: Settings
+metadata:
+  labels:
+    app: gloo
+  name: default
+  namespace: gloo-system
+spec:
+  gloo:
+    xdsBindAddr: "0.0.0.0:9977"
+    restXdsBindAddr: "0.0.0.0:9976"
+    enableRestEds: true
+    disableKubernetesDestinations: false
+    disableProxyGarbageCollection: false
+  discoveryNamespace: gloo-system
+  kubernetesArtifactSource: {}
+  kubernetesConfigSource: {}
+  kubernetesSecretSource: {}
+  refreshRate: 60s
+
+  gateway:
+    readGatewaysFromAllNamespaces: false
+    validation:
+      proxyValidationServerAddr: gloo:9988
+      alwaysAccept: true
+      allowWarnings: true
+  discovery:
+    fdsMode: WHITELIST
+  extauth:
+    extauthzServerRef:
+      name: test
+      namespace: testspace
+`)
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"global.extensions.extAuth.extauthzServerRef.name=test",
+								"global.extensions.extAuth.extauthzServerRef.namespace=testspace",
+							},
+						})
+
+						testManifest.ExpectUnstructured(expectedYaml.GetKind(), expectedYaml.GetNamespace(), expectedYaml.GetName()).To(BeEquivalentTo(expectedYaml))
+
+					})
+
 					It("finds resources on all containers, with identical resources on all sds and sidecar containers", func() {
 						envoySidecarVals := []string{"100Mi", "200m", "300Mi", "400m"}
 						sdsVals := []string{"101Mi", "201m", "301Mi", "401m"}


### PR DESCRIPTION
# Description

Add helm values `.global.extensions.extAuth` to allow setting ext auth settings in the `Settings` k8s resource.

# Context

Previously users were using Kustomize or manually editing the resource after deployment.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation - **Note this depends on some changes to how we handle Enterprise vs open source helm values, out of scope for this PR**
- [X] I have added tests that prove my fix is effective or that my feature works

Thank you to @eshepelyuk for getting us started with the contribution for this one.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/1892