### PR TITLE
Remove trailing whitespace from helm templates.

### DIFF
--- a/changelog/v1.8.0-beta12/configmap-remove-trailing-whitespace.yaml
+++ b/changelog/v1.8.0-beta12/configmap-remove-trailing-whitespace.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Remove trailing whitespace from helm templates to make gateway-proxy-envoy-config configmap readable.
+    issueLink: https://github.com/solo-io/gloo/issues/4645

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -40,7 +40,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gloo
       volumes:
 {{- if .Values.global.glooMtls.enabled }}

--- a/install/helm/gloo/templates/10-ingress-deployment.yaml
+++ b/install/helm/gloo/templates/10-ingress-deployment.yaml
@@ -35,7 +35,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       securityContext:
         runAsNonRoot: true
         {{- if not .Values.ingress.deployment.floatingUserId }}

--- a/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
@@ -37,7 +37,7 @@ spec:
         {{- end }}
       {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       containers:
       - args: ["--disable-hot-restart"]
         env:

--- a/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/14-clusteringress-proxy-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       containers:
       - args: ["--disable-hot-restart"]
         env:

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -21,7 +21,7 @@ spec:
       labels:
         gloo: gloo-mtls-certs
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: certgen
       containers:
         - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/26-knative-external-proxy-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       containers:
       - args: ["--disable-hot-restart"]
         env:

--- a/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/29-knative-internal-proxy-deployment.yaml
@@ -36,7 +36,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       containers:
       - args: ["--disable-hot-restart"]
         env:

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -43,7 +43,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: discovery
       containers:
       - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/5-gateway-deployment.yaml
+++ b/install/helm/gloo/templates/5-gateway-deployment.yaml
@@ -41,7 +41,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gateway
       containers:
       - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/6-access-logger-deployment.yaml
+++ b/install/helm/gloo/templates/6-access-logger-deployment.yaml
@@ -44,7 +44,7 @@ spec:
         {{- end }}
         {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gateway-proxy
       securityContext:
         runAsNonRoot: true

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -26,7 +26,7 @@ spec:
         sidecar.istio.io/inject: "false"
       {{- end }}
     spec:
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: certgen
       containers:
         - image: {{template "gloo.image" $image}}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -110,7 +110,7 @@ spec:
       {{ toYaml $spec.affinity | nindent 8 }}
 {{- end }}
 {{- end}}
-      {{- include "gloo.pullSecret" $image | nindent 6 }}
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gateway-proxy
       {{- if $spec.extraInitContainersHelper }}
       initContainers:
@@ -238,12 +238,12 @@ spec:
         - mountPath: /etc/envoy/ssl
           name: gloo-mtls-certs
           readOnly: true
-{{- end}} {{/* $global.glooMtls.enabled */}}
+{{- end}} {{- /* $global.glooMtls.enabled */}}
 {{- if $spec.extraContainersHelper }}
         - mountPath: /usr/share/shared-data
           name: shared-data
 {{- include $spec.extraContainersHelper $ | nindent 6 }}
-{{- end }} {{/* $spec.extraContainersHelper */}}
+{{- end }} {{- /* $spec.extraContainersHelper */}}
 {{- if or $global.glooMtls.enabled $global.istioSDS.enabled }}
       {{- $sdsImage := merge $global.glooMtls.sds.image $global.image }}
       - name: sds
@@ -286,7 +286,7 @@ spec:
         - containerPort: 8234
           name: sds
           protocol: TCP
-{{- end }} {{/* $global.glooMtls.enabled or $.Values.istioSDS.enabled */}}
+{{- end }} {{- /* $global.glooMtls.enabled or $.Values.istioSDS.enabled */}}
       {{- if $spec.kind.daemonSet }}
       {{- if $spec.kind.daemonSet.hostPort}}
       hostNetwork: true

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -28,8 +28,8 @@ spec:
     {{- range . }}
     - {{ . }}
     {{- end }}
-{{- end }} {{/* with spec.service.externalIPs */}}
-{{- end }} {{/* $spec.service.externalIPs */}}
+{{- end }} {{- /* with spec.service.externalIPs */}}
+{{- end }} {{- /* $spec.service.externalIPs */}}
 {{- if $spec.service.externalTrafficPolicy }}
   externalTrafficPolicy: {{ $spec.service.externalTrafficPolicy }}
 {{- end }}
@@ -73,8 +73,8 @@ spec:
     protocol: TCP
     name: failover
     nodePort: {{ $spec.failover.nodePort }}
-{{- end }} {{/* if failover.enabled */}}
-{{- end }} {{/* if failover */}}
+{{- end }} {{- /* if failover.enabled */}}
+{{- end }} {{- /* if failover */}}
 {{- if $spec.service.customPorts }}
 {{ toYaml $spec.service.customPorts | indent 2 }}
 {{- end}}

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -45,10 +45,10 @@ data:
     static_resources:
 {{- if or $statsConfig.enabled (or $spec.readConfig $spec.extraListenersHelper) }}
       listeners:
-{{- end }} {{/* if or $statsConfig.enabled (or $spec.readConfig $spec.extraListenersHelper) */}}
+{{- end }} {{- /* if or $statsConfig.enabled (or $spec.readConfig $spec.extraListenersHelper) */}}
 {{- if $spec.extraListenersHelper }}
 {{- include $spec.extraListenersHelper $ | nindent 8 }}
-{{- end }} {{/* $spec.extraListenersHelper */}}
+{{- end }} {{- /* $spec.extraListenersHelper */}}
 {{- if $statsConfig.enabled }}
         - name: prometheus_listener
           address:
@@ -86,7 +86,7 @@ data:
                                 cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router
-{{- end}} {{/* if $statsConfig.enabled */}}
+{{- end}} {{- /* if $statsConfig.enabled */}}
 {{- if $spec.readConfig }}
         - name: read_config_listener
           address:
@@ -130,7 +130,7 @@ data:
                                 cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router
-{{- end}} {{/* if $spec.readConfig */}}
+{{- end}} {{- /* if $spec.readConfig */}}
       clusters:
       - name: gloo.{{ $.Release.Namespace }}.svc.{{ $.Values.k8s.clusterName}}:{{ $.Values.gloo.deployment.xdsPort }}
         alt_stat_name: xds_cluster
@@ -264,12 +264,12 @@ data:
                             port_value: {{$.Values.accessLogger.port}}
         http2_protocol_options: {}
         type: STRICT_DNS
-{{- end}} {{/* if .Values.accessLogger.enabled */}}
+{{- end}} {{- /* if .Values.accessLogger.enabled */}}
 {{- if $spec.tracing -}}
 {{- if $spec.tracing.cluster}}
 {{ toYaml $spec.tracing.cluster | indent 6}}
-{{- end}} {{/* if $spec.tracing.cluster */}}
-{{- end}} {{/* if $spec.tracing */}}
+{{- end}} {{- /* if $spec.tracing.cluster */}}
+{{- end}} {{- /* if $spec.tracing */}}
 
 {{- if $.Values.settings.aws.enableServiceAccountCredentials }}
       - name: aws_sts_cluster
@@ -298,7 +298,7 @@ data:
 {{- else }}
                     address: sts.{{ $.Values.settings.aws.stsCredentialsRegion }}.amazonaws.com
 {{- end }}
-{{- end}} {{/* if $.Values.settings.aws.enableServiceAccountCredentials */}}
+{{- end}} {{- /* if $.Values.settings.aws.enableServiceAccountCredentials */}}
 
 {{- if or $statsConfig.enabled ($spec.readConfig) }}
       - name: admin_port_cluster
@@ -314,7 +314,7 @@ data:
                   socket_address:
                     address: {{ $spec.loopBackAddress }}
                     port_value: 19000
-{{- end}} {{/* if or $statsConfig.enabled ($spec.readConfig) */}}
+{{- end}} {{- /* if or $statsConfig.enabled ($spec.readConfig) */}}
 {{- if $spec.envoyStaticClusters }}
 {{ toYaml $spec.envoyStaticClusters | indent 6}}
 {{- end}}

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -27,5 +27,5 @@ Expand the name of a container image
 {{- if .pullSecret -}}
 imagePullSecrets:
 - name: {{ .pullSecret }}
-{{- end -}}
+{{ end -}}
 {{- end -}}


### PR DESCRIPTION
# Description

Remove trailing whitespace from helm templates.

This bug fixes https://github.com/solo-io/gloo/issues/4645

# Context

Trailing whitespace was causing our gateway-proxy-envoy-config configmap to be non-human readable (relevant kubernetes bug: https://github.com/kubernetes/kubernetes/issues/36222#issuecomment-426587162).  Tests and/or lint checks to be added in follow-up PR to ensure this doesn't happen again moving forward.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4645