### PR TITLE
updating apiVersion cert-manager.io to v1 from v1alpha2

### DIFF
--- a/docs/content/guides/integrations/cert_manager/_index.md
+++ b/docs/content/guides/integrations/cert_manager/_index.md
@@ -81,7 +81,7 @@ Create a cluster issuer for Let's Encrypt with Route 53.
 
 ```shell
 cat << EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging
@@ -115,7 +115,7 @@ Ready
 Create the certificate for the Gloo Edge ingress:
 ```shell
 cat << EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: test-123456789.solo.io
@@ -198,7 +198,7 @@ These steps are specific for Gloo Edge running in gateway mode. When running in 
 First, create a `ClusterIssuer` which will utilize the `http01` solver:
 ```shell
 cat << EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
 metadata:
   name: letsencrypt-staging-http01
@@ -229,7 +229,7 @@ Next we will create the actual `Certificate` which will utilize the `ClusterIssu
 
 ```shell
 cat << EOF | kubectl apply -f -
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: nip-io


### PR DESCRIPTION
documentation: updating apiVersion: cert-manager.io to v1 from v1alpha2
