### PR TITLE
Fix field name in delegate action API documentation

### DIFF
--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway/api/v1/virtual_service.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway/api/v1/virtual_service.proto.sk.md
@@ -230,8 +230,8 @@ DelegateActions are used to delegate routing decisions to Route Tables.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
-| `name` | `string` | The name of the Route Table to delegate to. Deprecated: these fields have been added for backwards-compatibility. Please use the `single` field. If `name` and/or `namespace` have been specified, Gloo will ignore `single` and `selector`. |
-| `namespace` | `string` | The namespace of the Route Table to delegate to. Deprecated: these fields have been added for backwards-compatibility. Please use the `single` field. If `name` and/or `namespace` have been specified, Gloo will ignore `single` and `selector`. |
+| `name` | `string` | The name of the Route Table to delegate to. Deprecated: these fields have been added for backwards-compatibility. Please use the `ref` field. If `name` and/or `namespace` have been specified, Gloo will ignore `ref` and `selector`. |
+| `namespace` | `string` | The namespace of the Route Table to delegate to. Deprecated: these fields have been added for backwards-compatibility. Please use the `ref` field. If `name` and/or `namespace` have been specified, Gloo will ignore `ref` and `selector`. |
 | `ref` | [.core.solo.io.ResourceRef](../../../../../../solo-kit/api/v1/ref.proto.sk/#resourceref) | Delegate to the Route Table resource with the given `name` and `namespace. Only one of `ref` or `selector` can be set. |
 | `selector` | [.gateway.solo.io.RouteTableSelector](../virtual_service.proto.sk/#routetableselector) | Delegate to the Route Tables that match the given selector. Only one of `selector` or `ref` can be set. |
 

--- a/projects/gateway/api/v1/virtual_service.proto
+++ b/projects/gateway/api/v1/virtual_service.proto
@@ -224,13 +224,13 @@ message Route {
 message DelegateAction {
 
     // The name of the Route Table to delegate to.
-    // Deprecated: these fields have been added for backwards-compatibility. Please use the `single` field. If `name`
-    // and/or `namespace` have been specified, Gloo will ignore `single` and `selector`.
+    // Deprecated: these fields have been added for backwards-compatibility. Please use the `ref` field. If `name`
+    // and/or `namespace` have been specified, Gloo will ignore `ref` and `selector`.
     string name = 1 [deprecated = true];
 
     // The namespace of the Route Table to delegate to.
-    // Deprecated: these fields have been added for backwards-compatibility. Please use the `single` field. If `name`
-    // and/or `namespace` have been specified, Gloo will ignore `single` and `selector`.
+    // Deprecated: these fields have been added for backwards-compatibility. Please use the `ref` field. If `name`
+    // and/or `namespace` have been specified, Gloo will ignore `ref` and `selector`.
     string namespace = 2 [deprecated = true];
 
     oneof delegation_type {

--- a/projects/gateway/pkg/api/v1/virtual_service.pb.go
+++ b/projects/gateway/pkg/api/v1/virtual_service.pb.go
@@ -559,14 +559,14 @@ type DelegateAction struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The name of the Route Table to delegate to.
-	// Deprecated: these fields have been added for backwards-compatibility. Please use the `single` field. If `name`
-	// and/or `namespace` have been specified, Gloo will ignore `single` and `selector`.
+	// Deprecated: these fields have been added for backwards-compatibility. Please use the `ref` field. If `name`
+	// and/or `namespace` have been specified, Gloo will ignore `ref` and `selector`.
 	//
 	// Deprecated: Do not use.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// The namespace of the Route Table to delegate to.
-	// Deprecated: these fields have been added for backwards-compatibility. Please use the `single` field. If `name`
-	// and/or `namespace` have been specified, Gloo will ignore `single` and `selector`.
+	// Deprecated: these fields have been added for backwards-compatibility. Please use the `ref` field. If `name`
+	// and/or `namespace` have been specified, Gloo will ignore `ref` and `selector`.
 	//
 	// Deprecated: Do not use.
 	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`


### PR DESCRIPTION
Comments on the `DelegateAction` protobuf message were referencing a non-existing `single` field instead of the intended `ref` one.