### PR TITLE
Docs: Add 1.8.x upgrade steps

### DIFF
--- a/docs/content/operations/upgrading/1.8.0.md
+++ b/docs/content/operations/upgrading/1.8.0.md
@@ -20,7 +20,7 @@ Also, please make sure to check out our [general configuration recommendations](
 Gloo Edge CRDs now include an OpenAPI v3.0 validation schema with structural schema constraints (https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema).
 Previously custom resources could be defined with yaml that contained snake_case or camelCase fields. For example, the following definition was valid:
 
-```yaml
+{{< highlight yaml "hl_lines=10-12" >}}
 apiVersion: gloo.solo.io/v1
 kind: Upstream
 metadata:
@@ -33,11 +33,11 @@ spec:
     service_name: productpage
     service_namespace: default
     service_port: 9080
-```
+{{< /highlight >}}
 
 The validation schemas require that fields be defined using camelCase. The previous definition should be converted to:
 
-```yaml
+{{< highlight yaml "hl_lines=10-12" >}}
 apiVersion: gloo.solo.io/v1
 kind: Upstream
 metadata:
@@ -50,7 +50,7 @@ spec:
     serviceName: productpage
     serviceNamespace: default
     servicePort: 9080
-```
+{{< /highlight >}}
 
 If you do not make this change, you will see the following type of error:
 `ValidationError(Upstream.spec.kube): unknown field "service_name" in io.solo.gloo.v1.Upstream.spec.kube`

--- a/docs/content/operations/upgrading/1.8.0.md
+++ b/docs/content/operations/upgrading/1.8.0.md
@@ -1,0 +1,56 @@
+---
+title: 1.8.0+ Upgrade Notice
+weight: 5
+description: Migrating to Gloo Edge 1.8.x and Gloo Edge Enterprise 1.8.x
+---
+
+In this guide we will describe the necessary steps to upgrade your Gloo Edge or Gloo Edge Enterprise deployments to their `1.8`
+versions. We recommend that you follow these steps only after you have followed our [guide to upgrade to 1.7]({{< versioned_link_path fromRoot="/operations/upgrading/1.7.0" >}}).
+
+This upgrade guide also assumes that was gloo installed via `helm` or with `glooctl` version 1.7.0+
+(i.e., gloo is a helm release named "gloo", which you can confirm exists by running `helm ls --all-namespaces`).
+
+Also, please make sure to check out our [general configuration recommendations]({{< versioned_link_path fromRoot="/operations/upgrading/upgrade_steps#upgrading-the-server-components" >}}) to avoid downtime during upgrades.
+
+### Breaking Changes
+
+#### Open Source
+
+###### CRDs with Validation Schemas
+Gloo Edge CRDs now include an OpenAPI v3.0 validation schema with structural schema constraints (https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema).
+Previously custom resources could be defined with yaml that contained snake_case or camelCase fields. For example, the following definition was valid:
+
+```yaml
+apiVersion: gloo.solo.io/v1
+kind: Upstream
+metadata:
+  name: default-productpage-9080
+  namespace: gloo-system
+spec:
+  kube:
+    selector:
+      app: productpage
+    service_name: productpage
+    service_namespace: default
+    service_port: 9080
+```
+
+The validation schemas require that fields be defined using camelCase. The previous definition should be converted to:
+
+```yaml
+apiVersion: gloo.solo.io/v1
+kind: Upstream
+metadata:
+  name: default-productpage-9080
+  namespace: gloo-system
+spec:
+  kube:
+    selector:
+      app: productpage
+    serviceName: productpage
+    serviceNamespace: default
+    servicePort: 9080
+```
+
+If you do not make this change, you will see the following type of error:
+`ValidationError(Upstream.spec.kube): unknown field "service_name" in io.solo.gloo.v1.Upstream.spec.kube`


### PR DESCRIPTION
# Description

Add a document to outline how to upgrade to Gloo Edge 1.8.x

# Context

The validation schema work (glooOS: https://github.com/solo-io/gloo/pull/4757, glooEE: https://github.com/solo-io/solo-projects/pull/2346) requires that CRDs be defined with camelCase fields instead of snake_case. We need to outline this so that when users upgrade to 1.8.x they do not run into issues.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works