### PR TITLE
Specify Gloo versions to be scanned in security scan

### DIFF
--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -4,8 +4,28 @@ on:
     # Monday 9am EST
     - cron: "0 13 * * 1"
   workflow_dispatch: # on button click
+    inputs:
+      gloo-version:
+        description: 'Gloo version'
+        required: false
+        default: ''
 jobs:
+  setup-versions:
+    runs-on: "ubuntu-18.04"
+    outputs:
+      matrix: ${{ steps.set-gloo-version.outputs.matrix }}
+    steps:
+      - id: set-gloo-version
+        run: |
+          if [ -z "${{github.event.inputs.gloo-version}}" ]; then
+#            todo(sai): dynamically fetch recent versions to do security scan on
+#            VERSIONS=$(echo $(curl "https://api.github.com/repos/solo-io/gloo/releases?page=1&per_page=100" | jq -c 'map(.tag_name|select(.|test("^((?!-).)*$")))'))
+            echo '::set-output name=matrix::["master","v1.8.x","v1.7.x","v1.6.x","v1.5.x"]'
+          else
+            echo '::set-output name=matrix::["${{github.event.inputs.gloo-version}}"]'
+          fi
   scan-images:
+    needs: setup-versions
     name: Trivy Scan
     runs-on: "ubuntu-18.04"
     env:
@@ -14,7 +34,7 @@ jobs:
     strategy:
       matrix:
         image-type: [ 'access-logger', 'certgen', 'discovery', 'gateway', 'gloo', 'gloo-envoy-wrapper', 'ingress', 'sds' ]
-        gloo-version: [ 'master', 'v1.8.x', 'v1.7.x', 'v1.6.x', 'v1.5.x']
+        gloo-version: ${{ fromJson(needs.setup-versions.outputs.matrix) }}
     steps:
       - name: Cancel Previous Actions
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -1,14 +1,15 @@
 name: security-scan-scheduled
 on:
-  schedule:
-    # Monday 9am EST
-    - cron: "0 13 * * 1"
-  workflow_dispatch: # on button click
+  workflow_dispatch:
+    # allow for version to be manually specified under actions page
     inputs:
       gloo-version:
         description: 'Gloo version'
         required: false
         default: ''
+  schedule:
+    # Monday 9am EST
+    - cron: "0 13 * * 1"
 jobs:
   setup-versions:
     runs-on: "ubuntu-18.04"
@@ -18,8 +19,6 @@ jobs:
       - id: set-gloo-version
         run: |
           if [ -z "${{github.event.inputs.gloo-version}}" ]; then
-#            todo(sai): dynamically fetch recent versions to do security scan on
-#            VERSIONS=$(echo $(curl "https://api.github.com/repos/solo-io/gloo/releases?page=1&per_page=100" | jq -c 'map(.tag_name|select(.|test("^((?!-).)*$")))'))
             echo '::set-output name=matrix::["master","v1.8.x","v1.7.x","v1.6.x","v1.5.x"]'
           else
             echo '::set-output name=matrix::["${{github.event.inputs.gloo-version}}"]'

--- a/changelog/v1.9.0-beta3/temporary-fix-security-scan.yaml
+++ b/changelog/v1.9.0-beta3/temporary-fix-security-scan.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4974
+    description: >
+      Fixes duplicate versions issue in our [security scan docs](https://docs.solo.io/gloo-edge/master/reference/security-updates/enterprise/).
+      Also allows us to run security scans on individual versions that may be missing security scans because more than one version was
+      released in between weekly security scans.

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/sergi/go-diff v1.1.0
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/solo-io/go-list-licenses v0.1.0
-	github.com/solo-io/go-utils v0.21.8
+	github.com/solo-io/go-utils v0.21.9
 	github.com/solo-io/k8s-utils v0.0.8
 	github.com/solo-io/protoc-gen-ext v0.0.15
 	github.com/solo-io/reporting-client v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -1304,8 +1304,8 @@ github.com/solo-io/go-utils v0.19.0/go.mod h1:If8NiehXROCFU65PGeDTrrZCNA5gJXvbcV
 github.com/solo-io/go-utils v0.20.0/go.mod h1:wy4um9xnqPNlASld4eSuQQqjNCXRBtDjVRLJsoGqkdE=
 github.com/solo-io/go-utils v0.20.2/go.mod h1:6e8K1spnMWwlnJRSNp/J84GEyJbrcK4Gm7i+ehzCi8c=
 github.com/solo-io/go-utils v0.21.6/go.mod h1:N6jeYnrAKq5uGv6m/hBkJ+g6i3AwgkyfVoaDlQ/z64o=
-github.com/solo-io/go-utils v0.21.8 h1:NDeI4Wpi1nagqD3cgAKIBa0YInXkHeurUv73sohF3ww=
-github.com/solo-io/go-utils v0.21.8/go.mod h1:pknK3JQM9l+u+nSaK9veTjAFDMcvxVVslIBVt1Ku5Ig=
+github.com/solo-io/go-utils v0.21.9 h1:W+yNpZzzT3XqU/rkoPOPyTSfUWFekO38R8HLeXPems4=
+github.com/solo-io/go-utils v0.21.9/go.mod h1:pknK3JQM9l+u+nSaK9veTjAFDMcvxVVslIBVt1Ku5Ig=
 github.com/solo-io/k8s-utils v0.0.1/go.mod h1:53N9+9Gl2MwqIZJ7/ocA9gKvWt+6z7MPD2qKQix7oFE=
 github.com/solo-io/k8s-utils v0.0.8 h1:GJ+DLBFfR8WRg2WofGQ3o3DVPByDEYgANX9kQYhprow=
 github.com/solo-io/k8s-utils v0.0.8/go.mod h1:Cg2ymG0xhLdyS3NJ0D98yxiSWjAKYPNopzPTwVDl7e4=


### PR DESCRIPTION
# Description

Currently, our security scans miss some versions. This is because they scan once a week and run on the latest master, v1.8.x, v1.7.x, v1.6.x, etc branches. This means that if we were to release v1.8.1 and v1.8.2 in the same week, a security scan would only run for release v1.8.2. This is not ideal, and as a temporary solution, this PR allows us to specify which versions that need to be scanned directly from the github action.

1. Navigate to the trivy schedule security scan GH action: https://github.com/solo-io/gloo/actions/workflows/trivy-analysis-scheduled.yaml
2. Click `Run Workflow`, and specify the version under "Gloo Version" , e.g. v1.7.8. If you leave Gloo Version empty, it will run the security scan on the master, v1.8.x, v1.7.x, etc branches as we do weekly.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4974