### PR TITLE
Remove the possibility of using 'localhost' in KubeService ExternalName

### DIFF
--- a/changelog/v1.5.26/prevent-localhost-external-name.yaml
+++ b/changelog/v1.5.26/prevent-localhost-external-name.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Remove the possibility of using 'localhost' in KubeService ExternalName

--- a/projects/ingress/pkg/status/status_syncer.go
+++ b/projects/ingress/pkg/status/status_syncer.go
@@ -85,7 +85,14 @@ func getLbStatus(services v1.KubeServiceList) ([]kubev1.LoadBalancerIngress, err
 		if err != nil {
 			return nil, errors.Wrapf(err, "internal error: converting proto svc to kube service")
 		}
-		return ingressStatusFromAddrs(serviceAddrs(kubeSvc)), nil
+
+		kubeSvcRef := services[0].Metadata.Ref()
+		kubeSvcAddrs, err := serviceAddrs(kubeSvc, kubeSvcRef)
+		if err != nil {
+			return nil, errors.Wrapf(err, "internal err: extracting service addrs from kube service")
+		}
+
+		return ingressStatusFromAddrs(kubeSvcAddrs), nil
 	}
 	return nil, errors.Errorf("failed to get lb status: expected 1 ingress service, found %v", func() []core.ResourceRef {
 		var refs []core.ResourceRef
@@ -96,9 +103,15 @@ func getLbStatus(services v1.KubeServiceList) ([]kubev1.LoadBalancerIngress, err
 	}())
 }
 
-func serviceAddrs(svc *kubev1.Service) []string {
+func serviceAddrs(svc *kubev1.Service, kubeSvcRef *core.ResourceRef) ([]string, error) {
 	if svc.Spec.Type == kubev1.ServiceTypeExternalName {
-		return []string{svc.Spec.ExternalName}
+
+		// Remove the possibility of using localhost in ExternalNames as endpoints
+		svcIp := net.ParseIP(svc.Spec.ExternalName)
+		if svc.Spec.ExternalName == "localhost" || (svcIp != nil && svcIp.IsLoopback()) {
+			return nil, errors.Errorf("Invalid attempt to use localhost name %s, in %v", svc.Spec.ExternalName, kubeSvcRef)
+		}
+		return []string{svc.Spec.ExternalName}, nil
 	}
 	var addrs []string
 
@@ -111,7 +124,7 @@ func serviceAddrs(svc *kubev1.Service) []string {
 	}
 	addrs = append(addrs, svc.Spec.ExternalIPs...)
 
-	return addrs
+	return addrs, nil
 }
 
 func ingressStatusFromAddrs(addrs []string) []kubev1.LoadBalancerIngress {

--- a/projects/ingress/pkg/status/status_syncer.go
+++ b/projects/ingress/pkg/status/status_syncer.go
@@ -103,7 +103,7 @@ func getLbStatus(services v1.KubeServiceList) ([]kubev1.LoadBalancerIngress, err
 	}())
 }
 
