### PR TITLE
Helm log level env var

### DIFF
--- a/changelog/v1.7.0-beta26/add-helm-log-level-env-variables.yaml
+++ b/changelog/v1.7.0-beta26/add-helm-log-level-env-variables.yaml
@@ -2,3 +2,7 @@ changelog:
   - type: HELM
     description: Added LOG_LEVEL environment variables to deployments templates
     issueLink: https://github.com/solo-io/gloo/issues/4090
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: go-utils
+    dependencyTag: v0.20.5

--- a/changelog/v1.7.0-beta26/add-helm-log-level-env-variables.yaml
+++ b/changelog/v1.7.0-beta26/add-helm-log-level-env-variables.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: HELM
+    description: Added LOG_LEVEL environment variables to deployments templates
+    issueLink: https://github.com/solo-io/gloo/issues/4090

--- a/docs/content/operations/debugging_gloo/_index.md
+++ b/docs/content/operations/debugging_gloo/_index.md
@@ -187,6 +187,21 @@ Now you can navigate to http://localhost:9091 and you get a simple page with som
 With these endpoints, you can profile the behavior of the component, adjust its logging, view the prometheus-style telemetry signals, as well as view tracing spans within the process. This is a very handy page to understand the behavior of a particular component. 
 
 
+#### Declaratively setting log levels on start
+
+Setting the `LOG_LEVEL` environment variable within `gloo`, `discovery`, `gateway` or gateway proxy deployments will change the level at which the stats server logs. The default log level for the stats server is `info`.
+
+Other acceptable log levels for Gloo Edge components are:
+
+* `debug`
+* `error`
+* `warn`
+* `panic`
+* `fatal`
+
+With Helm installations, these can be set for you by providing the desired level as a value for the `logLevel` key for each of those components. You can also define the [Envoy log level](https://www.envoyproxy.io/docs/envoy/latest/start/quick-start/run-envoy#debugging-envoy) by setting the `envoyLogLevel` value on gateway proxies.
+
+
 ### All else fails
 
 Again, if all else fails, you can capture the state of Gloo Edge configurations and logs and join us on our Slack (https://slack.solo.io) and one of our engineers will be able to help:

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/sergi/go-diff v1.1.0
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/solo-io/go-list-licenses v0.1.0
-	github.com/solo-io/go-utils v0.20.2
+	github.com/solo-io/go-utils v0.20.5
 	github.com/solo-io/k8s-utils v0.0.6
 	github.com/solo-io/protoc-gen-ext v0.0.15
 	github.com/solo-io/reporting-client v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1278,6 +1278,8 @@ github.com/solo-io/go-utils v0.19.0/go.mod h1:If8NiehXROCFU65PGeDTrrZCNA5gJXvbcV
 github.com/solo-io/go-utils v0.20.0/go.mod h1:wy4um9xnqPNlASld4eSuQQqjNCXRBtDjVRLJsoGqkdE=
 github.com/solo-io/go-utils v0.20.2 h1:lJFj9MsdosKU1Z/L9FDfiB2r3BFLvzFSLLAGR3p1e4U=
 github.com/solo-io/go-utils v0.20.2/go.mod h1:6e8K1spnMWwlnJRSNp/J84GEyJbrcK4Gm7i+ehzCi8c=
+github.com/solo-io/go-utils v0.20.5 h1:ymRAEVcGP+VUbp7dI/SaO6MmJkEbaH3HhBnEJUTDTw0=
+github.com/solo-io/go-utils v0.20.5/go.mod h1:6e8K1spnMWwlnJRSNp/J84GEyJbrcK4Gm7i+ehzCi8c=
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
 github.com/solo-io/k8s-utils v0.0.6 h1:jJ7ARv7HBvmkGH1AXCE2KOGgcMCo8PhlWL+6tSlTxlM=
 github.com/solo-io/k8s-utils v0.0.6/go.mod h1:NJFXCtSXXBErviEl7J+fIg4DU8xEvxFCQ2nEjxy2NdI=

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -171,6 +171,10 @@ spec:
           - name: DISABLE_USAGE_REPORTING
             value: "true"
         {{- end}}
+        {{- if .Values.gloo.deployment.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.gloo.deployment.logLevel }}
+        {{- end}}
 {{- if not .Values.global.glooMtls.enabled }}
         readinessProbe:
           tcpSocket:

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -171,9 +171,9 @@ spec:
           - name: DISABLE_USAGE_REPORTING
             value: "true"
         {{- end}}
-        {{- if .Values.gloo.deployment.logLevel }}
+        {{- if .Values.gloo.logLevel }}
           - name: LOG_LEVEL
-            value: {{ .Values.gloo.deployment.logLevel }}
+            value: {{ .Values.gloo.logLevel }}
         {{- end}}
 {{- if not .Values.global.glooMtls.enabled }}
         readinessProbe:

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -71,6 +71,10 @@ spec:
           - name: START_STATS_SERVER
             value: "true"
         {{- end}}
+        {{- if .Values.discovery.deployment.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.discovery.deployment.logLevel }}
+        {{- end}}
       # Pod security context
       securityContext:
         fsGroup: {{ printf "%.0f" (float64 .Values.discovery.deployment.fsGroup) }}

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -71,9 +71,9 @@ spec:
           - name: START_STATS_SERVER
             value: "true"
         {{- end}}
-        {{- if .Values.discovery.deployment.logLevel }}
+        {{- if .Values.discovery.logLevel }}
           - name: LOG_LEVEL
-            value: {{ .Values.discovery.deployment.logLevel }}
+            value: {{ .Values.discovery.logLevel }}
         {{- end}}
       # Pod security context
       securityContext:

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -80,6 +80,10 @@ spec:
           - name: VALIDATION_MUST_START
             value: "true"
         {{- end}}
+        {{- if .Values.gateway.deployment.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ .Values.gateway.deployment.logLevel }}
+        {{- end}}
 
 {{- if .Values.gateway.validation.enabled }}
         volumeMounts:

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -80,9 +80,9 @@ spec:
           - name: VALIDATION_MUST_START
             value: "true"
         {{- end}}
-        {{- if .Values.gateway.deployment.logLevel }}
+        {{- if .Values.gateway.logLevel }}
           - name: LOG_LEVEL
-            value: {{ .Values.gateway.deployment.logLevel }}
+            value: {{ .Values.gateway.logLevel }}
         {{- end}}
 
 {{- if .Values.gateway.validation.enabled }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -138,6 +138,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+      {{- if $spec.kind.deployment.logLevel }}
+        - name: LOG_LEVEL
+          value: {{ $spec.kind.deployment.logLevel }}
+      {{- end}}
         image: {{ template "gloo.image" $image }}
         imagePullPolicy: {{ $image.pullPolicy }}
         {{- if $spec.podTemplate.gracefulShutdown }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -119,6 +119,9 @@ spec:
       containers:
       - args:
           - --disable-hot-restart
+        {{- if $spec.envoyLogLevel }}
+          - --log-level {{ $spec.envoyLogLevel }}
+        {{- end}}
           {{- with $spec.extraEnvoyArgs}}
             {{- range . }}
           - {{ . | quote }}
@@ -138,9 +141,9 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
-      {{- if $spec.kind.deployment.logLevel }}
+      {{- if $spec.logLevel }}
         - name: LOG_LEVEL
-          value: {{ $spec.kind.deployment.logLevel }}
+          value: {{ $spec.logLevel }}
       {{- end}}
         image: {{ template "gloo.image" $image }}
         imagePullPolicy: {{ $image.pullPolicy }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2213,8 +2213,8 @@ spec:
 
 					It("can set log level env var", func() {
 						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Env = append(
-							[]v1.EnvVar{GetLogLevelEnvVar()},
-							gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Env...,
+							gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Env,
+							GetLogLevelEnvVar(),
 						)
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{"gatewayProxies.gatewayProxy.logLevel=debug"},
@@ -3034,8 +3034,8 @@ metadata:
 
 					It("can set log level env var", func() {
 						glooDeployment.Spec.Template.Spec.Containers[0].Env = append(
-							[]v1.EnvVar{GetLogLevelEnvVar()},
-							glooDeployment.Spec.Template.Spec.Containers[0].Env...,
+							glooDeployment.Spec.Template.Spec.Containers[0].Env,
+							GetLogLevelEnvVar(),
 						)
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{"gloo.logLevel=debug"},
@@ -3245,8 +3245,8 @@ metadata:
 
 					It("can set log level env var", func() {
 						gatewayDeployment.Spec.Template.Spec.Containers[0].Env = append(
-							[]v1.EnvVar{GetLogLevelEnvVar()},
-							gatewayDeployment.Spec.Template.Spec.Containers[0].Env...,
+							gatewayDeployment.Spec.Template.Spec.Containers[0].Env,
+							GetLogLevelEnvVar(),
 						)
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{"gateway.logLevel=debug"},
@@ -3444,8 +3444,8 @@ metadata:
 
 					It("can set log level env var", func() {
 						discoveryDeployment.Spec.Template.Spec.Containers[0].Env = append(
-							[]v1.EnvVar{GetLogLevelEnvVar()},
-							discoveryDeployment.Spec.Template.Spec.Containers[0].Env...,
+							discoveryDeployment.Spec.Template.Spec.Containers[0].Env,
+							GetLogLevelEnvVar(),
 						)
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{"discovery.logLevel=debug"},

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -62,6 +62,13 @@ func GetPodNameEnvVar() v1.EnvVar {
 	}
 }
 
+func GetLogLevelEnvVar() v1.EnvVar {
+	return v1.EnvVar{
+		Name:  "LOG_LEVEL",
+		Value: "debug",
+	}
+}
+
 func GetTestExtraEnvVar() v1.EnvVar {
 	return v1.EnvVar{
 		Name:  "TEST_EXTRA_ENV_VAR",
@@ -999,7 +1006,7 @@ metadata:
 spec:
   bindAddress: '::'
   bindPort: ` + bindPort + `
-  proxyNames: 
+  proxyNames:
   - gateway-proxy
   httpGateway: {}
   options:
@@ -1028,7 +1035,7 @@ metadata:
 spec:
   bindAddress: '::'
   bindPort: ` + bindPort + `
-  proxyNames: 
+  proxyNames:
   - gateway-proxy
   httpGateway: {}
   options:
@@ -2204,6 +2211,28 @@ spec:
 						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
 					})
 
+					It("can set log level env var", func() {
+						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Env = append(
+							[]v1.EnvVar{GetLogLevelEnvVar()},
+							gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Env...,
+						)
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gatewayProxies.gatewayProxy.logLevel=debug"},
+						})
+						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
+					})
+
+					It("can set the envoy log level arg", func() {
+						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Args = append(
+							gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Args,
+							"--log-level debug",
+						)
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gatewayProxies.gatewayProxy.envoyLogLevel=debug"},
+						})
+						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
+					})
+
 					It("can accept extra env vars", func() {
 						gatewayProxyDeployment.Spec.Template.Spec.Containers[0].Env = append(
 							[]v1.EnvVar{GetTestExtraEnvVar()},
@@ -3003,6 +3032,17 @@ metadata:
 
 					})
 
+					It("can set log level env var", func() {
+						glooDeployment.Spec.Template.Spec.Containers[0].Env = append(
+							[]v1.EnvVar{GetLogLevelEnvVar()},
+							glooDeployment.Spec.Template.Spec.Containers[0].Env...,
+						)
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gloo.logLevel=debug"},
+						})
+						testManifest.ExpectDeploymentAppsV1(glooDeployment)
+					})
+
 					It("can accept extra env vars", func() {
 						glooDeployment.Spec.Template.Spec.Containers[0].Env = append(
 							[]v1.EnvVar{GetTestExtraEnvVar()},
@@ -3203,6 +3243,17 @@ metadata:
 
 					})
 
+					It("can set log level env var", func() {
+						gatewayDeployment.Spec.Template.Spec.Containers[0].Env = append(
+							[]v1.EnvVar{GetLogLevelEnvVar()},
+							gatewayDeployment.Spec.Template.Spec.Containers[0].Env...,
+						)
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gateway.logLevel=debug"},
+						})
+						testManifest.ExpectDeploymentAppsV1(gatewayDeployment)
+					})
+
 					It("can accept extra env vars", func() {
 						gatewayDeployment.Spec.Template.Spec.Containers[0].Env = append(
 							[]v1.EnvVar{GetTestExtraEnvVar()},
@@ -3389,6 +3440,17 @@ metadata:
 							},
 						})
 
+					})
+
+					It("can set log level env var", func() {
+						discoveryDeployment.Spec.Template.Spec.Containers[0].Env = append(
+							[]v1.EnvVar{GetLogLevelEnvVar()},
+							discoveryDeployment.Spec.Template.Spec.Containers[0].Env...,
+						)
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"discovery.logLevel=debug"},
+						})
+						testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
 					})
 
 					It("can accept extra env vars", func() {


### PR DESCRIPTION
# Description

This change goes alongside https://github.com/solo-io/go-utils/pull/436 where we enable the stats server to set the log level by the `LOG_LEVEL` environment variable. This PR updates the Helm deployment templates to include that new environment variable that can be set in the values file.

I've tested that log level changes for the gloo resources and envoy components locally when the corresponding log level values are set.

# Context

Users have been asking for a way to declaratively define the log level for each Gloo & Envoy resource.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4090