### PR TITLE
Add Rest XDS to envoy tests

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -91,7 +91,7 @@ steps:
   - 'RUN_VAULT_TESTS=1'
   - 'DOCKER_CONFIG=/workspace/.docker/'
   dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor', 'test/e2e/...']
   waitFor: ['get-envoy', 'setup-aws-creds', 'set-gcr-zone', 'get-test-credentials']
   secretEnv: ['AWS_ARN_ROLE_1', "AWS_ROLE_ARN_STS", "JWT_PRIVATE_KEY"]
   id: 'test'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -91,7 +91,7 @@ steps:
   - 'RUN_VAULT_TESTS=1'
   - 'DOCKER_CONFIG=/workspace/.docker/'
   dir: *dir
-  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor', 'test/e2e/...']
+  args: ['-r', '-failFast', '-trace', '-progress', '-race', '-compilers=4', '-failOnPending', '-noColor']
   waitFor: ['get-envoy', 'setup-aws-creds', 'set-gcr-zone', 'get-test-credentials']
   secretEnv: ['AWS_ARN_ROLE_1', "AWS_ROLE_ARN_STS", "JWT_PRIVATE_KEY"]
   id: 'test'

--- a/test/consulvaulte2e/consul_vault_test.go
+++ b/test/consulvaulte2e/consul_vault_test.go
@@ -142,9 +142,8 @@ var _ = Describe("Consul + Vault Configuration Happy Path e2e", func() {
 		}()
 
 		// Start Envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(restXdsPort))
 		Expect(err).NotTo(HaveOccurred())
-		envoyInstance.RestXdsPort = uint32(restXdsPort)
 		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, glooPort)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/consulvaulte2e/consul_vault_test.go
+++ b/test/consulvaulte2e/consul_vault_test.go
@@ -142,9 +142,9 @@ var _ = Describe("Consul + Vault Configuration Happy Path e2e", func() {
 		}()
 
 		// Start Envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(restXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, glooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, glooPort, restXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run a simple web application locally

--- a/test/consulvaulte2e/consul_vault_test.go
+++ b/test/consulvaulte2e/consul_vault_test.go
@@ -144,7 +144,7 @@ var _ = Describe("Consul + Vault Configuration Happy Path e2e", func() {
 		// Start Envoy
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, glooPort, restXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, glooPort, restXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run a simple web application locally

--- a/test/e2e/access_log_test.go
+++ b/test/e2e/access_log_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Access Log", func() {
 			BeforeEach(func() {
 				ctx, cancel = context.WithCancel(context.Background())
 				var err error
-				envoyInstance, err = envoyFactory.NewEnvoyInstance()
+				envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 				Expect(err).NotTo(HaveOccurred())
 
 				tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())

--- a/test/e2e/access_log_test.go
+++ b/test/e2e/access_log_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Access Log", func() {
 					contextutils.SetFallbackLogger(logger.Sugar())
 
 					envoyInstance.AccessLogPort = accessLogPort
-					err := envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+					err := envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 					Expect(err).NotTo(HaveOccurred())
 
 					gatewaycli := testClients.GatewayClient

--- a/test/e2e/access_log_test.go
+++ b/test/e2e/access_log_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Access Log", func() {
 			BeforeEach(func() {
 				ctx, cancel = context.WithCancel(context.Background())
 				var err error
-				envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+				envoyInstance, err = envoyFactory.NewEnvoyInstance()
 				Expect(err).NotTo(HaveOccurred())
 
 				tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())
@@ -119,7 +119,7 @@ var _ = Describe("Access Log", func() {
 					contextutils.SetFallbackLogger(logger.Sugar())
 
 					envoyInstance.AccessLogPort = accessLogPort
-					err := envoyInstance.RunWithRole(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort)
+					err := envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 					Expect(err).NotTo(HaveOccurred())
 
 					gatewaycli := testClients.GatewayClient

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -154,7 +154,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 			}
 
 			return string(body), nil
-		}, "10s", "1s").Should(ContainSubstring(substring))
+		}, "50s", "1s").Should(ContainSubstring(substring))
 	}
 
 	validateEc2Endpoint := func(envoyPort uint32, substring string) {

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -237,7 +237,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 		testClients = services.RunGateway(ctx, false)
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 
 		addCredentials()

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -154,7 +154,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 			}
 
 			return string(body), nil
-		}, "50s", "1s").Should(ContainSubstring(substring))
+		}, "120s", "1s").Should(ContainSubstring(substring))
 	}
 
 	validateEc2Endpoint := func(envoyPort uint32, substring string) {

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -154,7 +154,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 			}
 
 			return string(body), nil
