### PR TITLE
Fix docs example with FDS step skipped

### DIFF
--- a/docs/content/guides/traffic_management/destination_types/discovered_upstream/_index.md
+++ b/docs/content/guides/traffic_management/destination_types/discovered_upstream/_index.md
@@ -55,7 +55,18 @@ glooctl get upstream -n gloo-system default-petstore-8080
 ```
 
 Here, we can see an upstream was created and accepted. The upstream points to the petstore service on port 8080 in the
-default namespace. In fact, Gloo Edge discovered that it was a REST service and, using it's function discovery system, 
+default namespace. 
+
+By default the upstream created is rather simple. It represents a specific kubernetes service. However, the petstore
+application is a swagger service. Gloo Edge can discover this swagger spec, but by default Gloo Edge's function
+discovery features are turned off to improve performance. To enable Function Discovery Service (fds) on our petstore,
+we need to label the namespace.
+
+```shell
+kubectl label namespace default  discovery.solo.io/function_discovery=enabled
+```
+
+Gloo Edge discovered that it was a REST service and, using it's function discovery system, 
 added the functions it found in the Swagger definition to the upstream.
 
 {{% notice note %}}


### PR DESCRIPTION
# Description

Users noticed this guide was missing the step to enable FDS

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works