### PR TITLE
Update docker-compose.yaml to reflect v1.8 config changes

### DIFF
--- a/docs/content/installation/gateway/development/docker-compose-file/_index.md
+++ b/docs/content/installation/gateway/development/docker-compose-file/_index.md
@@ -82,7 +82,7 @@ The files used for installation live in the `install/docker-compose-file` direct
 
 ### Prepare the Directory Structure
 
-Since we are using the filesystem to store the Gloo Edge configuration and credentials, we need to set up a directory structure to support that. Each of the Gloo Edge containers created by the `docker-compose.yaml` file will attach to the `data` directory inside the `install/docker-compose-file` parent directory. 
+Since we are using the filesystem to store the Gloo Edge configuration and credentials, we need to set up a directory structure to support that. Each of the Gloo Edge containers created by the `docker-compose.yaml` file will attach to the `data` directory inside the `install/docker-compose-file` parent directory.
 
 Although much of the structure is already set up, there are some additional empty directories that must be created for use by the Gloo Edge containers. Let's run the `prepare-directories.sh` script to create the rest.
 
@@ -106,6 +106,8 @@ The updated `data` directory structure should look like this:
 │   │   └── gloo-system
 │   ├── ratelimitconfigs
 │   │   └── gloo-system
+│   ├── routeoptions
+│   │   └── gloo-system
 │   ├── routetables
 │   │   └── gloo-system
 │   ├── upstreamgroups
@@ -113,6 +115,8 @@ The updated `data` directory structure should look like this:
 │   ├── upstreams
 │   │   └── gloo-system
 │   │       └── petstore.yaml
+│   └── virtualhostoptions
+│   │   └── gloo-system
 │   └── virtualservices
 │       └── gloo-system
 │           └── default.yaml
@@ -153,11 +157,11 @@ docker-compose up
 The following ports will be exposed to the host machine:
 
 |  service  | port |
-| ----- | ---- |  
-| gloo/http | 8080 | 
+| ----- | ---- |
+| gloo/http | 8080 |
 | petstore | 8090 |
-| gloo/https | 8443 | 
-| gloo/admin | 19000 | 
+| gloo/https | 8443 |
+| gloo/admin | 19000 |
 
 In addition to opening ports, there should be a new file in the `data` directory.
 
@@ -327,6 +331,6 @@ curl http://localhost:8080/petstore/findWithId/1
 
 ## Next Steps
 
-Congratulations! You've successfully deployed Gloo Edge with Docker Compose and created your first route. Now let's delve deeper into the world of [Traffic Management with Gloo Edge]({{< versioned_link_path fromRoot="/guides/traffic_management/" >}}). 
+Congratulations! You've successfully deployed Gloo Edge with Docker Compose and created your first route. Now let's delve deeper into the world of [Traffic Management with Gloo Edge]({{< versioned_link_path fromRoot="/guides/traffic_management/" >}}).
 
 Most of the existing tutorials for Gloo Edge use Kubernetes as the underlying resource, but they can also use a Docker Compose deployment. It will be necessary to handcraft the proper YAML files for each configuration, so it might make more sense to check out using either Kubernetes or Consul & Vault to store configuration data.

--- a/install/docker-compose-file/docker-compose.yaml
+++ b/install/docker-compose-file/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   gloo:
-    image: "${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.7.6}"
+    image: "${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.8.0}"
     working_dir: /
     command:
     - "--dir=/data/"
@@ -14,7 +14,7 @@ services:
     restart: always
 
   gateway:
-    image: "${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.7.6}"
+    image: "${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.8.0}"
     working_dir: /
     command:
     - "--dir=/data/"
@@ -23,7 +23,7 @@ services:
     restart: always
 
   gateway-proxy:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.7.6}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.8.0}
     entrypoint: ["envoy"]
     command: ["-c", "/config/envoy.yaml", "--disable-hot-restart"]
     volumes:
@@ -37,6 +37,6 @@ services:
  # example application, the swagger petstore
   petstore:
     image: ${PETSTORE_REPO:-quay.io/solo-io}/petstore:v1
-    ports: 
+    ports:
     - "8090:8080"
     restart: always

--- a/install/docker-compose-file/prepare-directories.sh
+++ b/install/docker-compose-file/prepare-directories.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
 mkdir -p ./data/artifact/artifacts/gloo-system
-mkdir -p ./data/config/{proxies,upstreams,upstreamgroups,routetables,authconfigs,ratelimitconfigs}/gloo-system
+mkdir -p ./data/config/{authconfigs,gateways,proxies,upstreams,upstreamgroups,ratelimitconfigs,routeoptions,routetables,virtualhostoptions,virtualservices}/gloo-system
 mkdir -p ./data/secret/secrets/{default,gloo-system}
-


### PR DESCRIPTION
# Description

Adress https://github.com/solo-io/gloo/issues/4971

# Context

Bumping from 1.7 w/o the proper folder structure available throws `fatal`

```
{"level":"fatal","ts":"2021-07-06T14:40:02.692Z","logger":"gateway","caller":"setuputils/main_setup.go:88","msg":"error in setup: starting snapshot watch: initial VirtualHostOption list: reading namespace dir: open /data/config/virtualhostoptions/gloo-system: no such file or directory","version":"1.8.0","stacktrace":"github.com/solo-io/gloo/pkg/utils/setuputils.Main\n\t/workspace/gloo/pkg/utils/setuputils/main_setup.go:88\ngithub.com/solo-io/gloo/projects/gateway/pkg/setup.Main\n\t/workspace/gloo/projects/gateway/pkg/setup/setup.go:13\nmain.main\n\t/workspace/gloo/projects/gateway/cmd/main.go:11\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:225"}
```
```
{"level":"fatal","ts":"2021-07-06T14:40:08.264Z","logger":"gateway","caller":"setuputils/main_setup.go:88","msg":"error in setup: starting snapshot watch: initial RouteOption list: reading namespace dir: open /data/config/routeoptions/gloo-system: no such file or directory","version":"1.8.0","stacktrace":"github.com/solo-io/gloo/pkg/utils/setuputils.Main\n\t/workspace/gloo/pkg/utils/setuputils/main_setup.go:88\ngithub.com/solo-io/gloo/projects/gateway/pkg/setup.Main\n\t/workspace/gloo/projects/gateway/pkg/setup/setup.go:13\nmain.main\n\t/workspace/gloo/projects/gateway/cmd/main.go:11\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:225"}
```

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
