### PR TITLE
Fix broken link in docs

### DIFF
--- a/changelog/v1.7.0-beta10/docs-link-fix-datadog.yaml
+++ b/changelog/v1.7.0-beta10/docs-link-fix-datadog.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4100
+    description: Fix broken link to install guide.

--- a/docs/content/guides/integrations/datadog/_index.md
+++ b/docs/content/guides/integrations/datadog/_index.md
@@ -24,7 +24,7 @@ You will need the following to complete this guide:
 
 * **Datadog account**: If you don't already have an account, you can sign up for a free trial [on their website](https://app.datadoghq.com).
 * **Kubernetes cluster**: This can be deployed in any environment, follow our [preparation guide]({{% versioned_link_path fromRoot="/installation/platform_configuration/cluster_setup/" %}}) for more information.
-* **Gloo Edge installation**: You can install Gloo Edge on Kubernetes by following our [setup guide](/installation/gateway/kubernetes).
+* **Gloo Edge installation**: You can install Gloo Edge on Kubernetes by following our [setup guide]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/" %}}).
 * **Helm**: You will be deploying the Datadog integration using [Helm v3](https://helm.sh/docs/intro/install/).
 * **kubectl**: Kubectl should be installed and configured to access the cluster where you are adding Datadog.
 


### PR DESCRIPTION
# Description

Fix broken link to install guide in datadog docs

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4100