### PR TITLE
Fix helm gateway proxy merge

### DIFF
--- a/changelog/v1.7.0-beta21/fix-helm-gateway-proxies-deep-merge.yaml
+++ b/changelog/v1.7.0-beta21/fix-helm-gateway-proxies-deep-merge.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Deep merge default gateway proxy values into the proxy templates
+    issueLink: https://github.com/solo-io/gloo/issues/3142

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -5,7 +5,9 @@
 {{- $global := .Values.global }}
 {{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- $image := $spec.podTemplate.image }}
 {{- if $global }}
 {{- $image = merge $spec.podTemplate.image $global.image }}
@@ -404,7 +406,7 @@ spec:
         - mountPath: /etc/istio-certs/
           name: istio-certs
         - mountPath: /var/run/secrets/tokens
-          name: istio-token 
+          name: istio-token
 {{- end}}
 {{- end}}
       volumes:

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -1,4 +1,6 @@
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- if and $spec.gatewaySettings (not $spec.disabled) }}
 {{$gatewaySettings := $spec.gatewaySettings}}
 {{- if not $gatewaySettings.disableGeneratedGateways -}}
@@ -32,7 +34,7 @@ spec:
   {{ toYaml $gatewaySettings.options | indent 4 }}
   {{- end }}
   {{- if $gatewaySettings.accessLoggingService }}
-    accessLoggingService:  
+    accessLoggingService:
   {{ toYaml $gatewaySettings.accessLoggingService | nindent 6 }}
   {{- end }}
   useProxyProto: {{ $gatewaySettings.useProxyProto }}
@@ -69,7 +71,7 @@ spec:
   {{ toYaml $gatewaySettings.options | indent 4 }}
   {{- end }}
   {{- if $gatewaySettings.accessLoggingService }}
-    accessLoggingService:  
+    accessLoggingService:
   {{ toYaml $gatewaySettings.accessLoggingService | nindent 6 }}
   {{- end }}
   useProxyProto: {{ $gatewaySettings.useProxyProto }}

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.gateway.enabled }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- if $spec.kind.deployment}}
 {{- if $spec.horizontalPodAutoscaler }}
 ---

--- a/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.gateway.enabled }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- if $spec.kind.deployment}}
 {{- if $spec.podDisruptionBudget }}
 ---

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -1,5 +1,7 @@
 {{- if .Values.gateway.enabled }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- if not $spec.disabled }}
 {{- $svcName := default $name $spec.service.name }}
 ---

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -3,7 +3,9 @@
 {{- end -}}
 {{- if .Values.gateway.enabled }}
 {{- $global := .Values.global }}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := deepCopy $gatewayProxy | merge $gatewaySpec -}}
 {{- if not $spec.disabled }}
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
 ---

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -62,7 +62,6 @@ type renderTestCase struct {
 }
 
 var renderers = []renderTestCase{
-	{"Helm 2", helm2Renderer{chartDir}},
 	{"Helm 3", helm3Renderer{chartDir}},
 }
 


### PR DESCRIPTION
# Description

Adds on to the https://github.com/solo-io/gloo/pull/4182 PR to resolve issues related to not having default gateway proxy helm values merged into custom gateway probes.

# Context
There have been a few related issues (#3946, #3142, #4295)  opened where users were not seeing the default gateway proxy values included in custom gateway proxies. This uses helm `deepcopy` and `merge` to deep merge those values.

Helm 2 does not support `deepcopy` and causes tests failures. Since Helm 2 is not supported for this, that test renderer was also removed.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3142