### PR TITLE
Fix docsgen for community users

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -40,6 +40,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         SKIP_CHANGELOG_GENERATION: ${{ steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
         SKIP_SECURITY_SCAN: ${{ steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
+        USE_PR_SHA_AS_MASTER: ${{ github.event_name == 'pull_request' && !steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
         PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Deploy to Firebase
       # Do not publish docs if this workflow was triggered by a pull request

--- a/changelog/v1.8.0-beta20/fix-docgen-community-users.yaml
+++ b/changelog/v1.8.0-beta20/fix-docgen-community-users.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Docgen was not working for community users, because it was attempting to checkout a commit
+      that existed in a forked repository. This reverts the old behavior for community users,
+      of using master as the latest commit, instead of the head SHA of the pull request.

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -104,6 +104,7 @@ function generateHugoVersionsYaml() {
 
 function generateSiteForVersion() {
   version=$1
+  latestMasterTag=$2
   echo "Generating site for version $version"
   cd $repoDir
   # Replace version with "latest" if it's the latest version. This enables URLs with "/latest/..."
@@ -111,7 +112,7 @@ function generateSiteForVersion() {
   then
     version="latest"
   fi
-  git checkout $tagToBuild
+  git checkout "$latestMasterTag"
 
   cd docs
   # Generate data/Solo.yaml file with version info populated.
@@ -146,11 +147,12 @@ function generateSiteForVersion() {
 # Copies the /docs/content directory from the specified version ($1) and stores it in a temp location
 function getContentForVersion() {
   version=$1
+  latestMasterTag=$2
   echo "Getting site content for version $version"
   cd $repoDir
   if [[ "$version" == "master" ]]
   then
-    git checkout $tagToBuild
+    git checkout "$latestMasterTag"
   else
     git checkout tags/v"$version"
   fi
@@ -163,37 +165,40 @@ function getContentForVersion() {
   cp -a $repoDir/docs/content/. $tempContentDir/$version/
 }
 
-# Only on pull requests to master, we want to checkout the pull request head SHA
-# rather than master
-tagToBuild="master"
-if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]
+# We build docs for all active and old version of Gloo, on pull requests (and merges) to master.
+# On pull requests to master by Solo developers, we want to run doc generation
+# against the commit that will become the latest master commit.
+# This will allow us to verify if the change we are introducing is valid.
+# Therefore, we use the head SHA on pull requests by Solo developers
+latestMasterTag="master"
+if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$IS_COMMUNITY_PR" == "false" ]]
 then
-  tagToBuild=$PULL_REQUEST_SHA
+  latestMasterTag=$PULL_REQUEST_SHA
   echo using $PULL_REQUEST_SHA, as this will be the next commit to master
 fi
 
 # Obtain /docs/content dir from all versions
 for version in "${versions[@]}"
 do
-  getContentForVersion $version
+  getContentForVersion $version $latestMasterTag
 done
 
 
 # Obtain /docs/content dir from all previous versions
 for version in "${oldVersions[@]}"
 do
-  getContentForVersion $version
+  getContentForVersion $version $latestMasterTag
 done
 
 
 # Generate docs for all versions
 for version in "${versions[@]}"
 do
-  generateSiteForVersion $version
+  generateSiteForVersion $version $latestMasterTag
 done
 
 # Generate docs for all previous versions
 for version in "${oldVersions[@]}"
 do
-  generateSiteForVersion $version
+  generateSiteForVersion $version $latestMasterTag
 done

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -171,7 +171,7 @@ function getContentForVersion() {
 # This will allow us to verify if the change we are introducing is valid.
 # Therefore, we use the head SHA on pull requests by Solo developers
 latestMasterTag="master"
-if [[ "$GITHUB_EVENT_NAME" == "pull_request" && "$IS_COMMUNITY_PR" == "false" ]]
+if [[ "$USE_PR_SHA_AS_MASTER" == "true" ]]
 then
   latestMasterTag=$PULL_REQUEST_SHA
   echo using $PULL_REQUEST_SHA, as this will be the next commit to master


### PR DESCRIPTION
# Description

Fix docsgen CI for community users.

# Context

Docgen was not working for community users, because it was attempting to checkout a commit that existed in a forked repository. This reverts the old behavior for community users, of using master as the latest commit, instead of the head SHA of the pull request.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# Testing
- [x] This PR sets `latestMasterTag` to `master` and doc gen completes successfully
```
logs from CI...

+ getContentForVersion 1.7.10 master
+ version=1.7.10
+ latestMasterTag=master
```
- [x] Same PR for non-community user (https://github.com/solo-io/gloo/pull/4845) sets `latestMasterTag` to the commit SHA and docgen completes successfully.
```
logs from CI...

+ generateSiteForVersion 1.6.29 6a45fc0b538528f6c5cb75f9633ed767687d90e1
+ version=1.6.29
+ latestMasterTag=6a45fc0b538528f6c5cb75f9633ed767687d90e1
```