-		}, "120s", "1s").Should(ContainSubstring(substring))
+		}, "10s", "1s").Should(ContainSubstring(substring))
 	}
 
 	validateEc2Endpoint := func(envoyPort uint32, substring string) {
@@ -187,7 +187,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 
 	// NOTE: you need to configure EC2 instances before running this
 	It("be able to call upstream function", func() {
-		err := envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
+		err := envoyInstance.RunWithRoleAndRestXds(services.defaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		proxy := &gloov1.Proxy{

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -8,17 +8,18 @@ import (
 	"os"
 	"strings"
 
-	"github.com/rotisserie/eris"
-	glooec2 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/aws/ec2"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/rotisserie/eris"
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	glooec2 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/aws/ec2"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/gloo/test/services"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 /*
@@ -187,7 +188,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 
 	// NOTE: you need to configure EC2 instances before running this
 	It("be able to call upstream function", func() {
-		err := envoyInstance.Run(testClients.GlooPort)
+		err := envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		proxy := &gloov1.Proxy{
@@ -237,7 +238,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 		testClients = services.RunGateway(ctx, false)
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		addCredentials()

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -187,7 +187,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 
 	// NOTE: you need to configure EC2 instances before running this
 	It("be able to call upstream function", func() {
-		err := envoyInstance.RunWithRoleAndRestXds(services.defaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err := envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		proxy := &gloov1.Proxy{

--- a/test/e2e/aws_ec2_test.go
+++ b/test/e2e/aws_ec2_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/rotisserie/eris"
-	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	glooec2 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/aws/ec2"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
@@ -188,7 +187,7 @@ var _ = Describe("AWS EC2 Plugin utils test", func() {
 
 	// NOTE: you need to configure EC2 instances before running this
 	It("be able to call upstream function", func() {
-		err := envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err := envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		proxy := &gloov1.Proxy{

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -65,7 +65,7 @@ var _ = Describe("AWS Lambda", func() {
 		err := helpers.WriteDefaultGateways(defaults.GlooSystem, testClients.GatewayClient)
 		Expect(err).NotTo(HaveOccurred(), "Should be able to write default gateways")
 
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 	}
 
@@ -494,7 +494,7 @@ var _ = Describe("AWS Lambda", func() {
 			err := helpers.WriteDefaultGateways(defaults.GlooSystem, testClients.GatewayClient)
 			Expect(err).NotTo(HaveOccurred(), "Should be able to write default gateways")
 
-			envoyInstance, err = envoyFactory.NewEnvoyInstance()
+			envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 			Expect(err).NotTo(HaveOccurred())
 		}
 

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -135,7 +135,7 @@ var _ = Describe("AWS Lambda", func() {
 	}
 
 	testProxy := func() {
-		err := envoyInstance.Run(testClients.GlooPort)
+		err := envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		proxy := &gloov1.Proxy{
@@ -186,7 +186,7 @@ var _ = Describe("AWS Lambda", func() {
 	}
 
 	testProxyWithResponseTransform := func() {
-		err := envoyInstance.Run(testClients.GlooPort)
+		err := envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		proxy := &gloov1.Proxy{

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -238,7 +238,7 @@ var _ = Describe("AWS Lambda", func() {
 	}
 
 	testLambdaWithVirtualService := func() {
-		err := envoyInstance.RunWithRestXds("gloo-system~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err := envoyInstance.RunWithRoleAndRestXds("gloo-system~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		vs := &gw1.VirtualService{

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -65,7 +65,7 @@ var _ = Describe("AWS Lambda", func() {
 		err := helpers.WriteDefaultGateways(defaults.GlooSystem, testClients.GatewayClient)
 		Expect(err).NotTo(HaveOccurred(), "Should be able to write default gateways")
 
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 	}
 
@@ -238,7 +238,7 @@ var _ = Describe("AWS Lambda", func() {
 	}
 
 	testLambdaWithVirtualService := func() {
-		err := envoyInstance.RunWithRole("gloo-system~"+gwdefaults.GatewayProxyName, testClients.GlooPort)
+		err := envoyInstance.RunWithRestXds("gloo-system~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		vs := &gw1.VirtualService{
@@ -494,7 +494,7 @@ var _ = Describe("AWS Lambda", func() {
 			err := helpers.WriteDefaultGateways(defaults.GlooSystem, testClients.GatewayClient)
 			Expect(err).NotTo(HaveOccurred(), "Should be able to write default gateways")
 
-			envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+			envoyInstance, err = envoyFactory.NewEnvoyInstance()
 			Expect(err).NotTo(HaveOccurred())
 		}
 

--- a/test/e2e/buffer_test.go
+++ b/test/e2e/buffer_test.go
@@ -63,7 +63,7 @@ var _ = Describe("buffer", func() {
 		}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 		// run envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/buffer_test.go
+++ b/test/e2e/buffer_test.go
@@ -65,7 +65,7 @@ var _ = Describe("buffer", func() {
 		// run envoy
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// write a test upstream

--- a/test/e2e/buffer_test.go
+++ b/test/e2e/buffer_test.go
@@ -63,9 +63,9 @@ var _ = Describe("buffer", func() {
 		}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 		// run envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// write a test upstream

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
-var _ = FDescribe("Consul e2e", func() {
+var _ = Describe("Consul e2e", func() {
 
 	var (
 		ctx            context.Context

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -196,7 +196,7 @@ var _ = Describe("Consul e2e", func() {
 				return false
 			}
 			return proxy.GetStatus().GetState() == core.Status_Accepted
-		}, "50s", "0.2s").Should(BeTrue())
+		}, "20s", "0.2s").Should(BeTrue())
 
 		time.Sleep(3 * time.Second)
 
@@ -207,7 +207,7 @@ var _ = Describe("Consul e2e", func() {
 				return svc1.C, err
 			}
 			return svc1.C, nil
-		}, "50s", "0.2s").Should(Receive())
+		}, "20s", "0.2s").Should(Receive())
 
 		By("requests only go to service with tag '1'")
 

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -121,7 +121,7 @@ var _ = FDescribe("Consul e2e", func() {
 		cancel()
 	})
 
-	FIt("works as expected", func() {
+	It("works as expected", func() {
 		_, err := testClients.ProxyClient.Write(getProxyWithConsulRoute(writeNamespace, envoyPort), clients.WriteOpts{Ctx: ctx})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -181,7 +181,7 @@ var _ = FDescribe("Consul e2e", func() {
 
 	})
 
-	FIt("resolves consul services with hostname addresses (as opposed to IPs addresses)", func() {
+	It("resolves consul services with hostname addresses (as opposed to IPs addresses)", func() {
 		err = consulInstance.RegisterService("my-svc", "my-svc-1", "my-svc.service.dc1.consul", []string{"svc", "1"}, svc1.Port)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -91,7 +91,7 @@ var _ = Describe("Consul e2e", func() {
 
 		// Start Envoy
 		envoyPort = defaults.HttpPort
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 		envoyInstance.RestXdsPort = uint32(testClients.RestXdsPort)
 		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -91,10 +91,10 @@ var _ = Describe("Consul e2e", func() {
 
 		// Start Envoy
 		envoyPort = defaults.HttpPort
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 		envoyInstance.RestXdsPort = uint32(testClients.RestXdsPort)
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run two simple web applications locally

--- a/test/e2e/consul_test.go
+++ b/test/e2e/consul_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Consul e2e", func() {
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 		envoyInstance.RestXdsPort = uint32(testClients.RestXdsPort)
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run two simple web applications locally

--- a/test/e2e/cors_test.go
+++ b/test/e2e/cors_test.go
@@ -63,7 +63,7 @@ var _ = Describe("CORS", func() {
 
 		BeforeEach(func() {
 			var err error
-			td.per.envoyInstance, err = envoyFactory.NewEnvoyInstance()
+			td.per.envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(td.testClients.RestXdsPort))
 			Expect(err).NotTo(HaveOccurred())
 			td.per.envoyAdminUrl = fmt.Sprintf("http://%s:%d/config_dump",
 				td.per.envoyInstance.LocalAddr(),

--- a/test/e2e/cors_test.go
+++ b/test/e2e/cors_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/cors"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
@@ -69,7 +68,7 @@ var _ = Describe("CORS", func() {
 				td.per.envoyInstance.LocalAddr(),
 				td.per.envoyInstance.AdminPort)
 
-			err = td.per.envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, td.testClients.GlooPort, td.testClients.RestXdsPort)
+			err = td.per.envoyInstance.RunWithRestXds("default~proxy", td.testClients.GlooPort, td.testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			td.per.up = td.setupUpstream()

--- a/test/e2e/cors_test.go
+++ b/test/e2e/cors_test.go
@@ -8,14 +8,14 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/cors"
-	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/cors"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/gloo/test/services"
 	"github.com/solo-io/gloo/test/v1helpers"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -63,13 +63,13 @@ var _ = Describe("CORS", func() {
 
 		BeforeEach(func() {
 			var err error
-			td.per.envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(td.testClients.RestXdsPort))
+			td.per.envoyInstance, err = envoyFactory.NewEnvoyInstance()
 			Expect(err).NotTo(HaveOccurred())
 			td.per.envoyAdminUrl = fmt.Sprintf("http://%s:%d/config_dump",
 				td.per.envoyInstance.LocalAddr(),
 				td.per.envoyInstance.AdminPort)
 
-			err = td.per.envoyInstance.Run(td.testClients.GlooPort)
+			err = td.per.envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, td.testClients.GlooPort, td.testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			td.per.up = td.setupUpstream()

--- a/test/e2e/cors_test.go
+++ b/test/e2e/cors_test.go
@@ -68,7 +68,7 @@ var _ = Describe("CORS", func() {
 				td.per.envoyInstance.LocalAddr(),
 				td.per.envoyInstance.AdminPort)
 
-			err = td.per.envoyInstance.RunWithRestXds("default~proxy", td.testClients.GlooPort, td.testClients.RestXdsPort)
+			err = td.per.envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, td.testClients.GlooPort, td.testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			td.per.up = td.setupUpstream()

--- a/test/e2e/csrf_test.go
+++ b/test/e2e/csrf_test.go
@@ -78,7 +78,7 @@ var _ = Describe("CSRF", func() {
 		}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 		// run envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/csrf_test.go
+++ b/test/e2e/csrf_test.go
@@ -78,7 +78,7 @@ var _ = Describe("CSRF", func() {
 		// run envoy
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// write a test upstream

--- a/test/e2e/csrf_test.go
+++ b/test/e2e/csrf_test.go
@@ -9,22 +9,20 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/onsi/gomega/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
+	"github.com/onsi/gomega/types"
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloo_config_core "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/core/v3"
+	csrf "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/csrf/v3"
 	gloo_type_matcher "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/type/matcher/v3"
 	glootype "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/type/v3"
-	gloohelpers "github.com/solo-io/gloo/test/helpers"
-
-	csrf "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/csrf/v3"
-	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
+	gloohelpers "github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/gloo/test/services"
 	"github.com/solo-io/gloo/test/v1helpers"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -78,9 +76,9 @@ var _ = Describe("CSRF", func() {
 		}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 		// run envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// write a test upstream

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -41,7 +41,7 @@ var _ = Describe("CustomAuth", func() {
 
 		// Initialize Envoy instance
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start custom extauth server and create upstream for it

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -88,7 +88,7 @@ var _ = Describe("CustomAuth", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run envoy
-		err = envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create a test upstream

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -13,7 +13,6 @@ import (
 	pb "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"github.com/gogo/googleapis/google/rpc"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
@@ -89,7 +88,7 @@ var _ = Describe("CustomAuth", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run envoy
-		err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create a test upstream

--- a/test/e2e/custom_auth_test.go
+++ b/test/e2e/custom_auth_test.go
@@ -6,12 +6,14 @@ import (
 	"net"
 	"net/http"
 
-	pb "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
-	"github.com/gogo/googleapis/google/rpc"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	"github.com/gogo/googleapis/google/rpc"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
@@ -41,7 +43,7 @@ var _ = Describe("CustomAuth", func() {
 
 		// Initialize Envoy instance
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start custom extauth server and create upstream for it
@@ -87,7 +89,7 @@ var _ = Describe("CustomAuth", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		// Run envoy
-		err = envoyInstance.Run(testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// Create a test upstream

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/utils/prototime"
 )
 
-var _ = FDescribe("Fault Injection", func() {
+var _ = Describe("Fault Injection", func() {
 
 	var (
 		testClients services.TestClients

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/solo-io/solo-kit/pkg/utils/prototime"
 )
 
-var _ = Describe("Fault Injection", func() {
+var _ = FDescribe("Fault Injection", func() {
 
 	var (
 		testClients services.TestClients
@@ -77,6 +77,7 @@ var _ = Describe("Fault Injection", func() {
 			var err error
 			envoyInstance, err = envoyFactory.NewEnvoyInstance()
 			Expect(err).NotTo(HaveOccurred())
+			envoyInstance.RestXdsPort = uint32(testClients.RestXdsPort)
 
 			err = envoyInstance.Run(testClients.GlooPort)
 			Expect(err).NotTo(HaveOccurred())
@@ -91,7 +92,7 @@ var _ = Describe("Fault Injection", func() {
 			}
 		})
 
-		It("should cause envoy abort fault", func() {
+		FIt("should cause envoy abort fault", func() {
 			abort := &fault.RouteAbort{
 				HttpStatus: uint32(503),
 				Percentage: float32(100),

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -75,9 +75,8 @@ var _ = Describe("Fault Injection", func() {
 
 		BeforeEach(func() {
 			var err error
-			envoyInstance, err = envoyFactory.NewEnvoyInstance()
+			envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 			Expect(err).NotTo(HaveOccurred())
-			envoyInstance.RestXdsPort = uint32(testClients.RestXdsPort)
 
 			err = envoyInstance.Run(testClients.GlooPort)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -92,7 +92,7 @@ var _ = FDescribe("Fault Injection", func() {
 			}
 		})
 
-		FIt("should cause envoy abort fault", func() {
+		It("should cause envoy abort fault", func() {
 			abort := &fault.RouteAbort{
 				HttpStatus: uint32(503),
 				Percentage: float32(100),

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	fault "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/faultinjection"
 	"github.com/solo-io/gloo/test/services"
@@ -80,7 +79,7 @@ var _ = Describe("Fault Injection", func() {
 			envoyInstance, err = envoyFactory.NewEnvoyInstance()
 			Expect(err).NotTo(HaveOccurred())
 
-			err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+			err = envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			setupUpstream()
@@ -117,7 +116,7 @@ var _ = Describe("Fault Injection", func() {
 					return errors.New(fmt.Sprintf("%v is not ServiceUnavailable", res.StatusCode))
 				}
 				return nil
-			}, "40s", ".1s").Should(BeNil())
+			}, "20s", ".1s").Should(BeNil())
 		})
 
 		It("should cause envoy delay fault", func() {

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -9,6 +9,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	fault "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/faultinjection"
 	"github.com/solo-io/gloo/test/services"
@@ -75,10 +77,10 @@ var _ = Describe("Fault Injection", func() {
 
 		BeforeEach(func() {
 			var err error
-			envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+			envoyInstance, err = envoyFactory.NewEnvoyInstance()
 			Expect(err).NotTo(HaveOccurred())
 
-			err = envoyInstance.Run(testClients.GlooPort)
+			err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			setupUpstream()

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Fault Injection", func() {
 			envoyInstance, err = envoyFactory.NewEnvoyInstance()
 			Expect(err).NotTo(HaveOccurred())
 
-			err = envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
+			err = envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			setupUpstream()

--- a/test/e2e/fault_injection_test.go
+++ b/test/e2e/fault_injection_test.go
@@ -117,7 +117,7 @@ var _ = Describe("Fault Injection", func() {
 					return errors.New(fmt.Sprintf("%v is not ServiceUnavailable", res.StatusCode))
 				}
 				return nil
-			}, "20s", ".1s").Should(BeNil())
+			}, "40s", ".1s").Should(BeNil())
 		})
 
 		It("should cause envoy delay fault", func() {

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -323,7 +323,7 @@ var _ = Describe("Gateway", func() {
 			BeforeEach(func() {
 				ctx, cancel = context.WithCancel(context.Background())
 				var err error
-				envoyInstance, err = envoyFactory.NewEnvoyInstance()
+				envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 				Expect(err).NotTo(HaveOccurred())
 
 				tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -323,14 +323,14 @@ var _ = Describe("Gateway", func() {
 			BeforeEach(func() {
 				ctx, cancel = context.WithCancel(context.Background())
 				var err error
-				envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+				envoyInstance, err = envoyFactory.NewEnvoyInstance()
 				Expect(err).NotTo(HaveOccurred())
 
 				tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())
 
 				_, err = testClients.UpstreamClient.Write(tu.Upstream, clients.WriteOpts{})
 				Expect(err).NotTo(HaveOccurred())
-				err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+				err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 				Expect(err).NotTo(HaveOccurred())
 				// Check that the new instance of envoy is running
 				request, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d", envoyInstance.AdminPort), nil)

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -330,7 +330,7 @@ var _ = Describe("Gateway", func() {
 
 				_, err = testClients.UpstreamClient.Write(tu.Upstream, clients.WriteOpts{})
 				Expect(err).NotTo(HaveOccurred())
-				err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+				err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 				Expect(err).NotTo(HaveOccurred())
 				// Check that the new instance of envoy is running
 				request, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d", envoyInstance.AdminPort), nil)

--- a/test/e2e/grpc_json_test.go
+++ b/test/e2e/grpc_json_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Envoy API", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 
 		writeNamespace = defaults.GlooSystem

--- a/test/e2e/grpc_json_test.go
+++ b/test/e2e/grpc_json_test.go
@@ -58,7 +58,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Envoy API", func() {
 		_, err = testClients.GatewayClient.Write(getGrpcJsonGateway(), clients.WriteOpts{Ctx: ctx})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestGRPCUpstream(ctx, envoyInstance.LocalAddr(), 1)

--- a/test/e2e/grpc_json_test.go
+++ b/test/e2e/grpc_json_test.go
@@ -40,7 +40,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Envoy API", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		writeNamespace = defaults.GlooSystem
@@ -58,7 +58,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Envoy API", func() {
 		_, err = testClients.GatewayClient.Write(getGrpcJsonGateway(), clients.WriteOpts{Ctx: ctx})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestGRPCUpstream(ctx, envoyInstance.LocalAddr(), 1)

--- a/test/e2e/grpc_plugin_test.go
+++ b/test/e2e/grpc_plugin_test.go
@@ -44,7 +44,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Gloo API", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 
 		writeNamespace = defaults.GlooSystem

--- a/test/e2e/grpc_plugin_test.go
+++ b/test/e2e/grpc_plugin_test.go
@@ -44,7 +44,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Gloo API", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		writeNamespace = defaults.GlooSystem
@@ -66,7 +66,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Gloo API", func() {
 		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
 		err = helpers.WriteDefaultGateways(writeNamespace, testClients.GatewayClient)
 		Expect(err).NotTo(HaveOccurred(), "Should be able to create the default gateways")
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestGRPCUpstream(ctx, envoyInstance.LocalAddr(), 1)

--- a/test/e2e/grpc_plugin_test.go
+++ b/test/e2e/grpc_plugin_test.go
@@ -66,7 +66,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Gloo API", func() {
 		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
 		err = helpers.WriteDefaultGateways(writeNamespace, testClients.GatewayClient)
 		Expect(err).NotTo(HaveOccurred(), "Should be able to create the default gateways")
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestGRPCUpstream(ctx, envoyInstance.LocalAddr(), 1)

--- a/test/e2e/grpcweb_test.go
+++ b/test/e2e/grpcweb_test.go
@@ -14,7 +14,6 @@ import (
 	envoyals "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	static_plugin_gloo "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
@@ -84,7 +83,7 @@ var _ = Describe("Grpc Web", func() {
 					_, err := tc.TestClients.UpstreamClient.Write(grpcUpstream, clients.WriteOpts{})
 					Expect(err).NotTo(HaveOccurred())
 
-					err = envoyInstance.RunWithRoleAndRestXds(gatewaydefaults.GatewayProxyName, tc.TestClients.GlooPort, tc.TestClients.RestXdsPort)
+					err = envoyInstance.RunWith(tc)
 					Expect(err).NotTo(HaveOccurred())
 
 					// we want to test grpc web, so lets reuse the access log service

--- a/test/e2e/grpcweb_test.go
+++ b/test/e2e/grpcweb_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http"
 	"time"
 
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
 	envoy_data_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v2"
 	envoyals "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	static_plugin_gloo "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
@@ -82,7 +84,7 @@ var _ = Describe("Grpc Web", func() {
 					_, err := tc.TestClients.UpstreamClient.Write(grpcUpstream, clients.WriteOpts{})
 					Expect(err).NotTo(HaveOccurred())
 
-					err = envoyInstance.RunWith(tc)
+					err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, tc.TestClients.GlooPort, tc.TestClients.RestXdsPort)
 					Expect(err).NotTo(HaveOccurred())
 
 					// we want to test grpc web, so lets reuse the access log service

--- a/test/e2e/grpcweb_test.go
+++ b/test/e2e/grpcweb_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Grpc Web", func() {
 					_, err := tc.TestClients.UpstreamClient.Write(grpcUpstream, clients.WriteOpts{})
 					Expect(err).NotTo(HaveOccurred())
 
-					err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, tc.TestClients.GlooPort, tc.TestClients.RestXdsPort)
+					err = envoyInstance.RunWithRoleAndRestXds(gatewaydefaults.GatewayProxyName, tc.TestClients.GlooPort, tc.TestClients.RestXdsPort)
 					Expect(err).NotTo(HaveOccurred())
 
 					// we want to test grpc web, so lets reuse the access log service

--- a/test/e2e/gzip_test.go
+++ b/test/e2e/gzip_test.go
@@ -62,7 +62,7 @@ var _ = Describe("gzip", func() {
 		}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 		// run envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/gzip_test.go
+++ b/test/e2e/gzip_test.go
@@ -62,9 +62,9 @@ var _ = Describe("gzip", func() {
 		}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 		// run envoy
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// write a test upstream

--- a/test/e2e/gzip_test.go
+++ b/test/e2e/gzip_test.go
@@ -64,7 +64,7 @@ var _ = Describe("gzip", func() {
 		// run envoy
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		// write a test upstream

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Happy path", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -136,7 +136,7 @@ var _ = Describe("Happy path", func() {
 					}
 					testClients = services.RunGlooGatewayUdsFds(ctx, ro)
 					envoyInstance.ApiVersion = testCase.TransportApiVersion.String()
-					err := envoyInstance.RunWithRestXds(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+					err := envoyInstance.RunWithRoleAndRestXds(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 					Expect(err).NotTo(HaveOccurred())
 
 					up = tu.Upstream

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Happy path", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())
@@ -136,7 +136,7 @@ var _ = Describe("Happy path", func() {
 					}
 					testClients = services.RunGlooGatewayUdsFds(ctx, ro)
 					envoyInstance.ApiVersion = testCase.TransportApiVersion.String()
-					err := envoyInstance.RunWithRole(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+					err := envoyInstance.RunWithRestXds(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 					Expect(err).NotTo(HaveOccurred())
 
 					up = tu.Upstream

--- a/test/e2e/health_checks_test.go
+++ b/test/e2e/health_checks_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Health Checks", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 
 		writeNamespace = defaults.GlooSystem

--- a/test/e2e/health_checks_test.go
+++ b/test/e2e/health_checks_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Health Checks", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		writeNamespace = defaults.GlooSystem
@@ -62,7 +62,7 @@ var _ = Describe("Health Checks", func() {
 			},
 		}
 		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
-		err = envoyInstance.RunWithRole(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 		err = helpers.WriteDefaultGateways(writeNamespace, testClients.GatewayClient)
 		Expect(err).NotTo(HaveOccurred(), "Should be able to write default gateways")

--- a/test/e2e/health_checks_test.go
+++ b/test/e2e/health_checks_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Health Checks", func() {
 			},
 		}
 		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
-		err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gwdefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 		err = helpers.WriteDefaultGateways(writeNamespace, testClients.GatewayClient)
 		Expect(err).NotTo(HaveOccurred(), "Should be able to write default gateways")

--- a/test/e2e/ratelimit_test.go
+++ b/test/e2e/ratelimit_test.go
@@ -147,7 +147,7 @@ var _ = Describe("Rate Limit", func() {
 
 		BeforeEach(func() {
 			var err error
-			envoyInstance, err = envoyFactory.NewEnvoyInstance()
+			envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 			Expect(err).NotTo(HaveOccurred())
 			// add the rl service as a static upstream
 			rlserver := &gloov1.Upstream{

--- a/test/e2e/ratelimit_test.go
+++ b/test/e2e/ratelimit_test.go
@@ -9,14 +9,12 @@ import (
 	"strings"
 	"time"
 
-	structpb "github.com/golang/protobuf/ptypes/struct"
-	"github.com/solo-io/go-utils/contextutils"
-	"go.uber.org/zap"
-
-	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	pb "github.com/envoyproxy/go-control-plane/envoy/service/ratelimit/v3"
+	structpb "github.com/golang/protobuf/ptypes/struct"
+	"github.com/golang/protobuf/ptypes/wrappers"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
 	gloov1static "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
@@ -24,10 +22,12 @@ import (
 	"github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/gloo/test/services"
 	"github.com/solo-io/gloo/test/v1helpers"
+	"github.com/solo-io/go-utils/contextutils"
 	rltypes "github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )
@@ -147,7 +147,7 @@ var _ = Describe("Rate Limit", func() {
 
 		BeforeEach(func() {
 			var err error
-			envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+			envoyInstance, err = envoyFactory.NewEnvoyInstance()
 			Expect(err).NotTo(HaveOccurred())
 			// add the rl service as a static upstream
 			rlserver := &gloov1.Upstream{

--- a/test/e2e/ratelimit_test.go
+++ b/test/e2e/ratelimit_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Rate Limit", func() {
 			err = helpers.WriteDefaultGateways(defaults.GlooSystem, testClients.GatewayClient)
 			Expect(err).NotTo(HaveOccurred(), "Should be able to write the default gateways")
 
-			err = envoyInstance.Run(testClients.GlooPort)
+			err = envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			testUpstream = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())

--- a/test/e2e/route_transformation_test.go
+++ b/test/e2e/route_transformation_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Transformations", func() {
 
 		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 		err = envoyInstance.Run(testClients.GlooPort)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/route_transformation_test.go
+++ b/test/e2e/route_transformation_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Transformations", func() {
 		var err error
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(services.DefaultProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 		envoyPort = defaults.HttpPort
 

--- a/test/e2e/route_transformation_test.go
+++ b/test/e2e/route_transformation_test.go
@@ -12,14 +12,14 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	envoy_transform "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/transformation"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	transformation "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/gloo/test/services"
 	"github.com/solo-io/gloo/test/v1helpers"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-
-	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
@@ -51,9 +51,9 @@ var _ = Describe("Transformations", func() {
 
 		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.Run(testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 		envoyPort = defaults.HttpPort
 

--- a/test/e2e/route_transformation_test.go
+++ b/test/e2e/route_transformation_test.go
@@ -12,7 +12,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	envoy_transform "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/transformation"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	transformation "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
@@ -53,7 +52,7 @@ var _ = Describe("Transformations", func() {
 		var err error
 		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
-		err = envoyInstance.RunWithRestXds(gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRestXds("default~proxy", testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 		envoyPort = defaults.HttpPort
 

--- a/test/e2e/staged_transformation_test.go
+++ b/test/e2e/staged_transformation_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Staged Transformation", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())

--- a/test/e2e/staged_transformation_test.go
+++ b/test/e2e/staged_transformation_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Staged Transformation", func() {
 		defaults.HttpsPort = services.NextBindPort()
 
 		var err error
-		envoyInstance, err = envoyFactory.NewEnvoyInstanceWithRestXdsPort(uint32(testClients.RestXdsPort))
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
 		Expect(err).NotTo(HaveOccurred())
 
 		tu = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())
@@ -89,7 +89,7 @@ var _ = Describe("Staged Transformation", func() {
 		_, err = testClients.UpstreamClient.Write(extauthn, clients.WriteOpts{})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = envoyInstance.RunWithRole(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+		err = envoyInstance.RunWithRestXds(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		up = tu.Upstream

--- a/test/e2e/staged_transformation_test.go
+++ b/test/e2e/staged_transformation_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Staged Transformation", func() {
 		_, err = testClients.UpstreamClient.Write(extauthn, clients.WriteOpts{})
 		Expect(err).NotTo(HaveOccurred())
 
-		err = envoyInstance.RunWithRestXds(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+		err = envoyInstance.RunWithRoleAndRestXds(ns+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 		Expect(err).NotTo(HaveOccurred())
 
 		up = tu.Upstream

--- a/test/e2e/util_test.go
+++ b/test/e2e/util_test.go
@@ -73,6 +73,11 @@ func (t TestContext) Role() string {
 func (t TestContext) Port() uint32 {
 	return uint32(t.TestClients.GlooPort)
 }
+
+func (t TestContext) RestXdsPort() uint32 {
+	return uint32(t.TestClients.RestXdsPort)
+}
+
 func (t TestContext) Context() context.Context {
 	return t.Ctx
 }

--- a/test/e2e/zipkin_test.go
+++ b/test/e2e/zipkin_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Zipkin config loading", func() {
 	}
 
 	It("should send trace msgs to the zipkin server", func() {
-		err := envoyInstance.RunWithConfigFile(int(defaults.HttpPort), defaults.GlooRestXdsPort, "./envoyconfigs/zipkin-envoy-conf.yaml")
+		err := envoyInstance.RunWithConfigFile(int(defaults.HttpPort),"./envoyconfigs/zipkin-envoy-conf.yaml")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start a dummy server listening on 9411 for Zipkin requests
@@ -339,7 +339,7 @@ var _ = Describe("Zipkin config loading", func() {
 			}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 			// run envoy
-			err = envoyInstance.RunWithConfigFile(testClients.GlooPort, testClients.RestXdsPort, "./envoyconfigs/zipkin-static-cluster.yaml")
+			err = envoyInstance.RunWithConfigFile(testClients.GlooPort, "./envoyconfigs/zipkin-static-cluster.yaml")
 			Expect(err).NotTo(HaveOccurred())
 
 			// create test upstream

--- a/test/e2e/zipkin_test.go
+++ b/test/e2e/zipkin_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Zipkin config loading", func() {
 	}
 
 	It("should send trace msgs to the zipkin server", func() {
-		err := envoyInstance.RunWithConfigFile(int(defaults.HttpPort),"./envoyconfigs/zipkin-envoy-conf.yaml")
+		err := envoyInstance.RunWithConfigFile(int(defaults.HttpPort), "./envoyconfigs/zipkin-envoy-conf.yaml")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start a dummy server listening on 9411 for Zipkin requests

--- a/test/e2e/zipkin_test.go
+++ b/test/e2e/zipkin_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Zipkin config loading", func() {
 			}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 			// run envoy
-			err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
+			err = envoyInstance.RunWithRoleAndRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			// create test upstream

--- a/test/e2e/zipkin_test.go
+++ b/test/e2e/zipkin_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Zipkin config loading", func() {
 	}
 
 	It("should send trace msgs to the zipkin server", func() {
-		err := envoyInstance.RunWithConfigFile(int(defaults.HttpPort), "./envoyconfigs/zipkin-envoy-conf.yaml")
+		err := envoyInstance.RunWithConfigFile(int(defaults.HttpPort), defaults.GlooRestXdsPort, "./envoyconfigs/zipkin-envoy-conf.yaml")
 		Expect(err).NotTo(HaveOccurred())
 
 		// Start a dummy server listening on 9411 for Zipkin requests
@@ -124,7 +124,7 @@ var _ = Describe("Zipkin config loading", func() {
 			}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 			// run envoy
-			err = envoyInstance.RunWithRole(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+			err = envoyInstance.RunWithRestXds(writeNamespace+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort, testClients.RestXdsPort)
 			Expect(err).NotTo(HaveOccurred())
 
 			// create test upstream
@@ -339,7 +339,7 @@ var _ = Describe("Zipkin config loading", func() {
 			}, "10s", "0.1s").Should(HaveLen(2), "Gateways should be present")
 
 			// run envoy
-			err = envoyInstance.RunWithConfigFile(testClients.GlooPort, "./envoyconfigs/zipkin-static-cluster.yaml")
+			err = envoyInstance.RunWithConfigFile(testClients.GlooPort, testClients.RestXdsPort, "./envoyconfigs/zipkin-static-cluster.yaml")
 			Expect(err).NotTo(HaveOccurred())
 
 			// create test upstream

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -389,7 +389,6 @@ func (ef *EnvoyFactory) NewEnvoyInstance() (*EnvoyInstance, error) {
 		GlooAddr:      gloo,
 		AccessLogAddr: gloo,
 		AdminPort:     atomic.AddUint32(&adminPort, 1) + uint32(config.GinkgoConfig.ParallelNode*1000),
-		RestXdsPort:   uint32(defaults.GlooRestXdsPort),
 		ApiVersion:    "V3",
 	}
 	ef.instances = append(ef.instances, ei)

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -396,6 +396,13 @@ func (ef *EnvoyFactory) NewEnvoyInstance() (*EnvoyInstance, error) {
 
 }
 
+func (ef *EnvoyFactory) NewEnvoyInstanceWithRestXdsPort(restXdsPort uint32) (*EnvoyInstance, error) {
+	ei, err := ef.NewEnvoyInstance()
+	ei.RestXdsPort = restXdsPort
+	return ei, err
+
+}
+
 func (ei *EnvoyInstance) RunWithId(id string) error {
 	ei.ID = id
 	return ei.RunWithRole("default~proxy", 8081)

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -29,7 +29,8 @@ import (
 )
 
 const (
-	containerName = "e2e_envoy"
+	containerName    = "e2e_envoy"
+	DefaultProxyName = "default~proxy"
 )
 
 var adminPort = uint32(20000)
@@ -398,11 +399,11 @@ func (ef *EnvoyFactory) NewEnvoyInstance() (*EnvoyInstance, error) {
 
 func (ei *EnvoyInstance) RunWithId(id string) error {
 	ei.ID = id
-	return ei.RunWithRole("default~proxy", 8081)
+	return ei.RunWithRole(DefaultProxyName, 8081)
 }
 
 func (ei *EnvoyInstance) Run(port int) error {
-	return ei.RunWithRole("default~proxy", port)
+	return ei.RunWithRole(DefaultProxyName, port)
 }
 
 func (ei *EnvoyInstance) RunWith(eic EnvoyInstanceConfig) error {
@@ -423,7 +424,7 @@ func (ei *EnvoyInstance) RunWithRole(role string, port int) error {
 	return ei.runWithAll(eic, boostrapBuilder)
 }
 
-func (ei *EnvoyInstance) RunWithRestXds(role string, glooPort, restXdsPort int) error {
+func (ei *EnvoyInstance) RunWithRoleAndRestXds(role string, glooPort, restXdsPort int) error {
 	eic := &envoyInstanceConfig{
 		role:        role,
 		port:        uint32(glooPort),

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -437,11 +437,10 @@ func (ei *EnvoyInstance) RunWithRoleAndRestXds(role string, glooPort, restXdsPor
 	return ei.runWithAll(eic, boostrapBuilder)
 }
 
-func (ei *EnvoyInstance) RunWithConfigFile(port, restXdsPort int, configFile string) error {
+func (ei *EnvoyInstance) RunWithConfigFile(port int, configFile string) error {
 	eic := &envoyInstanceConfig{
 		role:        "gloo-system~gateway-proxy",
 		port:        uint32(port),
-		restXdsPort: uint32(restXdsPort),
 		context:     context.TODO(),
 	}
 	boostrapBuilder := &fileBootstrapBuilder{

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -436,11 +436,12 @@ func (ei *EnvoyInstance) RunWithRestXds(role string, glooPort, restXdsPort int) 
 	return ei.runWithAll(eic, boostrapBuilder)
 }
 
-func (ei *EnvoyInstance) RunWithConfigFile(port int, configFile string) error {
+func (ei *EnvoyInstance) RunWithConfigFile(port, restXdsPort int, configFile string) error {
 	eic := &envoyInstanceConfig{
-		role:    "gloo-system~gateway-proxy",
-		port:    uint32(port),
-		context: context.TODO(),
+		role:        "gloo-system~gateway-proxy",
+		port:        uint32(port),
+		restXdsPort: uint32(restXdsPort),
+		context:     context.TODO(),
 	}
 	boostrapBuilder := &fileBootstrapBuilder{
 		file: configFile,

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -439,9 +439,9 @@ func (ei *EnvoyInstance) RunWithRoleAndRestXds(role string, glooPort, restXdsPor
 
 func (ei *EnvoyInstance) RunWithConfigFile(port int, configFile string) error {
 	eic := &envoyInstanceConfig{
-		role:        "gloo-system~gateway-proxy",
-		port:        uint32(port),
-		context:     context.TODO(),
+		role:    "gloo-system~gateway-proxy",
+		port:    uint32(port),
+		context: context.TODO(),
 	}
 	boostrapBuilder := &fileBootstrapBuilder{
 		file: configFile,

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"net"
 	"time"
 
@@ -61,6 +62,7 @@ type TestClients struct {
 	SecretClient         gloov1.SecretClient
 	ServiceClient        skkube.ServiceClient
 	GlooPort             int
+	RestXdsPort          int
 }
 
 var glooPortBase = int32(30400)
@@ -94,6 +96,7 @@ type RunOptions struct {
 	WhatToRun        What
 	GlooPort         int32
 	ValidationPort   int32
+	RestXdsPort      int32
 	Settings         *gloov1.Settings
 	Extensions       setup.Extensions
 	Cache            memory.InMemoryResourceCache
@@ -109,6 +112,9 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 	}
 	if runOptions.ValidationPort == 0 {
 		runOptions.ValidationPort = AllocateGlooPort()
+	}
+	if runOptions.RestXdsPort == 0 {
+		runOptions.RestXdsPort = AllocateGlooPort()
 	}
 
 	if runOptions.Cache == nil {
@@ -129,7 +135,13 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 
 	glooOpts.Settings = runOptions.Settings
 	if glooOpts.Settings == nil {
-		glooOpts.Settings = &gloov1.Settings{}
+		glooOpts.Settings = &gloov1.Settings{
+			Gloo:                 &gloov1.GlooOptions{
+				RestXdsBindAddr: fmt.Sprintf("0.0.0.0:%v", int(runOptions.RestXdsPort)),
+			},
+		}
+	} else {
+		glooOpts.Settings.Gloo.RestXdsBindAddr = fmt.Sprintf("0.0.0.0:%v", int(runOptions.RestXdsPort))
 	}
 
 	runOptions.Extensions.SyncerExtensions = []syncer.TranslatorSyncerExtensionFactory{
@@ -162,6 +174,7 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 
 	testClients := getTestClients(ctx, runOptions.Cache, glooOpts.KubeServiceClient)
 	testClients.GlooPort = int(runOptions.GlooPort)
+	testClients.RestXdsPort = int(runOptions.RestXdsPort)
 	return testClients
 }
 

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -141,7 +141,15 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 			},
 		}
 	} else {
-		glooOpts.Settings.Gloo.RestXdsBindAddr = fmt.Sprintf("0.0.0.0:%v", int(runOptions.RestXdsPort))
+		if glooOpts.Settings.Gloo == nil {
+			glooOpts.Settings.Gloo = &gloov1.GlooOptions{
+				RestXdsBindAddr: fmt.Sprintf("0.0.0.0:%v", int(runOptions.RestXdsPort)),
+			}
+		} else {
+			if glooOpts.Settings.Gloo.RestXdsBindAddr == "" {
+				glooOpts.Settings.Gloo.RestXdsBindAddr = fmt.Sprintf("0.0.0.0:%v", int(runOptions.RestXdsPort))
+			}
+		}
 	}
 
 	runOptions.Extensions.SyncerExtensions = []syncer.TranslatorSyncerExtensionFactory{

--- a/test/services/gateway.go
+++ b/test/services/gateway.go
@@ -136,7 +136,7 @@ func RunGlooGatewayUdsFds(ctx context.Context, runOptions *RunOptions) TestClien
 	glooOpts.Settings = runOptions.Settings
 	if glooOpts.Settings == nil {
 		glooOpts.Settings = &gloov1.Settings{
-			Gloo:                 &gloov1.GlooOptions{
+			Gloo: &gloov1.GlooOptions{
 				RestXdsBindAddr: fmt.Sprintf("0.0.0.0:%v", int(runOptions.RestXdsPort)),
 			},
 		}


### PR DESCRIPTION
# Description

This adds RunWithRoleAndRestXds to the envoy tests being run.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works