### PR TITLE
Add gateway-proxy-specific services

### DIFF
--- a/changelog/v1.7.0-beta7/proxy-specific-config-dump-services.yaml
+++ b/changelog/v1.7.0-beta7/proxy-specific-config-dump-services.yaml
@@ -1,5 +1,5 @@
 changelog:
-  - type: FIX
+  - type: NON_USER_FACING
     description: >
       Instead of creating a default gateway-proxy-config-dump-service, create a service named
       [gateway-proxy-name]-config-dump-service.

--- a/changelog/v1.7.0-beta7/proxy-specific-config-dump-services.yaml
+++ b/changelog/v1.7.0-beta7/proxy-specific-config-dump-services.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      This is a change to a template that only changes if you enable the
+      readConfigMulticluster helm value. Instead of creating a default
+      gateway-proxy-config-dump-service, create a service named
+      [gateway-proxy-name]-config-dump-service.

--- a/changelog/v1.7.0-beta7/proxy-specific-config-dump-services.yaml
+++ b/changelog/v1.7.0-beta7/proxy-specific-config-dump-services.yaml
@@ -1,7 +1,5 @@
 changelog:
-  - type: NON_USER_FACING
+  - type: FIX
     description: >
-      This is a change to a template that only changes if you enable the
-      readConfigMulticluster helm value. Instead of creating a default
-      gateway-proxy-config-dump-service, create a service named
+      Instead of creating a default gateway-proxy-config-dump-service, create a service named
       [gateway-proxy-name]-config-dump-service.

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -86,14 +86,16 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: gateway-proxy-config-dump-service
+  name: {{ $name | kebabcase }}-config-dump-service
   namespace: {{ $.Release.Namespace }}
   labels:
     gloo: gateway-proxy
+    gateway-proxy-id: {{ $name | kebabcase }}
 spec:
   type: ClusterIP
   selector:
     gloo: gateway-proxy
+    gateway-proxy-id: {{ $name | kebabcase }}
   ports:
     - protocol: TCP
       port: 8082

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3145,6 +3145,7 @@ metadata:
 						})
 						serviceLabels := map[string]string{
 							"gloo": "gateway-proxy",
+							"gateway-proxy-id": "gateway-proxy",
 						}
 						rb := ResourceBuilder{
 							Namespace: namespace,

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3144,7 +3144,7 @@ metadata:
 								"gatewayProxies.gatewayProxy.readConfigMulticluster=true"},
 						})
 						serviceLabels := map[string]string{
-							"gloo": "gateway-proxy",
+							"gloo":             "gateway-proxy",
 							"gateway-proxy-id": "gateway-proxy",
 						}
 						rb := ResourceBuilder{


### PR DESCRIPTION
# Description

This is a change to a template that only changes if you enable the `readConfigMulticluster` helm value. Instead of creating a default `gateway-proxy-config-dump-service`, create one service that is `[gateway-proxy-name]-config-dump-service` for each of the listed gatewayProxies in the helm chart. This allows us to address the edge case of having custom gateway proxies added by users.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works