### PR TITLE
documentation change.  clarify, `k` -> `kubectl`

### DIFF
--- a/docs/content/installation/gateway/kubernetes/_index.md
+++ b/docs/content/installation/gateway/kubernetes/_index.md
@@ -121,7 +121,7 @@ or `helm template`:
 helm fetch --untar --untardir . 'gloo/gloo'
 
 # deploy gloo resources to my-namespace with our value overrides
-helm template gloo --namespace my-namespace  --set crds.create=true | k apply -f - -n my-namespace
+helm template gloo --namespace my-namespace  --set crds.create=true | kubectl apply -f - -n my-namespace
 ```
 {{< /tab >}}
 {{< tab name="Helm 3" codelang="shell">}}


### PR DESCRIPTION
be explicit about using kubectl, and not use the alias `k`

# Description

Please include a summary of the changes.

This bug claifies documentation

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works