### PR TITLE
[Draft] Expose circuit breaker settings to helm template

### DIFF
--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -18,6 +18,10 @@ spec:
     restXdsBindAddr: "0.0.0.0:{{ .Values.gloo.deployment.restXdsPort }}"
     enableRestEds: {{ .Values.settings.enableRestEds }}
 {{- end }}
+{{- if .Values.settings.circuitBreakers }}
+    circuitBreakers:
+{{ toYaml .Values.settings.circuitBreakers | indent 6}}
+{{- end }}
 {{- /* .Values.settings.replaceInvalidRoutes for backwards compatibility */}}
 {{- if or (.Values.settings.invalidConfigPolicy) (.Values.settings.replaceInvalidRoutes) }}
     invalidConfigPolicy:

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -28,6 +28,8 @@ settings:
           extraAnnotations: {}
           httpPort: 80
           httpsPort: 443
+  circuitBreakers: {}
+
   # Namespaces that Gloo should watch. This includes watches set for pods, services, as well as CRD configuration objects.
   watchNamespaces: []
   # Gloo allows you to directly reference a Kubernetes service as a routing destination. To enable this feature,


### PR DESCRIPTION
# Description

Hi,
This is a draft PR to get early feedback. I'll complete the checklist (docs, tests, etc) once it seems ok to continue.
I would like to expose circuit breaker settings to helm template. 

# Context

I want to set Settings.spec.gloo.circuitBreakers.maxConnections etc, but I want to do it via helm.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works