### PR TITLE
Parameterize nodeselector + tolerations on gloo pod, and hostNetwork on gateway proxy daemonsets

### DIFF
--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -37,6 +37,14 @@ spec:
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 }}
       serviceAccountName: gloo
+{{- with .Values.gloo.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.gloo.deployment.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 6 }}
+{{- end }}
       volumes:
 {{- if .Values.global.glooMtls.enabled }}
       - name: gloo-mtls-certs

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -288,8 +288,12 @@ spec:
           protocol: TCP
 {{- end }} {{/* $global.glooMtls.enabled or $.Values.istioSDS.enabled */}}
       {{- if $spec.kind.daemonSet }}
-      {{- if $spec.kind.daemonSet.hostPort}}
+      {{- if $spec.kind.daemonSet.hostPort }}
+      {{- if or ($spec.kind.daemonSet.hostNetwork) (eq ($spec.kind.daemonSet.hostNetwork | toString) "<nil>") }}
       hostNetwork: true
+      {{- else }}
+      hostNetwork: false
+      {{- end }}
       dnsPolicy: ClusterFirstWithHostNet
       {{- end}}
       {{- end}}


### PR DESCRIPTION
# Description

Reverse compatible parameterization of small amount of config in gloo pod and gateway proxy daemonsets.

This bug fixes ... \ This new feature can be used to ...
- specify nodeSelector on gloo pod
- specify tolerations on gloo pod
- specify hostNetwork on gateway proxy daemonsets (was hardcoded to true prior)

# Context

Users ran into this bug doing ... \ Users needed this feature to ...
- Previously unable to pin the gloo pod to a specific node group with taints.
- Previously unable to run gateway proxies as daemonsets with hostNetwork set to false

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works