### PR TITLE
Update glooctl docs for upgrades

### DIFF
--- a/changelog/v1.7.0-beta1/document-glooctl-upgrade.yaml
+++ b/changelog/v1.7.0-beta1/document-glooctl-upgrade.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4037
+    description: Document the process for upgrading/downgrading glooctl CLI
+    resolvesIssue: false

--- a/docs/content/installation/glooctl_setup.md
+++ b/docs/content/installation/glooctl_setup.md
@@ -27,3 +27,17 @@ The command returns your client version and a missing server version (we have no
 Client: {"version":"1.2.3"}
 Server: version undefined, could not find any version of gloo running
 ```
+
+#### Update glooctl CLI version
+
+You should always try to use the same minor `glooctl` version as the version of Gloo Edge instsalled in your cluster. Ie if you're using Gloo Edge 1.6.x, you should use a 1.6.x release of `glooctl`.
+
+Fortunately, `glooctl` is able to update itself to different versions. To change the version of glooctl you currently have installed, you can run:
+
+```bash
+glooctl upgrade --release v1.6.0
+```
+
+{{% notice note %}}
+The glooctl upgrade command can also be used to roll back your glooctl version to previous releases. This can be convenient if you are using an older version of Gloo Edge and want to use the same verison of glooctl to ensure compatability.
+{{% /notice %}}


### PR DESCRIPTION
Docs only update.

Documents existing `glooctl upgrade` functionality better, and explicitly explains `upgrade` can be used to go up _or down_ versions.

This is an improvement suggested in https://github.com/solo-io/gloo/issues/4037 . I'm not marking that issue as resolved yet, as there is another suggestion to add an alias for `glooctl upgrade` to make it clearer that it can be used to upgrade or downgrade. eg `glooctl set-version` or similar.