### PR TITLE
update docker-compose-file docs to work with 1.7

### DIFF
--- a/changelog/v1.8.0-beta12/docker-compose-file-docs.yaml
+++ b/changelog/v1.8.0-beta12/docker-compose-file-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Update the Docker Compose docs to work with Gloo Edge 1.7+
+    issueLink: https://github.com/solo-io/gloo/issues/4692

--- a/docs/content/installation/gateway/development/docker-compose-file/_index.md
+++ b/docs/content/installation/gateway/development/docker-compose-file/_index.md
@@ -14,7 +14,7 @@ Fortunately, Gloo Edge provides alternate mechanisms for configuration, credenti
 This tutorial provides a basic installation flow for running Gloo Edge with Docker Compose, using the local filesystem of the containers to store configuration and credentials data.
 (A similar tutorial using Consul and Vault instead of the local filesystem can be found [here]({{< versioned_link_path fromRoot="/installation/gateway/development/docker-compose-consul/" >}}).)
 
-First we will copy the necessary files from the [Solo.io GitHub](https://github.com/solo-io/gloo) repository. 
+First we will copy the necessary files from the [Gloo Edge GitHub repository](https://github.com/solo-io/gloo).
 
 Then we will use `docker-compose` to create the containers for Gloo Edge and the Pet Store application.
 
@@ -103,6 +103,8 @@ The updated `data` directory structure should look like this:
 │   │   └── gloo-system
 │   │       └── gateway-proxy.yaml
 │   ├── proxies
+│   │   └── gloo-system
+│   ├── ratelimitconfigs
 │   │   └── gloo-system
 │   ├── routetables
 │   │   └── gloo-system

--- a/docs/content/installation/glooctl_setup.md
+++ b/docs/content/installation/glooctl_setup.md
@@ -30,7 +30,7 @@ Server: version undefined, could not find any version of gloo running
 
 #### Update glooctl CLI version
 
-You should always try to use the same minor `glooctl` version as the version of Gloo Edge instsalled in your cluster. Ie if you're using Gloo Edge 1.6.x, you should use a 1.6.x release of `glooctl`.
+You should always try to use the same minor `glooctl` version as the version of Gloo Edge installed in your cluster, i.e., if you're using Gloo Edge 1.6.x, you should use a 1.6.x release of `glooctl`.
 
 Fortunately, `glooctl` is able to update itself to different versions. To change the version of glooctl you currently have installed, you can run:
 

--- a/install/docker-compose-file/.gitignore
+++ b/install/docker-compose-file/.gitignore
@@ -1,0 +1,2 @@
+data/config/proxies
+

--- a/install/docker-compose-file/data/config/gateways/gloo-system/gateway-proxy.yaml
+++ b/install/docker-compose-file/data/config/gateways/gloo-system/gateway-proxy.yaml
@@ -8,4 +8,3 @@ proxyNames:
   - gateway-proxy
 ssl: false
 useProxyProto: false
-status: {}

--- a/install/docker-compose-file/data/config/virtualservices/gloo-system/default.yaml
+++ b/install/docker-compose-file/data/config/virtualservices/gloo-system/default.yaml
@@ -2,13 +2,6 @@ metadata:
   name: default
   namespace: gloo-system
   resourceVersion: "2"
-status:
-  reportedBy: gateway
-  state: Accepted
-  subresourceStatuses:
-    '*v1.Proxy.gloo-system.gateway-proxy':
-      reportedBy: gloo
-      state: Accepted
 virtualHost:
   domains:
   - '*'

--- a/install/docker-compose-file/data/envoy-config.yaml
+++ b/install/docker-compose-file/data/envoy-config.yaml
@@ -7,6 +7,7 @@ node:
 static_resources:
   clusters:
   - name: xds_cluster
+    http2_protocol_options: {}
     connect_timeout: 5.000s
     load_assignment:
       cluster_name: xds_cluster
@@ -21,13 +22,16 @@ static_resources:
     type: STRICT_DNS
 dynamic_resources:
   ads_config:
+    transport_api_version: V3
     api_type: GRPC
     grpc_services:
     - envoy_grpc: {cluster_name: xds_cluster}
   cds_config:
     ads: {}
+    resource_api_version: V3
   lds_config:
     ads: {}
+    resource_api_version: V3
 admin:
   access_log_path: /dev/null
   address:

--- a/install/docker-compose-file/docker-compose.yaml
+++ b/install/docker-compose-file/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   gloo:
-    image: "${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.5.12}"
+    image: "${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.7.6}"
     working_dir: /
     command:
     - "--dir=/data/"
@@ -14,7 +14,7 @@ services:
     restart: always
 
   gateway:
-    image: "${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.5.12}"
+    image: "${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.7.6}"
     working_dir: /
     command:
     - "--dir=/data/"
@@ -23,7 +23,7 @@ services:
     restart: always
 
   gateway-proxy:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.5.12}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.7.6}
     entrypoint: ["envoy"]
     command: ["-c", "/config/envoy.yaml", "--disable-hot-restart"]
     volumes:


### PR DESCRIPTION
# Description

Update the docker-compose-file docs to work with Gloo Edge 1.7+

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4692