### PR TITLE
Skip enterprise docs generation on community PRs

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -57,6 +57,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         SKIP_CHANGELOG_GENERATION: ${{ steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
         SKIP_SECURITY_SCAN: ${{ steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
+        SKIP_ENTERPRISE_DOCS_GENERATION: ${{ steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
         USE_PR_SHA_AS_MASTER: ${{ github.event_name == 'pull_request' && !steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
         PULL_REQUEST_SHA: ${{ github.event.pull_request.head.sha }}
     - name: Deploy to Firebase

--- a/changelog/v1.9.0-beta3/skip-enterprise-docs-gen-community-pr.yaml
+++ b/changelog/v1.9.0-beta3/skip-enterprise-docs-gen-community-pr.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: > 
+      Skip enterprise docs generation on community PRs. CI was failing on community PRs during the
+      "Generate versioned docs site" step of the docs-gen workflow, because enterprise docs generation
+      required the presence of a github access token with access to the solo-projects repository.

--- a/docs/cmd/generate_docs.go
+++ b/docs/cmd/generate_docs.go
@@ -119,6 +119,9 @@ func enterpriseHelmValuesMdFromGithubCmd(opts *options) *cobra.Command {
 		Use:   "get-enterprise-helm-values",
 		Short: "Get documentation of valid helm values from Gloo Enterprise github",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if os.Getenv(skipEnterpriseDocsGeneration) != "" {
+				return nil
+			}
 			return fetchEnterpriseHelmValues(args)
 		},
 	}
@@ -139,10 +142,11 @@ func getRepoReleases(ctx context.Context, repo string, client *github.Client) er
 }
 
 const (
-	glooDocGen              = "gloo"
-	glooEDocGen             = "glooe"
-	skipChangelogGeneration = "SKIP_CHANGELOG_GENERATION"
-	skipSecurityScan        = "SKIP_SECURITY_SCAN"
+	glooDocGen                   = "gloo"
+	glooEDocGen                  = "glooe"
+	skipChangelogGeneration      = "SKIP_CHANGELOG_GENERATION"
+	skipSecurityScan             = "SKIP_SECURITY_SCAN"
+	skipEnterpriseDocsGeneration = "SKIP_ENTERPRISE_DOCS_GENERATION"
 )
 
 const (


### PR DESCRIPTION
# Description

- Skip enterprise docs generation during the `docs-gen` GH workflow on community PRs.

# Context

- CI was failing on community PRs during the "Generate versioned docs site" step of the docs-gen workflow, because enterprise docs generation required the presence of a Github access token with access to the solo-projects repository.
