### PR TITLE
Expose envoy custom tags via environment variable & literal

### DIFF
--- a/changelog/v1.8.0-beta12/tracing-customtags-envvar-literal.yaml
+++ b/changelog/v1.8.0-beta12/tracing-customtags-envvar-literal.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/4699
+    description: Exposes envoy functionality to define tracing custom tags based on environment variables and literals.

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/tracing/tracing.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/tracing/tracing.proto.sk.md
@@ -14,6 +14,8 @@ weight: 5
 - [ListenerTracingSettings](#listenertracingsettings)
 - [RouteTracingSettings](#routetracingsettings)
 - [TracePercentages](#tracepercentages)
+- [TracingTagEnvironmentVariable](#tracingtagenvironmentvariable)
+- [TracingTagLiteral](#tracingtagliteral)
   
 
 
@@ -38,6 +40,8 @@ See here for additional information about configuring tracing with Gloo: https:/
 "tracePercentages": .tracing.options.gloo.solo.io.TracePercentages
 "zipkinConfig": .solo.io.envoy.config.trace.v3.ZipkinConfig
 "datadogConfig": .solo.io.envoy.config.trace.v3.DatadogConfig
+"environmentVariablesForTags": []tracing.options.gloo.solo.io.TracingTagEnvironmentVariable
+"literalsForTags": []tracing.options.gloo.solo.io.TracingTagLiteral
 
 ```
 
@@ -48,6 +52,8 @@ See here for additional information about configuring tracing with Gloo: https:/
 | `tracePercentages` | [.tracing.options.gloo.solo.io.TracePercentages](../tracing.proto.sk/#tracepercentages) | Requests can produce traces by random sampling or when the `x-client-trace-id` header is provided. TracePercentages defines the limits for random, forced, and overall tracing percentages. |
 | `zipkinConfig` | [.solo.io.envoy.config.trace.v3.ZipkinConfig](../../../../external/envoy/config/trace/v3/zipkin.proto.sk/#zipkinconfig) |  Only one of `zipkinConfig` or `datadogConfig` can be set. |
 | `datadogConfig` | [.solo.io.envoy.config.trace.v3.DatadogConfig](../../../../external/envoy/config/trace/v3/datadog.proto.sk/#datadogconfig) |  Only one of `datadogConfig` or `zipkinConfig` can be set. |
+| `environmentVariablesForTags` | [[]tracing.options.gloo.solo.io.TracingTagEnvironmentVariable](../tracing.proto.sk/#tracingtagenvironmentvariable) | Optional. If specified, Envoy will include the environment variables with the given tag as tracing tags. |
+| `literalsForTags` | [[]tracing.options.gloo.solo.io.TracingTagLiteral](../tracing.proto.sk/#tracingtagliteral) | Optional. If specified, Envoy will include the literals with the given tag as tracing tags. |
 
 
 
@@ -96,6 +102,50 @@ TracePercentages defines the limits for random, forced, and overall tracing perc
 | `clientSamplePercentage` | [.google.protobuf.FloatValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/float-value) | Percentage of requests that should produce traces when the `x-client-trace-id` header is provided. optional, defaults to 100.0 This should be a value between 0.0 and 100.0, with up to 6 significant digits. |
 | `randomSamplePercentage` | [.google.protobuf.FloatValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/float-value) | Percentage of requests that should produce traces by random sampling. optional, defaults to 100.0 This should be a value between 0.0 and 100.0, with up to 6 significant digits. |
 | `overallSamplePercentage` | [.google.protobuf.FloatValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/float-value) | Overall percentage of requests that should produce traces. optional, defaults to 100.0 This should be a value between 0.0 and 100.0, with up to 6 significant digits. |
+
+
+
+
+---
+### TracingTagEnvironmentVariable
+
+ 
+Requests can produce traces with custom tags.
+TracingTagEnvironmentVariable defines an environment variable which gets added as custom tag.
+
+```yaml
+"tag": string
+"name": string
+"defaultValue": string
+
+```
+
+| Field | Type | Description |
+| ----- | ---- | ----------- | 
+| `tag` | `string` | Used to populate the tag name. |
+| `name` | `string` | Environment variable name to obtain the value to populate the tag value. |
+| `defaultValue` | `string` | When the environment variable is not found, the tag value will be populated with this default value if specified, otherwise no tag will be populated. |
+
+
+
+
+---
+### TracingTagLiteral
+
+ 
+Requests can produce traces with custom tags.
+TracingTagLiteral defines a literal which gets added as custom tag.
+
+```yaml
+"tag": string
+"value": string
+
+```
+
+| Field | Type | Description |
+| ----- | ---- | ----------- | 
+| `tag` | `string` | Used to populate the tag name. |
+| `value` | `string` | Static literal value to populate the tag value. |
 
 
 

--- a/docs/data/ProtoMap.yaml
+++ b/docs/data/ProtoMap.yaml
@@ -1322,6 +1322,12 @@ apis:
   tracing.options.gloo.solo.io.TracePercentages:
     relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/tracing/tracing.proto.sk/#TracePercentages
     package: tracing.options.gloo.solo.io
+  tracing.options.gloo.solo.io.TracingTagEnvironmentVariable:
+    relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/tracing/tracing.proto.sk/#TracingTagEnvironmentVariable
+    package: tracing.options.gloo.solo.io
+  tracing.options.gloo.solo.io.TracingTagLiteral:
+    relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/tracing/tracing.proto.sk/#TracingTagLiteral
+    package: tracing.options.gloo.solo.io
   transformation.options.gloo.solo.io.Parameters:
     relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/transformation/parameters.proto.sk/#Parameters
     package: transformation.options.gloo.solo.io

--- a/projects/gloo/api/v1/options/tracing/tracing.proto
+++ b/projects/gloo/api/v1/options/tracing/tracing.proto
@@ -34,6 +34,10 @@ message ListenerTracingSettings {
         .solo.io.envoy.config.trace.v3.ZipkinConfig zipkin_config = 4;
         .solo.io.envoy.config.trace.v3.DatadogConfig datadog_config = 5;
     }
+    // Optional. If specified, Envoy will include the environment variables with the given tag as tracing tags.
+    repeated TracingTagEnvironmentVariable environment_variables_for_tags = 6;
+    // Optional. If specified, Envoy will include the literals with the given tag as tracing tags.
+    repeated TracingTagLiteral literals_for_tags = 7;
 }
 
 // Contains settings for configuring Envoy's tracing capabilities at the route level.
@@ -66,4 +70,25 @@ message TracePercentages {
     // optional, defaults to 100.0
     // This should be a value between 0.0 and 100.0, with up to 6 significant digits.
     google.protobuf.FloatValue overall_sample_percentage = 3;
+}
+
+// Requests can produce traces with custom tags.
+// TracingTagEnvironmentVariable defines an environment variable which gets added as custom tag.
+message TracingTagEnvironmentVariable {
+    // Used to populate the tag name.
+    string tag = 1;
+    // Environment variable name to obtain the value to populate the tag value.
+    string name = 2;
+    // When the environment variable is not found, the tag value will be populated with this default value if specified,
+    // otherwise no tag will be populated.
+    string default_value = 3;
+}
+
+// Requests can produce traces with custom tags.
+// TracingTagLiteral defines a literal which gets added as custom tag.
+message TracingTagLiteral {
+    // Used to populate the tag name.
+    string tag = 1;
+    // Static literal value to populate the tag value.
+    string value = 2;
 }

--- a/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.equal.go
+++ b/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.equal.go
@@ -71,6 +71,40 @@ func (m *ListenerTracingSettings) Equal(that interface{}) bool {
 		}
 	}
 
+	if len(m.GetEnvironmentVariablesForTags()) != len(target.GetEnvironmentVariablesForTags()) {
+		return false
+	}
+	for idx, v := range m.GetEnvironmentVariablesForTags() {
+
+		if h, ok := interface{}(v).(equality.Equalizer); ok {
+			if !h.Equal(target.GetEnvironmentVariablesForTags()[idx]) {
+				return false
+			}
+		} else {
+			if !proto.Equal(v, target.GetEnvironmentVariablesForTags()[idx]) {
+				return false
+			}
+		}
+
+	}
+
+	if len(m.GetLiteralsForTags()) != len(target.GetLiteralsForTags()) {
+		return false
+	}
+	for idx, v := range m.GetLiteralsForTags() {
+
+		if h, ok := interface{}(v).(equality.Equalizer); ok {
+			if !h.Equal(target.GetLiteralsForTags()[idx]) {
+				return false
+			}
+		} else {
+			if !proto.Equal(v, target.GetLiteralsForTags()[idx]) {
+				return false
+			}
+		}
+
+	}
+
 	switch m.ProviderConfig.(type) {
 
 	case *ListenerTracingSettings_ZipkinConfig:
@@ -210,6 +244,74 @@ func (m *TracePercentages) Equal(that interface{}) bool {
 		if !proto.Equal(m.GetOverallSamplePercentage(), target.GetOverallSamplePercentage()) {
 			return false
 		}
+	}
+
+	return true
+}
+
+// Equal function
+func (m *TracingTagEnvironmentVariable) Equal(that interface{}) bool {
+	if that == nil {
+		return m == nil
+	}
+
+	target, ok := that.(*TracingTagEnvironmentVariable)
+	if !ok {
+		that2, ok := that.(TracingTagEnvironmentVariable)
+		if ok {
+			target = &that2
+		} else {
+			return false
+		}
+	}
+	if target == nil {
+		return m == nil
+	} else if m == nil {
+		return false
+	}
+
+	if strings.Compare(m.GetTag(), target.GetTag()) != 0 {
+		return false
+	}
+
+	if strings.Compare(m.GetName(), target.GetName()) != 0 {
+		return false
+	}
+
+	if strings.Compare(m.GetDefaultValue(), target.GetDefaultValue()) != 0 {
+		return false
+	}
+
+	return true
+}
+
+// Equal function
+func (m *TracingTagLiteral) Equal(that interface{}) bool {
+	if that == nil {
+		return m == nil
+	}
+
+	target, ok := that.(*TracingTagLiteral)
+	if !ok {
+		that2, ok := that.(TracingTagLiteral)
+		if ok {
+			target = &that2
+		} else {
+			return false
+		}
+	}
+	if target == nil {
+		return m == nil
+	} else if m == nil {
+		return false
+	}
+
+	if strings.Compare(m.GetTag(), target.GetTag()) != 0 {
+		return false
+	}
+
+	if strings.Compare(m.GetValue(), target.GetValue()) != 0 {
+		return false
 	}
 
 	return true

--- a/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.go
+++ b/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.go
@@ -53,6 +53,10 @@ type ListenerTracingSettings struct {
 	//	*ListenerTracingSettings_ZipkinConfig
 	//	*ListenerTracingSettings_DatadogConfig
 	ProviderConfig isListenerTracingSettings_ProviderConfig `protobuf_oneof:"provider_config"`
+	// Optional. If specified, Envoy will include the environment variables with the given tag as tracing tags.
+	EnvironmentVariablesForTags []*TracingTagEnvironmentVariable `protobuf:"bytes,6,rep,name=environment_variables_for_tags,json=environmentVariablesForTags,proto3" json:"environment_variables_for_tags,omitempty"`
+	// Optional. If specified, Envoy will include the literals with the given tag as tracing tags.
+	LiteralsForTags []*TracingTagLiteral `protobuf:"bytes,7,rep,name=literals_for_tags,json=literalsForTags,proto3" json:"literals_for_tags,omitempty"`
 }
 
 func (x *ListenerTracingSettings) Reset() {
@@ -125,6 +129,20 @@ func (x *ListenerTracingSettings) GetZipkinConfig() *v3.ZipkinConfig {
 func (x *ListenerTracingSettings) GetDatadogConfig() *v3.DatadogConfig {
 	if x, ok := x.GetProviderConfig().(*ListenerTracingSettings_DatadogConfig); ok {
 		return x.DatadogConfig
+	}
+	return nil
+}
+
+func (x *ListenerTracingSettings) GetEnvironmentVariablesForTags() []*TracingTagEnvironmentVariable {
+	if x != nil {
+		return x.EnvironmentVariablesForTags
+	}
+	return nil
+}
+
+func (x *ListenerTracingSettings) GetLiteralsForTags() []*TracingTagLiteral {
+	if x != nil {
+		return x.LiteralsForTags
 	}
 	return nil
 }
@@ -291,6 +309,134 @@ func (x *TracePercentages) GetOverallSamplePercentage() *wrappers.FloatValue {
 	return nil
 }
 
+// Requests can produce traces with custom tags.
+// TracingTagEnvironmentVariable defines an environment variable which gets added as custom tag.
+type TracingTagEnvironmentVariable struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Used to populate the tag name.
+	Tag string `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	// Environment variable name to obtain the value to populate the tag value.
+	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	// When the environment variable is not found, the tag value will be populated with this default value if specified,
+	// otherwise no tag will be populated.
+	DefaultValue string `protobuf:"bytes,3,opt,name=default_value,json=defaultValue,proto3" json:"default_value,omitempty"`
+}
+
+func (x *TracingTagEnvironmentVariable) Reset() {
+	*x = TracingTagEnvironmentVariable{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes[3]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TracingTagEnvironmentVariable) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TracingTagEnvironmentVariable) ProtoMessage() {}
+
+func (x *TracingTagEnvironmentVariable) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes[3]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TracingTagEnvironmentVariable.ProtoReflect.Descriptor instead.
+func (*TracingTagEnvironmentVariable) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_rawDescGZIP(), []int{3}
+}
+
+func (x *TracingTagEnvironmentVariable) GetTag() string {
+	if x != nil {
+		return x.Tag
+	}
+	return ""
+}
+
+func (x *TracingTagEnvironmentVariable) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *TracingTagEnvironmentVariable) GetDefaultValue() string {
+	if x != nil {
+		return x.DefaultValue
+	}
+	return ""
+}
+
+// Requests can produce traces with custom tags.
+// TracingTagLiteral defines a literal which gets added as custom tag.
+type TracingTagLiteral struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	// Used to populate the tag name.
+	Tag string `protobuf:"bytes,1,opt,name=tag,proto3" json:"tag,omitempty"`
+	// Static literal value to populate the tag value.
+	Value string `protobuf:"bytes,2,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (x *TracingTagLiteral) Reset() {
+	*x = TracingTagLiteral{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes[4]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *TracingTagLiteral) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TracingTagLiteral) ProtoMessage() {}
+
+func (x *TracingTagLiteral) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes[4]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TracingTagLiteral.ProtoReflect.Descriptor instead.
+func (*TracingTagLiteral) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *TracingTagLiteral) GetTag() string {
+	if x != nil {
+		return x.Tag
+	}
+	return ""
+}
+
+func (x *TracingTagLiteral) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
 var File_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto protoreflect.FileDescriptor
 
 var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_rawDesc = []byte{
@@ -319,7 +465,7 @@ var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_pr
 	0x78, 0x74, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x1a, 0x2c, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62,
 	0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x6f, 0x6c, 0x6f, 0x2d, 0x69, 0x6f, 0x2f, 0x73, 0x6f, 0x6c,
 	0x6f, 0x2d, 0x6b, 0x69, 0x74, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x76, 0x31, 0x2f, 0x72, 0x65, 0x66,
-	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0x87, 0x03, 0x0a, 0x17, 0x4c, 0x69, 0x73, 0x74, 0x65,
+	0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x22, 0xe7, 0x04, 0x0a, 0x17, 0x4c, 0x69, 0x73, 0x74, 0x65,
 	0x6e, 0x65, 0x72, 0x54, 0x72, 0x61, 0x63, 0x69, 0x6e, 0x67, 0x53, 0x65, 0x74, 0x74, 0x69, 0x6e,
 	0x67, 0x73, 0x12, 0x37, 0x0a, 0x18, 0x72, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x5f, 0x68, 0x65,
 	0x61, 0x64, 0x65, 0x72, 0x73, 0x5f, 0x66, 0x6f, 0x72, 0x5f, 0x74, 0x61, 0x67, 0x73, 0x18, 0x01,
@@ -342,7 +488,21 @@ var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_pr
 	0x2e, 0x73, 0x6f, 0x6c, 0x6f, 0x2e, 0x69, 0x6f, 0x2e, 0x65, 0x6e, 0x76, 0x6f, 0x79, 0x2e, 0x63,
 	0x6f, 0x6e, 0x66, 0x69, 0x67, 0x2e, 0x74, 0x72, 0x61, 0x63, 0x65, 0x2e, 0x76, 0x33, 0x2e, 0x44,
 	0x61, 0x74, 0x61, 0x64, 0x6f, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x48, 0x00, 0x52, 0x0d,
-	0x64, 0x61, 0x74, 0x61, 0x64, 0x6f, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x42, 0x11, 0x0a,
+	0x64, 0x61, 0x74, 0x61, 0x64, 0x6f, 0x67, 0x43, 0x6f, 0x6e, 0x66, 0x69, 0x67, 0x12, 0x80, 0x01,
+	0x0a, 0x1e, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x5f, 0x76, 0x61,
+	0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x5f, 0x66, 0x6f, 0x72, 0x5f, 0x74, 0x61, 0x67, 0x73,
+	0x18, 0x06, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x3b, 0x2e, 0x74, 0x72, 0x61, 0x63, 0x69, 0x6e, 0x67,
+	0x2e, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x67, 0x6c, 0x6f, 0x6f, 0x2e, 0x73, 0x6f,
+	0x6c, 0x6f, 0x2e, 0x69, 0x6f, 0x2e, 0x54, 0x72, 0x61, 0x63, 0x69, 0x6e, 0x67, 0x54, 0x61, 0x67,
+	0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61,
+	0x62, 0x6c, 0x65, 0x52, 0x1b, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
+	0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x46, 0x6f, 0x72, 0x54, 0x61, 0x67, 0x73,
+	0x12, 0x5b, 0x0a, 0x11, 0x6c, 0x69, 0x74, 0x65, 0x72, 0x61, 0x6c, 0x73, 0x5f, 0x66, 0x6f, 0x72,
+	0x5f, 0x74, 0x61, 0x67, 0x73, 0x18, 0x07, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2f, 0x2e, 0x74, 0x72,
+	0x61, 0x63, 0x69, 0x6e, 0x67, 0x2e, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2e, 0x67, 0x6c,
+	0x6f, 0x6f, 0x2e, 0x73, 0x6f, 0x6c, 0x6f, 0x2e, 0x69, 0x6f, 0x2e, 0x54, 0x72, 0x61, 0x63, 0x69,
+	0x6e, 0x67, 0x54, 0x61, 0x67, 0x4c, 0x69, 0x74, 0x65, 0x72, 0x61, 0x6c, 0x52, 0x0f, 0x6c, 0x69,
+	0x74, 0x65, 0x72, 0x61, 0x6c, 0x73, 0x46, 0x6f, 0x72, 0x54, 0x61, 0x67, 0x73, 0x42, 0x11, 0x0a,
 	0x0f, 0x70, 0x72, 0x6f, 0x76, 0x69, 0x64, 0x65, 0x72, 0x5f, 0x63, 0x6f, 0x6e, 0x66, 0x69, 0x67,
 	0x22, 0xd8, 0x01, 0x0a, 0x14, 0x52, 0x6f, 0x75, 0x74, 0x65, 0x54, 0x72, 0x61, 0x63, 0x69, 0x6e,
 	0x67, 0x53, 0x65, 0x74, 0x74, 0x69, 0x6e, 0x67, 0x73, 0x12, 0x29, 0x0a, 0x10, 0x72, 0x6f, 0x75,
@@ -375,12 +535,23 @@ var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_pr
 	0x0b, 0x32, 0x1b, 0x2e, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f,
 	0x62, 0x75, 0x66, 0x2e, 0x46, 0x6c, 0x6f, 0x61, 0x74, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x52, 0x17,
 	0x6f, 0x76, 0x65, 0x72, 0x61, 0x6c, 0x6c, 0x53, 0x61, 0x6d, 0x70, 0x6c, 0x65, 0x50, 0x65, 0x72,
-	0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x42, 0x4a, 0x5a, 0x40, 0x67, 0x69, 0x74, 0x68, 0x75,
-	0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73, 0x6f, 0x6c, 0x6f, 0x2d, 0x69, 0x6f, 0x2f, 0x67, 0x6c,
-	0x6f, 0x6f, 0x2f, 0x70, 0x72, 0x6f, 0x6a, 0x65, 0x63, 0x74, 0x73, 0x2f, 0x67, 0x6c, 0x6f, 0x6f,
-	0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x61, 0x70, 0x69, 0x2f, 0x76, 0x31, 0x2f, 0x6f, 0x70, 0x74, 0x69,
-	0x6f, 0x6e, 0x73, 0x2f, 0x74, 0x72, 0x61, 0x63, 0x69, 0x6e, 0x67, 0xb8, 0xf5, 0x04, 0x01, 0xc0,
-	0xf5, 0x04, 0x01, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x63, 0x65, 0x6e, 0x74, 0x61, 0x67, 0x65, 0x22, 0x6a, 0x0a, 0x1d, 0x54, 0x72, 0x61, 0x63, 0x69,
+	0x6e, 0x67, 0x54, 0x61, 0x67, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
+	0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12, 0x10, 0x0a, 0x03, 0x74, 0x61, 0x67, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x74, 0x61, 0x67, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61,
+	0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x23,
+	0x0a, 0x0d, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x5f, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18,
+	0x03, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0c, 0x64, 0x65, 0x66, 0x61, 0x75, 0x6c, 0x74, 0x56, 0x61,
+	0x6c, 0x75, 0x65, 0x22, 0x3b, 0x0a, 0x11, 0x54, 0x72, 0x61, 0x63, 0x69, 0x6e, 0x67, 0x54, 0x61,
+	0x67, 0x4c, 0x69, 0x74, 0x65, 0x72, 0x61, 0x6c, 0x12, 0x10, 0x0a, 0x03, 0x74, 0x61, 0x67, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x03, 0x74, 0x61, 0x67, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61,
+	0x6c, 0x75, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65,
+	0x42, 0x4a, 0x5a, 0x40, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x73,
+	0x6f, 0x6c, 0x6f, 0x2d, 0x69, 0x6f, 0x2f, 0x67, 0x6c, 0x6f, 0x6f, 0x2f, 0x70, 0x72, 0x6f, 0x6a,
+	0x65, 0x63, 0x74, 0x73, 0x2f, 0x67, 0x6c, 0x6f, 0x6f, 0x2f, 0x70, 0x6b, 0x67, 0x2f, 0x61, 0x70,
+	0x69, 0x2f, 0x76, 0x31, 0x2f, 0x6f, 0x70, 0x74, 0x69, 0x6f, 0x6e, 0x73, 0x2f, 0x74, 0x72, 0x61,
+	0x63, 0x69, 0x6e, 0x67, 0xb8, 0xf5, 0x04, 0x01, 0xc0, 0xf5, 0x04, 0x01, 0x62, 0x06, 0x70, 0x72,
+	0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -395,30 +566,34 @@ func file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_p
 	return file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_rawDescData
 }
 
-var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
 var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_goTypes = []interface{}{
-	(*ListenerTracingSettings)(nil), // 0: tracing.options.gloo.solo.io.ListenerTracingSettings
-	(*RouteTracingSettings)(nil),    // 1: tracing.options.gloo.solo.io.RouteTracingSettings
-	(*TracePercentages)(nil),        // 2: tracing.options.gloo.solo.io.TracePercentages
-	(*v3.ZipkinConfig)(nil),         // 3: solo.io.envoy.config.trace.v3.ZipkinConfig
-	(*v3.DatadogConfig)(nil),        // 4: solo.io.envoy.config.trace.v3.DatadogConfig
-	(*wrappers.BoolValue)(nil),      // 5: google.protobuf.BoolValue
-	(*wrappers.FloatValue)(nil),     // 6: google.protobuf.FloatValue
+	(*ListenerTracingSettings)(nil),       // 0: tracing.options.gloo.solo.io.ListenerTracingSettings
+	(*RouteTracingSettings)(nil),          // 1: tracing.options.gloo.solo.io.RouteTracingSettings
+	(*TracePercentages)(nil),              // 2: tracing.options.gloo.solo.io.TracePercentages
+	(*TracingTagEnvironmentVariable)(nil), // 3: tracing.options.gloo.solo.io.TracingTagEnvironmentVariable
+	(*TracingTagLiteral)(nil),             // 4: tracing.options.gloo.solo.io.TracingTagLiteral
+	(*v3.ZipkinConfig)(nil),               // 5: solo.io.envoy.config.trace.v3.ZipkinConfig
+	(*v3.DatadogConfig)(nil),              // 6: solo.io.envoy.config.trace.v3.DatadogConfig
+	(*wrappers.BoolValue)(nil),            // 7: google.protobuf.BoolValue
+	(*wrappers.FloatValue)(nil),           // 8: google.protobuf.FloatValue
 }
 var file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_depIdxs = []int32{
-	2, // 0: tracing.options.gloo.solo.io.ListenerTracingSettings.trace_percentages:type_name -> tracing.options.gloo.solo.io.TracePercentages
-	3, // 1: tracing.options.gloo.solo.io.ListenerTracingSettings.zipkin_config:type_name -> solo.io.envoy.config.trace.v3.ZipkinConfig
-	4, // 2: tracing.options.gloo.solo.io.ListenerTracingSettings.datadog_config:type_name -> solo.io.envoy.config.trace.v3.DatadogConfig
-	2, // 3: tracing.options.gloo.solo.io.RouteTracingSettings.trace_percentages:type_name -> tracing.options.gloo.solo.io.TracePercentages
-	5, // 4: tracing.options.gloo.solo.io.RouteTracingSettings.propagate:type_name -> google.protobuf.BoolValue
-	6, // 5: tracing.options.gloo.solo.io.TracePercentages.client_sample_percentage:type_name -> google.protobuf.FloatValue
-	6, // 6: tracing.options.gloo.solo.io.TracePercentages.random_sample_percentage:type_name -> google.protobuf.FloatValue
-	6, // 7: tracing.options.gloo.solo.io.TracePercentages.overall_sample_percentage:type_name -> google.protobuf.FloatValue
-	8, // [8:8] is the sub-list for method output_type
-	8, // [8:8] is the sub-list for method input_type
-	8, // [8:8] is the sub-list for extension type_name
-	8, // [8:8] is the sub-list for extension extendee
-	0, // [0:8] is the sub-list for field type_name
+	2,  // 0: tracing.options.gloo.solo.io.ListenerTracingSettings.trace_percentages:type_name -> tracing.options.gloo.solo.io.TracePercentages
+	5,  // 1: tracing.options.gloo.solo.io.ListenerTracingSettings.zipkin_config:type_name -> solo.io.envoy.config.trace.v3.ZipkinConfig
+	6,  // 2: tracing.options.gloo.solo.io.ListenerTracingSettings.datadog_config:type_name -> solo.io.envoy.config.trace.v3.DatadogConfig
+	3,  // 3: tracing.options.gloo.solo.io.ListenerTracingSettings.environment_variables_for_tags:type_name -> tracing.options.gloo.solo.io.TracingTagEnvironmentVariable
+	4,  // 4: tracing.options.gloo.solo.io.ListenerTracingSettings.literals_for_tags:type_name -> tracing.options.gloo.solo.io.TracingTagLiteral
+	2,  // 5: tracing.options.gloo.solo.io.RouteTracingSettings.trace_percentages:type_name -> tracing.options.gloo.solo.io.TracePercentages
+	7,  // 6: tracing.options.gloo.solo.io.RouteTracingSettings.propagate:type_name -> google.protobuf.BoolValue
+	8,  // 7: tracing.options.gloo.solo.io.TracePercentages.client_sample_percentage:type_name -> google.protobuf.FloatValue
+	8,  // 8: tracing.options.gloo.solo.io.TracePercentages.random_sample_percentage:type_name -> google.protobuf.FloatValue
+	8,  // 9: tracing.options.gloo.solo.io.TracePercentages.overall_sample_percentage:type_name -> google.protobuf.FloatValue
+	10, // [10:10] is the sub-list for method output_type
+	10, // [10:10] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_init() }
@@ -463,6 +638,30 @@ func file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_p
 				return nil
 			}
 		}
+		file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes[3].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TracingTagEnvironmentVariable); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes[4].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*TracingTagLiteral); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_msgTypes[0].OneofWrappers = []interface{}{
 		(*ListenerTracingSettings_ZipkinConfig)(nil),
@@ -474,7 +673,7 @@ func file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_p
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_github_com_solo_io_gloo_projects_gloo_api_v1_options_tracing_tracing_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   3,
+			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.hash.go
+++ b/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.hash.go
@@ -71,6 +71,54 @@ func (m *ListenerTracingSettings) Hash(hasher hash.Hash64) (uint64, error) {
 		}
 	}
 
+	for _, v := range m.GetEnvironmentVariablesForTags() {
+
+		if h, ok := interface{}(v).(safe_hasher.SafeHasher); ok {
+			if _, err = hasher.Write([]byte("")); err != nil {
+				return 0, err
+			}
+			if _, err = h.Hash(hasher); err != nil {
+				return 0, err
+			}
+		} else {
+			if fieldValue, err := hashstructure.Hash(v, nil); err != nil {
+				return 0, err
+			} else {
+				if _, err = hasher.Write([]byte("")); err != nil {
+					return 0, err
+				}
+				if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+					return 0, err
+				}
+			}
+		}
+
+	}
+
+	for _, v := range m.GetLiteralsForTags() {
+
+		if h, ok := interface{}(v).(safe_hasher.SafeHasher); ok {
+			if _, err = hasher.Write([]byte("")); err != nil {
+				return 0, err
+			}
+			if _, err = h.Hash(hasher); err != nil {
+				return 0, err
+			}
+		} else {
+			if fieldValue, err := hashstructure.Hash(v, nil); err != nil {
+				return 0, err
+			} else {
+				if _, err = hasher.Write([]byte("")); err != nil {
+					return 0, err
+				}
+				if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+					return 0, err
+				}
+			}
+		}
+
+	}
+
 	switch m.ProviderConfig.(type) {
 
 	case *ListenerTracingSettings_ZipkinConfig:
@@ -253,6 +301,58 @@ func (m *TracePercentages) Hash(hasher hash.Hash64) (uint64, error) {
 				return 0, err
 			}
 		}
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// Hash function
+func (m *TracingTagEnvironmentVariable) Hash(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("tracing.options.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/tracing.TracingTagEnvironmentVariable")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetTag())); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetName())); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetDefaultValue())); err != nil {
+		return 0, err
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// Hash function
+func (m *TracingTagLiteral) Hash(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("tracing.options.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/tracing.TracingTagLiteral")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetTag())); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetValue())); err != nil {
+		return 0, err
 	}
 
 	return hasher.Sum64(), nil

--- a/projects/gloo/pkg/plugins/tracing/plugin_test.go
+++ b/projects/gloo/pkg/plugins/tracing/plugin_test.go
@@ -29,7 +29,24 @@ var _ = Describe("Plugin", func() {
 		hcmSettings := &hcm.HttpConnectionManagerSettings{
 			Tracing: &tracing.ListenerTracingSettings{
 				RequestHeadersForTags: []string{"header1", "header2"},
-				Verbose:               true,
+				EnvironmentVariablesForTags: []*tracing.TracingTagEnvironmentVariable{
+					{
+						Tag:  "k8s.pod.name",
+						Name: "POD_NAME",
+					},
+					{
+						Tag:          "k8s.pod.ip",
+						Name:         "POD_IP",
+						DefaultValue: "NO_POD_IP",
+					},
+				},
+				LiteralsForTags: []*tracing.TracingTagLiteral{
+					{
+						Tag:   "foo",
+						Value: "bar",
+					},
+				},
+				Verbose: true,
 				TracePercentages: &tracing.TracePercentages{
 					ClientSamplePercentage:  &wrappers.FloatValue{Value: 10},
 					RandomSamplePercentage:  &wrappers.FloatValue{Value: 20},
@@ -56,6 +73,31 @@ var _ = Describe("Plugin", func() {
 						Type: &envoytracing.CustomTag_RequestHeader{
 							RequestHeader: &envoytracing.CustomTag_Header{
 								Name: "header2",
+							},
+						},
+					},
+					{
+						Tag: "k8s.pod.name",
+						Type: &envoytracing.CustomTag_Environment_{
+							Environment: &envoytracing.CustomTag_Environment{
+								Name: "POD_NAME",
+							},
+						},
+					},
+					{
+						Tag: "k8s.pod.ip",
+						Type: &envoytracing.CustomTag_Environment_{
+							Environment: &envoytracing.CustomTag_Environment{
+								Name:         "POD_IP",
+								DefaultValue: "NO_POD_IP",
+							},
+						},
+					},
+					{
+						Tag: "foo",
+						Type: &envoytracing.CustomTag_Literal_{
+							Literal: &envoytracing.CustomTag_Literal{
+								Value: "bar",
 							},
 						},
 					},


### PR DESCRIPTION
# Description

Adding the possibility to add tracing custom tags based on environment variables and fixed literals in addition to request headers.

# Context

A mentioned in https://github.com/solo-io/gloo/issues/4699, it would be great to be able to add custom tags for tracing spans based on other sources then request headers - especially from environment variables. In combination with the K8s Downward API this would allow to add Kubernetes Information (Node Name, Namespace Name, Pod Name, ...) to a tracing span. E.g. according to the OpenTelemetry Specification.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4699