### PR TITLE
Helm support tracing on default gateway

### DIFF
--- a/changelog/v1.6.19/tracing-provider-helm.yaml
+++ b/changelog/v1.6.19/tracing-provider-helm.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: HELM
+    description: Allow tracing to be configured via helm on the default gateway.
+    issueLink: https://github.com/solo-io/gloo/issues/4494

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -27,7 +27,7 @@ spec:
     options:
       httpConnectionManagerSettings:
         tracing:
-{{ toYaml $gatewayProxy.tracing.provider | indent 10 }}
+{{ toYaml $spec.tracing.provider | indent 10 }}
 {{- end }}
 {{- else }}
   httpGateway: {}
@@ -66,7 +66,7 @@ spec:
     options:
       httpConnectionManagerSettings:
         tracing:
-{{ toYaml $gatewayProxy.tracing.provider | indent 10 }}
+{{ toYaml $spec.tracing.provider | indent 10 }}
 {{- end }}
 {{- else }}
   httpGateway: {}

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -21,6 +21,14 @@ spec:
 {{- if $gatewaySettings.customHttpGateway}}
   httpGateway:
 {{ toYaml $gatewaySettings.customHttpGateway | indent 4}}
+{{- else if $spec.tracing }}
+{{- if $spec.tracing.provider }}
+  httpGateway:
+    options:
+      httpConnectionManagerSettings:
+        tracing:
+{{ toYaml $gatewayProxy.tracing.provider | indent 10 }}
+{{- end }}
 {{- else }}
   httpGateway: {}
 {{- end }}
@@ -52,6 +60,14 @@ spec:
 {{- if $gatewaySettings.customHttpsGateway}}
   httpGateway:
 {{ toYaml $gatewaySettings.customHttpsGateway | indent 6}}
+{{- else if $spec.tracing }}
+{{- if $spec.tracing.provider }}
+  httpGateway:
+    options:
+      httpConnectionManagerSettings:
+        tracing:
+{{ toYaml $gatewayProxy.tracing.provider | indent 10 }}
+{{- end }}
 {{- else }}
   httpGateway: {}
 {{- end }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -895,7 +895,6 @@ var _ = Describe("Helm Test", func() {
 						testManifest.ExpectUnstructured("Gateway", namespace, defaults.GatewayProxyName+"-ssl").To(BeNil())
 					})
 
-
 					It("can set tracing provider", func() {
 						name := defaults.GatewayProxyName
 						bindPort := "8080"

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -895,6 +895,67 @@ var _ = Describe("Helm Test", func() {
 						testManifest.ExpectUnstructured("Gateway", namespace, defaults.GatewayProxyName+"-ssl").To(BeNil())
 					})
 
+
+					It("can set tracing provider", func() {
+						name := defaults.GatewayProxyName
+						bindPort := "8080"
+						ssl := "false"
+						gw := makeUnstructured(`
+apiVersion: gateway.solo.io/v1
+kind: Gateway
+metadata:
+  labels:
+    app: gloo
+  name: ` + name + `
+  namespace: gloo-system
+spec:
+  bindAddress: '::'
+  bindPort: ` + bindPort + `
+  proxyNames:
+  - gateway-proxy
+  httpGateway:
+    options:
+      httpConnectionManagerSettings:
+        tracing:
+          zipkinConfig:
+            collector_cluster: zipkin
+            collector_endpoint: /api/v2/spans
+  ssl: ` + ssl + `
+  useProxyProto: false
+`)
+						prepareMakefileFromValuesFile("values/val_tracing_provider_cluster.yaml")
+						testManifest.ExpectUnstructured("Gateway", namespace, defaults.GatewayProxyName).To(BeEquivalentTo(gw))
+
+						name = defaults.GatewayProxyName + "-ssl"
+						bindPort = "8443"
+						ssl = "true"
+						gw = makeUnstructured(`
+apiVersion: gateway.solo.io/v1
+kind: Gateway
+metadata:
+  labels:
+    app: gloo
+  name: ` + name + `
+  namespace: gloo-system
+spec:
+  bindAddress: '::'
+  bindPort: ` + bindPort + `
+  proxyNames:
+  - gateway-proxy
+  httpGateway:
+    options:
+      httpConnectionManagerSettings:
+        tracing:
+          zipkinConfig:
+            collector_cluster: zipkin
+            collector_endpoint: /api/v2/spans
+  ssl: ` + ssl + `
+  useProxyProto: false
+`)
+
+						testManifest.ExpectUnstructured("Gateway", namespace, defaults.GatewayProxyName+"-ssl").To(BeEquivalentTo(gw))
+					})
+
 					It("can render with custom listener yaml", func() {
 						newGatewayProxyName := "test-name"
 						vsList := []*core.ResourceRef{

--- a/install/test/values/val_tracing_provider_cluster.yaml
+++ b/install/test/values/val_tracing_provider_cluster.yaml
@@ -2,10 +2,9 @@ gatewayProxies:
   gatewayProxy:
     tracing:
       provider:
-        typed_config:
-          "@type": "type.googleapis.com/envoy.config.trace.v2.ZipkinConfig"
+        zipkinConfig:
           collector_cluster: zipkin
-          collector_endpoint: "/api/v2/spans"
+          collector_endpoint: /api/v2/spans
       cluster:
         - name: zipkin
           connect_timeout: 1s
@@ -16,8 +15,8 @@ gatewayProxies:
             cluster_name: zipkin
             endpoints:
               - lb_endpoints:
-                  - endpoint:
-                      address:
-                        socket_address:
-                          address: zipkin
-                          port_value: 1234
+                - endpoint:
+                    address:
+                      socket_address:
+                        address: zipkin
+                        port_value: 1234


### PR DESCRIPTION
Backport of: https://github.com/solo-io/gloo/pull/4496

# Description

Allow tracing to be configured on gateways via Helm.

# Context

Envoy updated when tracing provider config is defined. Previously, it was at the bootstrap level, and then it was moved to the listener level. As part of https://github.com/solo-io/gloo/pull/3903, we removed the tracing config from the proxy config map. However, we didn't add the helm support to the gateway.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4494