### PR TITLE
Disable rest eds

### DIFF
--- a/changelog/v1.6.0-beta24/disable-rest-eds.yaml
+++ b/changelog/v1.6.0-beta24/disable-rest-eds.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3805
+    description: >
+      Disable REST EDS server by default, which is no longer necessary now that upstream envoy has fixed
+      https://github.com/envoyproxy/envoy/issues/13070

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -83,7 +83,7 @@
 |settings.aws.enableServiceAccountCredentials|bool|false|Use ServiceAccount credentials to authenticate lambda requests. If enableCredentialsDiscovery is also set, this will take precedence as only one may be enabled in Gloo Edge|
 |settings.aws.stsCredentialsRegion|string||Regional endpoint to use for AWS STS requests. If empty will default to global sts endpoint.|
 |settings.rateLimit|interface||Partial config for Gloo Edge Enterprise’s rate-limiting service, based on Envoy’s rate-limit service; supports Envoy’s rate-limit service API. (reference here: https://github.com/lyft/ratelimit#configuration) Configure rate-limit descriptors here, which define the limits for requests based on their descriptors. Configure rate-limits (composed of actions, which define how request characteristics get translated into descriptors) on the VirtualHost or its routes.|
-|settings.enableRestEds|bool|true|Whether or not to use rest xds for all EDS by default. Set to true by default in versions > v1.6.0.|
+|settings.enableRestEds|bool|false|Whether or not to use rest xds for all EDS by default. Set to true by default in versions > v1.6.0.|
 |gloo.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |gloo.deployment.image.repository|string|gloo|image name (repository) for the container.|
 |gloo.deployment.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -15,7 +15,7 @@ spec:
 {{- else }}
     xdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.xdsPort }}"
     restXdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.restXdsPort }}"
-    enableRestEds: {{ .Values.settings.enableRestEds }}
+    enableRestEds: {{ .Values.settings.enableRestEds | default false }}
 {{- end }}
 {{- if .Values.settings.replaceInvalidRoutes }}
     invalidConfigPolicy:

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -9,7 +9,7 @@ settings:
   # if this is set to false, default settings will be created by pods upon boot
   create: true
   linkerd: false
-  enableRestEds: true
+  enableRestEds: false
   aws: {}
   invalidConfigPolicy:
     replaceInvalidRoutes: false

--- a/install/test/fixtures/settings/consul_config_upstream_discovery.yaml
+++ b/install/test/fixtures/settings/consul_config_upstream_discovery.yaml
@@ -15,7 +15,7 @@ spec:
      allowWarnings: true
      proxyValidationServerAddr: gloo:9988
  gloo:
-   enableRestEds: true
+   enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/consul_config_values.yaml
+++ b/install/test/fixtures/settings/consul_config_values.yaml
@@ -15,7 +15,7 @@ spec:
      allowWarnings: true
      proxyValidationServerAddr: gloo:9988
  gloo:
-   enableRestEds: true
+   enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/disable_kubernetes_destinations.yaml
+++ b/install/test/fixtures/settings/disable_kubernetes_destinations.yaml
@@ -15,7 +15,7 @@ spec:
      allowWarnings: true
      proxyValidationServerAddr: gloo:9988
  gloo:
-   enableRestEds: true
+   enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: true

--- a/install/test/fixtures/settings/disable_proxy_garbage_collection.yaml
+++ b/install/test/fixtures/settings/disable_proxy_garbage_collection.yaml
@@ -15,7 +15,7 @@ spec:
      allowWarnings: true
      proxyValidationServerAddr: gloo:9988
  gloo:
-   enableRestEds: true
+   enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/enable_default_credentials.yaml
+++ b/install/test/fixtures/settings/enable_default_credentials.yaml
@@ -15,7 +15,7 @@ spec:
       allowWarnings: true
       proxyValidationServerAddr: gloo:9988
   gloo:
-    enableRestEds: true
+    enableRestEds: false
     xdsBindAddr: 0.0.0.0:9977
     restXdsBindAddr: 0.0.0.0:9976
     disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/enable_rest_eds.yaml
+++ b/install/test/fixtures/settings/enable_rest_eds.yaml
@@ -15,7 +15,7 @@ spec:
      allowWarnings: true
      proxyValidationServerAddr: gloo:9988
  gloo:
-   enableRestEds: false
+   enableRestEds: true
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/gateway_settings.yaml
+++ b/install/test/fixtures/settings/gateway_settings.yaml
@@ -15,7 +15,7 @@ spec:
      allowWarnings: true
      proxyValidationServerAddr: gloo:9988
  gloo:
-   enableRestEds: true
+   enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/ratelimit_descriptors.yaml
+++ b/install/test/fixtures/settings/ratelimit_descriptors.yaml
@@ -15,7 +15,7 @@ spec:
      allowWarnings: true
      proxyValidationServerAddr: gloo:9988
  gloo:
