### PR TITLE
report invalid namespaces

### DIFF
--- a/changelog/v1.6.0-beta26/report-invalid-namespaces.yaml
+++ b/changelog/v1.6.0-beta26/report-invalid-namespaces.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4006
+    description: >
+      Kubernetes plugin reports error when encountering upstream with nonexistant ServiceNamespace 
+      instead of crashing.
+
+

--- a/projects/gloo/pkg/plugins/kubernetes/plugin.go
+++ b/projects/gloo/pkg/plugins/kubernetes/plugin.go
@@ -61,8 +61,16 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 
 	// configure the cluster to use EDS:ADS and call it a day
 	xds.SetEdsOnCluster(out, p.settings)
+	upstreamRef := in.GetMetadata().Ref()
 
-	svcs, err := p.kubeCoreCache.NamespacedServiceLister(kube.Kube.ServiceNamespace).List(labels.NewSelector())
+	// Lister functions obfuscate the typical (val, ok) pair returned values of maps, so we have to do a nil check instead.
+	lister := p.kubeCoreCache.NamespacedServiceLister(kube.Kube.ServiceNamespace)
+	if lister == nil {
+		return errors.Errorf("Upstream %s references the service \"%s\" which has an invalid ServiceNamespace \"%s\".",
+			upstreamRef.String(),  kube.Kube.ServiceName, kube.Kube.ServiceNamespace)
+	}
+
+	svcs, err := lister.List(labels.NewSelector())
 	if err != nil {
 		return err
 	}
@@ -72,7 +80,6 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 		}
 	}
 
-	upstreamRef := in.GetMetadata().Ref()
 	return errors.Errorf("Upstream %s references the service \"%s\" which does not exist in namespace \"%s\"",
 		upstreamRef.String(), kube.Kube.ServiceName, kube.Kube.ServiceNamespace)
 

--- a/projects/gloo/pkg/plugins/kubernetes/plugin.go
+++ b/projects/gloo/pkg/plugins/kubernetes/plugin.go
@@ -67,7 +67,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 	lister := p.kubeCoreCache.NamespacedServiceLister(kube.Kube.ServiceNamespace)
 	if lister == nil {
 		return errors.Errorf("Upstream %s references the service \"%s\" which has an invalid ServiceNamespace \"%s\".",
-			upstreamRef.String(),  kube.Kube.ServiceName, kube.Kube.ServiceNamespace)
+			upstreamRef.String(), kube.Kube.ServiceName, kube.Kube.ServiceNamespace)
 	}
 
 	svcs, err := lister.List(labels.NewSelector())

--- a/projects/gloo/pkg/plugins/kubernetes/plugin_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/plugin_test.go
@@ -3,6 +3,7 @@ package kubernetes
 import (
 	"context"
 	"strings"
+	"time"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -19,13 +20,14 @@ import (
 
 var _ = Describe("Plugin", func() {
 	var (
+		kube     *fake.Clientset
 		params   plugins.Params
 		plugin   plugins.Plugin
 		upstream *v1.Upstream
 		out      *envoy_config_cluster_v3.Cluster
 	)
 	BeforeEach(func() {
-		kube := fake.NewSimpleClientset()
+		kube = fake.NewSimpleClientset()
 		kubeCoreCache, err := corecache.NewKubeCoreCache(context.Background(), kube)
 		Expect(err).To(BeNil())
 		plugin = NewPlugin(kube, kubeCoreCache)
@@ -48,9 +50,27 @@ var _ = Describe("Plugin", func() {
 	Context("upstreams", func() {
 
 		It("should error upstream with nonexistent service", func() {
+
 			err := plugin.(plugins.UpstreamPlugin).ProcessUpstream(params, upstream, out)
 			Expect(err).To(HaveOccurred())
 			Expect(strings.Contains(err.Error(), "does not exist in namespace")).To(BeTrue())
+		})
+
+		It("should error upstream with nonexistent serviceNamespace", func() {
+			// Reset plugin to not watch all namespaces.
+			kubeCoreCache, err := corecache.NewKubeCoreCacheWithOptions(context.Background(), kube, time.Duration(1), []string{"ns"})
+			Expect(err).To(BeNil())
+			plugin = NewPlugin(kube, kubeCoreCache)
+			plugin.Init(plugins.InitParams{})
+			upstream.UpstreamType = &v1.Upstream_Kube{
+				Kube: &kubernetes.UpstreamSpec{
+					ServiceName:      "mySvc",
+					ServiceNamespace: "ns-fake",
+				},
+			}
+			err = plugin.(plugins.UpstreamPlugin).ProcessUpstream(params, upstream, out)
+			Expect(err).To(HaveOccurred())
+			Expect(strings.Contains(err.Error(), "invalid ServiceNamespace")).To(BeTrue())
 		})
 
 	})

--- a/projects/gloo/pkg/plugins/kubernetes/uds.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds.go
@@ -3,8 +3,8 @@ package kubernetes
 import (
 	"context"
 
-	"github.com/solo-io/go-utils/contextutils"
 	errors "github.com/rotisserie/eris"
+	"github.com/solo-io/go-utils/contextutils"
 
 	"github.com/solo-io/gloo/pkg/utils"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"

--- a/projects/gloo/pkg/plugins/kubernetes/uds.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds.go
@@ -39,7 +39,7 @@ func (p *plugin) DiscoverUpstreams(watchNamespaces []string, writeNamespace stri
 	discoverUpstreams := func() {
 		var serviceList []*kubev1.Service
 		for _, ns := range watchNamespaces {
-			
+
 			lister := p.kubeCoreCache.NamespacedServiceLister(ns)
 			if lister == nil {
 				errs <- errors.Errorf("Kubernetes upstream discovery: Tried to discover upstreams in invalid namespace \"%s\".", ns)


### PR DESCRIPTION
# Description

Adds a check in the kubernetes plugin to ensure that it actually found a non-nil ServiceLister from the call to `p.kubeCoreCache.NamespacedServiceLister(kube.Kube.ServiceNamespace)`, along with a test to ensure that it's working as expected. The code works, but it begs some questions about the solo-kit code behind this.

[The solo-kit lister functions](https://github.com/solo-io/solo-kit/blob/master/pkg/api/v1/clients/kube/cache/cache.go#L279) short circuit if they're scoped to all namespaces. When that's the case, the function creates and returns a new lister for any inputted namespace without any checks. This is why this error only occurred when gloo was namespace-restricted; it never reached line 283 of the above code otherwise. Do we want this behavior, or should we also see this error when trying to attach upstreams to non-existent namespaces when gloo is watching all namespaces? At the moment, gloo still returns an error, but it's the less informative error that's produced at the end of the k8s plugin function involved [here](https://github.com/solo-io/gloo/blob/master/projects/gloo/pkg/plugins/kubernetes/plugin.go#L76). It's also worth noting that we can also obfuscate this error by adding invalid namespaces to the watch namespaces list, at which point we'll once again reach the later error if we were to add an upstream to this non-existent-but-watched namespace.


# Context

https://github.com/solo-io/gloo/issues/4006

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4006