### PR TITLE
bug fix for settings invalidConfigPolicy helm value

### DIFF
--- a/changelog/v1.7.0-beta21/fix-replace-invalid-config-helm-values.yaml
+++ b/changelog/v1.7.0-beta21/fix-replace-invalid-config-helm-values.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Fix helm values mapping and test for .Values.settings.InvalidConfigPolicy
+    issueLink: https://github.com/solo-io/gloo/issues/4321

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -17,7 +17,7 @@ spec:
     restXdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.restXdsPort }}"
     enableRestEds: {{ .Values.settings.enableRestEds }}
 {{- end }}
-{{- if .Values.settings.replaceInvalidRoutes }}
+{{- if .Values.settings.InvalidConfigPolicy }}
     invalidConfigPolicy:
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}
 {{- end }}

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -18,7 +18,7 @@ spec:
     enableRestEds: {{ .Values.settings.enableRestEds }}
 {{- end }}
 {{- /* .Values.settings.replaceInvalidRoutes for backwards compatibility */}}
-{{- if or (.Values.settings.InvalidConfigPolicy) (.Values.settings.replaceInvalidRoutes) }}
+{{- if or (.Values.settings.invalidConfigPolicy) (.Values.settings.replaceInvalidRoutes) }}
     invalidConfigPolicy:
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}
 {{- end }}

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -20,6 +20,9 @@ spec:
 {{- /* .Values.settings.replaceInvalidRoutes for backwards compatibility */}}
 {{- if or (.Values.settings.invalidConfigPolicy) (.Values.settings.replaceInvalidRoutes) }}
     invalidConfigPolicy:
+    {{- if .Values.settings.replaceInvalidRoutes }}
+      replaceInvalidRoutes: {{ .Values.settings.replaceInvalidRoutes }}
+    {{- end }}
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}
 {{- end }}
     disableKubernetesDestinations: {{ .Values.settings.disableKubernetesDestinations | default false }}

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -17,7 +17,7 @@ spec:
     restXdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.restXdsPort }}"
     enableRestEds: {{ .Values.settings.enableRestEds }}
 {{- end }}
-{{-/* .Values.settings.replaceInvalidRoutes for backwards compatibility */}}
+{{- /* .Values.settings.replaceInvalidRoutes for backwards compatibility */}}
 {{- if or (.Values.settings.InvalidConfigPolicy) (.Values.settings.replaceInvalidRoutes) }}
     invalidConfigPolicy:
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -17,7 +17,8 @@ spec:
     restXdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.restXdsPort }}"
     enableRestEds: {{ .Values.settings.enableRestEds }}
 {{- end }}
-{{- if .Values.settings.InvalidConfigPolicy }}
+{{-/* .Values.settings.replaceInvalidRoutes for backwards compatibility */}}
+{{- if or (.Values.settings.InvalidConfigPolicy) (.Values.settings.replaceInvalidRoutes) }}
     invalidConfigPolicy:
 {{ toYaml .Values.settings.invalidConfigPolicy | indent 6}}
 {{- end }}

--- a/install/test/fixtures/settings/consul_config_upstream_discovery.yaml
+++ b/install/test/fixtures/settings/consul_config_upstream_discovery.yaml
@@ -20,6 +20,9 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+     invalidRouteResponseCode: 404 
  consulUpstreamDiscovery:
    useTlsDiscovery: true
    tlsTagName: tag

--- a/install/test/fixtures/settings/consul_config_values.yaml
+++ b/install/test/fixtures/settings/consul_config_values.yaml
@@ -20,6 +20,9 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+     invalidRouteResponseCode: 404 
  consul:
    datacenter: datacenter
    username: user

--- a/install/test/fixtures/settings/disable_kubernetes_destinations.yaml
+++ b/install/test/fixtures/settings/disable_kubernetes_destinations.yaml
@@ -20,6 +20,9 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: true
    disableProxyGarbageCollection: false
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+     invalidRouteResponseCode: 404 
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}

--- a/install/test/fixtures/settings/disable_proxy_garbage_collection.yaml
+++ b/install/test/fixtures/settings/disable_proxy_garbage_collection.yaml
@@ -20,6 +20,9 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: true
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+     invalidRouteResponseCode: 404  
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}

--- a/install/test/fixtures/settings/enable_default_credentials.yaml
+++ b/install/test/fixtures/settings/enable_default_credentials.yaml
@@ -20,6 +20,9 @@ spec:
     restXdsBindAddr: 0.0.0.0:9976
     disableKubernetesDestinations: false
     disableProxyGarbageCollection: false
