### PR TITLE
Add extractor regex note to docs

### DIFF
--- a/docs/content/guides/traffic_management/request_processing/transformations/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/transformations/_index.md
@@ -226,6 +226,30 @@ extractors:
     subgroup: 2
 ```
 
+Another example shows how to extract a value from the body using a regex.
+If the body is:
+
+```text
+Here is a body containing the identification number of the object.
+
+id: 4423
+```
+and we want to extract the id number, we can define an extractor:
+```yaml
+extractors:
+  # This is the name of the extraction
+  bodyIdExtractor:
+    # This empty struct must be included to extract from the body
+    body: {}
+    # The regex must match the ENTIRE body, else the extraction will not work
+    # The [\s\S]* allows us to match any character, making the regex match the entire source.
+    regex: '[\s\S]*id: ([0-9]{4})[\s\S]*'
+    # Select the first subgroup match ([0-9]{4}) since we only want the id number
+    subgroup: 1
+```
+
+The result will be the `bodyIdExtractor` having value `4423`.
+
 Extracted values can be used in two ways:
 
 - You can reference extractors by their name in template strings, e.g. `{{ my-extractor }}` (or `{{ extraction(my-extractor) }}`, if you are setting `advancedTemplates` to `true`) will render to the value of the `my-extractor` extractor.

--- a/docs/content/guides/traffic_management/request_processing/transformations/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/transformations/_index.md
@@ -205,10 +205,11 @@ The `body` extraction source has been introduced with **Gloo Edge**, release 0.2
 
 Extracting the body is generally not useful when Gloo Edge has already parsed it as JSON, the default behavior. The parsed body data can be directly referenced using standard JSON syntax. The `body` extractor treats the body as plaintext, and is interpreted using a regular expression as noted below. This can be useful for body data that cannot be parsed as JSON.
 
-An extraction must also define which information is to be extracted from the source. This can be done by providing a regular expression via the `regex` attribute. The regular expression will be applied to the body or to the value of relevant header. If your regular expression uses _capturing groups_, you can select the group match you want to use via the `subgroup` attribute.
+An extraction must also define which information is to be extracted from the source. This can be done by providing a regular expression via the `regex` attribute. The regular expression will be applied to the body or to the value of relevant header and must match the entire source. If your regular expression uses _capturing groups_, you can select the group match you want to use via the `subgroup` attribute.
 
 {{% notice note %}}
 The `regex` attribute is required when specifying an extraction. Even if a `regex` attribute is not required to capture a subset of the source information, you must still specify a catch-all pattern like `regex: '.*'`. If no `regex` is specified, the extractor will silently fail.
+The `regex` **must match the entire source** even if you are looking to extract a subset of the source information in a capturing group. If the regex doesn't match the entire input, the regex will silently fail.
 {{% /notice %}}
 
 As an example, to define an extraction named `foo` which will contain the value of the `foo` query parameter you can apply the following configuration:

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/external/envoy/extensions/transformation/transformation.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/external/envoy/extensions/transformation/transformation.proto.sk.md
@@ -267,7 +267,7 @@ The extracted information can then be referenced in template fields.
 | ----- | ---- | ----------- | 
 | `header` | `string` | Extract information from headers. Only one of `header` or `body` can be set. |
 | `body` | [.google.protobuf.Empty](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/empty) | Extract information from the request/response body. Only one of `body` or `header` can be set. |
-| `regex` | `string` | Only strings matching this regular expression will be part of the extraction. The most simple value for this field is '.*', which matches the whole source. The field is required. If extraction fails the result is an empty value. |
+| `regex` | `string` | Only strings matching this regular expression will be part of the extraction. This regex **must match the entire source** in order for a value to be extracted. The most simple value for this field is '.*', which matches the whole source. The field is required. If extraction fails the result is an empty value. |
 | `subgroup` | `int` | If your regex contains capturing groups, use this field to determine which group should be selected. |
 
 

--- a/install/helm/gloo/crds/gateway.solo.io_v1_Gateway.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_Gateway.yaml
@@ -1675,9 +1675,12 @@ spec:
                                                             description: Only strings
                                                               matching this regular
                                                               expression will be part
-                                                              of the extraction. The
-                                                              most simple value for
-                                                              this field is '.*',
+                                                              of the extraction. This
+                                                              regex **must match the
+                                                              entire source** in order
+                                                              for a value to be extracted.
+                                                              The most simple value
+                                                              for this field is '.*',
                                                               which matches the whole
                                                               source. The field is
                                                               required. If extraction
@@ -2480,6 +2483,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -2804,6 +2814,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -3192,6 +3209,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -3739,6 +3763,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -4063,6 +4094,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -4451,6 +4489,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -4772,9 +4817,12 @@ spec:
                                                             description: Only strings
                                                               matching this regular
                                                               expression will be part
-                                                              of the extraction. The
-                                                              most simple value for
-                                                              this field is '.*',
+                                                              of the extraction. This
+                                                              regex **must match the
+                                                              entire source** in order
+                                                              for a value to be extracted.
+                                                              The most simple value
+                                                              for this field is '.*',
                                                               which matches the whole
                                                               source. The field is
                                                               required. If extraction
@@ -5017,9 +5065,12 @@ spec:
                                                             description: Only strings
                                                               matching this regular
                                                               expression will be part
-                                                              of the extraction. The
-                                                              most simple value for
-                                                              this field is '.*',
+                                                              of the extraction. This
+                                                              regex **must match the
+                                                              entire source** in order
+                                                              for a value to be extracted.
+                                                              The most simple value
+                                                              for this field is '.*',
                                                               which matches the whole
                                                               source. The field is
                                                               required. If extraction
@@ -5379,10 +5430,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string

--- a/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
@@ -1365,11 +1365,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -1560,11 +1562,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -1799,11 +1803,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2133,11 +2139,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2328,11 +2336,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2567,11 +2577,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2825,10 +2837,12 @@ spec:
                                     type: string
                                   regex:
                                     description: Only strings matching this regular
-                                      expression will be part of the extraction. The
-                                      most simple value for this field is '.*', which
-                                      matches the whole source. The field is required.
-                                      If extraction fails the result is an empty value.
+                                      expression will be part of the extraction. This
+                                      regex **must match the entire source** in order
+                                      for a value to be extracted. The most simple
+                                      value for this field is '.*', which matches
+                                      the whole source. The field is required. If
+                                      extraction fails the result is an empty value.
                                     type: string
                                   subgroup:
                                     description: If your regex contains capturing
@@ -3001,10 +3015,12 @@ spec:
                                     type: string
                                   regex:
                                     description: Only strings matching this regular
-                                      expression will be part of the extraction. The
-                                      most simple value for this field is '.*', which
-                                      matches the whole source. The field is required.
-                                      If extraction fails the result is an empty value.
+                                      expression will be part of the extraction. This
+                                      regex **must match the entire source** in order
+                                      for a value to be extracted. The most simple
+                                      value for this field is '.*', which matches
+                                      the whole source. The field is required. If
+                                      extraction fails the result is an empty value.
                                     type: string
                                   subgroup:
                                     description: If your regex contains capturing

--- a/install/helm/gloo/crds/gateway.solo.io_v1_RouteTable.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_RouteTable.yaml
@@ -1659,12 +1659,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -1870,12 +1873,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -2129,12 +2135,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -2491,12 +2500,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -2702,12 +2714,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -2961,12 +2976,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -3234,7 +3252,9 @@ spec:
                                         regex:
                                           description: Only strings matching this
                                             regular expression will be part of the
-                                            extraction. The most simple value for
+                                            extraction. This regex **must match the
+                                            entire source** in order for a value to
+                                            be extracted. The most simple value for
                                             this field is '.*', which matches the
                                             whole source. The field is required. If
                                             extraction fails the result is an empty
@@ -3419,7 +3439,9 @@ spec:
                                         regex:
                                           description: Only strings matching this
                                             regular expression will be part of the
-                                            extraction. The most simple value for
+                                            extraction. This regex **must match the
+                                            entire source** in order for a value to
+                                            be extracted. The most simple value for
                                             this field is '.*', which matches the
                                             whole source. The field is required. If
                                             extraction fails the result is an empty
@@ -3913,6 +3935,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -4653,6 +4678,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -4938,6 +4968,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -5281,6 +5316,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -5759,6 +5799,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -6044,6 +6089,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -6387,6 +6437,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -6672,6 +6727,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -6899,6 +6957,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -7238,11 +7299,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains

--- a/install/helm/gloo/crds/gateway.solo.io_v1_VirtualHostOption.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_VirtualHostOption.yaml
@@ -1536,11 +1536,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -1731,11 +1733,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -1970,11 +1974,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2304,11 +2310,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2499,11 +2507,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2738,11 +2748,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -2983,10 +2995,12 @@ spec:
                                     type: string
                                   regex:
                                     description: Only strings matching this regular
-                                      expression will be part of the extraction. The
-                                      most simple value for this field is '.*', which
-                                      matches the whole source. The field is required.
-                                      If extraction fails the result is an empty value.
+                                      expression will be part of the extraction. This
+                                      regex **must match the entire source** in order
+                                      for a value to be extracted. The most simple
+                                      value for this field is '.*', which matches
+                                      the whole source. The field is required. If
+                                      extraction fails the result is an empty value.
                                     type: string
                                   subgroup:
                                     description: If your regex contains capturing
@@ -3159,10 +3173,12 @@ spec:
                                     type: string
                                   regex:
                                     description: Only strings matching this regular
-                                      expression will be part of the extraction. The
-                                      most simple value for this field is '.*', which
-                                      matches the whole source. The field is required.
-                                      If extraction fails the result is an empty value.
+                                      expression will be part of the extraction. This
+                                      regex **must match the entire source** in order
+                                      for a value to be extracted. The most simple
+                                      value for this field is '.*', which matches
+                                      the whole source. The field is required. If
+                                      extraction fails the result is an empty value.
                                     type: string
                                   subgroup:
                                     description: If your regex contains capturing

--- a/install/helm/gloo/crds/gateway.solo.io_v1_VirtualService.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_VirtualService.yaml
@@ -1726,10 +1726,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string
@@ -1931,10 +1933,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string
@@ -2183,10 +2187,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string
@@ -2534,10 +2540,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string
@@ -2739,10 +2747,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string
@@ -2991,10 +3001,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string
@@ -3247,10 +3259,12 @@ spec:
                                       regex:
                                         description: Only strings matching this regular
                                           expression will be part of the extraction.
-                                          The most simple value for this field is
-                                          '.*', which matches the whole source. The
-                                          field is required. If extraction fails the
-                                          result is an empty value.
+                                          This regex **must match the entire source**
+                                          in order for a value to be extracted. The
+                                          most simple value for this field is '.*',
+                                          which matches the whole source. The field
+                                          is required. If extraction fails the result
+                                          is an empty value.
                                         type: string
                                       subgroup:
                                         description: If your regex contains capturing
@@ -3429,10 +3443,12 @@ spec:
                                       regex:
                                         description: Only strings matching this regular
                                           expression will be part of the extraction.
-                                          The most simple value for this field is
-                                          '.*', which matches the whole source. The
-                                          field is required. If extraction fails the
-                                          result is an empty value.
+                                          This regex **must match the entire source**
+                                          in order for a value to be extracted. The
+                                          most simple value for this field is '.*',
+                                          which matches the whole source. The field
+                                          is required. If extraction fails the result
+                                          is an empty value.
                                         type: string
                                       subgroup:
                                         description: If your regex contains capturing
@@ -5354,6 +5370,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -5582,6 +5601,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -5860,6 +5882,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -6244,6 +6269,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -6472,6 +6500,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -6750,6 +6781,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.
@@ -7038,11 +7072,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -7233,11 +7269,13 @@ spec:
                                             regex:
                                               description: Only strings matching this
                                                 regular expression will be part of
-                                                the extraction. The most simple value
-                                                for this field is '.*', which matches
-                                                the whole source. The field is required.
-                                                If extraction fails the result is
-                                                an empty value.
+                                                the extraction. This regex **must
+                                                match the entire source** in order
+                                                for a value to be extracted. The most
+                                                simple value for this field is '.*',
+                                                which matches the whole source. The
+                                                field is required. If extraction fails
+                                                the result is an empty value.
                                               type: string
                                             subgroup:
                                               description: If your regex contains
@@ -7745,9 +7783,12 @@ spec:
                                                             description: Only strings
                                                               matching this regular
                                                               expression will be part
-                                                              of the extraction. The
-                                                              most simple value for
-                                                              this field is '.*',
+                                                              of the extraction. This
+                                                              regex **must match the
+                                                              entire source** in order
+                                                              for a value to be extracted.
+                                                              The most simple value
+                                                              for this field is '.*',
                                                               which matches the whole
                                                               source. The field is
                                                               required. If extraction
@@ -8550,6 +8591,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -8874,6 +8922,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -9262,6 +9317,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -9809,6 +9871,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -10133,6 +10202,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -10521,6 +10597,13 @@ spec:
                                                                         expression
                                                                         will be part
                                                                         of the extraction.
+                                                                        This regex
+                                                                        **must match
+                                                                        the entire
+                                                                        source** in
+                                                                        order for
+                                                                        a value to
+                                                                        be extracted.
                                                                         The most simple
                                                                         value for
                                                                         this field
@@ -10842,9 +10925,12 @@ spec:
                                                             description: Only strings
                                                               matching this regular
                                                               expression will be part
-                                                              of the extraction. The
-                                                              most simple value for
-                                                              this field is '.*',
+                                                              of the extraction. This
+                                                              regex **must match the
+                                                              entire source** in order
+                                                              for a value to be extracted.
+                                                              The most simple value
+                                                              for this field is '.*',
                                                               which matches the whole
                                                               source. The field is
                                                               required. If extraction
@@ -11087,9 +11173,12 @@ spec:
                                                             description: Only strings
                                                               matching this regular
                                                               expression will be part
-                                                              of the extraction. The
-                                                              most simple value for
-                                                              this field is '.*',
+                                                              of the extraction. This
+                                                              regex **must match the
+                                                              entire source** in order
+                                                              for a value to be extracted.
+                                                              The most simple value
+                                                              for this field is '.*',
                                                               which matches the whole
                                                               source. The field is
                                                               required. If extraction
@@ -11449,10 +11538,12 @@ spec:
                                                 regex:
                                                   description: Only strings matching
                                                     this regular expression will be
-                                                    part of the extraction. The most
-                                                    simple value for this field is
-                                                    '.*', which matches the whole
-                                                    source. The field is required.
+                                                    part of the extraction. This regex
+                                                    **must match the entire source**
+                                                    in order for a value to be extracted.
+                                                    The most simple value for this
+                                                    field is '.*', which matches the
+                                                    whole source. The field is required.
                                                     If extraction fails the result
                                                     is an empty value.
                                                   type: string

--- a/install/helm/gloo/crds/gloo.solo.io_v1_Proxy.yaml
+++ b/install/helm/gloo/crds/gloo.solo.io_v1_Proxy.yaml
@@ -3134,7 +3134,11 @@ spec:
                                                                 matching this regular
                                                                 expression will be
                                                                 part of the extraction.
-                                                                The most simple value
+                                                                This regex **must
+                                                                match the entire source**
+                                                                in order for a value
+                                                                to be extracted. The
+                                                                most simple value
                                                                 for this field is
                                                                 '.*', which matches
                                                                 the whole source.
@@ -3386,7 +3390,11 @@ spec:
                                                                 matching this regular
                                                                 expression will be
                                                                 part of the extraction.
-                                                                The most simple value
+                                                                This regex **must
+                                                                match the entire source**
+                                                                in order for a value
+                                                                to be extracted. The
+                                                                most simple value
                                                                 for this field is
                                                                 '.*', which matches
                                                                 the whole source.
@@ -3692,7 +3700,11 @@ spec:
                                                                 matching this regular
                                                                 expression will be
                                                                 part of the extraction.
-                                                                The most simple value
+                                                                This regex **must
+                                                                match the entire source**
+                                                                in order for a value
+                                                                to be extracted. The
+                                                                most simple value
                                                                 for this field is
                                                                 '.*', which matches
                                                                 the whole source.
@@ -4123,7 +4135,11 @@ spec:
                                                                 matching this regular
                                                                 expression will be
                                                                 part of the extraction.
-                                                                The most simple value
+                                                                This regex **must
+                                                                match the entire source**
+                                                                in order for a value
+                                                                to be extracted. The
+                                                                most simple value
                                                                 for this field is
                                                                 '.*', which matches
                                                                 the whole source.
@@ -4375,7 +4391,11 @@ spec:
                                                                 matching this regular
                                                                 expression will be
                                                                 part of the extraction.
-                                                                The most simple value
+                                                                This regex **must
+                                                                match the entire source**
+                                                                in order for a value
+                                                                to be extracted. The
+                                                                most simple value
                                                                 for this field is
                                                                 '.*', which matches
                                                                 the whole source.
@@ -4681,7 +4701,11 @@ spec:
                                                                 matching this regular
                                                                 expression will be
                                                                 part of the extraction.
-                                                                The most simple value
+                                                                This regex **must
+                                                                match the entire source**
+                                                                in order for a value
+                                                                to be extracted. The
+                                                                most simple value
                                                                 for this field is
                                                                 '.*', which matches
                                                                 the whole source.
@@ -4989,12 +5013,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -5199,12 +5226,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -7410,7 +7440,13 @@ spec:
                                                                       expression will
                                                                       be part of the
                                                                       extraction.
-                                                                      The most simple
+                                                                      This regex **must
+                                                                      match the entire
+                                                                      source** in
+                                                                      order for a
+                                                                      value to be
+                                                                      extracted. The
+                                                                      most simple
                                                                       value for this
                                                                       field is '.*',
                                                                       which matches
@@ -7710,7 +7746,13 @@ spec:
                                                                       expression will
                                                                       be part of the
                                                                       extraction.
-                                                                      The most simple
+                                                                      This regex **must
+                                                                      match the entire
+                                                                      source** in
+                                                                      order for a
+                                                                      value to be
+                                                                      extracted. The
+                                                                      most simple
                                                                       value for this
                                                                       field is '.*',
                                                                       which matches
@@ -8071,7 +8113,13 @@ spec:
                                                                       expression will
                                                                       be part of the
                                                                       extraction.
-                                                                      The most simple
+                                                                      This regex **must
+                                                                      match the entire
+                                                                      source** in
+                                                                      order for a
+                                                                      value to be
+                                                                      extracted. The
+                                                                      most simple
                                                                       value for this
                                                                       field is '.*',
                                                                       which matches
@@ -8579,7 +8627,13 @@ spec:
                                                                       expression will
                                                                       be part of the
                                                                       extraction.
-                                                                      The most simple
+                                                                      This regex **must
+                                                                      match the entire
+                                                                      source** in
+                                                                      order for a
+                                                                      value to be
+                                                                      extracted. The
+                                                                      most simple
                                                                       value for this
                                                                       field is '.*',
                                                                       which matches
@@ -8879,7 +8933,13 @@ spec:
                                                                       expression will
                                                                       be part of the
                                                                       extraction.
-                                                                      The most simple
+                                                                      This regex **must
+                                                                      match the entire
+                                                                      source** in
+                                                                      order for a
+                                                                      value to be
+                                                                      extracted. The
+                                                                      most simple
                                                                       value for this
                                                                       field is '.*',
                                                                       which matches
@@ -9240,7 +9300,13 @@ spec:
                                                                       expression will
                                                                       be part of the
                                                                       extraction.
-                                                                      The most simple
+                                                                      This regex **must
+                                                                      match the entire
+                                                                      source** in
+                                                                      order for a
+                                                                      value to be
+                                                                      extracted. The
+                                                                      most simple
                                                                       value for this
                                                                       field is '.*',
                                                                       which matches
@@ -9607,11 +9673,14 @@ spec:
                                                           description: Only strings
                                                             matching this regular
                                                             expression will be part
-                                                            of the extraction. The
-                                                            most simple value for
-                                                            this field is '.*', which
-                                                            matches the whole source.
-                                                            The field is required.
+                                                            of the extraction. This
+                                                            regex **must match the
+                                                            entire source** in order
+                                                            for a value to be extracted.
+                                                            The most simple value
+                                                            for this field is '.*',
+                                                            which matches the whole
+                                                            source. The field is required.
                                                             If extraction fails the
                                                             result is an empty value.
                                                           type: string
@@ -9844,11 +9913,14 @@ spec:
                                                           description: Only strings
                                                             matching this regular
                                                             expression will be part
-                                                            of the extraction. The
-                                                            most simple value for
-                                                            this field is '.*', which
-                                                            matches the whole source.
-                                                            The field is required.
+                                                            of the extraction. This
+                                                            regex **must match the
+                                                            entire source** in order
+                                                            for a value to be extracted.
+                                                            The most simple value
+                                                            for this field is '.*',
+                                                            which matches the whole
+                                                            source. The field is required.
                                                             If extraction fails the
                                                             result is an empty value.
                                                           type: string
@@ -10434,6 +10506,13 @@ spec:
                                                                           will be
                                                                           part of
                                                                           the extraction.
+                                                                          This regex
+                                                                          **must match
+                                                                          the entire
+                                                                          source**
+                                                                          in order
+                                                                          for a value
+                                                                          to be extracted.
                                                                           The most
                                                                           simple value
                                                                           for this
@@ -11624,6 +11703,21 @@ spec:
                                                                                     of
                                                                                     the
                                                                                     extraction.
+                                                                                    This
+                                                                                    regex
+                                                                                    **must
+                                                                                    match
+                                                                                    the
+                                                                                    entire
+                                                                                    source**
+                                                                                    in
+                                                                                    order
+                                                                                    for
+                                                                                    a
+                                                                                    value
+                                                                                    to
+                                                                                    be
+                                                                                    extracted.
                                                                                     The
                                                                                     most
                                                                                     simple
@@ -12225,6 +12319,21 @@ spec:
                                                                                     of
                                                                                     the
                                                                                     extraction.
+                                                                                    This
+                                                                                    regex
+                                                                                    **must
+                                                                                    match
+                                                                                    the
+                                                                                    entire
+                                                                                    source**
+                                                                                    in
+                                                                                    order
+                                                                                    for
+                                                                                    a
+                                                                                    value
+                                                                                    to
+                                                                                    be
+                                                                                    extracted.
                                                                                     The
                                                                                     most
                                                                                     simple
@@ -12925,6 +13034,21 @@ spec:
                                                                                     of
                                                                                     the
                                                                                     extraction.
+                                                                                    This
+                                                                                    regex
+                                                                                    **must
+                                                                                    match
+                                                                                    the
+                                                                                    entire
+                                                                                    source**
+                                                                                    in
+                                                                                    order
+                                                                                    for
+                                                                                    a
+                                                                                    value
+                                                                                    to
+                                                                                    be
+                                                                                    extracted.
                                                                                     The
                                                                                     most
                                                                                     simple
@@ -13938,6 +14062,21 @@ spec:
                                                                                     of
                                                                                     the
                                                                                     extraction.
+                                                                                    This
+                                                                                    regex
+                                                                                    **must
+                                                                                    match
+                                                                                    the
+                                                                                    entire
+                                                                                    source**
+                                                                                    in
+                                                                                    order
+                                                                                    for
+                                                                                    a
+                                                                                    value
+                                                                                    to
+                                                                                    be
+                                                                                    extracted.
                                                                                     The
                                                                                     most
                                                                                     simple
@@ -14539,6 +14678,21 @@ spec:
                                                                                     of
                                                                                     the
                                                                                     extraction.
+                                                                                    This
+                                                                                    regex
+                                                                                    **must
+                                                                                    match
+                                                                                    the
+                                                                                    entire
+                                                                                    source**
+                                                                                    in
+                                                                                    order
+                                                                                    for
+                                                                                    a
+                                                                                    value
+                                                                                    to
+                                                                                    be
+                                                                                    extracted.
                                                                                     The
                                                                                     most
                                                                                     simple
@@ -15239,6 +15393,21 @@ spec:
                                                                                     of
                                                                                     the
                                                                                     extraction.
+                                                                                    This
+                                                                                    regex
+                                                                                    **must
+                                                                                    match
+                                                                                    the
+                                                                                    entire
+                                                                                    source**
+                                                                                    in
+                                                                                    order
+                                                                                    for
+                                                                                    a
+                                                                                    value
+                                                                                    to
+                                                                                    be
+                                                                                    extracted.
                                                                                     The
                                                                                     most
                                                                                     simple
@@ -15822,6 +15991,13 @@ spec:
                                                                           will be
                                                                           part of
                                                                           the extraction.
+                                                                          This regex
+                                                                          **must match
+                                                                          the entire
+                                                                          source**
+                                                                          in order
+                                                                          for a value
+                                                                          to be extracted.
                                                                           The most
                                                                           simple value
                                                                           for this
@@ -16176,6 +16352,13 @@ spec:
                                                                           will be
                                                                           part of
                                                                           the extraction.
+                                                                          This regex
+                                                                          **must match
+                                                                          the entire
+                                                                          source**
+                                                                          in order
+                                                                          for a value
+                                                                          to be extracted.
                                                                           The most
                                                                           simple value
                                                                           for this
@@ -16649,7 +16832,11 @@ spec:
                                                                 matching this regular
                                                                 expression will be
                                                                 part of the extraction.
-                                                                The most simple value
+                                                                This regex **must
+                                                                match the entire source**
+                                                                in order for a value
+                                                                to be extracted. The
+                                                                most simple value
                                                                 for this field is
                                                                 '.*', which matches
                                                                 the whole source.
@@ -17373,6 +17560,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -18324,6 +18516,18 @@ spec:
                                                                               be part
                                                                               of the
                                                                               extraction.
+                                                                              This
+                                                                              regex
+                                                                              **must
+                                                                              match
+                                                                              the
+                                                                              entire
+                                                                              source**
+                                                                              in order
+                                                                              for
+                                                                              a value
+                                                                              to be
+                                                                              extracted.
                                                                               The
                                                                               most
                                                                               simple
@@ -18743,6 +18947,18 @@ spec:
                                                                               be part
                                                                               of the
                                                                               extraction.
+                                                                              This
+                                                                              regex
+                                                                              **must
+                                                                              match
+                                                                              the
+                                                                              entire
+                                                                              source**
+                                                                              in order
+                                                                              for
+                                                                              a value
+                                                                              to be
+                                                                              extracted.
                                                                               The
                                                                               most
                                                                               simple
@@ -19240,6 +19456,18 @@ spec:
                                                                               be part
                                                                               of the
                                                                               extraction.
+                                                                              This
+                                                                              regex
+                                                                              **must
+                                                                              match
+                                                                              the
+                                                                              entire
+                                                                              source**
+                                                                              in order
+                                                                              for
+                                                                              a value
+                                                                              to be
+                                                                              extracted.
                                                                               The
                                                                               most
                                                                               simple
@@ -19937,6 +20165,18 @@ spec:
                                                                               be part
                                                                               of the
                                                                               extraction.
+                                                                              This
+                                                                              regex
+                                                                              **must
+                                                                              match
+                                                                              the
+                                                                              entire
+                                                                              source**
+                                                                              in order
+                                                                              for
+                                                                              a value
+                                                                              to be
+                                                                              extracted.
                                                                               The
                                                                               most
                                                                               simple
@@ -20356,6 +20596,18 @@ spec:
                                                                               be part
                                                                               of the
                                                                               extraction.
+                                                                              This
+                                                                              regex
+                                                                              **must
+                                                                              match
+                                                                              the
+                                                                              entire
+                                                                              source**
+                                                                              in order
+                                                                              for
+                                                                              a value
+                                                                              to be
+                                                                              extracted.
                                                                               The
                                                                               most
                                                                               simple
@@ -20853,6 +21105,18 @@ spec:
                                                                               be part
                                                                               of the
                                                                               extraction.
+                                                                              This
+                                                                              regex
+                                                                              **must
+                                                                              match
+                                                                              the
+                                                                              entire
+                                                                              source**
+                                                                              in order
+                                                                              for
+                                                                              a value
+                                                                              to be
+                                                                              extracted.
                                                                               The
                                                                               most
                                                                               simple
@@ -21259,6 +21523,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -21544,6 +21813,11 @@ spec:
                                                                     this regular expression
                                                                     will be part of
                                                                     the extraction.
+                                                                    This regex **must
+                                                                    match the entire
+                                                                    source** in order
+                                                                    for a value to
+                                                                    be extracted.
                                                                     The most simple
                                                                     value for this
                                                                     field is '.*',
@@ -21950,6 +22224,9 @@ spec:
                                                         description: Only strings
                                                           matching this regular expression
                                                           will be part of the extraction.
+                                                          This regex **must match
+                                                          the entire source** in order
+                                                          for a value to be extracted.
                                                           The most simple value for
                                                           this field is '.*', which
                                                           matches the whole source.

--- a/install/helm/gloo/crds/gloo.solo.io_v1_Upstream.yaml
+++ b/install/helm/gloo/crds/gloo.solo.io_v1_Upstream.yaml
@@ -414,7 +414,9 @@ spec:
                                     regex:
                                       description: Only strings matching this regular
                                         expression will be part of the extraction.
-                                        The most simple value for this field is '.*',
+                                        This regex **must match the entire source**
+                                        in order for a value to be extracted. The
+                                        most simple value for this field is '.*',
                                         which matches the whole source. The field
                                         is required. If extraction fails the result
                                         is an empty value.
@@ -1210,7 +1212,9 @@ spec:
                                     regex:
                                       description: Only strings matching this regular
                                         expression will be part of the extraction.
-                                        The most simple value for this field is '.*',
+                                        This regex **must match the entire source**
+                                        in order for a value to be extracted. The
+                                        most simple value for this field is '.*',
                                         which matches the whole source. The field
                                         is required. If extraction fails the result
                                         is an empty value.
@@ -1613,7 +1617,9 @@ spec:
                                     regex:
                                       description: Only strings matching this regular
                                         expression will be part of the extraction.
-                                        The most simple value for this field is '.*',
+                                        This regex **must match the entire source**
+                                        in order for a value to be extracted. The
+                                        most simple value for this field is '.*',
                                         which matches the whole source. The field
                                         is required. If extraction fails the result
                                         is an empty value.
@@ -1951,7 +1957,9 @@ spec:
                                     regex:
                                       description: Only strings matching this regular
                                         expression will be part of the extraction.
-                                        The most simple value for this field is '.*',
+                                        This regex **must match the entire source**
+                                        in order for a value to be extracted. The
+                                        most simple value for this field is '.*',
                                         which matches the whole source. The field
                                         is required. If extraction fails the result
                                         is an empty value.

--- a/install/helm/gloo/crds/gloo.solo.io_v1_UpstreamGroup.yaml
+++ b/install/helm/gloo/crds/gloo.solo.io_v1_UpstreamGroup.yaml
@@ -193,7 +193,9 @@ spec:
                                         regex:
                                           description: Only strings matching this
                                             regular expression will be part of the
-                                            extraction. The most simple value for
+                                            extraction. This regex **must match the
+                                            entire source** in order for a value to
+                                            be extracted. The most simple value for
                                             this field is '.*', which matches the
                                             whole source. The field is required. If
                                             extraction fails the result is an empty
@@ -816,12 +818,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -1027,12 +1032,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -1286,12 +1294,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -1648,12 +1659,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -1859,12 +1873,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -2118,12 +2135,15 @@ spec:
                                                   regex:
                                                     description: Only strings matching
                                                       this regular expression will
-                                                      be part of the extraction. The
-                                                      most simple value for this field
-                                                      is '.*', which matches the whole
-                                                      source. The field is required.
-                                                      If extraction fails the result
-                                                      is an empty value.
+                                                      be part of the extraction. This
+                                                      regex **must match the entire
+                                                      source** in order for a value
+                                                      to be extracted. The most simple
+                                                      value for this field is '.*',
+                                                      which matches the whole source.
+                                                      The field is required. If extraction
+                                                      fails the result is an empty
+                                                      value.
                                                     type: string
                                                   subgroup:
                                                     description: If your regex contains
@@ -2335,7 +2355,9 @@ spec:
                                         regex:
                                           description: Only strings matching this
                                             regular expression will be part of the
-                                            extraction. The most simple value for
+                                            extraction. This regex **must match the
+                                            entire source** in order for a value to
+                                            be extracted. The most simple value for
                                             this field is '.*', which matches the
                                             whole source. The field is required. If
                                             extraction fails the result is an empty
@@ -2520,7 +2542,9 @@ spec:
                                         regex:
                                           description: Only strings matching this
                                             regular expression will be part of the
-                                            extraction. The most simple value for
+                                            extraction. This regex **must match the
+                                            entire source** in order for a value to
+                                            be extracted. The most simple value for
                                             this field is '.*', which matches the
                                             whole source. The field is required. If
                                             extraction fails the result is an empty

--- a/projects/gloo/api/external/envoy/extensions/transformation/transformation.proto
+++ b/projects/gloo/api/external/envoy/extensions/transformation/transformation.proto
@@ -146,7 +146,8 @@ message Extraction {
   }
 
   // Only strings matching this regular expression will be part of the
-  // extraction. The most simple value for this field is '.*', which matches the
+  // extraction. This regex **must match the entire source** in order for a value to be extracted.
+  // The most simple value for this field is '.*', which matches the
   // whole source. The field is required. If extraction fails the result is an
   // empty value.
   string regex = 2;

--- a/projects/gloo/pkg/api/external/envoy/extensions/transformation/transformation.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/transformation/transformation.pb.go
@@ -529,7 +529,8 @@ type Extraction struct {
 	//	*Extraction_Body
 	Source isExtraction_Source `protobuf_oneof:"source"`
 	// Only strings matching this regular expression will be part of the
-	// extraction. The most simple value for this field is '.*', which matches the
+	// extraction. This regex **must match the entire source** in order for a value to be extracted.
+	// The most simple value for this field is '.*', which matches the
 	// whole source. The field is required. If extraction fails the result is an
 	// empty value.
 	Regex string `protobuf:"bytes,2,opt,name=regex,proto3" json:"regex,omitempty"`


### PR DESCRIPTION
Make it more clear to customers / engineers that extractor `regex` needs to match the _entire_ source in order to work.

Issue here for more context: https://github.com/solo-io/gloo/issues/5000