### PR TITLE
Fix disabling default gateway #4696

### DIFF
--- a/changelog/v1.8.0-beta20/fix-disable-default-gatewayProxy.yaml
+++ b/changelog/v1.8.0-beta20/fix-disable-default-gatewayProxy.yaml
@@ -1,5 +1,4 @@
 changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/4696
-    resolvesIssue: true
     description: Gatway objects for custom proxies are still created when the default gateway proxy is disabled.

--- a/changelog/v1.8.0-beta20/fix-disable-default-gatewayProxy.yaml
+++ b/changelog/v1.8.0-beta20/fix-disable-default-gatewayProxy.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4696
+    resolvesIssue: true
+    description: Gatway objects for custom proxies are still created when the default gateway proxy is disabled.

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -134,9 +134,9 @@ spec:
 
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy }}
 {{- range $name, $gatewaySpec := .Values.gatewayProxies }}
-{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy ) -}}
 {{- $gatewaySettings := $spec.gatewaySettings }}
-{{- if and $spec.gatewaySettings (not $spec.disabled) }}
+{{- if and $spec.gatewaySettings (not $gatewaySpec.disabled) }}
 {{- $ctx := (list $ $name $spec)}}
 {{- if not $gatewaySettings.disableGeneratedGateways }}
 {{- if not $gatewaySettings.disableHttpGateway }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -937,6 +937,17 @@ var _ = Describe("Helm Test", func() {
 						testManifest.ExpectCustomResource("Gateway", namespace, "another-gateway-proxy")
 					})
 
+					It("renders custom gateway when gatewayProxy is disabled and custom disabled is not set", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"gatewayProxies.gatewayProxy.disabled=true",
+								//anotherGatewayProxy should exist but not have a value for disabled
+								"gatewayProxies.anotherGatewayProxy.loopbackAddress=127.0.0.1",
+							},
+						})
+						testManifest.Expect("Gateway", namespace, defaults.GatewayProxyName).To(BeNil())
+						testManifest.ExpectCustomResource("Gateway", namespace, "another-gateway-proxy")
+					})
 					var (
 						proxyNames = []string{defaults.GatewayProxyName}
 					)


### PR DESCRIPTION
# Description

When installing a custom gateway proxy, always get the value for "disabled" from the custom spec rather than the default.
Currently the custom settings are merged with the default settings when installing a non-default gateway. However this means that disabling the default gateway effectively disables any custom gateways that do not have `disabled: false` explicitly set.
# Context

Users ran into this bug when trying to install a proxy other than the default when the default was disabled. 

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4696