### PR TITLE
Fix testspace file glob

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -57,7 +57,7 @@ jobs:
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     - name: Push result to Testspace server
       run: |
-        testspace */junit.xml
+        testspace junit.xml
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     - name: Debug Info
       if: failure()

--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,4 @@ old_docs_temp_dir/
 .vscode/settings.json
 
 # junit
-*/junit.xml
+junit.xml


### PR DESCRIPTION
# Description

The old file blob only worked on junit results only one folder deep

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works