### PR TITLE
Fix lambda route validation bug

### DIFF
--- a/changelog/v1.6.0-beta18/fix-usptream-lambda-destination-validation.yaml
+++ b/changelog/v1.6.0-beta18/fix-usptream-lambda-destination-validation.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3975
+    description: fixes bug where route validation marks redirect and direct response route destinations as invalid.

--- a/projects/gloo/pkg/translator/clusters.go
+++ b/projects/gloo/pkg/translator/clusters.go
@@ -255,9 +255,7 @@ func validateUpstreamLambdaFunctions(proxy *v1.Proxy, upstreams v1.UpstreamList,
 			for _, virtualHost := range httpListener.GetVirtualHosts() {
 				// Validate all routes to make sure that if they point to a lambda, it exists.
 				for _, route := range virtualHost.GetRoutes() {
-					if route.GetDirectResponseAction() == nil {
-						validateRouteDestinationForValidLambdas(proxy, route.GetRouteAction(), upstreamGroups, reports, upstreamLambdas)
-					}
+					validateRouteDestinationForValidLambdas(proxy, route, upstreamGroups, reports, upstreamLambdas)
 				}
 			}
 		}
@@ -265,18 +263,24 @@ func validateUpstreamLambdaFunctions(proxy *v1.Proxy, upstreams v1.UpstreamList,
 }
 
 // Validates a route that may have a single or multi upstream destinations to make sure that any lambda upstreams are referencing valid lambdas
-func validateRouteDestinationForValidLambdas(proxy *v1.Proxy, route *v1.RouteAction, upstreamGroups v1.UpstreamGroupList, reports reporter.ResourceReports, upstreamLambdas map[core.ResourceRef]map[string]bool) {
+func validateRouteDestinationForValidLambdas(proxy *v1.Proxy, route *v1.Route, upstreamGroups v1.UpstreamGroupList, reports reporter.ResourceReports, upstreamLambdas map[core.ResourceRef]map[string]bool) {
 	// Append destinations to a destination list to process all of them in one go
 	var destinations []*v1.Destination
 
-	switch typedRoute := route.GetDestination().(type) {
+	_, ok := route.GetAction().(*v1.Route_RouteAction)
+	if !ok {
+		// If this is not a Route_RouteAction (e.g. Route_DirectResponseAction, Route_RedirectAction), there is no destination to validate
+		return
+	}
+	routeAction := route.GetRouteAction()
+	switch typedRoute := routeAction.GetDestination().(type) {
 	case *v1.RouteAction_Single:
 		{
-			destinations = append(destinations, route.GetSingle())
+			destinations = append(destinations, routeAction.GetSingle())
 		}
 	case *v1.RouteAction_Multi:
 		{
-			multiDest := route.GetMulti()
+			multiDest := routeAction.GetMulti()
 			for _, weightedDest := range multiDest.GetDestinations() {
 				destinations = append(destinations, weightedDest.GetDestination())
 			}

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -528,6 +528,30 @@ var _ = Describe("Translator", func() {
 		})
 	})
 
+	Context("non route_routeaction routes", func() {
+		BeforeEach(func() {
+			redirectRoute := &v1.Route{
+				Action: &v1.Route_RedirectAction{
+					RedirectAction: &v1.RedirectAction{
+						ResponseCode: 400,
+					},
+				},
+			}
+			directResponseRoute := &v1.Route{
+				Action: &v1.Route_DirectResponseAction{
+					DirectResponseAction: &v1.DirectResponseAction{
+						Status: 400,
+					},
+				},
+			}
+			routes = []*v1.Route{redirectRoute, directResponseRoute}
+		})
+
+		It("reports no errors with a redirect route or direct response route", func() {
+			translate()
+		})
+	})
+
 	Context("Health check config", func() {
 
 		It("will error if required field is nil", func() {


### PR DESCRIPTION
# Description

fixes bug where route validation marks redirect and direct response route destinations as invalid.

# Context

Ran into this bug configuring a redirect or direct response action on a route
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3975