### PR TITLE
Fix doc gen formatting

### DIFF
--- a/changelog/v1.7.0-beta32/doc-gen-format-fix-security-updates.yaml
+++ b/changelog/v1.7.0-beta32/doc-gen-format-fix-security-updates.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fixes formatting in generated security scan report.

--- a/docs/cmd/securityscanutils/securityscan_utils.go
+++ b/docs/cmd/securityscanutils/securityscan_utils.go
@@ -72,15 +72,16 @@ func printImageReportGloo(tag string) error {
 			return err
 		}
 		fmt.Println(report)
+		fmt.Println()
 	}
 	return nil
 }
 
 func printImageReportGlooE(semver *version.Version) error {
 	tag := semver.String()
-	images := []string{"rate-limit-ee", "grpcserver-ee", "grpcserver-envoy", "grpcserver-ui", "gloo-ee", "gloo-envoy-wrapper-ee", "observability-ee", "extauth-ee", "ext-auth-plugins"}
+	images := []string{"rate-limit-ee", "grpcserver-ee", "grpcserver-envoy", "grpcserver-ui", "gloo-ee", "gloo-envoy-ee-wrapper", "observability-ee", "extauth-ee", "ext-auth-plugins"}
 	fedImages := []string{"gloo-fed", "gloo-fed-apiserver", "gloo-fed-apiserver-envoy", "gloo-federation-console", "gloo-fed-rbac-validating-webhook"}
-	hasFedVersion, _ := semver.Compare("1.6.0")
+	hasFedVersion, _ := semver.Compare("1.7.0")
 	if hasFedVersion >= 0 {
 		images = append(images, fedImages...)
 	}
@@ -95,6 +96,7 @@ func printImageReportGlooE(semver *version.Version) error {
 			return err
 		}
 		fmt.Println(report)
+		fmt.Println()
 	}
 	return nil
 }


### PR DESCRIPTION
# Description

Fixes new line formatting in security scan doc generation. 

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works