-   enableRestEds: true
+   enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/read_gateways_from_all_namespaces.yaml
+++ b/install/test/fixtures/settings/read_gateways_from_all_namespaces.yaml
@@ -11,7 +11,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: true
  gloo:
-   enableRestEds: true
+   enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false

--- a/install/test/fixtures/settings/sts_discovery.yaml
+++ b/install/test/fixtures/settings/sts_discovery.yaml
@@ -15,7 +15,7 @@ spec:
       allowWarnings: true
       proxyValidationServerAddr: gloo:9988
   gloo:
-    enableRestEds: true
+    enableRestEds: false
     xdsBindAddr: 0.0.0.0:9977
     restXdsBindAddr: 0.0.0.0:9976
     disableKubernetesDestinations: false

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1788,12 +1788,12 @@ spec:
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
 
-					It("correctly sets the `gloo.enableRestEds` to false in the settings", func() {
-						settings := makeUnstructureFromTemplateFile("fixtures/settings/disable_rest_eds.yaml", namespace)
+					It("correctly sets the `gloo.enableRestEds` to true in the settings", func() {
+						settings := makeUnstructureFromTemplateFile("fixtures/settings/enable_rest_eds.yaml", namespace)
 
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{
-								"settings.enableRestEds=false",
+								"settings.enableRestEds=true",
 							},
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1823,7 +1823,7 @@ spec:
   gloo:
     xdsBindAddr: "0.0.0.0:9977"
     restXdsBindAddr: "0.0.0.0:9976"
-    enableRestEds: true
+    enableRestEds: false
     disableKubernetesDestinations: false
     disableProxyGarbageCollection: false
   discoveryNamespace: gloo-system

--- a/projects/gloo/pkg/xds/utils.go
+++ b/projects/gloo/pkg/xds/utils.go
@@ -14,7 +14,7 @@ func SetEdsOnCluster(out *envoy_config_cluster_v3.Cluster, settings *v1.Settings
 	out.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}
-	// The default value for enableRestEds should be set to true via helm.
+	// The default value for enableRestEds should be set to false via helm.
 	// If nil will not enable rest eds.
 	if settings.GetGloo().GetEnableRestEds().GetValue() {
 		out.EdsClusterConfig = &envoy_config_cluster_v3.Cluster_EdsClusterConfig{

--- a/projects/gloo/pkg/xds/utils.go
+++ b/projects/gloo/pkg/xds/utils.go
@@ -15,17 +15,8 @@ func SetEdsOnCluster(out *envoy_config_cluster_v3.Cluster, settings *v1.Settings
 		Type: envoy_config_cluster_v3.Cluster_EDS,
 	}
 	// The default value for enableRestEds should be set to true via helm.
-	// If nil will default to rest eds.
-	if !settings.GetGloo().GetEnableRestEds().GetValue() {
-		out.EdsClusterConfig = &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
-			EdsConfig: &envoy_config_core_v3.ConfigSource{
-				ResourceApiVersion: envoy_config_core_v3.ApiVersion_V3,
-				ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_Ads{
-					Ads: &envoy_config_core_v3.AggregatedConfigSource{},
-				},
-			},
-		}
-	} else {
+	// If nil will not enable rest eds.
+	if settings.GetGloo().GetEnableRestEds().GetValue() {
 		out.EdsClusterConfig = &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
 			EdsConfig: &envoy_config_core_v3.ConfigSource{
 				ResourceApiVersion: envoy_config_core_v3.ApiVersion_V3,
@@ -37,6 +28,15 @@ func SetEdsOnCluster(out *envoy_config_cluster_v3.Cluster, settings *v1.Settings
 						RefreshDelay:        ptypes.DurationProto(time.Second * 5),
 						RequestTimeout:      ptypes.DurationProto(time.Second * 5),
 					},
+				},
+			},
+		}
+	} else {
+		out.EdsClusterConfig = &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+			EdsConfig: &envoy_config_core_v3.ConfigSource{
+				ResourceApiVersion: envoy_config_core_v3.ApiVersion_V3,
+				ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_Ads{
+					Ads: &envoy_config_core_v3.AggregatedConfigSource{},
 				},
 			},
 		}


### PR DESCRIPTION
# Description

Disable REST EDS server by default, which is no longer necessary now that upstream envoy has fixed https://github.com/envoyproxy/envoy/issues/13070

# Context

REST EDS was a workaround to avoid the bug in envoy, but we now depend on [envoy-gloo 1.17.0-rc3](https://github.com/solo-io/gloo/blob/c24a007d91165b08a04215a6a7d0f7a54e03245a/Makefile#L24) which itself depends on envoy https://github.com/solo-io/envoy-gloo/blob/master/bazel/repository_locations.bzl#L4 from commit [6be36debaf627925ebf5e22e84e7e066191b14d5](https://github.com/envoyproxy/envoy/tree/6be36debaf627925ebf5e22e84e7e066191b14d5)

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3805