### PR TITLE
Fix gloo-fed demo script

### DIFF
--- a/projects/gloo/cli/pkg/cmd/demo/federation.go
+++ b/projects/gloo/cli/pkg/cmd/demo/federation.go
@@ -139,7 +139,7 @@ gloo:
       service:
         type: NodePort
 EOF
-glooctl install gateway enterprise --version $3 --values basic-enterprise.yaml --license-key=$4
+glooctl install gateway enterprise --version $3 --values basic-enterprise.yaml --license-key=$4 --with-gloo-fed=false
 rm basic-enterprise.yaml
 kubectl -n gloo-system rollout status deployment gloo --timeout=2m || true
 kubectl -n gloo-system rollout status deployment discovery --timeout=2m || true


### PR DESCRIPTION
# Description

Adds `--with-gloo-fed=false` to fix installation script for gloo-fed demo.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works