### PR TITLE
Fix gzip flake

### DIFF
--- a/changelog/v1.7.0-beta13/endpoint-discovery-flake-test.yaml
+++ b/changelog/v1.7.0-beta13/endpoint-discovery-flake-test.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Fix a flake in gzip e2e tests where requests sometimes
+      were tested before new gateway config was written.


### PR DESCRIPTION
Fix a flake in gzip e2e tests where requests sometimes were tested before new gateway config was written.

Example of this occurring in CI - https://storage.googleapis.com/solo-public-build-logs/logs.html?buildid=c0fe9d63-b901-4afc-954e-c29f62cf2a93&authuser=1