### PR TITLE
fix extra v in branch name

### DIFF
--- a/.github/workflows/update-solo-apis.yaml
+++ b/.github/workflows/update-solo-apis.yaml
@@ -44,6 +44,6 @@ jobs:
           git config --local user.email soloio-bot@github.com
           git add .
           git commit -m "Sync Gloo APIs to ${TAG_NAME}" --allow-empty
-          git checkout -B gloo-v${TAG_NAME}
+          git checkout -B gloo-${TAG_NAME}
           git remote add solo-apis git@github.com:solo-io/solo-apis.git
-          git push solo-apis gloo-v${TAG_NAME}
+          git push solo-apis gloo-${TAG_NAME}


### PR DESCRIPTION
# Description

Fix extra v in branch name

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works