### PR TITLE
Publish docs after security scan

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -8,7 +8,7 @@ on:
     branches:
     - 'master'
   workflow_run:
-    workflows: ["security-scan"]
+    workflows: ["security-scan-scheduled"]
     types:
       - completed
 jobs:


### PR DESCRIPTION
I haven't tested it, but I think the names accidentally diverged.
If I understand correctly, this will result in the Docs getting re-published whenever a security scan is run, as originally intended, and which I'm suspicious hasn't been happening.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
