### PR TITLE
Fix: Istio mTLS not working in permissive mode (1.7)

### DIFF
--- a/changelog/v1.7.3/fix-istio-mtls-sds-alpn.yaml
+++ b/changelog/v1.7.3/fix-istio-mtls-sds-alpn.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3994
+    description: Apply alpn protocols when resolving common ssl config to support Istio mtls in permissive mode.

--- a/projects/gloo/pkg/utils/ssl.go
+++ b/projects/gloo/pkg/utils/ssl.go
@@ -247,7 +247,12 @@ func (s *sslConfigTranslator) ResolveCommonSslConfig(cs CertSource, secrets v1.S
 	} else if sslSecrets := cs.GetSslFiles(); sslSecrets != nil {
 		certChain, privateKey, rootCa = sslSecrets.TlsCert, sslSecrets.TlsKey, sslSecrets.RootCa
 	} else if sslSecrets := cs.GetSds(); sslSecrets != nil {
-		return s.handleSds(sslSecrets, verifySanListToMatchSanList(cs.GetVerifySubjectAltName()))
+		tlsContext, err := s.handleSds(sslSecrets, verifySanListToMatchSanList(cs.GetVerifySubjectAltName()))
+		if err != nil {
+			return nil, err
+		}
+		tlsContext.AlpnProtocols = cs.GetAlpnProtocols()
+		return tlsContext, err
 	} else {
 		if mustHaveCert {
 			return nil, NoCertificateFoundError


### PR DESCRIPTION
# Description

Backport for: https://github.com/solo-io/gloo/pull/4647 
