### PR TITLE
Fix CI Test Flake: istio inject works on gateway-pod

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        kube-e2e-test-type: ['glooctl']
+        kube-e2e-test-type: ['gateway', 'ingress', 'knative', 'helm', 'gloomtls', 'glooctl', 'eds']
     steps:
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        kube-e2e-test-type: ['gateway', 'ingress', 'knative', 'helm', 'gloomtls', 'glooctl', 'eds']
+        kube-e2e-test-type: ['glooctl']
     steps:
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.4.1

--- a/changelog/v1.8.0-beta2/fix-glooctl-test-flake.yaml
+++ b/changelog/v1.8.0-beta2/fix-glooctl-test-flake.yaml
@@ -4,5 +4,3 @@ changelog:
     resolvesIssue: false
     description: >
       Fix a glooctl test flake that slowed down development.
-
-

--- a/changelog/v1.8.0-beta2/fix-glooctl-test-flake.yaml
+++ b/changelog/v1.8.0-beta2/fix-glooctl-test-flake.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4428
+    resolvesIssue: false
+    description: >
+      Fix a glooctl test flake that slowed down development.
+
+

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -2,7 +2,6 @@ package glooctl_test
 
 import (
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
@@ -34,12 +33,12 @@ var _ = Describe("Kube2e: glooctl", func() {
 			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "apply", "-f", "https://raw.githubusercontent.com/solo-io/gloo/v1.4.12/example/petstore/petstore.yaml")
 			Expect(err).NotTo(HaveOccurred(), "should be able to install petstore")
 
-			// Add the gloo route
-			err = runGlooctlCommand(strings.Split("add route --name petstore --namespace "+testHelper.InstallNamespace+" --path-prefix / --dest-name default-petstore-8080  --dest-namespace "+testHelper.InstallNamespace, " ")...)
+			// Add the gloo route to petstore
+			err = runGlooctlCommand("add", "route", "--name", "petstore", "--namespace", testHelper.InstallNamespace, "--path-prefix", "/", "--dest-name", "default-petstore-8080" , "--dest-namespace", testHelper.InstallNamespace)
 			Expect(err).NotTo(HaveOccurred(), "should be able to add gloo route to petstore")
 
 			// Enable Istio Injection on default namespace
-			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "label", "namespace", "default", "istio-injection=enabled")
+			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "label", "namespace", "default", "istio-injection=enabled", "--overwrite")
 			Expect(err).NotTo(HaveOccurred(), "should be able to add a label to enable istio injection")
 
 			petstoreCurlOpts = helper.CurlOpts{
@@ -62,6 +61,10 @@ var _ = Describe("Kube2e: glooctl", func() {
 			// Disable Istio Injection on default namespace
 			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "label", "namespace", "default", "istio-injection-")
 			Expect(err).NotTo(HaveOccurred(), "should be able to remove the istio injection label")
+
+			// Remove the gloo route to petstore
+			err = runGlooctlCommand("remove", "route", "--name", "petstore", "--namespace", testHelper.InstallNamespace)
+			Expect(err).NotTo(HaveOccurred(), "should be able to remove gloo route to petstore")
 		})
 
 		ExpectIstioInjected := func() {
@@ -101,6 +104,8 @@ var _ = Describe("Kube2e: glooctl", func() {
 		Context("istio inject", func() {
 
 			It("works on gateway-pod", func() {
+				testHelper.CurlEventuallyShouldRespond(petstoreCurlOpts, goodResponse, 1, 60*time.Second, 1*time.Second)
+
 				err = runGlooctlCommand("istio", "inject", "--namespace", testHelper.InstallNamespace)
 				Expect(err).NotTo(HaveOccurred(), "should be able to run 'glooctl istio inject' without errors")
 
@@ -129,6 +134,8 @@ var _ = Describe("Kube2e: glooctl", func() {
 		Context("istio uninject", func() {
 
 			BeforeEach(func() {
+				testHelper.CurlEventuallyShouldRespond(petstoreCurlOpts, goodResponse, 1, 60*time.Second, 1*time.Second)
+
 				err = runGlooctlCommand("istio", "inject", "--namespace", testHelper.InstallNamespace)
 				Expect(err).NotTo(HaveOccurred(), "should be able to run 'glooctl istio inject' without errors")
 

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Kube2e: glooctl", func() {
 			Expect(err).NotTo(HaveOccurred(), "should be able to install petstore")
 
 			// Add the gloo route to petstore
-			err = runGlooctlCommand("add", "route", "--name", "petstore", "--namespace", testHelper.InstallNamespace, "--path-prefix", "/", "--dest-name", "default-petstore-8080" , "--dest-namespace", testHelper.InstallNamespace)
+			err = runGlooctlCommand("add", "route", "--name", "petstore", "--namespace", testHelper.InstallNamespace, "--path-prefix", "/", "--dest-name", "default-petstore-8080", "--dest-namespace", testHelper.InstallNamespace)
 			Expect(err).NotTo(HaveOccurred(), "should be able to add gloo route to petstore")
 
 			// Enable Istio Injection on default namespace


### PR DESCRIPTION
# Description

Fix a test flake

# Context

This slowed down development considerably

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
