### PR TITLE
add dep bump to changelog for 1.19

### DIFF
--- a/changelog/v1.7.0-beta9/update-k8s-19.yaml
+++ b/changelog/v1.7.0-beta9/update-k8s-19.yaml
@@ -2,3 +2,35 @@ changelog:
   - type: NON_USER_FACING
     description: Update to k8s 0.19.
     issueLink: https://github.com/solo-io/gloo/issues/3582
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: skv1
+    dependencyTag: v0.7.0
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: solo-apis
+    dependencyTag: v0.0.0-20210122142844-ac0df2dce136
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: helm
+    dependencyRepo: helm
+    dependencyTag: v3.4.2
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: containerd
+    dependencyRepo: containerd
+    dependencyTag: v1.4.3
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: k8s.io
+    dependencyRepo: kube-openapi
+    dependencyTag: v0.0.0-20200805222855-6aeccd4b50c6
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: k8s.io
+    dependencyRepo: utils
+    dependencyTag: v0.0.0-20201110183641-67b214c5f920
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: k8s.io
+    dependencyRepo: controller-runtime
+    dependencyTag: v0.7.0
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: k8s.io
+    dependencyRepo: kubernetes
+    dependencyTag: v1.19.6


### PR DESCRIPTION
# Context

Add DEPENDENCY_BUMP type to changelog for k8 1.19 upgrade.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works