### PR TITLE
check for alternative python executables

### DIFF
--- a/changelog/v1.8.0-beta12/fix-install-script-python.yaml
+++ b/changelog/v1.8.0-beta12/fix-install-script-python.yaml
@@ -1,3 +1,5 @@
 changelog:
   - type: NON_USER_FACING
     description: glooctl install sscript will now check for python3 and python2 executables
+    issueLink: https://github.com/solo-io/gloo/issues/4730
+    issueLink: https://github.com/solo-io/gloo/issues/2877

--- a/changelog/v1.8.0-beta12/fix-install-script-python.yaml
+++ b/changelog/v1.8.0-beta12/fix-install-script-python.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: glooctl install sscript will now check for python3 and python2 executables

--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -2,13 +2,33 @@
 
 set -eu
 
-if ! [ -x "$(command -v python)" ]; then
+python_version=
+if [ -x "$(command -v python)" ]; then
+  python_version="$(command -v python)"
+  echo "Using $python_version"
+fi
+
+if [ ! $python_version ]; then
+  if [ -x "$(command -v python3)" ]; then
+    python_version="$(command -v python3)"
+    echo "Using $python_version"
+  fi
+fi
+
+if [ ! $python_version ]; then
+  if [ -x "$(command -v python2)" ]; then
+    python_version="$(command -v python2)"
+    echo "Using $python_version"
+  fi
+fi
+
+if [ ! $python_version ]; then
   echo Python is required to install glooctl
   exit 1
 fi
 
 if [ -z "${GLOO_VERSION:-}" ]; then
-  GLOO_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | python -c "import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None, releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\n'.join(filtered_releases))")
+  GLOO_VERSIONS=$(curl -sH"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | $python_version -c "import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None, releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\n'.join(filtered_releases))")
 else
   GLOO_VERSIONS="${GLOO_VERSION}"
 fi


### PR DESCRIPTION
# Description

Add checks to the `glooctl` install script for alternative python executables (e.g. `python3`, `python2`)

This is done in a somewhat verbose way as no bash-isms are allowed since [we are using `sh` explicitly](https://github.com/solo-io/gloo/blob/master/projects/gloo/cli/install.sh#L1).

# Context

The install script was breaking on systems like Ubuntu where e.g. the default `python` installation is `python3`.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/2877