### PR TITLE
Revert buffer filter behavior

### DIFF
--- a/changelog/v1.6.0-beta24/add-gzip-buffer.yaml
+++ b/changelog/v1.6.0-beta24/add-gzip-buffer.yaml
@@ -1,6 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/gloo/issues/4000
-    description: >
-      Buffer envoy filter is now added to the filter chain correctly so it can be used other than on the Gateway level.
-      Added end-to-end tests for buffer filter.

--- a/changelog/v1.6.27/revert-adding-buffer-config-default.yaml
+++ b/changelog/v1.6.27/revert-adding-buffer-config-default.yaml
@@ -1,3 +1,4 @@
 changelog:
   - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4000
     description: Reverts adding the buffer filter to the filter chain by default when route and vh buffer config is added.

--- a/changelog/v1.6.27/revert-adding-buffer-config-default.yaml
+++ b/changelog/v1.6.27/revert-adding-buffer-config-default.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: FIX
+    description: Reverts adding the buffer filter to the filter chain by default when route and vh buffer config is added.

--- a/projects/gloo/pkg/plugins/buffer/plugin.go
+++ b/projects/gloo/pkg/plugins/buffer/plugin.go
@@ -68,7 +68,10 @@ func (p *Plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *env
 	}
 
 	if bufPerRoute.GetBuffer() != nil {
-		config := getBufferConfig(bufPerRoute)
+		config, err := getBufferConfig(bufPerRoute)
+		if err != nil {
+			return err
+		}
 		return pluginutils.SetRoutePerFilterConfig(out, wellknown.Buffer, config)
 	}
 
@@ -90,7 +93,10 @@ func (p *Plugin) ProcessVirtualHost(
 	}
 
 	if bufPerRoute.GetBuffer() != nil {
-		config := getBufferConfig(bufPerRoute)
+		config, err := getBufferConfig(bufPerRoute)
+		if err != nil {
+			return err
+		}
 		return pluginutils.SetVhostPerFilterConfig(out, wellknown.Buffer, config)
 	}
 
@@ -112,7 +118,10 @@ func (p *Plugin) ProcessWeightedDestination(
 	}
 
 	if bufPerRoute.GetBuffer() != nil {
-		config := getBufferConfig(bufPerRoute)
+		config, err := getBufferConfig(bufPerRoute)
+		if err != nil {
+			return err
+		}
 		return pluginutils.SetWeightedClusterPerFilterConfig(out, wellknown.Buffer, config)
 	}
 
@@ -127,12 +136,13 @@ func getNoBufferConfig() *envoybuffer.BufferPerRoute {
 	}
 }
 
