### PR TITLE
Fix semver check for security scan versions

### DIFF
--- a/docs/cmd/generate_docs.go
+++ b/docs/cmd/generate_docs.go
@@ -265,7 +265,7 @@ func generateSecurityScanMd() error {
 		// ignore beta releases when display security scan results
 		test, err := semver.NewVersion(release.GetTagName())
 		stableOnlyConstraint, _ := semver.NewConstraint("*")
-		if err != nil && stableOnlyConstraint.Check(test) {
+		if err == nil && stableOnlyConstraint.Check(test) {
 			tagNames = append(tagNames, release.GetTagName())
 		}
 	}


### PR DESCRIPTION
# Description

Security scan docs missing versions because of semver error check

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works