### PR TITLE
Remove the possibility of using 'localhost' in KubeService ExternalName

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -50,6 +50,7 @@ jobs:
           ${{ runner.os }}-go-
     - uses: engineerd/setup-kind@v0.5.0
       with:
+        # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
         skipClusterCreation: true
     - uses: azure/setup-kubectl@v1
       id: kubectl
@@ -61,8 +62,11 @@ jobs:
     - name: Setup test env
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
+        CLUSTER_NAME: 'kind'
+        CLUSTER_NODE_VERSION: 'v1.17.0'
+        VERSION: 'kind'
       run: |
-        ./ci/kind.sh
+        ./ci/deploy-to-kind-cluster.sh
     - name: Testing - kube e2e regression tests
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ OUTPUT_DIR ?= $(ROOTDIR)/_output
 # To use quay images, set the IMAGE_REPO to "quay.io/solo-io" (or leave unset)
 # To use dockerhub images, set the IMAGE_REPO to "soloio"
 # To use gcr images, set the IMAGE_REPO to "gcr.io/$PROJECT_NAME"
-IMAGE_REPO ?= "quay.io/solo-io"
+IMAGE_REPO ?= quay.io/solo-io
 
 # Kind of a hack to make sure _output exists
 z := $(shell mkdir -p $(OUTPUT_DIR))

--- a/changelog/v1.9.0-beta3/prevent-localhost-external-name.yaml
+++ b/changelog/v1.9.0-beta3/prevent-localhost-external-name.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Remove the possibility of using 'localhost' in KubeService ExternalName
+  - type: NON_USER_FACING
+    description: >
+      Update script used for CI regression tests to expose useful environment variables.
+      This allows developers to leverage this script to easily run regression tests locally.
+      Also, update the README for our regression tests to clarify how to setup and run them.

--- a/ci/deploy-to-kind-cluster.sh
+++ b/ci/deploy-to-kind-cluster.sh
@@ -1,12 +1,29 @@
 #!/bin/bash -ex
 
-kindClusterName=kind
-kindClusterImage=kindest/node:v1.17.0
+# 0. Assign default values to some of our environment variables
 
+# The name of the kind cluster to deploy to
+CLUSTER_NAME="${CLUSTER_NAME:-kind}"
+# The version of the Node Docker image to use for booting the cluster
+CLUSTER_NODE_VERSION="${CLUSTER_NODE_VERSION:-v1.17.0}"
+# The version used to tag images
+VERSION="${VERSION:-kind}"
+
+# 1. Create a kind cluster
 # This config is roughly based on: https://kind.sigs.k8s.io/docs/user/ingress/
