### PR TITLE
Fix workflow name for trivy scanner

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -8,7 +8,7 @@ on:
     branches:
     - 'master'
   workflow_run:
-    workflows: ["Trivy Scan"]
+    workflows: ["security-scan"]
     types:
       - completed
 jobs:

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -1,4 +1,4 @@
-name: release
+name: security-scan
 on:
   release:
     types: [created]

--- a/changelog/v1.7.0-beta27/fix-workflow-name.yaml
+++ b/changelog/v1.7.0-beta27/fix-workflow-name.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Fix the workflow name to trigger rebuilding the docs after trivy security scan is run on release.


### PR DESCRIPTION
# Description

The doc generation was not getting triggered on release because the workflow name did not match. This should now trigger the docs generation to also run on release after the trivy scan in complete. 

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works