### PR TITLE
Docs build validate latest

### DIFF
--- a/changelog/v1.7.0-beta7/validate-latest-docs-version.yaml
+++ b/changelog/v1.7.0-beta7/validate-latest-docs-version.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4050
+    description: Adds validation to make sure that docs latest version is present in active versions.

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -12,6 +12,19 @@ declare -a versions=($(cat active_versions.json | jq -rc '."versions" | join(" "
 declare -a oldVersions=($(cat active_versions.json | jq -rc '."oldVersions" | join(" ")'))
 latestVersion=$(cat active_versions.json | jq -r ."latest")
 
+# verify that latestVersion is in versions
+latestVersionInVersions=false
+for version in "${versions[@]}"
+do
+    if [ "$version" == "$latestVersion" ]; then
+      latestVersionInVersions=true
+    fi
+done
+if ! $latestVersionInVersions ; then
+  echo "latest version not in versions, update the versions in active_versions.json"
+  exit 1
+fi
+
 # Firebase configuration
 firebaseJson=$(cat <<EOF
 { 


### PR DESCRIPTION
# Description

Adds validation to `build_docs.sh` to make sure that `latestVersion` is included in `activeVersions`.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4050