### PR TITLE
Upgrade envoy and add helm value

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifeq ($(VERSION), $(WASM_VERSION))
 	WASM_VERSION = wasm-$(VERSION)
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.16.3
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.16.4
 ENVOY_GLOO_WASM_IMAGE ?= quay.io/solo-io/envoy-gloo:1.16.0-wasm-rc1
 
 # The full SHA of the currently checked out commit

--- a/changelog/v1.5.22/bump-envoy-gloo.yaml
+++ b/changelog/v1.5.22/bump-envoy-gloo.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: v1.16.4
+  - type: FIX
+    description: >-
+      Add helm setting to define envoy runtime override for CVE-2021-29492 (https://github.com/envoyproxy/envoy/security/advisories/GHSA-4987-27fx-x6cf).
+      By default, Envoy's behavior does not change to address this vulnerability. The desired Http Connection Manager runtime
+      setting option must be defined and is exposed as the `gatewayProxies.[proxy].pathWithEscapedSlashesAction` helm value.
+      See https://www.envoyproxy.io/docs/envoy/v1.16.4/configuration/http/http_conn_man/runtime.html for values.
+    issueLink: https://github.com/solo-io/gloo/issues/4727
+    resolvesIssue: false

--- a/changelog/v1.5.22/bump-envoy-gloo.yaml
+++ b/changelog/v1.5.22/bump-envoy-gloo.yaml
@@ -7,7 +7,7 @@ changelog:
     description: >-
       Add helm setting to define envoy runtime override for CVE-2021-29492 (https://github.com/envoyproxy/envoy/security/advisories/GHSA-4987-27fx-x6cf).
       By default, Envoy's behavior does not change to address this vulnerability. The desired Http Connection Manager runtime
-      setting option must be defined and is exposed as the `gatewayProxies.[proxy].pathWithEscapedSlashesAction` helm value.
+      setting option must be defined and is exposed as the `gatewayProxies.NAME.pathWithEscapedSlashesAction` helm value.
       See https://www.envoyproxy.io/docs/envoy/v1.16.4/configuration/http/http_conn_man/runtime.html for values.
     issueLink: https://github.com/solo-io/gloo/issues/4727
     resolvesIssue: false

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -327,6 +327,7 @@
 |gatewayProxies.NAME.failover.nodePort|uint||(Enterprise Only): Optional NodePort for failover Service|
 |gatewayProxies.NAME.failover.secretName|string||(Enterprise Only): Secret containing downstream Ssl Secrets Default is failover-downstream|
 |gatewayProxies.NAME.disabled|bool||Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations|
+|gatewayProxies.NAME.pathWithEscapedSlashesAction|uint32||Used to configure the Envoy Http Connection Manager's path_with_escaped_slashes_action runtime override setting. Defaults to 0 (IMPLEMENTATION_SPECIFIC_DEFAULT). See other value options here https://www.envoyproxy.io/docs/envoy/v1.16.4/configuration/http/http_conn_man/runtime.html|
 |gatewayProxies.gatewayProxy.kind.deployment.replicas|int|1|number of instances to deploy|
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].name|string|||
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].value|string|||
@@ -452,6 +453,7 @@
 |gatewayProxies.gatewayProxy.failover.nodePort|uint|0|(Enterprise Only): Optional NodePort for failover Service|
 |gatewayProxies.gatewayProxy.failover.secretName|string|failover-downstream|(Enterprise Only): Secret containing downstream Ssl Secrets Default is failover-downstream|
 |gatewayProxies.gatewayProxy.disabled|bool|false|Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations|
