### PR TITLE
fix shadow translation

### DIFF
--- a/changelog/v1.6.0-beta24/fix-csrf-shadow-enabled.yaml
+++ b/changelog/v1.6.0-beta24/fix-csrf-shadow-enabled.yaml
@@ -1,4 +1,5 @@
 changelog:
   - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3898
     description: >
       Csrf envoy filter shadow mode now gets correctly applied to the envoy config.

--- a/changelog/v1.6.0-beta24/fix-csrf-shadow-enabled.yaml
+++ b/changelog/v1.6.0-beta24/fix-csrf-shadow-enabled.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: >
+      Csrf envoy filter shadow mode now gets correctly applied to the envoy config.

--- a/projects/gloo/pkg/plugins/csrf/plugin.go
+++ b/projects/gloo/pkg/plugins/csrf/plugin.go
@@ -113,7 +113,7 @@ func translateCsrfConfig(csrf *csrf.CsrfPolicy) (*envoycsrf.CsrfPolicy, error) {
 	} else if csrf.GetShadowEnabled() != nil {
 		csrfPolicy := &envoycsrf.CsrfPolicy{
 			FilterEnabled:     translateFilterEnabled(csrf.GetFilterEnabled()),
-			ShadowEnabled:     translateFilterEnabled(csrf.GetShadowEnabled()),
+			ShadowEnabled:     translateShadowEnabled(csrf.GetShadowEnabled()),
 			AdditionalOrigins: translateAdditionalOrigins(csrf.GetAdditionalOrigins()),
 		}
 


### PR DESCRIPTION
# Description

Shadow Enabled mode rejects the request rather than just logging that the request triggered the CSRF filter. 

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3898