### PR TITLE
Build docs fix

### DIFF
--- a/changelog/v1.6.9/fix-build-docs-script.yaml
+++ b/changelog/v1.6.9/fix-build-docs-script.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Use checked out Makefile and generate_docs when building docs for active versions.

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -109,8 +109,6 @@ function generateSiteForVersion() {
   # Use styles as defined on master, not the checked out temp repo.
   mkdir -p layouts/partials cmd/changelogutils
   cp -a $workingDir/layouts/partials/. layouts/partials/
-  cp -f $workingDir/Makefile Makefile
-  cp -f $workingDir/cmd/generate_changelog_doc.go cmd/generate_changelog_doc.go
   cp -a $workingDir/cmd/changelogutils/. cmd/changelogutils/
   # Generate the versioned static site.
   make site-release


### PR DESCRIPTION
# Description

The build-docs.sh script is using the local Makefile and generate_docs.go files instead of the files from the checkout version.

# Context

On releases we generate a versioned site for all the active versions (master, 1.6.8, 1.5.4, etc.), but the build docs script uses the release branch's Makefile and generate_docs instead of the checked out active version.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works