### PR TITLE
check ci fails when tls_inspector injection is removed

### DIFF
--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -16,7 +16,6 @@ data:
       - name: static_layer
         static_layer:
           envoy.reloadable_features.enable_deprecated_v2_api: true
-          envoy.reloadable_features.disable_tls_inspector_injection: false
           overload:
             global_downstream_max_connections: 250000
       - name: admin_layer

--- a/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/15-clusteringress-proxy-configmap.yaml
@@ -17,7 +17,6 @@ data:
       - name: static_layer
         static_layer:
           envoy.reloadable_features.enable_deprecated_v2_api: true
-          envoy.reloadable_features.disable_tls_inspector_injection: false
           overload:
             global_downstream_max_connections: 250000
       - name: admin_layer

--- a/install/helm/gloo/templates/19-gloo-mtls-configmap.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-configmap.yaml
@@ -16,7 +16,6 @@ data:
       - name: static_layer
         static_layer:
           envoy.reloadable_features.enable_deprecated_v2_api: true
-          envoy.reloadable_features.disable_tls_inspector_injection: false
           overload:
             global_downstream_max_connections: 250000
       - name: admin_layer

--- a/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/27-knative-external-proxy-configmap.yaml
@@ -17,7 +17,6 @@ data:
       - name: static_layer
         static_layer:
           envoy.reloadable_features.enable_deprecated_v2_api: true
-          envoy.reloadable_features.disable_tls_inspector_injection: false
           overload:
             global_downstream_max_connections: 250000
       - name: admin_layer

--- a/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/30-knative-internal-proxy-configmap.yaml
@@ -17,7 +17,6 @@ data:
       - name: static_layer
         static_layer:
           envoy.reloadable_features.enable_deprecated_v2_api: true
-          envoy.reloadable_features.disable_tls_inspector_injection: false
           overload:
             global_downstream_max_connections: 250000
       - name: admin_layer

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -25,7 +25,6 @@ data:
       - name: static_layer
         static_layer:
           envoy.reloadable_features.enable_deprecated_v2_api: true
-          envoy.reloadable_features.disable_tls_inspector_injection: false
           overload:
             global_downstream_max_connections: {{ $spec.globalDownstreamMaxConnections }}
           upstream:

--- a/install/test/fixtures.go
+++ b/install/test/fixtures.go
@@ -6,7 +6,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:
@@ -185,7 +184,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:
@@ -325,7 +323,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:
@@ -469,7 +466,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:
@@ -623,7 +619,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:
@@ -805,7 +800,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:

--- a/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
+++ b/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
@@ -3,7 +3,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:

--- a/install/test/fixtures/envoy_config/static_clusters.yaml
+++ b/install/test/fixtures/envoy_config/static_clusters.yaml
@@ -3,7 +3,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       overload:
         global_downstream_max_connections: 250000
       upstream:

--- a/out.yaml
+++ b/out.yaml
@@ -58,7 +58,6 @@ data:
       - name: static_layer
         static_layer:
           envoy.reloadable_features.enable_deprecated_v2_api: true
-          envoy.reloadable_features.disable_tls_inspector_injection: false
           overload:
             global_downstream_max_connections: 250000
           upstream:

--- a/test/e2e/envoyconfigs/zipkin-envoy-conf.yaml
+++ b/test/e2e/envoyconfigs/zipkin-envoy-conf.yaml
@@ -3,7 +3,6 @@ layered_runtime:
   - name: static_layer
     static_layer:
       envoy.reloadable_features.enable_deprecated_v2_api: true
-      envoy.reloadable_features.disable_tls_inspector_injection: false
       cluster:
         healthy_panic_threshold:
           value: 0

--- a/test/e2e/envoyconfigs/zipkin-static-cluster.yaml
+++ b/test/e2e/envoyconfigs/zipkin-static-cluster.yaml
@@ -3,7 +3,6 @@ layered_runtime:
     - name: static_layer
       static_layer:
         envoy.reloadable_features.enable_deprecated_v2_api: true
-        envoy.reloadable_features.disable_tls_inspector_injection: false
         cluster:
           healthy_panic_threshold:
             value: 0


### PR DESCRIPTION
Sanity check that removing `disable_tls_inspector_injection` does not pass CI. 

# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works