### PR TITLE
Bump envoy 1.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.18.0-rc3
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.18.0
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.7.2/bump-envoy.yaml
+++ b/changelog/v1.7.2/bump-envoy.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: envoy-gloo
+    dependencyRepo: solo-io
+    dependencyTag: v1.18.0
+    description: >-
+      Upgrade envoy-gloo version to handle CVEs https://groups.google.com/g/envoy-announce/c/DGegalK__BA


### PR DESCRIPTION
# Description

Bumps envoy to pick up CVE fixes:

CVE-2021-28682: Remotely exploitable integer overflow via a very large grpc-timeout value causes undefined behavior.
CVE-2021-28683: Crash when peer sends a TLS Alert with an unknown code
CVE-2021-29258: Remotely exploitable crash in Envoy's HTTP2 Metadata, when an empty METADATA map is sent.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works