### PR TITLE
Update docs to use newer example filter

### DIFF
--- a/docs/content/installation/advanced_configuration/wasm.md
+++ b/docs/content/installation/advanced_configuration/wasm.md
@@ -76,7 +76,7 @@ and change the `httpGateway` object to the following:
         - config:
             '@type': type.googleapis.com/google.protobuf.StringValue
             value: "world"
-          image: webassemblyhub.io/sodman/example-filter:v0.3
+          image: webassemblyhub.io/sodman/example-filter:v0.5
           name: myfilter
           root_id: add_header_root_id
 ```


### PR DESCRIPTION
# Description

(Docs only change)

V0.3 of this wasm header is ABI 0_1_0, updating docs to use v0.5, as Gloo Edge 1.6.0 uses ABI 0_2_1