### PR TITLE
Trigger on release for trivy scan

### DIFF
--- a/.github/workflows/trivy-analysis.yaml
+++ b/.github/workflows/trivy-analysis.yaml
@@ -9,6 +9,7 @@ jobs:
     env:
       IMAGE_REPO: quay.io/solo-io
       SCAN_DIR: _output/scans
+      TAGGED_VERSION: ${{ github.ref }}
     strategy:
       matrix:
         image-type: [ 'access-logger', 'certgen', 'discovery', 'gateway', 'gloo', 'gloo-envoy-wrapper', 'ingress', 'sds' ]

--- a/Makefile
+++ b/Makefile
@@ -663,11 +663,11 @@ update-licenses:
 
 print-%  : ; @echo $($*)
 
-SCAN_BUCKET ?= solo-gloo-security-scans
-SCAN_DIR ?= $(OUTPUT_DIR)/scans/$(VERSION)
+SCAN_BUCKET ?= solo-gloo-security-scans/gloo
+SCAN_DIR ?= $(OUTPUT_DIR)/scans
 
 .PHONY: publish-security-scan
 publish-security-scan:
 ifeq ($(RELEASE),"true")
-	gsutil cp -r $(SCAN_DIR)/$(SCAN_FILE) gs://$(SCAN_BUCKET)/$(VERSION)
+	gsutil cp -r $(SCAN_DIR)/$(VERSION)/$(SCAN_FILE) gs://$(SCAN_BUCKET)/$(VERSION)/$(SCAN_FILE)
 endif

--- a/changelog/v1.5.17/trigger-trivy-on-release.yaml
+++ b/changelog/v1.5.17/trigger-trivy-on-release.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Update trivy doc generation directory and fix trigger upload to gcloud bucket on release.


### PR DESCRIPTION
# Description

Updates the trivy doc generation directory and includes TAGGED_VERSION in the environment to set RELEASE=true and trigger uploading the generated docs.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works