### PR TITLE
Fix incorrect WAF acronym expansion

### DIFF
--- a/docs/content/guides/security/csrf/_index.md
+++ b/docs/content/guides/security/csrf/_index.md
@@ -14,7 +14,7 @@ Application owners can battle CSRF attacks at multiple levels of their stack.  A
 
 A primary benefit of API Gateways like Gloo Edge is that they provide these weapons at a controlled access point and thus can off-load responsibilities from the application team.
 
-One option for Gloo Edge Enterprise users is to  activate its [Web Application Framework]({{% versioned_link_path fromRoot="/guides/security/waf/" %}}) based on Apache ModSecurity.  It supports use of CSRF rules in the OWASP [Core Rule Set](https://coreruleset.org/).
+One option for Gloo Edge Enterprise users is to  activate its [Web Application Firewall]({{% versioned_link_path fromRoot="/guides/security/waf/" %}}) based on Apache ModSecurity.  It supports use of CSRF rules in the OWASP [Core Rule Set](https://coreruleset.org/).
 
 Alternatively, Envoy provides a simple [CSRF filter](https://www.envoyproxy.io/docs/envoy/latest/api-v2/config/filter/http/csrf/v2/csrf.proto) that may be applied to an entire Gloo `Gateway`, a `VirtualService`, or even individual `Routes` within a `VirtualService`.  To understand more about how this filter works in Envoy, we recommend playing in their CSRF [sandbox](https://www.envoyproxy.io/docs/envoy/latest/start/sandboxes/csrf).
 


### PR DESCRIPTION
# Description

Small documentation fix, in this context I'm pretty sure we're talking Firewall, not Framework

# Context

N/A

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works