### PR TITLE
Fix bad email reference in Auth0 doc

### DIFF
--- a/docs/content/guides/security/auth/extauth/oauth/auth0/_index.md
+++ b/docs/content/guides/security/auth/extauth/oauth/auth0/_index.md
@@ -739,7 +739,7 @@ spec:
             principals:
             - jwtPrincipal:
                 claims:
-                  email: jimhbarton@gmail.com
+                  email: jim.barton@solo.io
 ```
 
 Now when you refresh the browser, you should see just the `X-Solo-Claim-Email` header, which was used by Gloo to authorize the request.  Try a different endpoint, such as `https://glootest.com/base64/R2xvbyBpcyBhd2Vzb21lCg==`, and you will see the `RBAC: access denied` message.


### PR DESCRIPTION
# Description

The recently added Auth0 integration doc has an error in one of the AuthConfigs that would cause the procedure to fail.  This PR fixes that error.