### PR TITLE
Add modsecurity RBL warning to docs

### DIFF
--- a/changelog/v1.7.0-beta30/add-rbl-warning.yaml
+++ b/changelog/v1.7.0-beta30/add-rbl-warning.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4433
+    resolvesIssue: false
+    description: adds warning against using RBL in modsecurity filter

--- a/changelog/v1.7.0-beta30/add-rbl-warning.yaml
+++ b/changelog/v1.7.0-beta30/add-rbl-warning.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    issueLink: https://github.com/solo-io/gloo/issues/4433
-    resolvesIssue: false
-    description: adds warning against using RBL in modsecurity filter

--- a/changelog/v1.7.0-beta31/add-rbl-warning.yaml
+++ b/changelog/v1.7.0-beta31/add-rbl-warning.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4433
+    resolvesIssue: false
+    description: adds warning against using RBL in modsecurity filter

--- a/docs/content/guides/security/waf/_index.md
+++ b/docs/content/guides/security/waf/_index.md
@@ -21,7 +21,7 @@ Gloo Edge now supports the popular Web Application Firewall framework/ruleset [M
 Gloo Edge Enterprise now includes the ability to enable the ModSecurity Web Application Firewall for any incoming and outgoing HTTP connections. There is support for configuring rule sets based on the OWASP Core Rule Set as well as custom rule sets. More information on available rule sets, and the rules language generally, can be found [here](https://www.modsecurity.org/rules.html).
 
 ## **Why Mod Security**
-API Gateways act as a control point for the outside world to access the various application services running in your environment. A Web Application Firewall offers a standard way to to inspect and handle all incoming traffic. Mod Security is one such firewall. ModSecurity uses a simple rules language to interpret and process incoming http traffic. There are many rule sets publically available, such as the [OWASP Core Rule Set](https://github.com/SpiderLabs/owasp-modsecurity-crs).
+API Gateways act as a control point for the outside world to access the various application services running in your environment. A Web Application Firewall offers a standard way to to inspect and handle all incoming traffic. Mod Security is one such firewall. ModSecurity uses a simple rules language to interpret and process incoming http traffic. There are many rule sets publically available, such as the [OWASP Core Rule Set](https://github.com/coreruleset/coreruleset).
 
 ### Configuring WAF in Gloo Edge
 ModSecurity rule sets are defined in gloo in one of 3 places:
@@ -168,6 +168,10 @@ After this config has been successfully applied, run the curl command from above
 The two methods outlined above represent the two main ways to apply basic rule string WAF configs to Gloo Edge routes.
 
 #### Core Rule Set
+
+{{% notice warning %}}
+Using the `rbl` modsecurity rule in Gloo Edge will cause envoy performance issues and should be avoided. If `rbl` blacklisting is a requirement, an [extauth plugin](../auth/extauth/plugin_auth) can be used to query the rbl list and forbid spam IPs.
+{{% /notice %}}
 
 As mentioned earlier, the main free Mod Security rule set available is the OWASP Core Rule Set. As with all other rule sets, the Core Rule Set can be applied manually via the rule set configs, Gloo Edge offers an easy way to apply the entire Core Rule Set, and configure it.
 
@@ -351,7 +355,7 @@ spec:
 
 Generate a request that will trigger ModSecurity:
 ```shell
-curl -v $(glooctl proxy url) -H"user-agent: scammer"
+curl -v $(glooctl proxy url) -H "user-agent: scammer"
 ```
 
 Check the logs:

--- a/docs/content/guides/security/waf/_index.md
+++ b/docs/content/guides/security/waf/_index.md
@@ -170,7 +170,7 @@ The two methods outlined above represent the two main ways to apply basic rule s
 #### Core Rule Set
 
 {{% notice warning %}}
-Using the `rbl` modsecurity rule in Gloo Edge will cause envoy performance issues and should be avoided. If `rbl` blacklisting is a requirement, an [extauth plugin](../auth/extauth/plugin_auth) can be used to query the rbl list and forbid spam IPs.
+Using the `rbl` modsecurity rule in Gloo Edge will cause envoy performance issues and should be avoided. If `rbl` blacklisting is a requirement, an [extauth plugin]({{< versioned_link_path fromRoot="/guides/security/auth/extauth/plugin_auth">}}) can be used to query the rbl list and forbid spam IPs.
 {{% /notice %}}
 
 As mentioned earlier, the main free Mod Security rule set available is the OWASP Core Rule Set. As with all other rule sets, the Core Rule Set can be applied manually via the rule set configs, Gloo Edge offers an easy way to apply the entire Core Rule Set, and configure it.


### PR DESCRIPTION
Using the `rbl` rule degrades envoy performance. Adds docs to warn against using rbl.