### PR TITLE
Update go to 1.16.3

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -9,10 +9,10 @@ jobs:
         uses: styfle/cancel-workflow-action@0.4.1
         with:
           access_token: ${{ github.token }}
-      - name: Set up Go 1.14
+      - name: Set up Go 1.16.3
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14
+          go-version: 1.16.3
         id: go
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -16,10 +16,10 @@ jobs:
       uses: styfle/cancel-workflow-action@0.4.1
       with:
         access_token: ${{ github.token }}
-    - name: Set up Go 1.14
+    - name: Set up Go 1.16.3
       uses: actions/setup-go@v1
       with:
-        go-version: 1.14
+        go-version: 1.16.3
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.9'
   entrypoint: 'bash'
   args:
   - '-c'


### PR DESCRIPTION
# Description

Update the version of golang Gloo was built with from 1.14.6 to 1.16.3.

This resolves #4576.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works