### PR TITLE
Additional route short-circuiting validation

### DIFF
--- a/changelog/v1.7.0-beta2/additional-short-circuiting-validation.yaml
+++ b/changelog/v1.7.0-beta2/additional-short-circuiting-validation.yaml
@@ -8,3 +8,5 @@ changelog:
       The cases now additionally covered are:
         - routes that have simple OR regex header matchers, ensuring each one of the OR'ed matchers can be reached
         - the same logic, but with method matchers
+      In addition, we support aggressively reporting errors on virtual services with invalid regex matchers. (no need
+      to enable short-circuiting reporting)

--- a/changelog/v1.7.0-beta2/additional-short-circuiting-validation.yaml
+++ b/changelog/v1.7.0-beta2/additional-short-circuiting-validation.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/3334
+    resolvesIssue: true
+    description: |
+      Gloo Edge now proactively reports warnings on virtual services that have matchers that are short-circuited.
+      To enable, update the Gloo `Settings` such that `spec.gateway.validation.warnRouteShortCircuiting=true`
+      The cases now additionally covered are:
+        - routes that have simple OR regex header matchers, ensuring each one of the OR'ed matchers can be reached
+        - the same logic, but with method matchers

--- a/projects/gateway/pkg/translator/http.go
+++ b/projects/gateway/pkg/translator/http.go
@@ -507,7 +507,7 @@ func earlyHeaderMatchersShortCircuitLaterOnes(laterMatcher, earlyMatcher matcher
 func laterOrRegexPartiallyShortCircuited(laterHeaderMatcher, earlyHeaderMatcher *matchers.HeaderMatcher) bool {
 
 	// regex matches simple OR regex, e.g. (GET|POST|...)
-	re := regexp.MustCompile("^\\([\\w]*[|]+[\\w]*\\)$")
+	re := regexp.MustCompile("^\\([\\w]+([|[\\w]+)+\\)$")
 	foundIndex := re.FindStringIndex(laterHeaderMatcher.Value)
 	if foundIndex != nil {
 

--- a/projects/gateway/pkg/translator/translator_test.go
+++ b/projects/gateway/pkg/translator/translator_test.go
@@ -741,6 +741,10 @@ var _ = Describe("Translator", func() {
 						&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/1"}, Headers: []*matchers.HeaderMatcher{{Name: ":method", Value: "GET", InvertMatch: true}}},
 						&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/1"}, Methods: []string{"GET", "POST"}}, // The POST method here is unreachable
 						UnorderedPrefixErr("gloo-system.name1", "/1", &matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/1"}, Methods: []string{"GET", "POST"}})),
+					Entry("invalid regex doesn't crash",
+						&matchers.Matcher{PathSpecifier: &matchers.Matcher_Regex{Regex: "["}},
+						&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/"}},
+						nil),
 				)
 			})
 		})

--- a/projects/gateway/pkg/translator/translator_test.go
+++ b/projects/gateway/pkg/translator/translator_test.go
@@ -593,7 +593,7 @@ var _ = Describe("Translator", func() {
 				})
 			})
 
-			FContext("validate matcher short-circuiting warnings", func() {
+			Context("validate matcher short-circuiting warnings", func() {
 
 				BeforeEach(func() {
 					translator = NewTranslator([]ListenerFactory{&HttpTranslator{WarnOnRouteShortCircuiting: true}, &TcpTranslator{}}, Opts{})


### PR DESCRIPTION
# Description

Gloo Edge now proactively reports warnings on virtual services that have matchers that are short-circuited. To enable, update the Gloo `Settings` such that `spec.gateway.validation.warnRouteShortCircuiting=true`. The cases now additionally covered are:
 - routes that have simple OR regex header matchers, ensuring each one of the OR'ed matchers can be reached
 - the same logic, but with method matchers
        
# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3334