### PR TITLE
Add ConfigDumpServiceSuffix constant

### DIFF
--- a/changelog/v1.7.0-beta9/service-name-suffix-constant.yaml
+++ b/changelog/v1.7.0-beta9/service-name-suffix-constant.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Add the ConfigDumpServiceSuffix to use across gloo and gloo-fed.
+    issueLink: https://github.com/solo-io/gloo/issues/4173

--- a/projects/gateway/pkg/defaults/gateway.go
+++ b/projects/gateway/pkg/defaults/gateway.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	GatewayProxyName   = "gateway-proxy"
-	GatewayBindAddress = "::"
+	GatewayProxyName        = "gateway-proxy"
+	GatewayBindAddress      = "::"
+	ConfigDumpServiceSuffix = "-config-dump-service"
 )
 
 func DefaultGateway(writeNamespace string) *v1.Gateway {
@@ -92,4 +93,8 @@ Delete the '` + name + ` Virtual Service to get started.
 
 func DefaultMatcher() *matchers.Matcher {
 	return &matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/"}}
+}
+
+func GatewayProxyConfigDumpServiceName(name string) string {
+	return name + ConfigDumpServiceSuffix
 }


### PR DESCRIPTION
# Description

If the readConfig and readConfigMulticluster helm values are enabled, gloo-fed will be able to query a service named: [gatewayProxyName]-config-dump-service. In case this changes, make the -config-dump-service suffix a constant used across both repos.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4173