### PR TITLE
fix-release-build

### DIFF
--- a/changelog/v1.6.21/disable-transformation-validation.yaml
+++ b/changelog/v1.6.21/disable-transformation-validation.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add the TAGGED_VERSION to the cloudbuild test step to fix the slice panic in the release build test.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -96,6 +96,7 @@ steps:
   - 'RUN_CONSUL_TESTS=1'
   - 'RUN_VAULT_TESTS=1'
   - 'DOCKER_CONFIG=/workspace/.docker/'
+  - 'TAGGED_VERSION=$TAG_NAME'
   dir: *dir
   args: ['run-tests']
   waitFor: ['get-envoy', 'setup-aws-creds', 'set-gcr-zone', 'get-test-credentials', 'install-go-tools']


### PR DESCRIPTION
# Description

Add TAGGED_VERSION to cloudbuild tests to alleviate a runtime panic during release builds