### PR TITLE
Add rate limiting UserID source note to docs

### DIFF
--- a/docs/content/guides/security/rate_limiting/simple/_index.md
+++ b/docs/content/guides/security/rate_limiting/simple/_index.md
@@ -25,7 +25,7 @@ ratelimitBasic:
 ```
 
 - Rate limits can be set for anonymous requests, authorized requests, both, or neither.
-- `authorized_requests` represent the rate limits imposed on requests that are associated with a known user id
+- `authorized_requests` represent the rate limits imposed on requests that are associated with a known user id. Note that this user id is included in the [external auth service's]({{% versioned_link_path fromRoot="/guides/security/auth/extauth" %}}) [AuthorizationResponse]({{% versioned_link_path fromRoot="/guides/dev/writing_auth_plugins/#header-propagation" %}}) in the `UserInfo.UserID` field.
 - `anonymous_requests` represent the rate limits imposed on requests that are not associated with a known user id. In this case, the limit is applied to the request's remote address.
 - `requests_per_unit` takes an integer value
 - `unit` must be one of these strings: `SECOND`, `MINUTE`, `HOUR`, `DAY`


### PR DESCRIPTION
# Description

A user was confused about the source of the user id that drives authorized request rate limiting and had to guess at the right answer. Adding a note in the docs to clarify.
