### PR TITLE
fix extauth_custom_ca doc link

### DIFF
--- a/docs/content/guides/security/auth/extauth/oauth/dex/_index.md
+++ b/docs/content/guides/security/auth/extauth/oauth/dex/_index.md
@@ -119,9 +119,7 @@ EOF
 
 This configures Dex with a static users. Notice how we choose a **client secret** with value `secretvalue` for the client named `gloo`. Gloo Edge will need to provide this secret when connecting to Dex in order to confirm its identity.
 
-{{< notice note >}}
-The above configuration uses unsecured http traffic without SSL certificates. You can have Dex generate its own certificates by including settings for the Helm chart on the path `certs.web.altNames`. The names should be set to the fully-qualified domain name of the Dex service on Kubernetes and the Dex URL, which would be `dex.gloo-system.svc.cluster.local` and `https://dex.gloo-system.svc.cluster.local:32000`. You would then need to add the Dex web server certificate authority to Gloo Edge's external authentication so the web certificates used by the Dex service will be trusted. You can find more information about adding trusted CAs to the Ext Auth service [here]({{< versioned_link_path fromRoot="/installation/advanced_configuration/extauth_custom/" >}}).
-{{< /notice >}}
+Note that the above configuration uses unsecured http traffic without SSL certificates. You can have Dex generate its own certificates by including settings for the Helm chart on the path `certs.web.altNames`. The names should be set to the fully-qualified domain name of the Dex service on Kubernetes and the Dex URL, which would be `dex.gloo-system.svc.cluster.local` and `https://dex.gloo-system.svc.cluster.local:32000`. You would then need to add the Dex web server certificate authority to Gloo Edge's external authentication so the web certificates used by the Dex service will be trusted. You can find more information about adding trusted CAs to the Ext Auth service [here]({{< versioned_link_path fromRoot="/installation/advanced_configuration/extauth_custom_ca/" >}}).
 
 Using this configuration, we can deploy Dex to our cluster using Helm.
 

--- a/docs/content/installation/advanced_configuration/extauth_custom_ca.md
+++ b/docs/content/installation/advanced_configuration/extauth_custom_ca.md
@@ -119,7 +119,7 @@ Once the installation is complete, we can validate our change with the following
 kubectl describe pods -n gloo-system -l gloo=extauth
 ```
 
-You should see the init container `add-ca-cert` has completed it's work.
+You should see the init container `add-ca-cert` has completed its work.
 
 ```bash
   State:          Terminated
@@ -210,7 +210,7 @@ This will force a recreation of the external authentication server pod(s). We ca
 kubectl describe pods -n gloo-system -l gloo=extauth
 ```
 
-You should see the init container `add-ca-cert` has completed it's work.
+You should see the init container `add-ca-cert` has completed its work.
 
 ```bash
   State:          Terminated


### PR DESCRIPTION
# Description

The Dex integration [guide](https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/oauth/dex/#install-dex) has a note with an embedded versioned_link_path that does not render properly and also contains an incorrect link.  This PR fixes that along with some other small editorial issues. 
