### PR TITLE
Remove helm2 references from 1.8 docs

### DIFF
--- a/changelog/v1.8.0-beta12/docs-remove-helm2.yaml
+++ b/changelog/v1.8.0-beta12/docs-remove-helm2.yaml
@@ -1,4 +1,3 @@
 changelog:
   - type: NON_USER_FACING
-    description: Helm 2 has been deprecated (https://helm.sh/docs/topics/v2_v3_migration/). Gloo Edge 1.8 charts use Helm3
-    functionality not supported in Helm 2.
+    description: Helm 2 has been deprecated (https://helm.sh/docs/topics/v2_v3_migration/). Gloo Edge 1.8 charts use Helm3 functionality not supported in Helm 2.

--- a/changelog/v1.8.0-beta12/docs-remove-helm2.yaml
+++ b/changelog/v1.8.0-beta12/docs-remove-helm2.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Helm 2 has been deprecated (https://helm.sh/docs/topics/v2_v3_migration/). Gloo Edge 1.8 charts use Helm3
+    functionality not supported in Helm 2.

--- a/docs/content/guides/observability/prometheus/metrics.md
+++ b/docs/content/guides/observability/prometheus/metrics.md
@@ -28,9 +28,7 @@ For example, to add stats to the Gloo Edge `gateway`, when installing with Helm 
 For example, to add stats to the Gloo Edge `discovery` pod, first write your values file. Run:
 
 ```shell script
-echo "crds:
-  create: true # see our installation guide- only required if you are using Helm 2
-discovery:
+echo "discovery:
   deployment:
     stats:
       enabled: true
@@ -43,23 +41,13 @@ Then install using one of the following methods:
 {{< tab name="glooctl" codelang="shell" >}}
 glooctl install gateway --values stats-values.yaml
 {{< /tab >}}
-{{% tab name="Helm 2" %}}
-Either:
-
-```shell script
-helm install gloo/gloo --name gloo --namespace gloo-system -f stats-values.yaml
-```
-
-or:
-
-```shell script
-helm template gloo --namespace gloo-system --values stats-values.yaml  | kubectl apply -f - -n gloo-system
-```
-{{% /tab %}}
 {{< tab name="Helm 3" codelang="shell">}}
 helm install gloo gloo/gloo --namespace gloo-system -f stats-values.yaml
-{{< /tab >}}
 {{< /tabs >}}
+
+{{% notice warning %}}
+Using Helm 2 is not supported in Gloo Edge v1.8.0.
+{{% /notice %}}
 
 Here's what the resulting `discovery` manifest would look like. Note the additions of the `prometheus.io` annotations,
 and the `START_STATS_SERVER` environment variable.

--- a/docs/content/installation/advanced_configuration/gloo-readonly-ui.md
+++ b/docs/content/installation/advanced_configuration/gloo-readonly-ui.md
@@ -30,19 +30,15 @@ With helm, add the following repo:
 helm repo add gloo-os-with-ui https://storage.googleapis.com/gloo-os-ui-helm
 ```
 
-and install it:
+and install it with Helm 3:
 
-{{< tabs >}}
-{{% tab name="Helm 3" %}}
 ```shell script
 helm install gloo gloo-os-with-ui/gloo-os-with-ui --namespace gloo-system
 ```
-{{< /tab >}}
-{{< tab name="Helm 2" codelang="shell">}}
-helm install --name gloo gloo-os-with-ui/gloo-os-with-ui --namespace my-namespace --set crds.create=true
-{{< /tab >}}
-{{< /tabs >}}
 
+{{% notice warning %}}
+Using Helm 2 is not supported in Gloo Edge v1.8.0.
+{{% /notice %}}
 
 ## Install Gloo Edge Enterprise Read-Only UI
 

--- a/docs/content/installation/advanced_configuration/multiple-gloo-installs.md
+++ b/docs/content/installation/advanced_configuration/multiple-gloo-installs.md
@@ -34,10 +34,7 @@ In this section we'll deploy Gloo Edge twice, each instance to a different names
 
 Create a file named `gloo1-overrides.yaml` and paste the following inside:
 
-{{< tabs >}}
-{{< tab name="Helm 2" codelang="yaml" >}}
-crds:
-  create: true
+```shell
 settings:
   create: true
   writeNamespace: gloo1
@@ -47,19 +44,7 @@ settings:
 grafana: # The grafana settings can be removed for Gloo Edge OSS
   rbac:
     namespaced: true
-{{< /tab >}}
-{{< tab name="Helm 3" codelang="yaml">}}
-settings:
-  create: true
-  writeNamespace: gloo1
-  watchNamespaces:
-  - default
-  - gloo1
-grafana: # The grafana settings can be removed for Gloo Edge OSS
-  rbac:
-    namespaced: true
-{{< /tab >}}
-{{< /tabs >}}
+```
 
 Now, let's install Gloo Edge. Review our [Kubernetes installation guide]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/" %}}) if you need a refresher.
 
@@ -75,23 +60,14 @@ Then install Gloo Edge using one of the following methods:
 {{< tab name="glooctl" codelang="shell" >}}
 glooctl install gateway -n gloo1 --values gloo1-overrides.yaml
 {{< /tab >}}
-{{% tab name="Helm 2" %}}
-Either:
-
-```shell script
-helm install gloo/gloo --name gloo1 --namespace gloo1 -f gloo1-overrides.yaml
-```
-
-or:
-
-```shell script
-helm template gloo --namespace gloo1 --values gloo1-overrides.yaml  | k apply -f - -n gloo1
-```
-{{% /tab %}}
 {{< tab name="Helm 3" codelang="shell">}}
 helm install gloo gloo/gloo --namespace gloo1 -f gloo1-overrides.yaml
 {{< /tab >}}
 {{< /tabs >}}
+
+{{% notice warning %}}
+Using Helm 2 is not supported in Gloo Edge v1.8.0.
+{{% /notice %}}
 
 Check that gloo pods are running: 
 
@@ -125,20 +101,7 @@ Let's repeat the above process, substituting `gloo2` for `gloo1`:
 
 Create a file named `gloo2-overrides.yaml` and paste the following inside:
 
-{{< tabs >}}
-{{< tab name="Helm 2" codelang="yaml" >}}
-crds:
-  create: true
-settings:
-  create: true
-  writeNamespace: gloo2
-  watchNamespaces:
-  - default
-  - gloo2
-grafana: # The grafana settings can be removed for Gloo Edge OSS
-  rbac:
-    namespaced: true
-{{< /tab >}}
+```shell
 {{< tab name="Helm 3" codelang="yaml">}}
 settings:
   create: true
@@ -149,8 +112,7 @@ settings:
 grafana: # The grafana settings can be removed for Gloo Edge OSS
   rbac:
     namespaced: true
-{{< /tab >}}
-{{< /tabs >}}
+```
 
 Now, let's install Gloo Edge for the second time. First create the second namespace:
 
@@ -165,19 +127,6 @@ Then perform the second installation using one of the following methods:
 {{< tab name="glooctl" codelang="shell" >}}
 glooctl install gateway -n gloo2 --values gloo2-overrides.yaml
 {{< /tab >}}
-{{% tab name="Helm 2" %}}
-Either:
-
-```shell script
-helm install gloo/gloo --name gloo2 --namespace gloo2 -f gloo2-overrides.yaml
-```
-
-or:
-
-```shell script
-helm template gloo --namespace gloo2 --values gloo2-overrides.yaml  | k apply -f - -n gloo2
-```
-{{% /tab %}}
 {{< tab name="Helm 3" codelang="shell">}}
 helm install gloo gloo/gloo --namespace gloo2 -f gloo2-overrides.yaml
 {{< /tab >}}

--- a/docs/content/installation/enterprise/_index.md
+++ b/docs/content/installation/enterprise/_index.md
@@ -99,16 +99,14 @@ helm repo add glooe http://storage.googleapis.com/gloo-ee-helm
 
 Finally, install Gloo Edge using the following command:
 
-{{< tabs >}}
-{{< tab name="Helm 2" codelang="shell">}}
-helm install glooe/gloo-ee --name gloo --namespace gloo-system \
-  --set gloo.crds.create=true --set-string license_key=YOUR_LICENSE_KEY
-{{< /tab >}}
-{{< tab name="Helm 3" codelang="shell">}}
+```shell
 helm install gloo glooe/gloo-ee --namespace gloo-system \
   --create-namespace --set-string license_key=YOUR_LICENSE_KEY
-{{< /tab >}}
-{{< /tabs >}}
+```
+
+{{% notice warning %}}
+Using Helm 2 is not supported in Gloo Edge v1.8.0.
+{{% /notice %}}
 
 Once you've installed Gloo Edge, please be sure [to verify your installation](#verify-your-installation).
 
@@ -128,18 +126,16 @@ settings:
   writeNamespace: my-custom-namespace
 ```
 
-and use it to override default values in the Gloo Edge Helm chart:
+and use it to override default values in the Gloo Edge Helm chart with Helm 3:
 
-{{< tabs >}}
-{{< tab name="Helm 2" codelang="shell">}}
-helm install glooe/gloo-ee --name gloo --namespace gloo-system \
-  -f value-overrides.yaml --set gloo.crds.create=true --set-string license_key=YOUR_LICENSE_KEY
-{{< /tab >}}
-{{< tab name="Helm 3" codelang="shell">}}
+```shell
 helm install gloo glooe/gloo-ee --namespace gloo-system \
   -f value-overrides.yaml --create-namespace --set-string license_key=YOUR_LICENSE_KEY
-{{< /tab >}}
-{{< /tabs >}}
+```
+
+{{% notice warning %}}
+Using Helm 2 is not supported in Gloo Edge v1.8.0.
+{{% /notice %}}
 
 #### List of Gloo Edge Helm chart values
 

--- a/docs/content/installation/gateway/kubernetes/_index.md
+++ b/docs/content/installation/gateway/kubernetes/_index.md
@@ -85,12 +85,7 @@ may not be correct if you install by directly applying the dry run manifests, e.
 ### Installing on Kubernetes with Helm
 
 {{% notice warning %}}
-
-##### Helm 2 Compatibility
-* Using Helm 2 with open source Gloo Edge v1.2.3 and later or Gloo Edge Enterprise v1.2.0 and later requires explicitly setting `crds.create=true`, as this is how we are managing compatibility between Helm 2 and 3.
-* Helm 2 **IS NOT** compatible with the open source Gloo Edge chart in Gloo Edge versions v1.2.0 through v1.2.2.
-* However, Helm 2 **IS** compatible with all stable versions of the Gloo Edge Enterprise chart.
-* `glooctl` prior to v1.2.0 cannot be used to install open source Gloo Edge v1.2.0 and later or Gloo Edge Enterprise v1.0.0 and later. 
+Using Helm 2 is not supported in Gloo Edge v1.8.0.
 {{% /notice %}}
 
 As a first step, you have to add the Gloo Edge repository to the list of known chart repositories, as well as prepare the installation namespace:
@@ -103,31 +98,9 @@ kubectl create namespace my-namespace
 
 For an installation with all the default values, use one of the following commands:
 
-{{< tabs >}}
-{{% tab name="Helm 2" %}}
-There are two options for installing with Helm 2. Note that in Gloo Edge including and later than v1.2.3, you will have to explicitly set `crds.create=true`, as that is how we are managing compatibility between Helm 2 and 3.
-
-You may use `helm install`:
-
-```shell script
-helm install --name gloo gloo/gloo --namespace my-namespace --set crds.create=true
-```
-
-or `helm template`:
-```shell script
-# download the gloo chart with helm cli. this is required 
-# as helm template does not support remote repos
-# https://github.com/helm/helm/issues/4527
-helm fetch --untar --untardir . 'gloo/gloo'
-
-# deploy gloo resources to my-namespace with our value overrides
-helm template gloo --namespace my-namespace  --set crds.create=true | kubectl apply -f - -n my-namespace
-```
-{{< /tab >}}
-{{< tab name="Helm 3" codelang="shell">}}
+```shell
 helm install gloo gloo/gloo --namespace my-namespace
-{{< /tab >}}
-{{< /tabs >}}
+```
 
 Once you've installed Gloo Edge, please be sure [to verify your installation]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/#verify-your-installation" %}}).
 
@@ -151,14 +124,9 @@ settings:
 
 and use it to override default values in the Gloo Edge Helm chart:
 
-{{< tabs >}}
-{{< tab name="Helm 2" codelang="shell">}}
-helm install gloo/gloo --name gloo-custom-0-7-6 --namespace my-namespace -f value-overrides.yaml
-{{< /tab >}}
-{{< tab name="Helm 3" codelang="shell">}}
+```shell
 helm install gloo-custom-0-7-6 gloo/gloo --namespace my-namespace -f value-overrides.yaml
-{{< /tab >}}
-{{< /tabs >}}
+```
 
 #### List of Gloo Edge Helm chart values
 

--- a/docs/content/operations/upgrading/upgrade_steps.md
+++ b/docs/content/operations/upgrading/upgrade_steps.md
@@ -25,7 +25,6 @@ Once you have reviewed the changes in the new release, there are two components 
     * [Download release asset](#download-release-asset)
 * [Gloo Edge (server components)](#upgrading-the-server-components)
     * [Helm 3](#helm-3)
-    * [Helm 2](#helm-2)
 
 Before upgrading, always make sure to check our changelogs (refer to our 
 [open-source]({{% versioned_link_path fromRoot="/reference/changelog/open_source/" %}}) or 
@@ -159,7 +158,7 @@ load-balancer.
 
 #### Using Helm
 
-For Enterprise users of Gloo Edge, the process with either Helm 2 or 3 is the same. You'll just need to set your license
+For Enterprise users of Gloo Edge, the process with either Helm 3 is the same. You'll just need to set your license
 key during installation by using `--set license_key="$license"` (or include the line `license_key: $LICENSE-KEY` in
 your values file).
 
@@ -171,6 +170,10 @@ additional steps to ensure there is no downtime because the charts do not have t
 {{% /notice %}}
 
 ##### Helm 3
+
+{{% notice warning %}}
+Using Helm 2 is not supported in Gloo Edge v1.8.0.
+{{% /notice %}}
 
 If we have Gloo Edge released under the Helm release name `gloo` to `gloo-system`, upgrading the server components is easy:
 
@@ -191,27 +194,3 @@ Verify that Gloo Edge has the expected version:
 ~ > kubectl -n gloo-system get pod -l gloo=gloo -ojsonpath='{.items[0].spec.containers[0].image}'
 quay.io/solo-io/gloo:1.2.1
 ```
-
-##### Helm 2
-
-{{% notice warning %}}
-Using Helm 2 with open source Gloo Edge v1.2.3 and later or Gloo Edge Enterprise v1.2.0 and later requires explicitly setting
-`crds.create=true` on the first install, as this is how we are managing compatibility between Helm 2 and 3.
-{{% /notice %}}
-
-Helm upgrade command should just work:
-```bash
-~ > helm upgrade gloo gloo/gloo --namespace gloo-system
-```
-
-If you'd rather delete and reinstall to get a clean slate, take care to manage your CRDs as Helm v2 
-[does not support managing CRDs](https://github.com/helm/helm/issues/5871#issuecomment-522096388). As a result, if you
-try to upgrade through deleting a helm release (`helm delete --purge gloo`) and reinstalling via `helm install`, you
-may encounter an error stating that a CRD already exists.
-
-```bash
-~ > helm install gloo/gloo --name gloo --namespace gloo-system --set crds.create=true
-Error: customresourcedefinitions.apiextensions.k8s.io "authconfigs.enterprise.gloo.solo.io" already exists
-```
-
-To successfully reinstall, run the same install command with `crds.create=false`.


### PR DESCRIPTION
# Description

Helm 2 has been deprecated and there will be no further Helm v2 releases (even for security patches). Gloo 1.8 uses `deepCopy` functionality that is only supported in Helm 3.  

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works