+|gatewayProxies.gatewayProxy.pathWithEscapedSlashesAction|uint32|0|Used to configure the Envoy Http Connection Manager's path_with_escaped_slashes_action runtime override setting. Defaults to 0 (IMPLEMENTATION_SPECIFIC_DEFAULT). See other value options here https://www.envoyproxy.io/docs/envoy/v1.16.4/configuration/http/http_conn_man/runtime.html|
 |ingress.enabled|bool|false||
 |ingress.deployment.image.tag|string|<release_version, ex: 1.2.3>|tag for the container|
 |ingress.deployment.image.repository|string|ingress|image name (repository) for the container.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -246,6 +246,7 @@ type GatewayProxy struct {
 	LoopBackAddress                string                       `json:"loopBackAddress,omitempty" desc:"Name on which to bind the loop-back interface for this instance of Envoy. Defaults to 127.0.0.1, but other common values may be localhost or ::1"`
 	Failover                       Failover                     `json:"failover" desc:"(Enterprise Only): Failover configuration"`
 	Disabled                       bool                         `json:"disabled,omitempty" desc:"Skips creation of this gateway proxy. Used to turn off gateway proxies created by preceding configurations"`
+	PathWithEscapedSlashesAction   uint32                       `json:"pathWithEscapedSlashesAction,omitempty" desc:"Used to configure the Envoy Http Connection Manager's path_with_escaped_slashes_action runtime override setting. Defaults to 0 (IMPLEMENTATION_SPECIFIC_DEFAULT). See other value options here https://www.envoyproxy.io/docs/envoy/v1.16.4/configuration/http/http_conn_man/runtime.html"`
 }
 
 type GatewayProxyGatewaySettings struct {

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -26,6 +26,8 @@ data:
         static_layer:
           overload:
             global_downstream_max_connections: {{ $spec.globalDownstreamMaxConnections }}
+          http_connection_manager:
+            path_with_escaped_slashes_action: {{ $spec.pathWithEscapedSlashesAction }}
       - name: admin_layer
         admin_layer: {}
     node:

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -26,8 +26,10 @@ data:
         static_layer:
           overload:
             global_downstream_max_connections: {{ $spec.globalDownstreamMaxConnections }}
+          {{- if $spec.pathWithEscapedSlashesAction }}
           http_connection_manager:
             path_with_escaped_slashes_action: {{ $spec.pathWithEscapedSlashesAction }}
+          {{- end }}
       - name: admin_layer
         admin_layer: {}
     node:

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -112,6 +112,7 @@ gatewayProxies:
         enabled: false
         sleepTimeSeconds: 25
       customReadinessProbe: {}
+      pathWithEscapedSlashesAction: 0
     service:
       customPorts: []
       type: LoadBalancer

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -112,7 +112,6 @@ gatewayProxies:
         enabled: false
         sleepTimeSeconds: 25
       customReadinessProbe: {}
-      pathWithEscapedSlashesAction: 0
     service:
       customPorts: []
       type: LoadBalancer

--- a/install/test/fixtures.go
+++ b/install/test/fixtures.go
@@ -895,3 +895,138 @@ static_resources:
         name: envoy.filters.network.http_connection_manager
     name: prometheus_listener
 `
+
+var confWithEscapedSlashesActionFmt = `
+layered_runtime:
+  layers:
+  - name: static_layer
+    static_layer:
+      overload:
+        global_downstream_max_connections: 250000
+      http_connection_manager:
+        path_with_escaped_slashes_action: 2
+  - name: admin_layer
+    admin_layer: {}
+node:
+  cluster: gateway
+  id: "{{.PodName}}.{{.PodNamespace}}"
+  metadata:
+    # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
+    role: "{{.PodNamespace}}~gateway-proxy"
+static_resources:
+  listeners: # if or $statsConfig.enabled (or $spec.readConfig $spec.extraListenersHelper) # $spec.extraListenersHelper
+  - name: prometheus_listener
+    address:
+      socket_address:
+        address: 0.0.0.0
+        port_value: 8081
+    filter_chains:
+    - filters:
+      - name: envoy.filters.network.http_connection_manager
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          codec_type: AUTO
+          stat_prefix: prometheus
+          route_config:
+            name: prometheus_route
+            virtual_hosts:
+            - name: prometheus_host
+              domains:
+              - "*"
+              routes:
+              - match:
+                  path: "/ready"
+                  headers:
+                  - name: ":method"
+                    exact_match: GET
+                route:
+                  cluster: admin_port_cluster
+              - match:
+                  prefix: "/metrics"
+                  headers:
+                  - name: ":method"
+                    exact_match: GET
+                route:
+                  prefix_rewrite: "/stats/prometheus"
+                  cluster: admin_port_cluster
+          http_filters:
+          - name: envoy.filters.http.router # if $spec.tracing # if $statsConfig.enabled # if $spec.readConfig
+  clusters:
+  - name: gloo.gloo-system.svc.cluster.local:9977
+    alt_stat_name: xds_cluster
+    connect_timeout: 5.000s
+    load_assignment:
+      cluster_name: gloo.gloo-system.svc.cluster.local:9977
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: gloo.gloo-system.svc.cluster.local
+                port_value: 9977
+    http2_protocol_options: {}
+    upstream_connection_options:
+      tcp_keepalive: {}
+    type: STRICT_DNS
+    respect_dns_ttl: true
+  - name: rest_xds_cluster
+    alt_stat_name: rest_xds_cluster
+    connect_timeout: 5.000s
+    load_assignment:
+      cluster_name: rest_xds_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: gloo.gloo-system.svc.cluster.local
+                port_value: 9976
+    upstream_connection_options:
+      tcp_keepalive: {}
+    type: STRICT_DNS
+    respect_dns_ttl: true
+  - name: wasm-cache
+    connect_timeout: 5.000s
+    load_assignment:
+      cluster_name: wasm-cache
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: gloo.gloo-system.svc.cluster.local
+                port_value: 9979
+    upstream_connection_options:
+      tcp_keepalive: {}
+    type: STRICT_DNS
+    respect_dns_ttl: true
+  - name: admin_port_cluster
+    connect_timeout: 5.000s
+    type: STATIC
+    lb_policy: ROUND_ROBIN
+    load_assignment:
+      cluster_name: admin_port_cluster
+      endpoints:
+      - lb_endpoints:
+        - endpoint:
+            address:
+              socket_address:
+                address: 127.0.0.1
+                port_value: 19000 # if or $statsConfig.enabled ($spec.readConfig)
+
+dynamic_resources:
+  ads_config:
+    api_type: GRPC
+    rate_limit_settings: {}
+    grpc_services:
+    - envoy_grpc: {cluster_name: gloo.gloo-system.svc.cluster.local:9977}
+  cds_config:
+    ads: {}
+  lds_config:
+    ads: {}
+admin:
+  access_log_path: /dev/null
+  address:
+    socket_address:
+      address: 127.0.0.1
+      port_value: 19000 # if (empty $spec.configMap.data) ## allows full custom # range $name, $spec := .Values.gatewayProxies# if .Values.gateway.enabled`

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2553,6 +2553,23 @@ metadata:
 					testManifest.Expect("ConfigMap", namespace, defaults.GatewayProxyName).To(BeNil())
 				})
 
