### PR TITLE
Fix CI Test Flake: istio inject works on gateway-pod

### DIFF
--- a/changelog/v1.7.0-rc3/fix-glooctl-test-flake.yaml
+++ b/changelog/v1.7.0-rc3/fix-glooctl-test-flake.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4428
+    resolvesIssue: true
+    description: >
+      Fix a glooctl test flake that slowed down development.


### PR DESCRIPTION
# Description

Fix a test flake

# Context

This slowed down development considerably

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4428