### PR TITLE
Allow users to set nodeSelector(s) on Gateway CertGen Job

### DIFF
--- a/changelog/v1.8.0-beta8/add-nodeselector-gateway-certgen-job.yaml
+++ b/changelog/v1.8.0-beta8/add-nodeselector-gateway-certgen-job.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4596
+    description: Allow uses to set a nodeSelector(s) for the Gateway CertGen Job

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -222,6 +222,7 @@
 |gateway.certGenJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.certGenJob.floatingUserId|bool||set to true to allow the cluster to dynamically assign a user ID|
 |gateway.certGenJob.runAsUser|float64||Explicitly set the user ID for the container to run as. Default is 10101|
+|gateway.certGenJob.nodeSelector.NAME|string||label selector for nodes|
 |gateway.updateValues|bool||if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions|
 |gateway.proxyServiceAccount.extraAnnotations.NAME|string||extra annotations to add to the service account|
 |gateway.proxyServiceAccount.disableAutomount|bool||disable automunting the service account to the gateway proxy. not mounting the token hardens the proxy container, but may interfere with service mesh integrations|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -266,11 +266,12 @@ type Job struct {
 
 type CertGenJob struct {
 	Job
-	Enabled                 *bool    `json:"enabled,omitempty" desc:"enable the job that generates the certificates for the validating webhook at install time (default true)"`
-	SetTtlAfterFinished     *bool    `json:"setTtlAfterFinished,omitempty" desc:"Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true"`
-	TtlSecondsAfterFinished *int     `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
-	FloatingUserId          *bool    `json:"floatingUserId,omitempty" desc:"set to true to allow the cluster to dynamically assign a user ID"`
-	RunAsUser               *float64 `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
+	Enabled                 *bool             `json:"enabled,omitempty" desc:"enable the job that generates the certificates for the validating webhook at install time (default true)"`
+	SetTtlAfterFinished     *bool             `json:"setTtlAfterFinished,omitempty" desc:"Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true"`
+	TtlSecondsAfterFinished *int              `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
+	FloatingUserId          *bool             `json:"floatingUserId,omitempty" desc:"set to true to allow the cluster to dynamically assign a user ID"`
+	RunAsUser               *float64          `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
+	NodeSelector            map[string]string `json:"nodeSelector,omitempty" desc:"label selector for nodes"`
 }
 
 type GatewayProxy struct {

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -46,6 +46,12 @@ spec:
             - "--secret-name={{ .Values.gateway.validation.secretName }}"
             - "--svc-name=gateway"
             - "--validating-webhook-configuration-name=gloo-gateway-validation-webhook-{{ .Release.Namespace }}"
+      {{- if .Values.gateway.certGenJob.nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := .Values.gateway.certGenJob.nodeSelector }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
       restartPolicy: {{ .Values.gateway.certGenJob.restartPolicy }}
   # this feature is still in Alpha, which means it must be manually enabled in the k8s api server
   # with --feature-gates="TTLAfterFinished=true". This flag also works with minikube start ...

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3038,6 +3038,56 @@ metadata:
 						testManifest.ExpectUnstructured(serviceAccount.GetKind(), serviceAccount.GetNamespace(), serviceAccount.GetName()).To(BeEquivalentTo(serviceAccount))
 
 					})
+
+					It("creates the certgen job with a nodeSelector", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"gateway.certGenJob.nodeSelector.special=true",
+							},
+						})
+						job := makeUnstructured(`
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: gloo
+    gloo: gateway-certgen
+  name: gateway-certgen
+  namespace: ` + namespace + `
+  annotations:
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": "hook-succeeded"
+    "helm.sh/hook-weight": "10"
+spec:
+  ttlSecondsAfterFinished: 60
+  template:
+    metadata:
+      labels:
+        gloo: gateway-certgen
+    spec:
+      serviceAccountName: certgen
+      containers:
+        - image: quay.io/solo-io/certgen:` + version + `
+          imagePullPolicy: IfNotPresent
+          name: certgen
+          securityContext:
+            runAsUser: 10101
+            runAsNonRoot: true
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          args:
+            - "--secret-name=gateway-validation-certs"
+            - "--svc-name=gateway"
+            - "--validating-webhook-configuration-name=gloo-gateway-validation-webhook-` + namespace + `"
+			nodeSelector:
+				special: "true"
+      restartPolicy: OnFailure
+`)
+						testManifest.ExpectUnstructured(job.GetKind(), job.GetNamespace(), job.GetName()).To(BeEquivalentTo(job))
+					})
 				})
 			})
 


### PR DESCRIPTION
Signed-off-by: Steve Richards <steve.james.richards@gmail.com>

# Description

Please include a summary of the changes.

This new feature can be used to schedule the Gateway CertGen Job on specific nodes.

# Context

Users needed this feature to allow them to schedule the Gateway CertGen Job on specific nodes.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4596