### PR TITLE
Backport workflow for trivy scan 1.6

### DIFF
--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -1,0 +1,66 @@
+name: security-scan
+on:
+  release:
+    types: [created]
+jobs:
+  release:
+    name: Trivy Scan
+    runs-on: "ubuntu-18.04"
+    env:
+      IMAGE_REPO: quay.io/solo-io
+      SCAN_DIR: _output/scans
+    strategy:
+      matrix:
+        image-type: [ 'access-logger', 'certgen', 'discovery', 'gateway', 'gloo', 'gloo-envoy-wrapper', 'ingress', 'sds' ]
+    steps:
+      - name: Cancel Previous Actions
+        uses: styfle/cancel-workflow-action@0.4.1
+        with:
+          access_token: ${{ github.token }}
+      - name: Set up Go 1.14
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.14
+        id: go
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup - gcloud / gsutil
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GLOO_VULN_REPORTER }}
+          project_id: solo-public
+          export_default_credentials: true
+      - name: Build an image from Dockerfile
+        id: build-docker-image
+        run: |
+          VERSION=$(git describe --tags | cut -c 2-)
+          TAGGED_VERSION=v$(echo $VERSION) make ${{ matrix.image-type }}-docker
+          echo "::set-output name=VERSION::$(echo $VERSION)"
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_REPO }}/${{ matrix.image-type }}:${{ steps.build-docker-image.outputs.VERSION }}
+          format: 'template'
+          template: '@/contrib/sarif.tpl'
+          output: trivy-results-${{ matrix.image-type }}.sarif
+          severity: 'CRITICAL,HIGH'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: trivy-results-${{ matrix.image-type }}.sarif
+      - name: Setup Gloo Docs Output
+        run: |
+          mkdir -p ${{ env.SCAN_DIR }}/${{ steps.build-docker-image.outputs.VERSION }}
+      - name: Gloo Docs
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: ${{ env.IMAGE_REPO }}/${{ matrix.image-type }}:${{ steps.build-docker-image.outputs.VERSION }}
+          format: 'template'
+          template: '@hack/utils/security_scan_report/markdown.tpl'
+          output: ${{ env.SCAN_DIR }}/${{ steps.build-docker-image.outputs.VERSION }}/${{ matrix.image-type }}_cve_report.docgen
+          severity: 'CRITICAL,HIGH'
+      - name: Publish Docs
+        run: |
+          VERSION=${{ steps.build-docker-image.outputs.VERSION }} SCAN_FILE=${{ matrix.image-type }}_cve_report.docgen make publish-security-scan

--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -1,4 +1,4 @@
-name: security-scan
+name: security-scan-1.6
 on:
   release:
     types: [created]

--- a/Makefile
+++ b/Makefile
@@ -621,3 +621,12 @@ update-licenses:
 # use `make print-MAKEFILE_VAR` to print the value of MAKEFILE_VAR
 
 print-%  : ; @echo $($*)
+
+SCAN_BUCKET ?= solo-gloo-security-scans
+SCAN_DIR ?= $(OUTPUT_DIR)/scans/$(VERSION)
+
+.PHONY: publish-security-scan
+publish-security-scan:
+ifeq ($(RELEASE),"true")
+	gsutil cp -r $(SCAN_DIR)/$(SCAN_FILE) gs://$(SCAN_BUCKET)/$(VERSION)
+endif

--- a/changelog/v1.6.15/backport-trivy-workflow.yaml
+++ b/changelog/v1.6.15/backport-trivy-workflow.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Add Trivy security scan to find CVEs in container images and generate github issues and security update docs.


### PR DESCRIPTION
# Description

Currently the trivy scanner is not running on release for 1.6.x because the github workflow was never backported. 

# Context

Backports github workflow for running trivy scan of 1.6.x branch releases.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works