### PR TITLE
Update docs

### DIFF
--- a/docs/content/guides/gloo_federation/federated_configuration.md
+++ b/docs/content/guides/gloo_federation/federated_configuration.md
@@ -78,7 +78,7 @@ NAME              AGE
 fed-upstream      97m
 ```
 
-Now we can created a Virtual Service for the Upstream.
+Now we can create a Virtual Service for the Upstream.
 
 ### Create a Federated Virtual Service
 

--- a/docs/content/guides/gloo_federation/service_failover.md
+++ b/docs/content/guides/gloo_federation/service_failover.md
@@ -556,10 +556,6 @@ You should see the following output. Note the message is "green-pod" instead of 
 * Connection #0 to host 52.154.156.176 left intact
 ```
 
-{{< notice note >}}
-If you receive a 503 error, it may be caused by a known issue. Delete the echo-blue pod and wait for it to be recreated. The "blue-pod" should be active again. Repeat the steps to fail the healthcheck service on the echo-blue pod and the failover will occur. This only needs to be done once.
-{{< /notice >}}
-
 You can switch between the two services by enabling and disabling the Blue Upstream service using the following commands:
 
 ```


### PR DESCRIPTION
# Description

small docs fixes to failover -- grammar and remove note about bug that only affected older versions of Gloo Edge (and even those shouldn't have been affected since they had REST EDS enabled by default)