### PR TITLE
Add comment around v2 xDS server

### DIFF
--- a/projects/gloo/pkg/xds/envoy.go
+++ b/projects/gloo/pkg/xds/envoy.go
@@ -80,6 +80,14 @@ func SetupEnvoyXds(grpcServer *grpc.Server, xdsServer envoyserver.Server, envoyC
 		return
 	}
 
+	// The v2 implementation is kept solely to support discovery of ext-auth and rate-limit configuration
+	// Relevant GitHub issue to remove this: https://github.com/solo-io/gloo/issues/4369
+	// Context: Envoy has deprecated the v2 API and no longer providing support for it. We use the v2 xDS
+	//	protocol as a transport mechanism to serve ext-auth and rate-limit with their configuration. Since
+	//	Envoy is not directly involved in this connection, we can continue to rely on the v2 go-control-plane
+	//  code, which, although deprecated, still works.
+	//  A preferred path forward would be for us to maintain the necessary code to support this version of
+	//	xDS, and to not rely on the go-control-plane, since that code might get removed in the future.
 	serverV2 := NewEnvoyServerV2(xdsServer)
 	envoy_api_v2.RegisterEndpointDiscoveryServiceServer(grpcServer, serverV2)
 	envoy_api_v2.RegisterClusterDiscoveryServiceServer(grpcServer, serverV2)


### PR DESCRIPTION
# Description

Provide comments for future developers to understand why we are still serving v2 envoy config.

# Context

We decided that as long as the go-control-plane doesn't remove the v2 discovery code, we can continue to rely on it to serve ext-auth and rate-limit config. We created a github issue to track this tech debt, and this comment is being added to provide context to developers who don't understand why we are referencing a deprecated envoy API.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works