### PR TITLE
Backport Make webhook more configurable such that it can be used with cert-man…

### DIFF
--- a/changelog/v1.6.23/webhook-helm.yaml
+++ b/changelog/v1.6.23/webhook-helm.yaml
@@ -1,0 +1,12 @@
+changelog:
+  - type: HELM
+    description: >-
+      Allow users to set custom annotations on gateway webhook, which enables for example use of 
+      cert-manager's ca-injector to inject the caBundle.
+    issueLink: https://github.com/solo-io/gloo/issues/3790
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/2679
+    description: >-
+      Allow users to opt-out from using Helm pre-install Hook to install gateway webhook. This 
+      can be usefull for GitOps workflows in which case the webhook must be updated 
+      (not just installed) via Helm.

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -175,6 +175,8 @@
 |gateway.validation.secretName|string|gateway-validation-certs|Name of the Kubernetes Secret containing TLS certificates used by the validation webhook server. This secret will be created by the certGen Job if the certGen Job is enabled.|
 |gateway.validation.failurePolicy|string|Ignore|failurePolicy defines how unrecognized errors from the Gateway validation endpoint are handled - allowed values are 'Ignore' or 'Fail'. Defaults to Ignore |
 |gateway.validation.webhook.enabled|bool|true|enable validation webhook (default true)|
+|gateway.validation.webhook.disableHelmHook|bool|false|do not create the webhook as helm hook (default false)|
+|gateway.validation.webhook.extraAnnotations.NAME|string||extra annotations to add to the webhook|
 |gateway.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |gateway.deployment.image.repository|string|gateway|image name (repository) for the container.|
 |gateway.deployment.image.registry|string||image prefix/registry e.g. (quay.io/solo-io)|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -243,7 +243,9 @@ type GatewayValidation struct {
 }
 
 type Webhook struct {
-	Enabled bool `json:"enabled" desc:"enable validation webhook (default true)"`
+	Enabled          *bool             `json:"enabled,omitempty" desc:"enable validation webhook (default true)"`
+	DisableHelmHook  *bool             `json:"disableHelmHook,omitempty" desc:"do not create the webhook as helm hook (default false)"`
+	ExtraAnnotations map[string]string `json:"extraAnnotations,omitempty" desc:"extra annotations to add to the webhook"`
 }
 
 type GatewayDeployment struct {

--- a/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
+++ b/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
@@ -7,8 +7,13 @@ metadata:
     app: gloo
     gloo: gateway
   annotations:
+    {{- if not .Values.gateway.validation.webhook.disableHelmHook }}
     "helm.sh/hook": pre-install
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job
+    {{- end }}
+    {{- range $key, $value := .Values.gateway.validation.webhook.extraAnnotations }}
+    {{ $key | quote }}: {{ $value | quote }}
+    {{- end }}
 webhooks:
 - name: gateway.{{ .Release.Namespace }}.svc  # must be a domain with at least three segments separated by dots
   clientConfig:
@@ -16,7 +21,7 @@ webhooks:
       name: gateway
       namespace: {{ .Release.Namespace }}
       path: "/validation"
-    caBundle: "" # update manually or use certgen job
+    caBundle: "" # update manually or use certgen job or cert-manager's ca-injector
   rules:
   - operations: [ "CREATE", "UPDATE", "DELETE" ]
     apiGroups: ["gateway.solo.io"]

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -74,6 +74,8 @@ gateway:
     disableTransformationValidation: false
     webhook:
       enabled: true
+      disableHelmHook: false
+      extraAnnotations: {}
   deployment:
     image:
       repository: gateway


### PR DESCRIPTION
# Description

Note, this is a backport of https://github.com/solo-io/gloo/pull/4610 for version `1.6.*`, required as we cannot yet upgrade to version `1.17.*` or `1.18.*` as we are affected by https://github.com/solo-io/gloo/issues/4488. 

Make webhook more configurable such that it can be used with cert-manager's ca-injector (by providing custom annotations) and let user choose whether the webhook should be installed as helm resources or via helm pre-install hook.

All default values and changes introduced with this commit are backward compatible and do not change the 
default behavior.

# Context

- Allow users to set custom annotations on gateway webhook, which enables for example use of 
   cert-manager's ca-injector to inject the caBundle.
- Allow users to opt-out from using Helm pre-install Hook to install gateway webhook. This 
   can be usefull for GitOps workflows in which case the webhook must be updated 
   (not just installed) via Helm.

# Related Issues

- https://github.com/solo-io/gloo/issues/3790: This changes allow using [cert-manager](https://cert-manager.io/) and cert manager's ca-injector to automatically provision certificates for the gateway and to inject `caBundle` into the webhook.
- https://github.com/solo-io/gloo/issues/2679

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/3790
resolves https://github.com/solo-io/gloo/issues/2679