### PR TITLE
Fix allow warnings

### DIFF
--- a/changelog/v1.8.0-beta3/fix-allow-warnings.yaml
+++ b/changelog/v1.8.0-beta3/fix-allow-warnings.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    description: >-
+      Fix allowWarnings setting so it is honored when set to false (the default) in configuration validation
+      API and admission webhook.
+    issueLink: https://github.com/solo-io/gloo/issues/4466

--- a/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
+++ b/projects/gateway/pkg/services/k8sadmisssion/validating_admission_webhook.go
@@ -343,7 +343,7 @@ func (wh *gatewayValidationWebhook) makeAdmissionResponse(ctx context.Context, r
 
 	// even if validation is set to always accept, we want to fail on unmarshal errors
 	if validationErrs.ErrorOrNil() == nil || (wh.alwaysAccept && !hasUnmarshalErr) {
-		logger.Debug("Succeeded, alwaysAccept: %v validationErrs: %v", wh.alwaysAccept, validationErrs)
+		logger.Debugf("Succeeded, alwaysAccept: %v validationErrs: %v", wh.alwaysAccept, validationErrs)
 		incrementMetric(ctx, gvk.String(), ref, mGatewayResourcesAccepted)
 		return &AdmissionResponseWithProxies{
 			AdmissionResponse: &v1beta1.AdmissionResponse{

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -256,6 +256,12 @@ func (v *validator) validateSnapshot(ctx context.Context, apply applyResource, d
 			errs = multierr.Append(errs, errors.Wrapf(err, "failed to validate Proxy with Gloo validation server"))
 			continue
 		}
+		if warnings := validationutils.GetProxyWarning(proxyReport.ProxyReport); !v.allowWarnings && len(warnings) > 0 {
+			for _, warning := range warnings {
+				errs = multierr.Append(errs, errors.New(warning))
+			}
+			continue
+		}
 	}
 
 	if errs != nil {

--- a/projects/gateway/pkg/validation/validator_test.go
+++ b/projects/gateway/pkg/validation/validator_test.go
@@ -92,6 +92,27 @@ var _ = Describe("Validator", func() {
 				Expect(err.Error()).To(ContainSubstring("failed to validate Proxy with Gloo validation server"))
 				Expect(proxyReports).To(HaveLen(1))
 			})
+
+			Context("allowWarnings=false", func() {
+				BeforeEach(func() {
+					v = NewValidator(NewValidatorConfig(t, vc, ns, true, false))
+				})
+				It("accepts a vs with missing route table ref", func() {
+					vc.validateProxy = warnProxy
+					us := samples.SimpleUpstream()
+					snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)
+					err := v.Sync(context.TODO(), snap)
+					Expect(err).NotTo(HaveOccurred())
+
+					// change something to change the hash
+					snap.RouteTables[0].Metadata.Labels = map[string]string{"change": "my mind"}
+
+					proxyReports, err := v.ValidateRouteTable(context.TODO(), snap.RouteTables[0], false)
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(ContainSubstring("Route Warning: InvalidDestinationWarning. Reason: you should try harder next time"))
+					Expect(proxyReports).To(HaveLen(1))
+				})
+			})
 		})
 
 		Context("proxy validation fails (bad connection)", func() {
@@ -844,6 +865,12 @@ func acceptProxy(ctx context.Context, in *validation.ProxyValidationServiceReque
 func failProxy(ctx context.Context, in *validation.ProxyValidationServiceRequest, opts ...grpc.CallOption) (*validation.ProxyValidationServiceResponse, error) {
 	rpt := validationutils.MakeReport(in.Proxy)
 	validationutils.AppendListenerError(rpt.ListenerReports[0], validation.ListenerReport_Error_SSLConfigError, "you should try harder next time")
+	return &validation.ProxyValidationServiceResponse{ProxyReport: rpt}, nil
+}
+
+func warnProxy(ctx context.Context, in *validation.ProxyValidationServiceRequest, opts ...grpc.CallOption) (*validation.ProxyValidationServiceResponse, error) {
+	rpt := validationutils.MakeReport(in.Proxy)
+	validationutils.AppendRouteWarning(rpt.ListenerReports[0].GetHttpListenerReport().GetVirtualHostReports()[0].GetRouteReports()[0], validation.RouteReport_Warning_InvalidDestinationWarning, "you should try harder next time")
 	return &validation.ProxyValidationServiceResponse{ProxyReport: rpt}, nil
 }
 

--- a/projects/gateway/pkg/validation/validator_test.go
+++ b/projects/gateway/pkg/validation/validator_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Validator", func() {
 				BeforeEach(func() {
 					v = NewValidator(NewValidatorConfig(t, vc, ns, true, false))
 				})
-				It("accepts a vs with missing route table ref", func() {
+				It("rejects a vs with missing route table ref", func() {
 					vc.validateProxy = warnProxy
 					us := samples.SimpleUpstream()
 					snap := samples.GatewaySnapshotWithDelegates(us.Metadata.Ref(), ns)


### PR DESCRIPTION
# Description

Fix allowWarnings setting so it is honored when set to false (the default) in configuration validation API and admission webhook.

# Testing

Also validated in cluster against [this](https://github.com/solo-io/gloo/issues/4466#issuecomment-812101643) use case to confirm it is fixed.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4466