-cat <<EOF | kind create cluster --name $kindClusterName --image $kindClusterImage --config=-
+function create_kind_cluster() {
+  echo "creating cluster ${CLUSTER_NAME}"
+
+  activeClusters=$(kind get clusters)
+
+  if [[ "$activeClusters" =~ .*"$CLUSTER_NAME".* ]]; then
+    echo "cluster exists"
+    return
+  fi
+
+  cat <<EOF | kind create cluster --name "$CLUSTER_NAME" --image "kindest/node:$CLUSTER_NODE_VERSION" --config=-
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta2
@@ -32,29 +49,23 @@ kubeadmConfigPatches:
       "feature-gates": "EphemeralContainers=true"
 EOF
 
-# make all the docker images
-# write the output to a temp file so that we can grab the image names out of it
-# also ensure we clean up the file once we're done
-TEMP_FILE=$(mktemp)
-VERSION=kind make docker | tee ${TEMP_FILE}
-
-cleanup() {
-    echo ">> Removing ${TEMP_FILE}"
-    rm ${TEMP_FILE}
+  echo "Finished setting up cluster $CLUSTER_NAME"
 }
-trap "cleanup" EXIT SIGINT
+create_kind_cluster
 
-echo ">> Temporary output file ${TEMP_FILE}"
+# 2. Make all the docker images and load them to the kind cluster
+VERSION=$VERSION CLUSTER_NAME=$CLUSTER_NAME make push-kind-images
 
-# grab the image names out of the `make docker` output
-sed -nE 's|(\\x1b\[0m)?Successfully tagged (.*$)|\2|p' ${TEMP_FILE} | while read f; do kind load docker-image --name kind $f; done
+# 3. Build the test helm chart, ensuring we have a chart in the `_test` folder
+VERSION=$VERSION make build-test-chart
 
-VERSION=kind make build-test-chart
+# 4. Build the gloo command line tool, ensuring we have one in the `_output` folder
 make glooctl-linux-amd64
 
+# 5. Install additional resources used for particular KUBE2E tests
 if [ "$KUBE2E_TESTS" = "eds" ]; then
   echo "Installing Gloo Edge"
-  _output/glooctl-linux-amd64 install gateway --file _test/gloo-kind.tgz
+  _output/glooctl-linux-amd64 install gateway --file _test/gloo-"$VERSION".tgz
 
   kubectl -n gloo-system rollout status deployment gloo --timeout=2m || true
   kubectl -n gloo-system rollout status deployment discovery --timeout=2m || true
@@ -70,6 +81,7 @@ if [ "$KUBE2E_TESTS" = "eds" ]; then
 fi
 
 if [ "$KUBE2E_TESTS" = "glooctl" ]; then
+  echo "Installing Istio 1.7.4"
   curl -sSL https://github.com/istio/istio/releases/download/1.7.4/istio-1.7.4-linux-amd64.tar.gz | tar -xzf - istio-1.7.4/bin/istioctl
   ./istio-1.7.4/bin/istioctl install --set profile=minimal
 fi

--- a/projects/ingress/pkg/status/status_syncer.go
+++ b/projects/ingress/pkg/status/status_syncer.go
@@ -85,7 +85,14 @@ func getLbStatus(services v1.KubeServiceList) ([]kubev1.LoadBalancerIngress, err
 		if err != nil {
 			return nil, errors.Wrapf(err, "internal error: converting proto svc to kube service")
 		}
-		return ingressStatusFromAddrs(serviceAddrs(kubeSvc)), nil
+
+		kubeSvcRef := services[0].Metadata.Ref()
+		kubeSvcAddrs, err := serviceAddrs(kubeSvc, kubeSvcRef)
+		if err != nil {
+			return nil, errors.Wrapf(err, "internal err: extracting service addrs from kube service")
+		}
+
+		return ingressStatusFromAddrs(kubeSvcAddrs), nil
 	}
 	return nil, errors.Errorf("failed to get lb status: expected 1 ingress service, found %v", func() []*core.ResourceRef {
 		var refs []*core.ResourceRef
@@ -96,9 +103,15 @@ func getLbStatus(services v1.KubeServiceList) ([]kubev1.LoadBalancerIngress, err
 	}())
 }
 
-func serviceAddrs(svc *kubev1.Service) []string {
+func serviceAddrs(svc *kubev1.Service, kubeSvcRef *core.ResourceRef) ([]string, error) {
 	if svc.Spec.Type == kubev1.ServiceTypeExternalName {
-		return []string{svc.Spec.ExternalName}
+
+		// Remove the possibility of using localhost in ExternalNames as endpoints
+		svcIp := net.ParseIP(svc.Spec.ExternalName)
+		if svc.Spec.ExternalName == "localhost" || (svcIp != nil && svcIp.IsLoopback()) {
+			return nil, errors.Errorf("Invalid attempt to use localhost name %s, in %q", svc.Spec.ExternalName, kubeSvcRef)
+		}
+		return []string{svc.Spec.ExternalName}, nil
 	}
 	var addrs []string
 
@@ -111,7 +124,7 @@ func serviceAddrs(svc *kubev1.Service) []string {
 	}
 	addrs = append(addrs, svc.Spec.ExternalIPs...)
 
-	return addrs
+	return addrs, nil
 }
 
 func ingressStatusFromAddrs(addrs []string) []kubev1.LoadBalancerIngress {

--- a/projects/ingress/pkg/status/status_syncer.go
+++ b/projects/ingress/pkg/status/status_syncer.go
@@ -109,7 +109,7 @@ func serviceAddrs(svc *kubev1.Service, kubeSvcRef *core.ResourceRef) ([]string, 
 		// Remove the possibility of using localhost in ExternalNames as endpoints
 		svcIp := net.ParseIP(svc.Spec.ExternalName)
 		if svc.Spec.ExternalName == "localhost" || (svcIp != nil && svcIp.IsLoopback()) {
-			return nil, errors.Errorf("Invalid attempt to use localhost name %s, in %q", svc.Spec.ExternalName, kubeSvcRef)
+			return nil, errors.Errorf("Invalid attempt to use localhost name %s, in %v", svc.Spec.ExternalName, kubeSvcRef)
 		}
 		return []string{svc.Spec.ExternalName}, nil
 	}

--- a/projects/ingress/pkg/status/status_syncer_test.go
+++ b/projects/ingress/pkg/status/status_syncer_test.go
@@ -178,9 +178,10 @@ var _ = Describe("StatusSyncer", func() {
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		time.Sleep(time.Second) // give the kube service time to update lb endpoints
-		svc, err = kubeSvcClient.Get(ctx, svc.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			svc, err = kubeSvcClient.Get(ctx, svc.Name, metav1.GetOptions{})
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
 
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			// kubernetes does set ingress lb, set service status explicitly instead
@@ -214,7 +215,7 @@ var _ = Describe("StatusSyncer", func() {
 			defer GinkgoRecover()
 			err := <-statusEventLoopErrs
 			// Expect an error to have occurred during the statusEventLoop
-			Expect(err).To(HaveOccurred())
+			Expect(err).Should(MatchError(ContainSubstring("Invalid attempt to use localhost name")))
 		}()
 
 		backend := &v1beta1.IngressBackend{
@@ -306,9 +307,10 @@ var _ = Describe("StatusSyncer", func() {
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		time.Sleep(time.Second) // give the kube service time to update lb endpoints
-		kubeSvc, err = kubeSvcClient.Get(ctx, kubeSvc.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			kubeSvc, err = kubeSvcClient.Get(ctx, kubeSvc.Name, metav1.GetOptions{})
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
 
 		if len(kubeSvc.Status.LoadBalancer.Ingress) == 0 {
 			// kubernetes does set ingress lb, set service status explicitly instead

--- a/projects/ingress/pkg/status/status_syncer_test.go
+++ b/projects/ingress/pkg/status/status_syncer_test.go
@@ -32,39 +32,44 @@ var _ = Describe("StatusSyncer", func() {
 		cfg       *rest.Config
 		ctx       context.Context
 		cancel    context.CancelFunc
+
+		err           error
+		kubeClientset *kubernetes.Clientset
 	)
 
 	BeforeEach(func() {
+		// https://github.com/solo-io/gloo/issues/3304
 		if os.Getenv("RUN_KUBE_TESTS") != "1" {
 			Skip("This test creates kubernetes resources and is disabled by default. To enable, set RUN_KUBE_TESTS=1 in your env.")
 		}
-		namespace = helpers.RandString(8)
-		var err error
+
 		ctx, cancel = context.WithCancel(context.Background())
 		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 
-		kube, err := kubernetes.NewForConfig(cfg)
+		// Initialize the kube Clientset
+		kubeClientset, err = kubernetes.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = kube.CoreV1().Namespaces().Create(ctx, &kubev1.Namespace{
+
+		// Create test namespace
+		namespace = helpers.RandString(8)
+		_, err = kubeClientset.CoreV1().Namespaces().Create(ctx, &kubev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
 			},
 		}, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
-
 	})
+
 	AfterEach(func() {
-		setup.TeardownKube(namespace)
+		_ = setup.TeardownKube(namespace)
 		cancel()
 	})
 
 	It("updates kube ingresses with endpoints from the service", func() {
-		kube, err := kubernetes.NewForConfig(cfg)
-		Expect(err).NotTo(HaveOccurred())
-		baseIngressClient := ingress.NewResourceClient(kube, &v1.Ingress{})
+		baseIngressClient := ingress.NewResourceClient(kubeClientset, &v1.Ingress{})
 		ingressClient := v1.NewIngressClientWithBase(baseIngressClient)
-		baseKubeServiceClient := service.NewResourceClient(kube, &v1.KubeService{})
+		baseKubeServiceClient := service.NewResourceClient(kubeClientset, &v1.KubeService{})
 		kubeServiceClient := v1.NewKubeServiceClientWithBase(baseKubeServiceClient)
 		kubeServiceClient = service.NewClientWithSelector(kubeServiceClient, map[string]string{
 			"gloo": "ingress-proxy",
@@ -80,7 +85,7 @@ var _ = Describe("StatusSyncer", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		kubeIngressClient := kube.ExtensionsV1beta1().Ingresses(namespace)
+		kubeIngressClient := kubeClientset.ExtensionsV1beta1().Ingresses(namespace)
 		backend := &v1beta1.IngressBackend{
 			ServiceName: "foo",
 			ServicePort: intstr.IntOrString{
@@ -120,7 +125,7 @@ var _ = Describe("StatusSyncer", func() {
 			},
 		}, metav1.CreateOptions{})
 
-		kubeSvcClient := kube.CoreV1().Services(namespace)
+		kubeSvcClient := kubeClientset.CoreV1().Services(namespace)
 		svc_def := kubev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dusty",
@@ -154,7 +159,7 @@ var _ = Describe("StatusSyncer", func() {
 		svc, err := kubeSvcClient.Create(ctx, &svc_def, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = kube.CoreV1().Pods(namespace).Create(ctx, &kubev1.Pod{
+		_, err = kubeClientset.CoreV1().Pods(namespace).Create(ctx, &kubev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "musty",
 				Namespace: namespace,
@@ -190,5 +195,134 @@ var _ = Describe("StatusSyncer", func() {
 			}
 			return ing.Status.LoadBalancer.Ingress, nil
 		}, time.Second*10).Should(Equal(svc.Status.LoadBalancer.Ingress))
+	})
+
+	It("errors when kube service ExternalName = localhost", func() {
+		baseIngressClient := ingress.NewResourceClient(kubeClientset, &v1.Ingress{})
+		ingressClient := v1.NewIngressClientWithBase(baseIngressClient)
+		baseKubeServiceClient := service.NewResourceClient(kubeClientset, &v1.KubeService{})
+		kubeServiceClient := v1.NewKubeServiceClientWithBase(baseKubeServiceClient)
+		kubeServiceClient = service.NewClientWithSelector(kubeServiceClient, map[string]string{
+			"gloo": "ingress-proxy",
+		})
+		statusEmitter := v1.NewStatusEmitter(kubeServiceClient, ingressClient)
+		statusSync := status.NewSyncer(ingressClient)
+		statusEventLoop := v1.NewStatusEventLoop(statusEmitter, statusSync)
+		statusEventLoopErrs, err := statusEventLoop.Run([]string{namespace}, clients.WatchOpts{Ctx: context.TODO()})
+		Expect(err).NotTo(HaveOccurred())
+		go func() {
+			defer GinkgoRecover()
+			err := <-statusEventLoopErrs
+			// Expect an error to have occurred during the statusEventLoop
+			Expect(err).To(HaveOccurred())
+		}()
+
+		backend := &v1beta1.IngressBackend{
+			ServiceName: "foo",
+			ServicePort: intstr.IntOrString{
+				IntVal: 8080,
+			},
+		}
+
+		kubeIngressClient := kubeClientset.ExtensionsV1beta1().Ingresses(namespace)
+		kubeIngress, err := kubeIngressClient.Create(ctx, &v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rusty",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					translator.IngressClassKey: "gloo",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Backend: backend,
+				TLS: []v1beta1.IngressTLS{
+					{
+						Hosts:      []string{"some.host"},
+						SecretName: "doesntexistanyway",
+					},
+				},
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "some.host",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Backend: *backend,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+
+		kubeSvcClient := kubeClientset.CoreV1().Services(namespace)
+		kubeSvcDefinition := kubev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dusty",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gloo": "ingress-proxy",
+				},
+			},
+			Spec: kubev1.ServiceSpec{
+				Selector: map[string]string{
+					"gloo": "ingress-proxy",
+				},
+				Type:         kubev1.ServiceTypeExternalName,
+				ExternalName: "localhost", // this should not be allowed
+			},
+			Status: kubev1.ServiceStatus{
+				LoadBalancer: kubev1.LoadBalancerStatus{
+					Ingress: []kubev1.LoadBalancerIngress{
+						{
+							Hostname: "hostname",
+						},
+					},
+				},
+			},
+		}
+		kubeSvc, err := kubeSvcClient.Create(ctx, &kubeSvcDefinition, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = kubeClientset.CoreV1().Pods(namespace).Create(ctx, &kubev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "musty",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gloo": "ingress-proxy",
+				},
+			},
+			Spec: kubev1.PodSpec{
+				Containers: []kubev1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx:latest",
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(time.Second) // give the kube service time to update lb endpoints
+		kubeSvc, err = kubeSvcClient.Get(ctx, kubeSvc.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		if len(kubeSvc.Status.LoadBalancer.Ingress) == 0 {
+			// kubernetes does set ingress lb, set service status explicitly instead
+			kubeSvc, err = kubeSvcClient.UpdateStatus(ctx, &kubeSvcDefinition, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// The only service that we have configured should be rejected
+		Eventually(func() ([]kubev1.LoadBalancerIngress, error) {
+			ing, err := kubeIngressClient.Get(ctx, kubeIngress.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return ing.Status.LoadBalancer.Ingress, nil
+		}, time.Second*10).Should(BeEmpty())
 	})
 })

--- a/test/kube2e/README.md
+++ b/test/kube2e/README.md
@@ -2,28 +2,83 @@
 This directory contains tests that install each of the 3 Gloo Edge flavors (`gateway`, `ingress`, and `knative`) and run
 regression tests against them.
 
+*Note: All commands should be run from the root directory of the Gloo repository*
+
 ## Setup
-These tests require that a Gloo Edge Helm chart archive be present in the `_test` folder, `glooctl` be built in the
-`_output` folder, and a kind cluster set up and loaded with the images to be installed by the helm chart.
+For these tests to run, we require the following conditions:
+  - Gloo Edge Helm chart archive be present in the `_test` folder,
+  - `glooctl` be built in the`_output` folder
+  - kind cluster set up and loaded with the images to be installed by the helm chart
 
-`ci/kind.sh` gets run in ci to setup the test environment for the above requirements. To run tests locally, it is
-recommended you create a kind cluster using the same command there, build a helm chart for the version you
-want to test (`VERSION=kind make build-test-chart`), build glooctl (`make glooctl`) and load the docker images into
-kind that will get installed (`CLUSTER_NAME=kind VERSION=kind make push-kind-images`).
+### (Option A) - Use the CI Install Script (preferred)
 
-## Run test
-To run the regression tests, your kubeconfig file must point to a running Kubernetes cluster. You can then start the 
-tests by running the following command from this directory:
+`ci/deploy-to-kind-cluster.sh` (`https://github.com/solo-io/gloo/blob/master/ci/deploy-to-kind-cluster.sh`) gets run in CI to setup the test environment for the above requirements.
+It accepts a number of environment variables, to control the creation of a kind cluster and deployment of Gloo resources to that kind cluster.
 
+| Name                  | Default   | Description |
+| ---                   |   ---     |    ---      |
+| CLUSTER_NAME          | kind      | The name of the cluster that will be generated |
+| CLUSTER_NODE_VERSION  | v1.17.0   | The version of the Node Docker image to use for booting the cluster |
+| VERSION               | kind      | The version used to tag Gloo images that are deployed to the cluster |
+
+Example:
 ```bash
-KUBE2E_TESTS=<test-to-run> ginkgo -r
+CLUSTER_NAME=solo-test-cluster CLUSTER_NODE_VERSION=v1.17.0 VERSION=v1.0.0-solo-test ci/deploy-to-kind-cluster.sh
 ```
 
-### Test environment variables
+### (Option B) - Manually Run Make Targets
+
+The CI install script executes a series of make targets.
+
+Create a kind cluster: `kind create cluster --name kind`
+Build the helm chart: `VERSION=kind make build-test-chart`
+Build glooctl: `make glooctl`
+Load the images into the cluster: `CLUSTER_NAME=kind VERSION=kind make push-kind-images`
+
+## Verify Your Setup
+Before running your tests, it's worthwhile to verify that a cluster was created, and the proper images have been loaded.
+
+```bash
+kubectl get nodes
+docker exec -ti <nodename> bash
+crictl images
+```
+
+You should see the list of images in the cluster, including the ones you just uploaded
+
+### Common Setup Errors
+`Error: validation: chart.metadata.version "solo" is invalid`
+In newer versions of helm (>3.5), the version used to build the helm chart (ie the VERSION env variable), needs to respect semantic versioning. This error implies that the version provided does not.
+
+## Run Tests
+
+To run the regression tests, your kubeconfig file must point to a running Kubernetes cluster.
+`kubectl config current-context` should run `kind-<CLUSTER_NAME>`
+
+### (Option A) - Use the Make Target (preferred)
+
+Use the same command that CI relies on:
+```bash
+KUBE2E_TESTS=<test-to-run> make run-ci-regression-tests
+```
+
+### (Option A) - Use Ginkgo Directly
+
+The make target just runs ginkgo with a set of useful flags. If you want to control the flags that are provided, you can run:
+```bash
+KUBE2E_TESTS=<test-to-run> ginkgo -r <other-flags>
+```
+
+### Test Environment Variables
 The below table contains the environment variables that can be used to configure the test execution.
 
-| Name              | Required  | Description |
+| Name              | Default   | Description |
 | ---               |   ---     |    ---      |
-| KUBE2E_TESTS      | Y         | Must be set to the test suite to be run, otherwise all tests will be skipped |
-| DEBUG             | N         | Set to 1 for debug log output |
-| WAIT_ON_FAIL      | N         | Set to 1 to prevent Ginkgo from cleaning up the Gloo Edge installation in case of failure. Useful to exec into inspect resources created by the test. A command to resume the test run (and thus clean up resources) will be logged to the output.
+| KUBE2E_TESTS      | ""        | Name of the test suite to be run. Options: `'gateway', 'ingress', 'knative', 'helm', 'gloomtls', 'glooctl', 'eds'` |
+| DEBUG             | 0         | Set to 1 for debug log output |
+| WAIT_ON_FAIL      | 0         | Set to 1 to prevent Ginkgo from cleaning up the Gloo Edge installation in case of failure. Useful to exec into inspect resources created by the test. A command to resume the test run (and thus clean up resources) will be logged to the output.
+| TEAR_DOWN         | false     | Set to true to uninstall Gloo after the test suite completes |
+
+### Common Test Errors
+`getting Helm chart version: expected a single entry with name [gloo], found: 5`
+The test helm charts are written to the `_test` directory, with the `index.yaml` file containing references to all available charts. The tests require that this file contain only 1 entry. Delete the other entries manually, or run `make clean` to delete this folder entirely, and then re-build the test helm chart.


### PR DESCRIPTION
# Description

Removes the possibility of using localhost in ExternalNames as endpoints

# Context

I also updated the README for our regression tests to make local development (and testing) easier.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
