### PR TITLE
Improve test to know when we can go back to gRPC

### DIFF
--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -152,6 +152,13 @@ func UpdateAlwaysAcceptSetting(ctx context.Context, alwaysAccept bool, installNa
 	}, ctx, installNamespace)
 }
 
+func UpdateRestEdsSetting(ctx context.Context, enableRestEds bool, installNamespace string) {
+	UpdateSettings(func(settings *v1.Settings) {
+		Expect(settings.Gloo).NotTo(BeNil())
+		settings.Gloo.EnableRestEds = &wrappers.BoolValue{Value: enableRestEds}
+	}, ctx, installNamespace)
+}
+
 func UpdateSettings(f func(settings *v1.Settings), ctx context.Context, installNamespace string) {
 	settingsClient := clienthelpers.MustSettingsClient(ctx)
 	settings, err := settingsClient.Read(installNamespace, "default", clients.ReadOpts{})


### PR DESCRIPTION
# Description

Upstream envoy has a bug, we might be hitting https://github.com/envoyproxy/envoy/issues/14598 on gRPC ADS

# Context

Update our test so we know when upstream has fixed the bug

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works