### PR TITLE
Back port istio 1.9.x and 1.10.x support changes

### DIFF
--- a/changelog/v1.7.12/backport-istio-support-changes.yaml
+++ b/changelog/v1.7.12/backport-istio-support-changes.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NON_USER_FACING
+  description: Backport add istio 1.10.0 support for glooctl istio inject
+  issueLink: https://github.com/solo-io/gloo/issues/4884
+- type: NON_USER_FACING
+  description: Backport bump istio proxy from 1.8.1 to 1.9.5 for CVE fixes
+  issueLink: https://github.com/solo-io/gloo/issues/4883

--- a/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
+++ b/docs/content/guides/integrations/service_mesh/gloo_istio_mtls/_index.md
@@ -9,7 +9,7 @@ Serving as the Ingress for an Istio cluster -- without compromising on security 
 
 ### Istio versions
 
-This guide was tested with Istio 1.6.6, 1.7.2, and 1.8.1. For older versions of Istio, see [here]({{% versioned_link_path fromRoot="/guides/integrations/service_mesh/gloo_istio_mtls/older_istio_versions/" %}}).
+This guide was tested with Istio 1.6.6, 1.7.2, 1.8.1, 1.9.5 and 1.10.0. For older versions of Istio, see [here]({{% versioned_link_path fromRoot="/guides/integrations/service_mesh/gloo_istio_mtls/older_istio_versions/" %}}).
 
 ### Gloo Edge versions
 
@@ -23,7 +23,7 @@ The Gloo Edge integration with Istio 1.6.6+ requires Gloo Edge version 1.4.10+, 
 
 ### Kubernetes versions
 
-This guide was tested with GKE v1.15.
+This guide was tested with GKE v1.17.
 
 
 {{% notice note %}}