-func serviceAddrs(svc *kubev1.Service, kubeSvcRef *core.ResourceRef) ([]string, error) {
+func serviceAddrs(svc *kubev1.Service, kubeSvcRef core.ResourceRef) ([]string, error) {
 	if svc.Spec.Type == kubev1.ServiceTypeExternalName {
 
 		// Remove the possibility of using localhost in ExternalNames as endpoints

--- a/projects/ingress/pkg/status/status_syncer_test.go
+++ b/projects/ingress/pkg/status/status_syncer_test.go
@@ -30,37 +30,46 @@ var _ = Describe("StatusSyncer", func() {
 	var (
 		namespace string
 		cfg       *rest.Config
+		ctx       context.Context
+		cancel    context.CancelFunc
+
+		err           error
+		kubeClientset *kubernetes.Clientset
 	)
 
 	BeforeEach(func() {
+		// https://github.com/solo-io/gloo/issues/3304
 		if os.Getenv("RUN_KUBE_TESTS") != "1" {
 			Skip("This test creates kubernetes resources and is disabled by default. To enable, set RUN_KUBE_TESTS=1 in your env.")
 		}
-		namespace = helpers.RandString(8)
-		var err error
+
+		ctx, cancel = context.WithCancel(context.Background())
 		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 
-		kube, err := kubernetes.NewForConfig(cfg)
+		// Initialize the kube Clientset
+		kubeClientset, err = kubernetes.NewForConfig(cfg)
 		Expect(err).NotTo(HaveOccurred())
-		_, err = kube.CoreV1().Namespaces().Create(&kubev1.Namespace{
+
+		// Create test namespace
+		namespace = helpers.RandString(8)
+		_, err = kubeClientset.CoreV1().Namespaces().Create(&kubev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: namespace,
 			},
 		})
 		Expect(err).NotTo(HaveOccurred())
-
 	})
+
 	AfterEach(func() {
-		setup.TeardownKube(namespace)
+		_ = setup.TeardownKube(namespace)
+		cancel()
 	})
 
 	It("updates kube ingresses with endpoints from the service", func() {
-		kube, err := kubernetes.NewForConfig(cfg)
-		Expect(err).NotTo(HaveOccurred())
-		baseIngressClient := ingress.NewResourceClient(kube, &v1.Ingress{})
+		baseIngressClient := ingress.NewResourceClient(kubeClientset, &v1.Ingress{})
 		ingressClient := v1.NewIngressClientWithBase(baseIngressClient)
-		baseKubeServiceClient := service.NewResourceClient(kube, &v1.KubeService{})
+		baseKubeServiceClient := service.NewResourceClient(kubeClientset, &v1.KubeService{})
 		kubeServiceClient := v1.NewKubeServiceClientWithBase(baseKubeServiceClient)
 		kubeServiceClient = service.NewClientWithSelector(kubeServiceClient, map[string]string{
 			"gloo": "ingress-proxy",
@@ -76,7 +85,7 @@ var _ = Describe("StatusSyncer", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}()
 
-		kubeIngressClient := kube.ExtensionsV1beta1().Ingresses(namespace)
+		kubeIngressClient := kubeClientset.ExtensionsV1beta1().Ingresses(namespace)
 		backend := &v1beta1.IngressBackend{
 			ServiceName: "foo",
 			ServicePort: intstr.IntOrString{
@@ -116,7 +125,7 @@ var _ = Describe("StatusSyncer", func() {
 			},
 		})
 
-		kubeSvcClient := kube.CoreV1().Services(namespace)
+		kubeSvcClient := kubeClientset.CoreV1().Services(namespace)
 		svc_def := kubev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "dusty",
@@ -150,7 +159,7 @@ var _ = Describe("StatusSyncer", func() {
 		svc, err := kubeSvcClient.Create(&svc_def)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = kube.CoreV1().Pods(namespace).Create(&kubev1.Pod{
+		_, err = kubeClientset.CoreV1().Pods(namespace).Create(&kubev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "musty",
 				Namespace: namespace,
@@ -169,9 +178,10 @@ var _ = Describe("StatusSyncer", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
-		time.Sleep(time.Second) // give the kube service time to update lb endpoints
-		svc, err = kubeSvcClient.Get(svc.Name, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		Eventually(func() error {
+			svc, err = kubeSvcClient.Get(svc.Name, metav1.GetOptions{})
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
 
 		if len(svc.Status.LoadBalancer.Ingress) == 0 {
 			// kubernetes does set ingress lb, set service status explicitly instead
@@ -186,5 +196,135 @@ var _ = Describe("StatusSyncer", func() {
 			}
 			return ing.Status.LoadBalancer.Ingress, nil
 		}, time.Second*10).Should(Equal(svc.Status.LoadBalancer.Ingress))
+	})
+
+	It("errors when kube service ExternalName = localhost", func() {
+		baseIngressClient := ingress.NewResourceClient(kubeClientset, &v1.Ingress{})
+		ingressClient := v1.NewIngressClientWithBase(baseIngressClient)
+		baseKubeServiceClient := service.NewResourceClient(kubeClientset, &v1.KubeService{})
+		kubeServiceClient := v1.NewKubeServiceClientWithBase(baseKubeServiceClient)
+		kubeServiceClient = service.NewClientWithSelector(kubeServiceClient, map[string]string{
+			"gloo": "ingress-proxy",
+		})
+		statusEmitter := v1.NewStatusEmitter(kubeServiceClient, ingressClient)
+		statusSync := status.NewSyncer(ingressClient)
+		statusEventLoop := v1.NewStatusEventLoop(statusEmitter, statusSync)
+		statusEventLoopErrs, err := statusEventLoop.Run([]string{namespace}, clients.WatchOpts{Ctx: context.TODO()})
+		Expect(err).NotTo(HaveOccurred())
+		go func() {
+			defer GinkgoRecover()
+			err := <-statusEventLoopErrs
+			// Expect an error to have occurred during the statusEventLoop
+			Expect(err).Should(MatchError(ContainSubstring("Invalid attempt to use localhost name")))
+		}()
+
+		backend := &v1beta1.IngressBackend{
+			ServiceName: "foo",
+			ServicePort: intstr.IntOrString{
+				IntVal: 8080,
+			},
+		}
+
+		kubeIngressClient := kubeClientset.ExtensionsV1beta1().Ingresses(namespace)
+		kubeIngress, err := kubeIngressClient.Create(&v1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "rusty",
+				Namespace: namespace,
+				Annotations: map[string]string{
+					translator.IngressClassKey: "gloo",
+				},
+			},
+			Spec: v1beta1.IngressSpec{
+				Backend: backend,
+				TLS: []v1beta1.IngressTLS{
+					{
+						Hosts:      []string{"some.host"},
+						SecretName: "doesntexistanyway",
+					},
+				},
+				Rules: []v1beta1.IngressRule{
+					{
+						Host: "some.host",
+						IngressRuleValue: v1beta1.IngressRuleValue{
+							HTTP: &v1beta1.HTTPIngressRuleValue{
+								Paths: []v1beta1.HTTPIngressPath{
+									{
+										Backend: *backend,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		kubeSvcClient := kubeClientset.CoreV1().Services(namespace)
+		kubeSvcDefinition := kubev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dusty",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gloo": "ingress-proxy",
+				},
+			},
+			Spec: kubev1.ServiceSpec{
+				Selector: map[string]string{
+					"gloo": "ingress-proxy",
+				},
+				Type:         kubev1.ServiceTypeExternalName,
+				ExternalName: "localhost", // this should not be allowed
+			},
+			Status: kubev1.ServiceStatus{
+				LoadBalancer: kubev1.LoadBalancerStatus{
+					Ingress: []kubev1.LoadBalancerIngress{
+						{
+							Hostname: "hostname",
+						},
+					},
+				},
+			},
+		}
+		kubeSvc, err := kubeSvcClient.Create(&kubeSvcDefinition)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = kubeClientset.CoreV1().Pods(namespace).Create(&kubev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "musty",
+				Namespace: namespace,
+				Labels: map[string]string{
+					"gloo": "ingress-proxy",
+				},
+			},
+			Spec: kubev1.PodSpec{
+				Containers: []kubev1.Container{
+					{
+						Name:  "nginx",
+						Image: "nginx:latest",
+					},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() error {
+			kubeSvc, err = kubeSvcClient.Get(kubeSvc.Name, metav1.GetOptions{})
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		if len(kubeSvc.Status.LoadBalancer.Ingress) == 0 {
+			// kubernetes does set ingress lb, set service status explicitly instead
+			kubeSvc, err = kubeSvcClient.UpdateStatus(&kubeSvcDefinition)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		// The only service that we have configured should be rejected
+		Eventually(func() ([]kubev1.LoadBalancerIngress, error) {
+			ing, err := kubeIngressClient.Get(kubeIngress.Name, metav1.GetOptions{})
+			if err != nil {
+				return nil, err
+			}
+			return ing.Status.LoadBalancer.Ingress, nil
+		}, time.Second*10).Should(BeEmpty())
 	})
 })

--- a/projects/ingress/pkg/status/status_syncer_test.go
+++ b/projects/ingress/pkg/status/status_syncer_test.go
@@ -30,8 +30,6 @@ var _ = Describe("StatusSyncer", func() {
 	var (
 		namespace string
 		cfg       *rest.Config
-		ctx       context.Context
-		cancel    context.CancelFunc
 
 		err           error
 		kubeClientset *kubernetes.Clientset
@@ -43,7 +41,6 @@ var _ = Describe("StatusSyncer", func() {
 			Skip("This test creates kubernetes resources and is disabled by default. To enable, set RUN_KUBE_TESTS=1 in your env.")
 		}
 
-		ctx, cancel = context.WithCancel(context.Background())
 		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
 
@@ -63,7 +60,6 @@ var _ = Describe("StatusSyncer", func() {
 
 	AfterEach(func() {
 		_ = setup.TeardownKube(namespace)
-		cancel()
 	})
 
 	It("updates kube ingresses with endpoints from the service", func() {


### PR DESCRIPTION
Backport of: https://github.com/solo-io/gloo/pull/4970

# Description

Removes the possibility of using localhost in ExternalNames as endpoints

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works