### PR TITLE
Fix template typo

### DIFF
--- a/changelog/v1.7.12/fix-gateways-whitespace.yaml
+++ b/changelog/v1.7.12/fix-gateways-whitespace.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4428
+    description: Backport a fix to the default-gateways helm template to stop consuming a newline.
+    

--- a/changelog/v1.7.12/fix-gateways-whitespace.yaml
+++ b/changelog/v1.7.12/fix-gateways-whitespace.yaml
@@ -2,4 +2,4 @@ changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/4428
     description: Backport a fix to the default-gateways helm template to stop consuming a newline.
-    
+  

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -53,7 +53,7 @@ spec:
   - {{ $name | kebabcase }}
 {{- end }}
 ---
-{{- if not $gatewaySettings.disableHttpsGateway -}}
+{{- if not $gatewaySettings.disableHttpsGateway }}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:


### PR DESCRIPTION
# Description

Remove a `-}}` that was missed in an earlier backported fix

# Context
Installing with helm

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works