### PR TITLE
Envoy bootstrap v3

### DIFF
--- a/changelog/v1.8.0-beta20/envoy-bootstrap-v3.yaml
+++ b/changelog/v1.8.0-beta20/envoy-bootstrap-v3.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4369
+    resolvesIssue: false
+    description: Specify that envoy boostrap version is v3

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -120,6 +120,8 @@ spec:
       containers:
       - args:
           - --disable-hot-restart
+          - --bootstrap-version
+          - "3"
         {{- if $spec.envoyLogLevel }}
           - --log-level {{ $spec.envoyLogLevel }}
         {{- end}}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1701,7 +1701,7 @@ spec:
 						}
 						container := GetQuayContainerSpec("gloo-envoy-wrapper", version, GetPodNamespaceEnvVar(), podname)
 						container.Name = "gateway-proxy"
-						container.Args = []string{"--disable-hot-restart"}
+						container.Args = []string{"--disable-hot-restart", "--bootstrap-version", "3"}
 
 						rb := ResourceBuilder{
 							Namespace:  namespace,

--- a/test/services/envoy.go
+++ b/test/services/envoy.go
@@ -507,7 +507,7 @@ func (ei *EnvoyInstance) runWithAll(eic EnvoyInstanceConfig, bootstrapBuilder En
 		return ei.runContainer(eic.Context())
 	}
 
-	args := []string{"--config-yaml", ei.envoycfg, "--disable-hot-restart", "--log-level", "debug"}
+	args := []string{"--config-yaml", ei.envoycfg, "--disable-hot-restart", "--log-level", "debug", "--bootstrap-version", "3"}
 
 	// run directly
 	cmd := exec.CommandContext(eic.Context(), ei.envoypath, args...)
@@ -595,7 +595,9 @@ func (ei *EnvoyInstance) runContainer(ctx context.Context) error {
 	args = append(args,
 		"--entrypoint=envoy",
 		image,
-		"--disable-hot-restart", "--log-level", "debug",
+		"--disable-hot-restart",
+		"--log-level", "debug",
+		"--bootstrap-version", "3",
 		"--config-yaml", ei.envoycfg,
 	)
 


### PR DESCRIPTION
# Description

Specify the API version to load the bootstrap envoy configuration as. Since we were not specifying it before, envoy loaded the bootstrap as v2.

# Context

From https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-bootstrap-version: 
```
The API version to load the bootstrap as. The value should be a single integer, e.g. to parse the bootstrap configuration as V3, specify --bootstrap-version 3. If unset, Envoy will attempt to load the bootstrap as the previous API version and upgrade it to the latest. If that fails, Envoy will attempt to load the configuration as the latest version.
```

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works