### PR TITLE
Update oauth example docs

### DIFF
--- a/docs/content/guides/security/auth/extauth/oauth/dex/_index.md
+++ b/docs/content/guides/security/auth/extauth/oauth/dex/_index.md
@@ -192,6 +192,9 @@ spec:
         issuer_url: http://dex.gloo-system.svc.cluster.local:32000/
         scopes:
         - email
+        session:
+          cookieOptions:
+            notSecure: true
 {{< /highlight >}}
 
 {{% notice note %}}

--- a/docs/content/guides/security/auth/extauth/oauth/google/_index.md
+++ b/docs/content/guides/security/auth/extauth/oauth/google/_index.md
@@ -132,6 +132,9 @@ spec:
           name: google
           namespace: gloo-system
         issuer_url: https://accounts.google.com
+        session:
+          cookieOptions:
+            notSecure: true
         scopes:
         - email
 EOF
@@ -139,6 +142,7 @@ EOF
 
 {{% notice note %}}
 The above configuration uses the new `oauth2` syntax. The older `oauth` syntax is still supported, but has been deprecated.
+Note this example explicitly allows insecure cookies (`session.cookieOptions.notSecure`), so that it works in this guide using localhost. In a live hosted environment secured with TLS, you should not set this.
 {{% /notice %}}
 
 Notice how we set the `CLIENT_ID` and reference the client secret we just created. The `callback_path` matches the authorized redirect URI we added for the OAuth Client ID. Redirecting to an unauthorized URI would result in an error from the Google authentication flow.


### PR DESCRIPTION
Now uses insecure cookie so that non-TLS localhost example works.

# Description

Before this exchange, users ran into issues following the tutorial because it was using http://localhost as the example, but the config was expecting secure cookies by default.

I've updated the Google and Dex examples. The [Okta Example](https://docs.solo.io/gloo-edge/1.6.0-beta14/guides/security/auth/extauth/oauth/okta/#secure-the-application-using-https) already walks the user through securing the app using https, so it did not need to be updated.


# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

FIXES https://github.com/solo-io/gloo/issues/3980