### PR TITLE
Update docs referencing oauth to use oauth2

### DIFF
--- a/docs/content/guides/security/auth/extauth/oauth/_index.md
+++ b/docs/content/guides/security/auth/extauth/oauth/_index.md
@@ -37,18 +37,19 @@ metadata:
   namespace: gloo-system
 spec:
   configs:
-  - oauth:
-      issuer_url: theissuer.com
-      auth_endpoint_query_params:
-        paramKey: paramValue
-      app_url: myapp.com
-      callback_path: /my/callback/path/
-      client_id: myclientid
-      client_secret_ref:
-        name: my-oauth-secret
-        namespace: gloo-system
-      scopes:
-      - email
+  - oauth2:
+      oidcAuthorizationCode:
+        issuer_url: theissuer.com
+        app_url: https://myapp.com
+        auth_endpoint_query_params:
+          paramKey: paramValue
+        callback_path: /my/callback/path/
+        client_id: myclientid
+        client_secret_ref:
+          name: my-oauth-secret
+          namespace: gloo-system
+        scopes:
+        - email
 {{< /highlight >}}
 
 The `AuthConfig` consists of a single `config` of type `oauth`. Let's go through each of its attributes:

--- a/docs/content/guides/security/auth/extauth/opa/_index.md
+++ b/docs/content/guides/security/auth/extauth/opa/_index.md
@@ -440,16 +440,20 @@ metadata:
   namespace: gloo-system
 spec:
   configs:
-  - oauth:
-      app_url: http://localhost:8080/
-      callback_path: /callback
-      client_id: gloo
-      client_secret_ref:
-        name: oauth
-        namespace: gloo-system
-      issuer_url: http://dex.gloo-system.svc.cluster.local:32000/
-      scopes:
-      - email
+  - oauth2:
+      oidcAuthorizationCode:
+        app_url: http://localhost:8080
+        callback_path: /callback
+        client_id: gloo
+        client_secret_ref:
+          name: oauth
+          namespace: gloo-system
+        issuer_url: http://dex.gloo-system.svc.cluster.local:32000/
+        session:
+          cookieOptions:
+            notSecure: true
+        scopes:
+        - email
   - opa_auth:
       modules:
       - name: allow-jwt


### PR DESCRIPTION
# Description

Docs-only change. Update any docs referencing the deprecates `oauth` syntax to instead use `oauth2` syntax.

# Context

When updating docs to include examples with insecure tokens enabled, some of the oauth examples were uploaded to oauth2. This PR updates all of the other examples across our docs to be the same oauth2 format.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works