### PR TITLE
Fix obsolete upstream_ref in JWT docs

### DIFF
--- a/docs/content/guides/security/auth/jwt/access_control.md
+++ b/docs/content/guides/security/auth/jwt/access_control.md
@@ -549,7 +549,7 @@ spec:
             issuer: solo.io
             jwks:
               remote:
-                upstream_ref:
+                upstreamRef:
                   name: gloo-system-jwks-server-80
                   namespace: gloo-system
                 url: http://jwks-server/jwks.json


### PR DESCRIPTION
# Description

A new user complained that an upstream_ref API error in the JWT and Access Control doc misled them as they were spinning up on Gloo Edge.  This PR fixes that.