### PR TITLE
Fix ci for community PRs

### DIFF
--- a/changelog/v1.8.0-beta2/fix-community-pr.yaml
+++ b/changelog/v1.8.0-beta2/fix-community-pr.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: fix docs gen check for community PRs


### PR DESCRIPTION
# Description

The docs gen check will fail on community PRs since the required secrets are removed from the GH action

# Context

We have several open community PRs that will need this fix

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works