### PR TITLE
Remove obsolete references to AMQP support + others

### DIFF
--- a/docs/content/guides/traffic_management/_index.md
+++ b/docs/content/guides/traffic_management/_index.md
@@ -6,7 +6,7 @@ description: Managing the traffic flowing through Gloo Edge to Upstream destinat
 
 Gloo Edge has a powerful routing engine that can handle simple use cases like API-to-API routing as well as more complex ones like HTTP to gRPC with body and header transformations. Routing can also be done natively to cloud-function providers like AWS Lambda, Google Cloud Functions and Azure Functions.
 
-Gloo Edge can route requests directly to functions, which can be: a serverless function call (e.g. AWS Lambda, Google Cloud Function, Microsoft Azure Function)or an API call on a microservice or a legacy service (e.g. a REST API call, OpenAPI operation, gRPC operation). This unique ability is what makes Gloo Edge the only API gateway that supports hybrid apps, as well as the only one that does not tie the user to a specific paradigm.
+Gloo Edge can route requests directly to functions, which can be: a serverless function call (e.g. AWS Lambda, Google Cloud Function, Microsoft Azure Function) or an API call on a microservice or a legacy service (e.g. a REST API call, OpenAPI operation, gRPC operation). This unique ability is what makes Gloo Edge the only API gateway that supports hybrid apps, as well as the only one that does not tie the user to a specific paradigm.
 
 Routes are the primary building block of the *Virtual Service*. A route contains matchers and an upstream which could be a single destination, a list of weighted destinations, or an upstream group. 
 

--- a/docs/content/guides/traffic_management/_index.md
+++ b/docs/content/guides/traffic_management/_index.md
@@ -6,7 +6,7 @@ description: Managing the traffic flowing through Gloo Edge to Upstream destinat
 
 Gloo Edge has a powerful routing engine that can handle simple use cases like API-to-API routing as well as more complex ones like HTTP to gRPC with body and header transformations. Routing can also be done natively to cloud-function providers like AWS Lambda, Google Cloud Functions and Azure Functions.
 
-Gloo Edge can route requests directly to functions, which can be: a serverless function call (e.g. Lambda, Google Cloud Function, OpenFaaS function, etc.); an API call on a microservice or a legacy service (e.g. a REST API call, OpenAPI operation, XML/SOAP request etc.); or publishing to a message queue (e.g. NATS, AMQP, etc.). This unique ability is what makes Gloo Edge the only API gateway that supports hybrid apps, as well as the only one that does not tie the user to a specific paradigm.
+Gloo Edge can route requests directly to functions, which can be: a serverless function call (e.g. AWS Lambda, Google Cloud Function, Microsoft Azure Function)or an API call on a microservice or a legacy service (e.g. a REST API call, OpenAPI operation, gRPC operation). This unique ability is what makes Gloo Edge the only API gateway that supports hybrid apps, as well as the only one that does not tie the user to a specific paradigm.
 
 Routes are the primary building block of the *Virtual Service*. A route contains matchers and an upstream which could be a single destination, a list of weighted destinations, or an upstream group. 
 

--- a/docs/content/introduction/architecture/concepts.md
+++ b/docs/content/introduction/architecture/concepts.md
@@ -141,7 +141,7 @@ A destination can be either an *upstream destination* or a *function destination
 
 **Upstream Destinations** are analogous to [Envoy clusters](https://www.envoyproxy.io/docs/envoy/v1.8.0/api-v1/cluster_manager/cluster). Requests routed to upstream destinations are routed to a server which handles the request once it has been admitted (and possibly transformed) by Gloo Edge.
 
-**Function Destinations** allow requests to be routed directly to *functions* that live on various Upstreams. A function can be a serverless function call (e.g., Lambda, Google Cloud Function, and OpenFaaS function), an API call on a service (e.g., a REST API call, OpenAPI operation, and XML/SOAP request), or publishing to a message queue (e.g., NATS and AMQP). Function-level routing is enabled in Envoy by Gloo Edge's function-level filters. Gloo Edge supports the addition of new Upstream types and new function types through our plugin interface.
+**Function Destinations** allow requests to be routed directly to *functions* that live on various Upstreams. A function can be a serverless function call (e.g., AWS Lambda, Google Cloud Function, Microsoft Azure Function) or an API call on a service (e.g., a REST API call, OpenAPI operation, gRPC operation). Function-level routing is enabled in Envoy by Gloo Edge's function-level filters. Gloo Edge supports the addition of new Upstream types and new function types through our plugin interface.
 
 ---
 


### PR DESCRIPTION
# Description

Remove obsolete references to AMQP support and refresh surrounding text w.r.t. NATS, XML/SOAP, OpenFaaS, Azure Functions.