### PR TITLE
bump istio proxy version to 1.9.5 for use during injection

### DIFF
--- a/changelog/v1.8.0-beta20/bump-istio-proxy-to-195.yaml
+++ b/changelog/v1.8.0-beta20/bump-istio-proxy-to-195.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4846
+    resolvesIssue: true
+    description: Bump istio proxy version to 1.9.5

--- a/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
+++ b/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
@@ -467,7 +467,7 @@ Any upstreams using mTLS will need to be contain the sslConfig as described abov
 
 ##### Custom Sidecars
 
-The default istio-proxy image used as a sidecar by this declarative approach is `docker.io/istio/proxyv2:1.9.4`. If this image doesn't work for you (for example, your mesh is on a different, incompatible Istio version), you can override the default sidecar with your own.
+The default istio-proxy image used as a sidecar by this declarative approach is `docker.io/istio/proxyv2:1.9.5`. If this image doesn't work for you (for example, your mesh is on a different, incompatible Istio version), you can override the default sidecar with your own.
 
 To do this, you must set your custom sidecar in the helm value `global.istioSDS.customSidecars`. For example, if you wanted to use istio proxy v1.6.6 instead:
 

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -318,7 +318,7 @@ spec:
 {{- end }}
 {{- if not $global.istioSDS.customSidecars }}
       - name: istio-proxy
-        image: docker.io/istio/proxyv2:1.9.4
+        image: docker.io/istio/proxyv2:1.9.5
         {{- if $global.glooMtls.sdsResources }}
         resources:
 {{ toYaml $global.glooMtls.sdsResources | indent 10}}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -606,7 +606,7 @@ var _ = Describe("Helm Test", func() {
 						if structuredDeployment.GetName() == "gateway-proxy" {
 							Expect(len(structuredDeployment.Spec.Template.Spec.Containers)).To(Equal(3), "should have exactly 3 containers")
 							Ω(haveSdsSidecar(structuredDeployment.Spec.Template.Spec.Containers)).To(BeTrue(), "gateway-proxy should have an sds sidecar")
-							Ω(istioSidecarVersion(structuredDeployment.Spec.Template.Spec.Containers)).To(Equal("docker.io/istio/proxyv2:1.9.4"), "istio proxy sidecar should be the default")
+							Ω(istioSidecarVersion(structuredDeployment.Spec.Template.Spec.Containers)).To(Equal("docker.io/istio/proxyv2:1.9.5"), "istio proxy sidecar should be the default")
 							Ω(haveIstioSidecar(structuredDeployment.Spec.Template.Spec.Containers)).To(BeTrue(), "gateway-proxy should have an istio-proxy sidecar")
 							Ω(sdsIsIstioMode(structuredDeployment.Spec.Template.Spec.Containers)).To(BeTrue(), "sds sidecar should have istio mode enabled")
 							Expect(structuredDeployment.Spec.Template.Spec.Volumes).To(ContainElement(istioCertsVolume), "should have istio-certs volume mounted")


### PR DESCRIPTION
# Description

Bump istio proxy from 1.9.4 to 1.9.5 for CVE fixes

# Context

Resolves: https://github.com/solo-io/gloo/issues/4846

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4846