+				It("sets the path_with_escaped_slashes_action", func() {
+
+					prepareMakefile(namespace, helmValues{
+						valuesArgs: []string{"gatewayProxies.gatewayProxy.pathWithEscapedSlashesAction=2"},
+					})
+					proxySpec := make(map[string]string)
+					proxySpec["envoy.yaml"] = fmt.Sprintf(confWithEscapedSlashesActionFmt, "", "")
+					cmRb := ResourceBuilder{
+						Namespace: namespace,
+						Name:      gatewayProxyConfigMapName,
+						Labels:    labels,
+						Data:      proxySpec,
+					}
+					proxy := cmRb.GetConfigMap()
+					testManifest.ExpectConfigMapWithYamlData(proxy)
+				})
+
 				Describe("gateway proxy - AWS", func() {
 
 					It("has a global cluster", func() {


### PR DESCRIPTION
# Description

This change pulls in the latest envou-gloo changes which address the Envoy CVE (https://github.com/envoyproxy/envoy/security/advisories/GHSA-4987-27fx-x6cf). We also had to bump the version of `go-control-plane` so that we can get the latest envoy API changes so that we can expose the hcm option that is needed to configure the fix for this CVE

# Context

See envoy CVE-2021-29492 (https://github.com/envoyproxy/envoy/security/advisories/GHSA-4987-27fx-x6cf)

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works