### PR TITLE
Fix security scan docs for gloo-ee-envoy-wrapper

### DIFF
--- a/changelog/v1.8.0-beta23/fix-sec-scan.yaml
+++ b/changelog/v1.8.0-beta23/fix-sec-scan.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4920
+    resolvesIssue: false
+    description: >
+      Fixes "No Scan Found" dialog under the security scan docs
+      for [gloo-ee-envoy-wrapper](https://github.com/solo-io/gloo/issues/4920).

--- a/docs/cmd/securityscanutils/securityscan_utils.go
+++ b/docs/cmd/securityscanutils/securityscan_utils.go
@@ -79,7 +79,7 @@ func printImageReportGloo(tag string) error {
 
 func printImageReportGlooE(semver *version.Version) error {
 	tag := semver.String()
-	images := []string{"rate-limit-ee", "gloo-ee", "gloo-envoy-ee-wrapper", "observability-ee", "extauth-ee", "ext-auth-plugins"}
+	images := []string{"rate-limit-ee", "gloo-ee", "gloo-ee-envoy-wrapper", "observability-ee", "extauth-ee", "ext-auth-plugins"}
 
 	// gloo-fed images replaced grpcserver images in 1.7+
 	grpcserverImages := []string{"grpcserver-ee", "grpcserver-envoy", "grpcserver-ui"}


### PR DESCRIPTION
Fixing quick typo. Needs to be backported to atleast 1.7 to show on 1.7 docs.