### PR TITLE
Disable gateway service port fix

### DIFF
--- a/changelog/v1.8.0-beta5/fix-disable-gateway-corresponding-port.yaml
+++ b/changelog/v1.8.0-beta5/fix-disable-gateway-corresponding-port.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4578
+    description: Disabling http/s gateway should disable corresponding port

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -2,6 +2,7 @@
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- range $name, $gatewaySpec := .Values.gatewayProxies }}
 {{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{$gatewaySettings := $spec.gatewaySettings}}
 {{- if not $spec.disabled }}
 {{- $svcName := default $name $spec.service.name }}
 ---
@@ -35,6 +36,7 @@ spec:
   # port order matters due to this issue: https://github.com/solo-io/gloo/issues/2571
   ports:
 {{- if $spec.service.httpsFirst }}
+  {{- if not $gatewaySettings.disableHttpsGateway }}
   - port: {{ $spec.service.httpsPort }}
     targetPort: {{ $spec.podTemplate.httpsPort }}
     protocol: TCP
@@ -42,7 +44,9 @@ spec:
     {{- if and (eq $spec.service.type "NodePort") $spec.service.httpsNodePort }}
     nodePort: {{ $spec.service.httpsNodePort }}
     {{- end}}
+  {{- end }}
 {{- end }}
+  {{- if not $gatewaySettings.disableHttpGateway }}
   - port: {{ $spec.service.httpPort }}
     targetPort: {{ $spec.podTemplate.httpPort }}
     protocol: TCP
@@ -50,7 +54,9 @@ spec:
     {{- if and (eq $spec.service.type "NodePort") $spec.service.httpNodePort }}
     nodePort: {{ $spec.service.httpNodePort }}
     {{- end}}
+  {{- end }}
 {{- if not $spec.service.httpsFirst }}
+  {{- if not $gatewaySettings.disableHttpsGateway }}
   - port: {{ $spec.service.httpsPort }}
     targetPort: {{ $spec.podTemplate.httpsPort }}
     protocol: TCP
@@ -58,6 +64,7 @@ spec:
     {{- if and (eq $spec.service.type "NodePort") $spec.service.httpsNodePort }}
     nodePort: {{ $spec.service.httpsNodePort }}
     {{- end}}
+  {{- end }}
 {{- end }}
 {{- if $spec.failover }}
 {{- if $spec.failover.enabled }}
@@ -113,3 +120,4 @@ spec:
 {{- end }} {{/* range $name, $spec := .Values.gatewayProxies */}}
 {{- end }} {{/* if not $spec.disabled */}}
 {{ end }} {{/* if .Values.gateway.enabled */}}
+


### PR DESCRIPTION
# Description
Disabling http/s gateway should disable corresponding port

# Context

Several users have reported this.

Fixes: https://github.com/solo-io/gloo/issues/4578 and https://github.com/solo-io/gloo/issues/4286

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4578