### PR TITLE
Add required regex attribute for extractors to Transformation doc

### DIFF
--- a/docs/content/guides/traffic_management/request_processing/transformations/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/transformations/_index.md
@@ -189,12 +189,14 @@ An extraction must have one of two sources:
     extractors:
       myExtractor:
         header: 'foo'
+        regex: '.*'
     ```
 - `body`: extract information from the body. This attribute takes an empty value (as there is always only one body).
     ```yaml
     extractors:
       myExtractor:
         body: {}
+        regex: '.*'
     ```
 
 {{% notice note %}}
@@ -204,6 +206,10 @@ The `body` extraction source has been introduced with **Gloo Edge**, release 0.2
 Extracting the body is generally not useful when Gloo Edge has already parsed it as JSON, the default behavior. The parsed body data can be directly referenced using standard JSON syntax. The `body` extractor treats the body as plaintext, and is interpreted using a regular expression as noted below. This can be useful for body data that cannot be parsed as JSON.
 
 An extraction must also define which information is to be extracted from the source. This can be done by providing a regular expression via the `regex` attribute. The regular expression will be applied to the body or to the value of relevant header. If your regular expression uses _capturing groups_, you can select the group match you want to use via the `subgroup` attribute.
+
+{{% notice note %}}
+The `regex` attribute is required when specifying an extraction. Even if a `regex` attribute is not required to capture a subset of the source information, you must still specify a catch-all pattern like `regex: '.*'`. If no `regex` is specified, the extractor will silently fail.
+{{% /notice %}}
 
 As an example, to define an extraction named `foo` which will contain the value of the `foo` query parameter you can apply the following configuration:
 


### PR DESCRIPTION
# Description

The current transformation doc [here](https://docs.solo.io/gloo-edge/latest/guides/traffic_management/request_processing/transformations/) does not highlight that the `regex` attribute is required for any `extractor` to work. This PR fixes that omission.
