### PR TITLE
Don't add keep-pr-updated label if community PR

### DIFF
--- a/.github/workflows/add-pr-label.yaml
+++ b/.github/workflows/add-pr-label.yaml
@@ -8,8 +8,16 @@ jobs:
     name: Add `keep pr updated` Label
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: christianvuerings/add-labels@v1
+      - name: Detect Community PR
+        id: community-pr-check
+        if: ${{ github.event.pull_request.head.repo.full_name != 'solo-io/gloo' }}
+        shell: bash
+        run: |
+          echo "Pull Request is from a fork. Setting IS_COMMUNITY_PR to true"
+          echo "::set-output name=IS_COMMUNITY_PR::true"
+      - name: Add PR label
+        uses: christianvuerings/add-labels@v1
+        if: ${{ !steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
         with:
           labels: |
             keep pr updated

--- a/changelog/v1.6.0-beta24/disable-community-pr-github-label.yaml
+++ b/changelog/v1.6.0-beta24/disable-community-pr-github-label.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: For community PRs, do not add the 'keep-pr-updated' label


### PR DESCRIPTION
# Description

Do not append the `keep-pr-updated` to community pull requests

# Context

On a recent community PR, the `Add 'keep-pr-updated' Label` github action failed with:

```
Run christianvuerings/add-labels@v1
Add labels: keep pr updated to solo-io/gloo#4019
Error: Resource not accessible by integration
```
see the logs here:  (https://github.com/solo-io/gloo/runs/1599785332?check_suite_focus=true)

This modifies the action to not run for community pull requests. 

This tests the behavior from a solo-dev PR. There was earlier work done [in this PR](https://github.com/solo-io/gloo/pull/4022) to test the behavior from a community PR.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works