### PR TITLE
Update docs referencing hello world traffic management guide

### DIFF
--- a/docs/content/guides/traffic_management/hello_world/_index.md
+++ b/docs/content/guides/traffic_management/hello_world/_index.md
@@ -346,20 +346,21 @@ status:
     '*v1.Proxy.gloo-system.gateway-proxy':
       reportedBy: gloo
       state: Accepted
-virtualHost:
-  domains:
-  - '*'
-  routes:
-  - matchers:
-    - exact: /all-pets
-    options:
-      prefixRewrite: /api/pets
-    routeAction:
-      single:
-        upstream:
-          name: default-petstore-8080
-          namespace: gloo-system
-```
+spec:
+  virtualHost:
+    domains:
+    - '*'
+    routes:
+    - matchers:
+      - exact: /all-pets
+      options:
+        prefixRewrite: /api/pets
+      routeAction:
+        single:
+          upstream:
+            name: default-petstore-8080
+            namespace: gloo-system
+  ```
     
 When a Virtual Service is created, Gloo Edge immediately updates the proxy configuration. Since the status of this Virtual Service is `Accepted`, we know this route is now active. 
 


### PR DESCRIPTION
# Description
there is typo in virtualservice yaml example - spec: is missing

# Context
we ran into this by trying out gloo-ee with an demo app

# Checklist:
- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works