-func getBufferConfig(bufPerRoute *buffer.BufferPerRoute) *envoybuffer.BufferPerRoute {
-	return &envoybuffer.BufferPerRoute{
+func getBufferConfig(bufPerRoute *buffer.BufferPerRoute) (*envoybuffer.BufferPerRoute, error) {
+	envoyConfig := &envoybuffer.BufferPerRoute{
 		Override: &envoybuffer.BufferPerRoute_Buffer{
 			Buffer: &envoybuffer.Buffer{
 				MaxRequestBytes: bufPerRoute.GetBuffer().GetMaxRequestBytes(),
 			},
 		},
 	}
+	return envoyConfig, envoyConfig.Validate()
 }

--- a/projects/gloo/pkg/plugins/buffer/plugin.go
+++ b/projects/gloo/pkg/plugins/buffer/plugin.go
@@ -4,7 +4,6 @@ import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoybuffer "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/buffer/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/rotisserie/eris"
 	buffer "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/buffer/v3"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -26,7 +25,6 @@ var _ plugins.VirtualHostPlugin = new(Plugin)
 var _ plugins.WeightedDestinationPlugin = new(Plugin)
 
 type Plugin struct {
-	present bool
 }
 
 func (p *Plugin) Init(params plugins.InitParams) error {
@@ -35,25 +33,12 @@ func (p *Plugin) Init(params plugins.InitParams) error {
 
 func (p *Plugin) HttpFilters(_ plugins.Params, listener *v1.HttpListener) ([]plugins.StagedHttpFilter, error) {
 
-	bufferConfig, err := p.translateBufferFilter(listener.GetOptions().GetBuffer())
-	if err != nil {
-		return nil, err
-	}
+	bufferConfig := p.translateBufferFilter(listener.GetOptions().GetBuffer())
 
 	if bufferConfig == nil {
-		if !p.present {
-			return nil, nil
-		}
-		// put the filter in the chain, actual buffer will be configured on route, vhost, etc.
-		bufferConfig = &envoybuffer.Buffer{
-			MaxRequestBytes: &wrappers.UInt32Value{
-				Value: 1,
-			},
-		}
-
+		return nil, nil
 	}
 
-	// put the filter in the chain, actual buffer will be configured on route, vhost, etc.
 	bufferFilter, err := plugins.NewStagedFilterWithConfig(wellknown.Buffer, bufferConfig, pluginStage)
 	if err != nil {
 		return nil, eris.Wrapf(err, "generating filter config")
@@ -62,16 +47,14 @@ func (p *Plugin) HttpFilters(_ plugins.Params, listener *v1.HttpListener) ([]plu
 	return []plugins.StagedHttpFilter{bufferFilter}, nil
 }
 
-func (p *Plugin) translateBufferFilter(buf *buffer.Buffer) (*envoybuffer.Buffer, error) {
+func (p *Plugin) translateBufferFilter(buf *buffer.Buffer) *envoybuffer.Buffer {
 	if buf == nil {
-		return nil, nil
+		return nil
 	}
 
-	envoyConfig := &envoybuffer.Buffer{
+	return &envoybuffer.Buffer{
 		MaxRequestBytes: buf.GetMaxRequestBytes(),
 	}
-
-	return envoyConfig, envoyConfig.Validate()
 }
 
 func (p *Plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *envoy_config_route_v3.Route) error {
@@ -81,16 +64,11 @@ func (p *Plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *env
 	}
 
 	if bufPerRoute.GetDisabled() {
-		p.present = true
 		return pluginutils.SetRoutePerFilterConfig(out, wellknown.Buffer, getNoBufferConfig())
 	}
 
 	if bufPerRoute.GetBuffer() != nil {
-		config, err := getBufferConfig(bufPerRoute)
-		if err != nil {
-			return err
-		}
-		p.present = true
+		config := getBufferConfig(bufPerRoute)
 		return pluginutils.SetRoutePerFilterConfig(out, wellknown.Buffer, config)
 	}
 
@@ -108,16 +86,11 @@ func (p *Plugin) ProcessVirtualHost(
 	}
 
 	if bufPerRoute.GetDisabled() {
-		p.present = true
 		return pluginutils.SetVhostPerFilterConfig(out, wellknown.Buffer, getNoBufferConfig())
 	}
 
 	if bufPerRoute.GetBuffer() != nil {
-		config, err := getBufferConfig(bufPerRoute)
-		if err != nil {
-			return err
-		}
-		p.present = true
+		config := getBufferConfig(bufPerRoute)
 		return pluginutils.SetVhostPerFilterConfig(out, wellknown.Buffer, config)
 	}
 
@@ -135,16 +108,11 @@ func (p *Plugin) ProcessWeightedDestination(
 	}
 
 	if bufPerRoute.GetDisabled() {
-		p.present = true
 		return pluginutils.SetWeightedClusterPerFilterConfig(out, wellknown.Buffer, getNoBufferConfig())
 	}
 
 	if bufPerRoute.GetBuffer() != nil {
-		config, err := getBufferConfig(bufPerRoute)
-		if err != nil {
-			return err
-		}
-		p.present = true
+		config := getBufferConfig(bufPerRoute)
 		return pluginutils.SetWeightedClusterPerFilterConfig(out, wellknown.Buffer, config)
 	}
 
@@ -159,13 +127,12 @@ func getNoBufferConfig() *envoybuffer.BufferPerRoute {
 	}
 }
 
-func getBufferConfig(bufPerRoute *buffer.BufferPerRoute) (*envoybuffer.BufferPerRoute, error) {
-	envoyConfig := &envoybuffer.BufferPerRoute{
+func getBufferConfig(bufPerRoute *buffer.BufferPerRoute) *envoybuffer.BufferPerRoute {
+	return &envoybuffer.BufferPerRoute{
 		Override: &envoybuffer.BufferPerRoute_Buffer{
 			Buffer: &envoybuffer.Buffer{
 				MaxRequestBytes: bufPerRoute.GetBuffer().GetMaxRequestBytes(),
 			},
 		},
 	}
-	return envoyConfig, envoyConfig.Validate()
 }

--- a/projects/gloo/pkg/plugins/buffer/plugin_test.go
+++ b/projects/gloo/pkg/plugins/buffer/plugin_test.go
@@ -177,47 +177,4 @@ var _ = Describe("Plugin", func() {
 		Expect(cfg.GetBuffer().GetMaxRequestBytes().GetValue()).To(Equal(uint32(4098)))
 	})
 
-	It("allows route specific buffer config", func() {
-		p := NewPlugin()
-		out := &envoy_config_route_v3.Route{}
-		err := p.ProcessRoute(plugins.RouteParams{}, &v1.Route{
-			Options: &v1.RouteOptions{
-				BufferPerRoute: &v3.BufferPerRoute{
-					Override: &v3.BufferPerRoute_Buffer{
-						Buffer: &v3.Buffer{
-							MaxRequestBytes: &wrappers.UInt32Value{
-								Value: 4098,
-							},
-						},
-					},
-				},
-			},
-		}, out)
-
-		var cfg envoybuffer.BufferPerRoute
-		err = ptypes.UnmarshalAny(out.GetTypedPerFilterConfig()[wellknown.Buffer], &cfg)
-
-		Expect(err).NotTo(HaveOccurred())
-		Expect(cfg.GetBuffer().GetMaxRequestBytes().GetValue()).To(Equal(uint32(4098)))
-
-		filters, err := p.HttpFilters(plugins.Params{}, &v1.HttpListener{})
-		Expect(err).NotTo(HaveOccurred())
-
-		expectedStageFilter := plugins.StagedHttpFilter{
-			HttpFilter: &envoyhcm.HttpFilter{
-				Name: wellknown.Buffer,
-				ConfigType: &envoyhcm.HttpFilter_TypedConfig{
-					TypedConfig: utils.MustMessageToAny(&envoybuffer.Buffer{
-						MaxRequestBytes: &wrappers.UInt32Value{Value: 1},
-					}),
-				},
-			},
-
-			Stage: plugins.DuringStage(plugins.RouteStage),
-		}
-
-		Expect(filters[0].HttpFilter).To(matchers.MatchProto(expectedStageFilter.HttpFilter))
-		Expect(filters[0].Stage).To(Equal(expectedStageFilter.Stage))
-	})
-
 })


### PR DESCRIPTION
# Description

Reverts: https://github.com/solo-io/gloo/pull/4015 
The buffer filter will need to be configured on the gateway level to be able to do BufferPerRoute on the route or vh.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4000