### PR TITLE
Fixed dex-values config

### DIFF
--- a/changelog/v1.9.0-beta1/extauth-opa-doc-fix.yaml
+++ b/changelog/v1.9.0-beta1/extauth-opa-doc-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4946
+    description: Fixed unparseable dex-values yaml

--- a/docs/content/guides/security/auth/extauth/opa/_index.md
+++ b/docs/content/guides/security/auth/extauth/opa/_index.md
@@ -332,12 +332,12 @@ config:
   staticPasswords:
   - email: "admin@example.com"
     # bcrypt hash of the string "password"
-    hash: "\$2a\$10\$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    hash: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
     username: "admin"
     userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
   - email: "user@example.com"
     # bcrypt hash of the string "password"
-    hash: "\$2a\$10\$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+    hash: $2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W
     username: "user"
     userID: "123456789-db88-4b73-90a9-3cd1661f5466"
 EOF
@@ -350,7 +350,7 @@ Using this configuration, we can deploy Dex to our cluster using Helm.
 If `help repo list` doesn't list the `stable` repo, invoke:
 
 ```shell
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
 ```
 
 And then install dex (helm 3 command follows):
@@ -460,6 +460,10 @@ spec:
         namespace: gloo-system
       query: "data.test.allow == true"
 {{< /highlight >}}
+
+```
+kubectl apply -f jwt-opa.yaml
+```
 
 The above `AuthConfig` defines two configurations that Gloo Edge will execute in order: 
 

--- a/docs/content/guides/security/auth/extauth/opa/_index.md
+++ b/docs/content/guides/security/auth/extauth/opa/_index.md
@@ -430,7 +430,7 @@ kubectl --namespace=gloo-system create configmap allow-jwt --from-file=check-jwt
 {{% /notice %}}
 
 Now that all the necessary resources are in place we can create the `AuthConfig` resource that we will use to secure our 
-Virtual Service.
+Virtual Service.  Save the code block below as `jwt-opa.yaml`.
 
 {{< highlight shell "hl_lines=8-22" >}}
 apiVersion: enterprise.gloo.solo.io/v1


### PR DESCRIPTION
# Description

Modified YAML values for dex-config to be parseable.

This bug fixes doc issue #4946 

# Context

Helm 3 fails to parse the current YAML.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4946