### PR TITLE
add links to changelog version headers

### DIFF
--- a/changelog/v1.8.0-beta1/changelog-link-releases.yaml
+++ b/changelog/v1.8.0-beta1/changelog-link-releases.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Adds links to releases on changelog version headers.

--- a/changelog/v1.8.0-beta1/changelog-link-releases.yaml
+++ b/changelog/v1.8.0-beta1/changelog-link-releases.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: NON_USER_FACING
     description: >
-      Adds links to releases on changelog version headers.
+      Adds links to github releases on changelog version headers.

--- a/docs/cmd/changelogutils/changelog_utils.go
+++ b/docs/cmd/changelogutils/changelog_utils.go
@@ -44,7 +44,7 @@ func ParseReleases(releases []*github.RepositoryRelease, byMinorVersion bool) (m
 		var header string
 		// If byMinorVersion, we only want to include the release notes in the string and not the release header
 		if byMinorVersion {
-			header = fmt.Sprintf("##### %v\n", version.String())
+			header = fmt.Sprintf("##### %v\n", GetReleaseMdLink(version.String(), "gloo"))
 			version.LabelVersion, version.Patch, version.Label = 0, 0, ""
 		}
 		minorReleaseMap[*version] = minorReleaseMap[*version] + header + release.GetBody()
@@ -315,4 +315,8 @@ func SortReleases(releases []*github.RepositoryRelease) []*github.RepositoryRele
 		return versionA.MustIsGreaterThan(*versionB)
 	})
 	return releasesCopy
+}
+
+func GetReleaseMdLink(releaseTag, repo string) string {
+	return fmt.Sprintf("[%s](https://github.com/solo-io/%s/releases/tag/%s)", releaseTag, repo, releaseTag)
 }


### PR DESCRIPTION
Adds links to releases on changelog version headers.

![image](https://user-images.githubusercontent.com/1731122/112650814-283c3a00-8e22-11eb-98e0-f194f8650d8e.png)