@@ -41,8 +41,8 @@ For local development and testing, if you remove the istio-token mount then Isti
 To download and install the latest version of Istio, we will be following the installation instructions [here](https://istio.io/docs/setup/getting-started/).
 
 ```bash
-curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.8.1 sh -
-cd istio-1.8.1
+curl -L https://istio.io/downloadIstio | ISTIO_VERSION=1.9.5 sh -
+cd istio-1.9.5
 istioctl install --set profile=demo
 ```
 
@@ -72,7 +72,7 @@ glooctl install gateway
 ```
 or with helm:
 ```
-kubectl create ns gloo-system; helm install --namespace gloo-system --version 1.5.0-beta25 gloo gloo/gloo
+kubectl create ns gloo-system; helm install --namespace gloo-system --version 1.5.0 gloo gloo/gloo
 ```
 See the [quick start]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/" %}}) guide for more information.
 
@@ -236,7 +236,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.name
-        image: quay.io/solo-io/gloo-envoy-wrapper:1.5.0-beta24
+        image: quay.io/solo-io/gloo-envoy-wrapper:1.5.0
         imagePullPolicy: IfNotPresent
         name: gateway-proxy
         ports:
@@ -273,7 +273,7 @@ spec:
               fieldPath: metadata.namespace
         - name: ISTIO_MTLS_SDS_ENABLED
           value: "true"
-        image: quay.io/solo-io/sds:1.5.0-beta24
+        image: quay.io/solo-io/sds:1.5.0
         imagePullPolicy: IfNotPresent
         name: sds
         ports:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -317,7 +317,7 @@ spec:
 {{- end }}
 {{- if not $global.istioSDS.customSidecars }}
       - name: istio-proxy
-        image: docker.io/istio/proxyv2:1.8.1
+        image: docker.io/istio/proxyv2:1.9.5
         {{- if $global.glooMtls.sdsResources }}
         resources:
 {{ toYaml $global.glooMtls.sdsResources | indent 10}}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -628,7 +628,7 @@ var _ = Describe("Helm Test", func() {
 						if structuredDeployment.GetName() == "gateway-proxy" {
 							Expect(len(structuredDeployment.Spec.Template.Spec.Containers)).To(Equal(3), "should have exactly 3 containers")
 							Ω(haveSdsSidecar(structuredDeployment.Spec.Template.Spec.Containers)).To(BeTrue(), "gateway-proxy should have an sds sidecar")
-							Ω(istioSidecarVersion(structuredDeployment.Spec.Template.Spec.Containers)).To(Equal("docker.io/istio/proxyv2:1.8.1"), "istio proxy sidecar should be the default")
+							Ω(istioSidecarVersion(structuredDeployment.Spec.Template.Spec.Containers)).To(Equal("docker.io/istio/proxyv2:1.9.5"), "istio proxy sidecar should be the default")
 							Ω(haveIstioSidecar(structuredDeployment.Spec.Template.Spec.Containers)).To(BeTrue(), "gateway-proxy should have an istio-proxy sidecar")
 							Ω(sdsIsIstioMode(structuredDeployment.Spec.Template.Spec.Containers)).To(BeTrue(), "sds sidecar should have istio mode enabled")
 							Expect(structuredDeployment.Spec.Template.Spec.Volumes).To(ContainElement(istioCertsVolume), "should have istio-certs volume mounted")

--- a/projects/gloo/cli/pkg/cmd/istio/inject.go
+++ b/projects/gloo/cli/pkg/cmd/istio/inject.go
@@ -151,6 +151,7 @@ func istioInject(args []string, opts *options.Options) error {
 				return err
 			}
 
+			fmt.Println("Istio injection was successful!")
 		}
 	}
 

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7-1.8-1.9-1.10.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7-1.8-1.9-1.10.go
@@ -5,7 +5,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-// Sidecar for Istio 1.7.x releases, also works for Istio 1.8.x releases
+// Sidecar for Istio 1.7.x releases, also works for Istio 1.8.x, 1.9.x and 1.10.x releases
 func generateIstio17or18Sidecar(version, jwtPolicy string, istioMetaMeshID string, istioMetaClusterID string) *corev1.Container {
 	sidecar := &corev1.Container{
 		Name:  "istio-proxy",

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/matcher.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/matcher.go
@@ -14,7 +14,7 @@ var ErrNoSupportedSidecar = errors.New("no valid istio sidecar found for this is
 // version of Istio, with the given jwtPolicy, to run
 // in the gateway-proxy pod
 func GetIstioSidecar(istioVersion, jwtPolicy string, istioMetaMeshID string, istioMetaClusterID string) (*corev1.Container, error) {
-	if strings.HasPrefix(istioVersion, "1.7.") || strings.HasPrefix(istioVersion, "1.8.") {
+	if strings.HasPrefix(istioVersion, "1.7.") || strings.HasPrefix(istioVersion, "1.8.") || strings.HasPrefix(istioVersion, "1.9.") || strings.HasPrefix(istioVersion, "1.10.") {
 		return generateIstio17or18Sidecar(istioVersion, jwtPolicy, istioMetaMeshID, istioMetaClusterID), nil
 	} else if strings.HasPrefix(istioVersion, "1.6.") {
 		return generateIstio16Sidecar(istioVersion, jwtPolicy, istioMetaMeshID, istioMetaClusterID), nil

--- a/projects/gloo/cli/pkg/cmd/istio/uninject.go
+++ b/projects/gloo/cli/pkg/cmd/istio/uninject.go
@@ -145,6 +145,8 @@ func istioUninject(args []string, opts *options.Options) error {
 		}
 	}
 
+	fmt.Println("Istio was successfully uninjected")
+
 	return nil
 }
 


### PR DESCRIPTION
# Description

Back port istio 1.9.x and 1.10.x support changes

# Context

Resolves: https://github.com/solo-io/gloo/issues/4883, https://github.com/solo-io/gloo/issues/4884

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4884
resolves https://github.com/solo-io/gloo/issues/4883