### PR TITLE
Do not mix extraAnnotations for gw-proxy service resources

### DIFF
--- a/changelog/v1.9.0-beta1/proxy-service-extra-annotations.yaml
+++ b/changelog/v1.9.0-beta1/proxy-service-extra-annotations.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: |
+      Ensure the annotations for custom gateway-proxy services do not contain
+      references to the default gateway-proxy service annotations
+    issueLink: https://github.com/solo-io/gloo/issues/4914
+    resolvesIssue: true

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -122,8 +122,10 @@ spec:
 
 {{- if .Values.gateway.enabled }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- $defaultGatewayProxySafe := deepCopy $gatewayProxy -}}
+{{- $_ := unset $defaultGatewayProxySafe.service "extraAnnotations" -}}
 {{- range $name, $gatewaySpec := .Values.gatewayProxies }}
-{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{- $spec := deepCopy $gatewaySpec | mergeOverwrite $defaultGatewayProxySafe -}}
 {{/* Render each gatewayProxy template with it's yaml overrides */}}
 {{- $serviceYamlOverride := dict -}}
 {{- $configDumpServiceYamlOverride := dict -}}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1395,6 +1395,7 @@ spec:
 				})
 
 				Context("custom gateway", func() {
+
 					Context("when the default values weren't overridden", func() {
 						BeforeEach(func() {
 							prepareMakefile(namespace, helmValues{
@@ -1435,6 +1436,7 @@ spec:
 							Expect(configMapStr.Data).ToNot(BeNil()) // Uses the default config data
 						})
 					})
+
 					Context("when default values are overridden by custom gatewayproxy", func() {
 						BeforeEach(func() {
 							prepareMakefile(namespace, helmValues{
@@ -1477,6 +1479,28 @@ spec:
 							Expect(configMapStr.Data).To(Equal(map[string]string{"customData": "someData"}))
 						})
 					})
+
+					Context("when non-default values are overridden by custom gatewayproxy", func() {
+						BeforeEach(func() {
+							prepareMakefile(namespace, helmValues{
+								valuesArgs: []string{
+									"gatewayProxies.gatewayProxy.service.extraAnnotations.original=original",
+									"gatewayProxies.anotherGatewayProxy.service.extraAnnotations.override=override",
+								},
+							})
+						})
+
+						It("does not merge extraAnnotations for service", func() {
+							serviceUns := testManifest.ExpectCustomResource("Service", namespace, "another-gateway-proxy")
+							service, err := kuberesource.ConvertUnstructured(serviceUns)
+							Expect(err).NotTo(HaveOccurred())
+							Expect(service).To(BeAssignableToTypeOf(&v1.Service{}))
+							serviceStr := *service.(*v1.Service)
+							Expect(serviceStr.ObjectMeta.Annotations).To(Equal(map[string]string{"override": "override"}))
+						})
+
+					})
+
 				})
 
 				Context("when multiple custom gatewayproxy override disabled default proxy", func() {


### PR DESCRIPTION
# Description

Ensure that gateway proxy service annotations are not mixed between the default and custom gateway proxies

# Context

Recently, we introduced a deep-merge operation on the Helm dictionary values, to reuse the defaults in .Values.gatewayProxies.gatewayProxy with additional gateway proxies. This enabled customers to avoid manually specifying all the values when running multiple gateway proxies, which is especially problematic during upgrades, as the expected helm values may have changed.

However, this also merges service annotations, which should be distinct per gateway proxy. Therefore, we unset the service annotations of the default gateway proxy copy, that we use to merge with additional gateway proxies.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4914