### PR TITLE
Consul timer leak

### DIFF
--- a/changelog/v1.7.0-beta7/fix-leak-timer.yaml
+++ b/changelog/v1.7.0-beta7/fix-leak-timer.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: >
+      Stop leaking memory for a timer in consul EDS.
+    issueLink: https://github.com/solo-io/gloo/issues/4112

--- a/projects/gloo/pkg/plugins/consul/eds.go
+++ b/projects/gloo/pkg/plugins/consul/eds.go
@@ -79,9 +79,10 @@ func (p *plugin) WatchEndpoints(writeNamespace string, upstreamsToTrack v1.Upstr
 			return true
 		}
 
+		// don't leak the timer.
+		defer timer.Stop()
+
 		for {
-			// don't leak the timer.
-			defer timer.Stop()
 			select {
 			case serviceMeta, ok := <-serviceMetaChan:
 				if !ok {

--- a/projects/gloo/pkg/plugins/consul/eds.go
+++ b/projects/gloo/pkg/plugins/consul/eds.go
@@ -66,6 +66,7 @@ func (p *plugin) WatchEndpoints(writeNamespace string, upstreamsToTrack v1.Upstr
 		defer func() { cancel() }()
 
 		timer := time.NewTicker(DefaultDnsPollingInterval)
+		defer timer.Stop()
 
 		publishEndpoints := func(endpoints v1.EndpointList) bool {
 			if opts.Ctx.Err() != nil {
@@ -78,9 +79,6 @@ func (p *plugin) WatchEndpoints(writeNamespace string, upstreamsToTrack v1.Upstr
 			}
 			return true
 		}
-
-		// don't leak the timer.
-		defer timer.Stop()
 
 		for {
 			select {


### PR DESCRIPTION
# Description

Stop leaking memory for a timer in consul EDS.

# Context

We were calling `timer.Stop()` in a for loop rather than before it.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4112