### PR TITLE
Always run testspace, even on failures

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -54,11 +54,11 @@ jobs:
     - uses: testspace-com/setup-testspace@v1
       with:
         domain: solo-io.testspace.com
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     - name: Push result to Testspace server
       run: |
         testspace push --verbose "**/junit.xml"
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/master' }}
     - name: Debug Info
       if: failure()
       run: |


### PR DESCRIPTION
# Description

Per https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions#job-status-check-functions the default condition is `success()` which doesn't run if previous steps failed. This means that job failures weren't getting uploaded to testspace. This fixes that.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works