### PR TITLE
Fix transport api version

### DIFF
--- a/changelog/v1.6.8-patch2/fix-transport-api-version.yaml
+++ b/changelog/v1.6.8-patch2/fix-transport-api-version.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4874
+    resolvesIssue: false
+    description: >
+      Update the transport API version to v3 in extauth to leverage v3 features in enterprise for the multi extauth flow.

--- a/projects/gloo/pkg/plugins/extauth/config_generator.go
+++ b/projects/gloo/pkg/plugins/extauth/config_generator.go
@@ -281,6 +281,8 @@ func GenerateEnvoyConfigForFilter(settings *extauthv1.Settings, upstreams v1.Ups
 	}
 	cfg.StatusOnError = statusOnError
 
+	cfg.TransportApiVersion = envoycore.ApiVersion_V3
+
 	return cfg, nil
 }
 

--- a/projects/gloo/pkg/plugins/extauth/config_generator_test.go
+++ b/projects/gloo/pkg/plugins/extauth/config_generator_test.go
@@ -189,6 +189,7 @@ var _ = Describe("ExtAuthzConfigGenerator", func() {
 						}
 
 						expectedConfig = &envoyauth.ExtAuthz{
+							TransportApiVersion:       envoycore.ApiVersion_V3,
 							MetadataContextNamespaces: []string{JWTFilterName},
 							Services: &envoyauth.ExtAuthz_GrpcService{
 								GrpcService: &envoycore.GrpcService{
@@ -234,6 +235,7 @@ var _ = Describe("ExtAuthzConfigGenerator", func() {
 						}
 
 						expectedConfig = &envoyauth.ExtAuthz{
+							TransportApiVersion:       envoycore.ApiVersion_V3,
 							MetadataContextNamespaces: []string{JWTFilterName},
 							Services: &envoyauth.ExtAuthz_GrpcService{
 								GrpcService: &envoycore.GrpcService{
@@ -306,6 +308,7 @@ var _ = Describe("ExtAuthzConfigGenerator", func() {
 						}
 
 						expectedConfig = &envoyauth.ExtAuthz{
+							TransportApiVersion:       envoycore.ApiVersion_V3,
 							MetadataContextNamespaces: []string{JWTFilterName},
 							Services: &envoyauth.ExtAuthz_HttpService{
 								HttpService: &envoyauth.HttpService{


### PR DESCRIPTION
# Description

This is a special Gloo release for enterprise to depend on in an enterprise stub release. The feature backported here depends on extauth features in the v3 api.

Gloo 1.6 supports both v2 and v3 transport API versions, so changing the version here is safe.

# Context

Ran enterprise tests against this change, this fixed the broken backported tests / behaviors.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works