+    invalidConfigPolicy:
+      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+      invalidRouteResponseCode: 404
     awsOptions:
       enableCredentialsDiscovey: true
   kubernetesArtifactSource: {}

--- a/install/test/fixtures/settings/enable_rest_eds.yaml
+++ b/install/test/fixtures/settings/enable_rest_eds.yaml
@@ -20,6 +20,9 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+     invalidRouteResponseCode: 404
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}

--- a/install/test/fixtures/settings/gateway_settings.yaml
+++ b/install/test/fixtures/settings/gateway_settings.yaml
@@ -21,6 +21,7 @@ spec:
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
    invalidConfigPolicy:
+     replaceInvalidRoutes: true
      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
      invalidRouteResponseCode: 404
  kubernetesArtifactSource: {}

--- a/install/test/fixtures/settings/ratelimit_descriptors.yaml
+++ b/install/test/fixtures/settings/ratelimit_descriptors.yaml
@@ -20,6 +20,9 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+     invalidRouteResponseCode: 404
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}

--- a/install/test/fixtures/settings/read_gateways_from_all_namespaces.yaml
+++ b/install/test/fixtures/settings/read_gateways_from_all_namespaces.yaml
@@ -16,6 +16,9 @@ spec:
    restXdsBindAddr: 0.0.0.0:9976
    disableKubernetesDestinations: false
    disableProxyGarbageCollection: false
+   invalidConfigPolicy:
+     invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+     invalidRouteResponseCode: 404
  kubernetesArtifactSource: {}
  kubernetesConfigSource: {}
  kubernetesSecretSource: {}

--- a/install/test/fixtures/settings/sts_discovery.yaml
+++ b/install/test/fixtures/settings/sts_discovery.yaml
@@ -20,6 +20,9 @@ spec:
     restXdsBindAddr: 0.0.0.0:9976
     disableKubernetesDestinations: false
     disableProxyGarbageCollection: false
+    invalidConfigPolicy:
+      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+      invalidRouteResponseCode: 404
     awsOptions:
       serviceAccountCredentials:
         cluster: aws_sts_cluster

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2136,6 +2136,16 @@ spec:
 
 					})
 
+					It("creates settings with the gateway config with old mapping", func() {
+						settings := makeUnstructureFromTemplateFile("fixtures/settings/gateway_settings.yaml", namespace)
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"settings.replaceInvalidRoutes=true",
+							},
+						})
+						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
+					})
+
 					It("creates settings with the gateway config", func() {
 						settings := makeUnstructureFromTemplateFile("fixtures/settings/gateway_settings.yaml", namespace)
 						prepareMakefile(namespace, helmValues{

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2150,7 +2150,7 @@ spec:
 						settings := makeUnstructureFromTemplateFile("fixtures/settings/gateway_settings.yaml", namespace)
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{
-								"settings.InvalidConfigPolicy.replaceInvalidRoutes=true",
+								"settings.invalidConfigPolicy.replaceInvalidRoutes=true",
 							},
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2141,6 +2141,8 @@ spec:
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{
 								"settings.replaceInvalidRoutes=true",
+								"settings.invalidConfigPolicy.invalidRouteResponseBody=Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.",
+								"settings.invalidConfigPolicy.invalidRouteResponseCode=404",
 							},
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
@@ -2151,6 +2153,8 @@ spec:
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{
 								"settings.invalidConfigPolicy.replaceInvalidRoutes=true",
+								"settings.invalidConfigPolicy.invalidRouteResponseBody=Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.",
+								"settings.invalidConfigPolicy.invalidRouteResponseCode=404",
 							},
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
@@ -2241,6 +2245,9 @@ spec:
     enableRestEds: true
     disableKubernetesDestinations: false
     disableProxyGarbageCollection: false
+    invalidConfigPolicy:
+      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run ` + "`glooctl check`" + ` to find and fix config errors.
+      invalidRouteResponseCode: 404
   discoveryNamespace: gloo-system
   kubernetesArtifactSource: {}
   kubernetesConfigSource: {}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2140,7 +2140,7 @@ spec:
 						settings := makeUnstructureFromTemplateFile("fixtures/settings/gateway_settings.yaml", namespace)
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{
-								"settings.replaceInvalidRoutes=true",
+								"settings.InvalidConfigPolicy.replaceInvalidRoutes=true",
 							},
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))


### PR DESCRIPTION
# Description

InvalidConfigPolicy was incorrectly mapped in the settings template. Updated mapping and test.

# Context

Users ran into this bug: https://github.com/solo-io/gloo/issues/4321

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4321