### PR TITLE
Ensure invalid virtual hosts are not duplicated on proxy

### DIFF
--- a/changelog/v1.9.0-beta6/fix-regression-flakes.yaml
+++ b/changelog/v1.9.0-beta6/fix-regression-flakes.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3247
+    resolvesIssue: false
+    description: Ensure proxy reconciliaton does not duplicate virtual hosts

--- a/changelog/v1.9.0-beta6/fix-regression-flakes.yaml
+++ b/changelog/v1.9.0-beta6/fix-regression-flakes.yaml
@@ -3,3 +3,7 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/3247
     resolvesIssue: false
     description: Ensure proxy reconciliaton does not duplicate virtual hosts
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4900
+    resolvesIssue: false
+    description: Ensure kube2e test gives validation settings enough time to propagate

--- a/test/helpers/kube_objects.go
+++ b/test/helpers/kube_objects.go
@@ -1,0 +1,23 @@
+package helpers
+
+import (
+	"github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ObjectGetter func() (client.Object, error)
+
+func EventuallyObjectDeleted(getter ObjectGetter, intervals ...interface{}) {
+	EventuallyObjectDeletedWithOffset(1, getter, intervals...)
+}
+
+func EventuallyObjectDeletedWithOffset(offset int, getter ObjectGetter, intervals ...interface{}) {
+	gomega.EventuallyWithOffset(offset+1, func() (bool, error) {
+		_, err := getter()
+		if err != nil && k8serrors.IsNotFound(err) {
+			return true, nil
+		}
+		return false, err
+	}, intervals...).Should(gomega.BeTrue())
+}

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -35,7 +35,6 @@ func TestGateway(t *testing.T) {
 
 var testHelper *helper.SoloTestHelper
 var ctx, cancel = context.WithCancel(context.Background())
-var installNamespace = "gloo-system"
 
 var _ = BeforeSuite(StartTestHelper)
 var _ = AfterSuite(TearDownTestHelper)

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/cors"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/headers"
 	"github.com/solo-io/go-utils/testutils"
@@ -467,13 +470,14 @@ var _ = Describe("Kube2e: gateway", func() {
 		})
 
 		Context("with a mix of valid and invalid virtual services", func() {
+
 			var (
 				validVsName   = "i-am-valid"
 				invalidVsName = "i-am-invalid"
 				petstoreName  = "petstore"
 			)
-			BeforeEach(func() {
 
+			BeforeEach(func() {
 				valid := withName(validVsName, withDomains([]string{"valid.com"},
 					getVirtualService(&gloov1.Destination{
 						DestinationType: &gloov1.Destination_Upstream{
@@ -491,37 +495,46 @@ var _ = Describe("Kube2e: gateway", func() {
 						},
 					}, nil)))
 
-				Eventually(func() error {
-					_, err := virtualServiceClient.Write(valid, clients.WriteOpts{})
-					return err
-				}, time.Second*10).ShouldNot(HaveOccurred())
+				_, err := virtualServiceClient.Write(valid, clients.WriteOpts{})
+				Expect(err).NotTo(HaveOccurred())
 
 				// sanity check that validation is enabled/strict
-				Eventually(func() error {
-					_, err := virtualServiceClient.Write(inValid, clients.WriteOpts{})
-					return err
-				}, time.Second*10).Should(And(HaveOccurred(), MatchError(ContainSubstring("could not render proxy"))))
+				_, err = virtualServiceClient.Write(inValid, clients.WriteOpts{})
+				Expect(err).To(MatchError(ContainSubstring("could not render proxy")))
 
 				// disable strict validation
 				kube2e.UpdateAlwaysAcceptSetting(ctx, true, testHelper.InstallNamespace)
 
+				// eventually we are able to write the invalid vs
 				Eventually(func() error {
 					_, err := virtualServiceClient.Write(inValid, clients.WriteOpts{})
 					return err
 				}, time.Second*10).ShouldNot(HaveOccurred())
 
 			})
+
 			AfterEach(func() {
 				_ = virtualServiceClient.Delete(testHelper.InstallNamespace, invalidVsName, clients.DeleteOpts{})
+				helpers.EventuallyResourceDeleted(func() (resources.InputResource, error) {
+					return virtualServiceClient.Read(testHelper.InstallNamespace, invalidVsName, clients.ReadOpts{})
+				}, "15s", "0.5s")
+
 				_ = virtualServiceClient.Delete(testHelper.InstallNamespace, validVsName, clients.DeleteOpts{})
+				helpers.EventuallyResourceDeleted(func() (resources.InputResource, error) {
+					return virtualServiceClient.Read(testHelper.InstallNamespace, validVsName, clients.ReadOpts{})
+				}, "15s", "0.5s")
+
 				_ = virtualServiceClient.Delete(testHelper.InstallNamespace, petstoreName, clients.DeleteOpts{})
-				_ = kubeClient.CoreV1().Services(testHelper.InstallNamespace).Delete(ctx, petstoreName, metav1.DeleteOptions{})
-				_ = kubeClient.AppsV1().Deployments(testHelper.InstallNamespace).Delete(ctx, petstoreName, metav1.DeleteOptions{})
+				helpers.EventuallyResourceDeleted(func() (resources.InputResource, error) {
+					return virtualServiceClient.Read(testHelper.InstallNamespace, petstoreName, clients.ReadOpts{})
+				}, "15s", "0.5s")
+
 				// important that we update the always accept setting after removing resources, or else we can have:
 				// "validation is disabled due to an invalid resource which has been written to storage.
 				// Please correct any Rejected resources to re-enable validation."
 				kube2e.UpdateAlwaysAcceptSetting(ctx, false, testHelper.InstallNamespace)
 			})
+
 			It("propagates the valid virtual services to envoy", func() {
 				testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{
 					Protocol:          "http",
@@ -590,93 +603,111 @@ var _ = Describe("Kube2e: gateway", func() {
 				}, helper.SimpleHttpResponse, 1, 60*time.Second, 1*time.Second)
 			})
 
-			It("adds the invalid virtual services back into the proxy when updating an upstream makes them valid", func() {
+			Context("adds the invalid virtual services back into the proxy", func() {
 
-				petstoreDeployment, petstoreSvc := petstore(testHelper.InstallNamespace)
+				var (
+					err                error
+					petstoreSvc        *corev1.Service
+					petstoreDeployment *v1.Deployment
+				)
 
-				// disable FDS for the petstore, create it without functions
-				petstoreSvc.Labels[syncer.FdsLabelKey] = "disabled"
+				BeforeEach(func() {
+					petstoreDeployment, petstoreSvc = petstore(testHelper.InstallNamespace)
 
-				petstoreSvc, err := kubeClient.CoreV1().Services(petstoreSvc.Namespace).Create(ctx, petstoreSvc, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				petstoreDeployment, err = kubeClient.AppsV1().Deployments(petstoreDeployment.Namespace).Create(ctx, petstoreDeployment, metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
+					// disable FDS for the petstore, create it without functions
+					petstoreSvc.Labels[syncer.FdsLabelKey] = "disabled"
 
-				upstreamName := fmt.Sprintf("%s-%s-%v", testHelper.InstallNamespace, petstoreName, 8080)
+					petstoreSvc, err = kubeClient.CoreV1().Services(petstoreSvc.Namespace).Create(ctx, petstoreSvc, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					petstoreDeployment, err = kubeClient.AppsV1().Deployments(petstoreDeployment.Namespace).Create(ctx, petstoreDeployment, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				})
 
-				// the vs will be invalid
-				vsWithFunctionRoute := withName(petstoreName, withDomains([]string{"petstore.com"},
-					getVirtualService(&gloov1.Destination{
-						DestinationType: &gloov1.Destination_Upstream{
-							Upstream: &core.ResourceRef{
-								Namespace: testHelper.InstallNamespace,
-								Name:      upstreamName,
-							},
-						},
-						DestinationSpec: &gloov1.DestinationSpec{
-							DestinationType: &gloov1.DestinationSpec_Rest{
-								Rest: &gloorest.DestinationSpec{
-									FunctionName: "findPetById",
+				AfterEach(func() {
+					_ = virtualServiceClient.Delete(petstoreSvc.Namespace, petstoreName, clients.DeleteOpts{})
+					helpers.EventuallyResourceDeleted(func() (resources.InputResource, error) {
+						return virtualServiceClient.Read(petstoreSvc.Namespace, petstoreName, clients.ReadOpts{})
+					}, "15s", "0.5s")
+
+					_ = kubeClient.CoreV1().Services(petstoreSvc.Namespace).Delete(ctx, petstoreName, metav1.DeleteOptions{})
+					helpers.EventuallyObjectDeleted(func() (client.Object, error) {
+						return kubeClient.CoreV1().Services(petstoreSvc.Namespace).Get(ctx, petstoreName, metav1.GetOptions{})
+					}, "15s", "0.5s")
+
+					_ = kubeClient.AppsV1().Deployments(petstoreDeployment.Namespace).Delete(ctx, petstoreName, metav1.DeleteOptions{})
+					helpers.EventuallyObjectDeleted(func() (client.Object, error) {
+						return kubeClient.AppsV1().Deployments(petstoreDeployment.Namespace).Get(ctx, petstoreName, metav1.GetOptions{})
+					}, "15s", "0.5s")
+				})
+
+				It("when updating an upstream makes them valid", func() {
+					upstreamName := fmt.Sprintf("%s-%s-%v", testHelper.InstallNamespace, petstoreName, 8080)
+
+					// the vs will be invalid
+					vsWithFunctionRoute := withName(petstoreName, withDomains([]string{"petstore.com"},
+						getVirtualService(&gloov1.Destination{
+							DestinationType: &gloov1.Destination_Upstream{
+								Upstream: &core.ResourceRef{
+									Namespace: testHelper.InstallNamespace,
+									Name:      upstreamName,
 								},
 							},
-						},
-					}, nil)))
+							DestinationSpec: &gloov1.DestinationSpec{
+								DestinationType: &gloov1.DestinationSpec_Rest{
+									Rest: &gloorest.DestinationSpec{
+										FunctionName: "findPetById",
+									},
+								},
+							},
+						}, nil)))
 
-				vsWithFunctionRoute, err = virtualServiceClient.Write(vsWithFunctionRoute, clients.WriteOpts{})
-				Expect(err).NotTo(HaveOccurred())
-
-				// the VS should not be rejected since the failure is sanitized by route replacement
-				Eventually(func() (core.Status_State, error) {
-					vs, err := virtualServiceClient.Read(testHelper.InstallNamespace, petstoreName, clients.ReadOpts{})
-					if err != nil {
-						return 0, err
-					}
-					return vs.GetStatus().GetState(), nil
-				}, "15s", "0.5s").Should(Equal(core.Status_Accepted))
-
-				// wrapped in eventually to get around resource version errors
-				Eventually(func() error {
-					petstoreUs, err := upstreamClient.Read(testHelper.InstallNamespace, upstreamName, clients.ReadOpts{})
+					vsWithFunctionRoute, err = virtualServiceClient.Write(vsWithFunctionRoute, clients.WriteOpts{})
 					Expect(err).NotTo(HaveOccurred())
 
-					Expect(petstoreUs.GetKube().GetServiceSpec().GetRest().GetSwaggerInfo().GetUrl()).To(BeEmpty())
-					petstoreUs.Metadata.Labels[syncer.FdsLabelKey] = "enabled"
+					// the VS should not be rejected since the failure is sanitized by route replacement
+					helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+						return virtualServiceClient.Read(testHelper.InstallNamespace, petstoreName, clients.ReadOpts{})
+					})
 
-					_, err = upstreamClient.Write(petstoreUs, clients.WriteOpts{OverwriteExisting: true})
-					return err
-				}, "5s", "0.5s").ShouldNot(HaveOccurred())
+					// wrapped in eventually to get around resource version errors
+					Eventually(func() error {
+						petstoreUs, err := upstreamClient.Read(testHelper.InstallNamespace, upstreamName, clients.ReadOpts{})
+						Expect(err).NotTo(HaveOccurred())
 
-				// FDS should update the upstream with discovered rest spec
-				// it can take a long time for this to happen, perhaps petstore wasn't healthy yet?
-				Eventually(func() interface{} {
-					petstoreUs, err := upstreamClient.Read(testHelper.InstallNamespace, upstreamName, clients.ReadOpts{})
-					Expect(err).ToNot(HaveOccurred())
-					return petstoreUs.GetKube().GetServiceSpec().GetRest().GetSwaggerInfo().GetUrl()
-				}, "120s", "1s").ShouldNot(BeEmpty())
+						Expect(petstoreUs.GetKube().GetServiceSpec().GetRest().GetSwaggerInfo().GetUrl()).To(BeEmpty())
+						petstoreUs.Metadata.Labels[syncer.FdsLabelKey] = "enabled"
 
-				// we have updated an upstream, which prompts Gloo to send a notification to the
-				// gateway to resync virtual service status
+						_, err = upstreamClient.Write(petstoreUs, clients.WriteOpts{OverwriteExisting: true})
+						return err
+					}, "5s", "0.5s").ShouldNot(HaveOccurred())
 
-				// the VS should get accepted
-				Eventually(func() (core.Status_State, error) {
-					vs, err := virtualServiceClient.Read(vsWithFunctionRoute.GetMetadata().GetNamespace(), vsWithFunctionRoute.GetMetadata().GetName(), clients.ReadOpts{})
-					if err != nil {
-						return 0, err
-					}
-					return vs.GetStatus().GetState(), nil
-				}, "15s", "0.5s").Should(Equal(core.Status_Accepted))
+					// FDS should update the upstream with discovered rest spec
+					// it can take a long time for this to happen, perhaps petstore wasn't healthy yet?
+					Eventually(func() interface{} {
+						petstoreUs, err := upstreamClient.Read(testHelper.InstallNamespace, upstreamName, clients.ReadOpts{})
+						Expect(err).ToNot(HaveOccurred())
+						return petstoreUs.GetKube().GetServiceSpec().GetRest().GetSwaggerInfo().GetUrl()
+					}, "120s", "1s").ShouldNot(BeEmpty())
+
+					// we have updated an upstream, which prompts Gloo to send a notification to the
+					// gateway to resync virtual service status
+
+					// the VS should get accepted
+					helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+						return virtualServiceClient.Read(vsWithFunctionRoute.GetMetadata().GetNamespace(), vsWithFunctionRoute.GetMetadata().GetName(), clients.ReadOpts{})
+					})
+				})
+
 			})
+
 		})
 
 		Context("with a mix of valid and invalid routes on a single virtual service", func() {
-			var vs *gatewayv1.VirtualService
-			BeforeEach(func() {
 
-				kube2e.UpdateSettings(func(settings *gloov1.Settings) {
-					Expect(settings.Gloo).NotTo(BeNil())
-					Expect(settings.Gloo.InvalidConfigPolicy).NotTo(BeNil())
-					settings.Gloo.InvalidConfigPolicy.ReplaceInvalidRoutes = true
-				}, ctx, testHelper.InstallNamespace)
+			var vs *gatewayv1.VirtualService
+
+			BeforeEach(func() {
+				kube2e.UpdateReplaceInvalidRoutes(ctx, true, testHelper.InstallNamespace)
 
 				vs = withRoute(&gatewayv1.Route{
 					Matchers: []*matchers.Matcher{{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/invalid-route"}}},
@@ -699,21 +730,19 @@ var _ = Describe("Kube2e: gateway", func() {
 					},
 				}, nil))
 
-				Eventually(func() error {
-					_, err := virtualServiceClient.Write(vs, clients.WriteOpts{})
-					return err
-				}, time.Second*10).ShouldNot(HaveOccurred())
+				_, err := virtualServiceClient.Write(vs, clients.WriteOpts{})
+				Expect(err).NotTo(HaveOccurred())
 			})
+
 			AfterEach(func() {
 				_ = virtualServiceClient.Delete(vs.Metadata.Namespace, vs.Metadata.Name, clients.DeleteOpts{})
+				helpers.EventuallyResourceDeleted(func() (resources.InputResource, error) {
+					return virtualServiceClient.Read(vs.GetMetadata().GetNamespace(), vs.GetMetadata().GetName(), clients.ReadOpts{})
+				}, "15s", "0.5s")
 
-				kube2e.UpdateSettings(func(settings *gloov1.Settings) {
-					Expect(settings.Gloo).NotTo(BeNil())
-					Expect(settings.Gloo.InvalidConfigPolicy).NotTo(BeNil())
-					settings.Gloo.InvalidConfigPolicy.ReplaceInvalidRoutes = false
-				}, ctx, testHelper.InstallNamespace)
-
+				kube2e.UpdateReplaceInvalidRoutes(ctx, false, testHelper.InstallNamespace)
 			})
+
 			It("serves a direct response for the invalid route response", func() {
 				// the valid route should work
 				testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{
@@ -899,25 +928,12 @@ var _ = Describe("Kube2e: gateway", func() {
 				return err
 			}, "5s", "0.1s").ShouldNot(HaveOccurred())
 
-			defaultGateway := defaults.DefaultGateway(testHelper.InstallNamespace)
-			// wait for default gateway to be created
-			Eventually(func() (*gatewayv1.Gateway, error) {
-				return gatewayClient.Read(testHelper.InstallNamespace, defaultGateway.Metadata.Name, clients.ReadOpts{})
-			}, "15s", "0.5s").Should(Not(BeNil()))
-
 			var proxy *gloov1.Proxy
-			// wait for the expected proxy configuration to be accepted
-			Eventually(func() error {
+			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
 				proxy, err = proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-				if err != nil {
-					return err
-				}
+				return proxy, err
+			}, "15s", ".5s")
 
-				if status := proxy.GetStatus(); status.GetState() != core.Status_Accepted {
-					return eris.Errorf("unexpected proxy state: %v. Reason: %v", status.GetState(), status.GetReason())
-				}
-				return nil
-			}, "15s", "0.5s").Should(BeNil())
 			var found bool
 			for _, l := range proxy.Listeners {
 				httpListener := l.GetHttpListener()
@@ -1060,25 +1076,12 @@ var _ = Describe("Kube2e: gateway", func() {
 				return err
 			}, "5s", "0.1s").ShouldNot(HaveOccurred())
 
-			defaultGateway := defaults.DefaultGateway(testHelper.InstallNamespace)
-			// wait for default gateway to be created
-			Eventually(func() (*gatewayv1.Gateway, error) {
-				return gatewayClient.Read(testHelper.InstallNamespace, defaultGateway.Metadata.Name, clients.ReadOpts{})
-			}, "15s", "0.5s").Should(Not(BeNil()))
-
 			var proxy *gloov1.Proxy
-			// wait for the expected proxy configuration to be accepted
-			Eventually(func() error {
+			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
 				proxy, err = proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-				if err != nil {
-					return err
-				}
+				return proxy, err
+			}, "15s", ".5s")
 
-				if status := proxy.GetStatus(); status.GetState() != core.Status_Accepted {
-					return eris.Errorf("unexpected proxy state: %v. Reason: %v", status.GetState(), status.GetReason())
-				}
-				return nil
-			}, "15s", "0.5s").Should(BeNil())
 			var found bool
 			for _, l := range proxy.Listeners {
 				httpListener := l.GetHttpListener()
@@ -1475,6 +1478,11 @@ var _ = Describe("Kube2e: gateway", func() {
 				err := upstreamGroupClient.Delete(testHelper.InstallNamespace, ug.Metadata.Name, clients.DeleteOpts{IgnoreNotExist: true})
 				Expect(err).NotTo(HaveOccurred())
 			}
+
+			// Ensure the redblue service is deleted
+			helpers.EventuallyObjectDeleted(func() (client.Object, error) {
+				return kubeClient.CoreV1().Services(testHelper.InstallNamespace).Get(ctx, service.Name, metav1.GetOptions{})
+			}, "15s", ".5s")
 
 			Eventually(func() error {
 				coloredPods, err := kubeClient.CoreV1().Pods(testHelper.InstallNamespace).List(ctx,

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -7,13 +7,12 @@ import (
 	"sort"
 	"time"
 
-	static_plugin_gloo "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
+	"github.com/solo-io/gloo/test/helpers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
-	skerrors "github.com/solo-io/solo-kit/pkg/errors"
-
 	"github.com/solo-io/gloo/projects/gateway/pkg/services/k8sadmisssion"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 
 	testutils "github.com/solo-io/k8s-utils/testutils/kube"
 
@@ -41,12 +40,6 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 )
 
-const (
-	configDumpPath = "http://localhost:19000/config_dump"
-	clustersPath   = "http://localhost:19000/clusters"
-	kubeCtx        = ""
-)
-
 var _ = Describe("Robustness tests", func() {
 
 	const (
@@ -55,16 +48,14 @@ var _ = Describe("Robustness tests", func() {
 	)
 
 	var (
-		ctx       context.Context
-		cancel    context.CancelFunc
-		cfg       *rest.Config
-		cache     kube.SharedCache
-		namespace string
+		ctx    context.Context
+		cancel context.CancelFunc
+		cfg    *rest.Config
+		cache  kube.SharedCache
 
 		kubeClient           kubernetes.Interface
 		proxyClient          gloov1.ProxyClient
 		virtualServiceClient gatewayv1.VirtualServiceClient
-		upstreamClient       gloov1.UpstreamClient
 
 		appName        = "echo-app-for-robustness-test"
 		appDeployment  *appsv1.Deployment
@@ -76,8 +67,6 @@ var _ = Describe("Robustness tests", func() {
 
 	BeforeEach(func() {
 		ctx, cancel = context.WithCancel(context.Background())
-
-		namespace = testHelper.InstallNamespace
 
 		cfg, err = kubeutils.GetConfig("", "")
 		Expect(err).NotTo(HaveOccurred())
@@ -96,11 +85,6 @@ var _ = Describe("Robustness tests", func() {
 			Cfg:         cfg,
 			SharedCache: cache,
 		}
-		upstreamClientFactory := &factory.KubeResourceClientFactory{
-			Crd:         gloov1.UpstreamCrd,
-			Cfg:         cfg,
-			SharedCache: cache,
-		}
 
 		virtualServiceClient, err = gatewayv1.NewVirtualServiceClient(ctx, virtualServiceClientFactory)
 		Expect(err).NotTo(HaveOccurred())
@@ -112,79 +96,57 @@ var _ = Describe("Robustness tests", func() {
 		err = proxyClient.Register()
 		Expect(err).NotTo(HaveOccurred())
 
-		upstreamClient, err = gloov1.NewUpstreamClient(ctx, upstreamClientFactory)
-		Expect(err).NotTo(HaveOccurred())
-		err = upstreamClient.Register()
-		Expect(err).NotTo(HaveOccurred())
-
-		appDeployment, appService, err = createDeploymentAndService(kubeClient, namespace, appName)
+		appDeployment, appService, err = createEchoDeploymentAndService(kubeClient, testHelper.InstallNamespace, appName)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
-		if virtualService != nil {
-			_ = virtualServiceClient.Delete(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.DeleteOpts{Ctx: ctx, IgnoreNotExist: true})
-
-			Eventually(func() bool {
-				_, err := virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
-				if err != nil && skerrors.IsNotExist(err) {
-					return true
-				}
-				return false
-			}, "15s", "0.5s").Should(BeTrue())
-		}
-		if appDeployment != nil {
-			err := kubeClient.AppsV1().Deployments(namespace).Delete(ctx, appDeployment.Name, metav1.DeleteOptions{GracePeriodSeconds: pointerToInt64(0)})
+		_ = kubeClient.AppsV1().Deployments(testHelper.InstallNamespace).Delete(ctx, appDeployment.Name, metav1.DeleteOptions{GracePeriodSeconds: pointerToInt64(0)})
+		Eventually(func() bool {
+			deployments, err := kubeClient.AppsV1().Deployments(testHelper.InstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"app": appName}).String()})
 			Expect(err).NotTo(HaveOccurred())
+			return len(deployments.Items) == 0
+		}, "15s", "0.5s").Should(BeTrue())
 
-			Eventually(func() bool {
-				deployments, err := kubeClient.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"app": appName}).String()})
-				Expect(err).NotTo(HaveOccurred())
-				return len(deployments.Items) == 0
-			}, "15s", "0.5s").Should(BeTrue())
-		}
-		if appService != nil {
-			err := kubeClient.CoreV1().Services(testHelper.InstallNamespace).Delete(ctx, appService.Name, metav1.DeleteOptions{GracePeriodSeconds: pointerToInt64(0)})
+		_ = kubeClient.CoreV1().Services(testHelper.InstallNamespace).Delete(ctx, appService.Name, metav1.DeleteOptions{GracePeriodSeconds: pointerToInt64(0)})
+		Eventually(func() bool {
+			services, err := kubeClient.CoreV1().Services(testHelper.InstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"app": appName}).String()})
 			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func() bool {
-				services, err := kubeClient.CoreV1().Services(testHelper.InstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"app": appName}).String()})
-				Expect(err).NotTo(HaveOccurred())
-				return len(services.Items) == 0
-			}, "15s", "0.5s").Should(BeTrue())
-		}
+			return len(services.Items) == 0
+		}, "15s", "0.5s").Should(BeTrue())
 
 		cancel()
 	})
 
-	It("updates Envoy endpoints even if proxy is rejected", func() {
+	Context("Updates Envoy endpoints, even if proxy is invalid", func() {
 
-		By("create a virtual service routing to the service")
-		virtualService, err = virtualServiceClient.Write(&gatewayv1.VirtualService{
-			Metadata: &core.Metadata{
-				Name:      "echo-vs",
-				Namespace: namespace,
-			},
-			VirtualHost: &gatewayv1.VirtualHost{
-				Domains: []string{"*"},
-				Routes: []*gatewayv1.Route{
-					{
-						Matchers: []*matchers.Matcher{{
-							PathSpecifier: &matchers.Matcher_Prefix{
-								Prefix: "/1",
-							},
-						}},
-						Action: &gatewayv1.Route_RouteAction{
-							RouteAction: &gloov1.RouteAction{
-								Destination: &gloov1.RouteAction_Single{
-									Single: &gloov1.Destination{
-										DestinationType: &gloov1.Destination_Kube{
-											Kube: &gloov1.KubernetesServiceDestination{
-												Ref: &core.ResourceRef{
-													Namespace: appService.Namespace,
-													Name:      appService.Name,
+		BeforeEach(func() {
+			virtualService = &gatewayv1.VirtualService{
+				Metadata: &core.Metadata{
+					Name:      "echo-vs",
+					Namespace: testHelper.InstallNamespace,
+				},
+				VirtualHost: &gatewayv1.VirtualHost{
+					Domains: []string{"*"},
+					Routes: []*gatewayv1.Route{
+						{
+							Matchers: []*matchers.Matcher{{
+								PathSpecifier: &matchers.Matcher_Prefix{
+									Prefix: "/1",
+								},
+							}},
+							Action: &gatewayv1.Route_RouteAction{
+								RouteAction: &gloov1.RouteAction{
+									Destination: &gloov1.RouteAction_Single{
+										Single: &gloov1.Destination{
+											DestinationType: &gloov1.Destination_Kube{
+												Kube: &gloov1.KubernetesServiceDestination{
+													Ref: &core.ResourceRef{
+														Namespace: appService.Namespace,
+														Name:      appService.Name,
+													},
+													Port: 5678,
 												},
-												Port: 5678,
 											},
 										},
 									},
@@ -193,284 +155,175 @@ var _ = Describe("Robustness tests", func() {
 						},
 					},
 				},
-			},
-		}, clients.WriteOpts{Ctx: ctx})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("wait for proxy to be accepted")
-		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-			if err != nil {
-				return err
 			}
-			if proxy.GetStatus().GetState() == core.Status_Accepted {
-				return nil
-			}
-			return eris.Errorf("waiting for proxy to be accepted, but status is %v", proxy.Status)
-		}, 60*time.Second, 1*time.Second).Should(BeNil())
-
-		By("verify that we can route to the service")
-		time.Sleep(1 * time.Second) // sleep a sec to save us some unnecessary polling
-		testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{
-			Protocol:          "http",
-			Path:              "/1",
-			Method:            "GET",
-			Host:              gatewayProxy,
-			Service:           gatewayProxy,
-			Port:              gatewayPort,
-			ConnectionTimeout: 1,
-			WithoutStats:      true,
-		}, expectedResponse(appName), 1, 30*time.Second, 1*time.Second)
-
-		By("add an invalid route to the virtual service")
-		virtualService, err = virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
-		Expect(err).NotTo(HaveOccurred())
-
-		virtualService.VirtualHost.Routes = append(virtualService.VirtualHost.Routes, &gatewayv1.Route{
-			Matchers: []*matchers.Matcher{{
-				PathSpecifier: &matchers.Matcher_Prefix{
-					Prefix: "/3",
-				},
-			}},
-			Action: &gatewayv1.Route_RouteAction{
-				RouteAction: &gloov1.RouteAction{
-					Destination: &gloov1.RouteAction_Single{
-						Single: &gloov1.Destination{
-							DestinationType: &gloov1.Destination_Kube{
-								Kube: &gloov1.KubernetesServiceDestination{
-									Ref: &core.ResourceRef{
-										Namespace: namespace,
-										Name:      "non-existent-svc",
-									},
-									Port: 1234,
-								},
-							},
-						},
-					},
-				},
-			},
 		})
 
-		// required to prevent gateway webhook from rejecting
-		virtualService.Metadata.Annotations = map[string]string{k8sadmisssion.SkipValidationKey: k8sadmisssion.SkipValidationValue}
+		JustBeforeEach(func() {
+			_, writeErr := virtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx})
+			Expect(writeErr).NotTo(HaveOccurred())
 
-		virtualServiceReconciler := gatewayv1.NewVirtualServiceReconciler(virtualServiceClient)
-		err = virtualServiceReconciler.Reconcile(testHelper.InstallNamespace, gatewayv1.VirtualServiceList{virtualService}, nil, clients.ListOpts{})
-		Expect(err).NotTo(HaveOccurred())
+			// Wait for the proxy to be accepted
+			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+				return proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+			}, 60*time.Second, 1*time.Second)
 
-		By("wait for proxy to enter warning state")
-		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-			if err != nil {
-				return err
-			}
-			if proxy.GetStatus().GetState() == core.Status_Warning {
-				return nil
-			}
-			return eris.Errorf("waiting for proxy to be warning, but status is %v", proxy.Status)
-		}, 20*time.Second, 1*time.Second).Should(BeNil())
+			// Ensure we can route to the service
+			testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{
+				Protocol:          "http",
+				Path:              "/1",
+				Method:            "GET",
+				Host:              gatewayProxy,
+				Service:           gatewayProxy,
+				Port:              gatewayPort,
+				ConnectionTimeout: 1,
+				WithoutStats:      true,
+			}, expectedResponse(appName), 1, 30*time.Second, 1*time.Second)
+		})
 
-		By("force an update of the service endpoints")
-		initialIps := endpointsFor(kubeClient, appService)
-		// Scale to 0 and back to 1 replicas until we have a different IP for the endpoint
-		Eventually(func() []string {
-			scaleDeploymentTo(kubeClient, appDeployment, 0)
-			scaleDeploymentTo(kubeClient, appDeployment, 1)
-			newIps := endpointsFor(kubeClient, appService)
-			return newIps
-		}, 20*time.Second, 1*time.Second).Should(And(
-			HaveLen(len(initialIps)),
-			Not(BeEquivalentTo(initialIps)),
-		))
+		AfterEach(func() {
+			_ = virtualServiceClient.Delete(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.DeleteOpts{Ctx: ctx, IgnoreNotExist: true})
+			helpers.EventuallyResourceDeleted(func() (resources.InputResource, error) {
+				return virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+			}, "15s", "0.5s")
+		})
 
-		By("verify that the new endpoints have been propagated to Envoy")
-		testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{
-			Protocol:          "http",
-			Path:              "/1",
-			Method:            "GET",
-			Host:              gatewayProxy,
-			Service:           gatewayProxy,
-			Port:              gatewayPort,
-			ConnectionTimeout: 1,
-			WithoutStats:      true,
-		}, expectedResponse(appName), 1, 30*time.Second, 1*time.Second)
-	})
-
-	It("updates Envoy endpoints even if proxy is invalid and snapshot cache is reset", func() {
-
-		upstream := &gloov1.Upstream{
-			Metadata: &core.Metadata{
-				Name:      "test",
-				Namespace: "gloo-system",
-			},
-			UpstreamType: &gloov1.Upstream_Static{
-				Static: &static_plugin_gloo.UpstreamSpec{
-					Hosts: []*static_plugin_gloo.Host{{
-						Addr: "localhost",
-						Port: 1234,
-					}},
-				},
-			},
-		}
-		_, err := upstreamClient.Write(upstream, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-		Expect(err).ToNot(HaveOccurred())
-
-		gatewayProxyPodName := testutils.FindPodNameByLabel(cfg, ctx, "gloo-system", "gloo=gateway-proxy")
-		// We should consistently be able to modify upstreams
-		Eventually(func() error {
-			// Modify the upstream
-			us, err := upstreamClient.Read(namespace, upstream.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+		forceProxyIntoWarningState := func(virtualService *gatewayv1.VirtualService) {
+			virtualService, err = virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
 			Expect(err).NotTo(HaveOccurred())
-			if us.Status.State == core.Status_Accepted {
-				return nil
-			}
-			return eris.Errorf("waiting for proxy to be accepted, but status is %v", us.Status)
-		}, "3m", "5s").Should(BeNil())
 
-		By("create a virtual service routing to the service")
-		virtualService, err = virtualServiceClient.Write(&gatewayv1.VirtualService{
-			Metadata: &core.Metadata{
-				Name:      "echo-vs",
-				Namespace: namespace,
-			},
-			VirtualHost: &gatewayv1.VirtualHost{
-				Domains: []string{"*"},
-				Routes: []*gatewayv1.Route{
-					{
-						Matchers: []*matchers.Matcher{{
-							PathSpecifier: &matchers.Matcher_Prefix{
-								Prefix: "/1",
-							},
-						}},
-						Action: &gatewayv1.Route_RouteAction{
-							RouteAction: &gloov1.RouteAction{
-								Destination: &gloov1.RouteAction_Single{
-									Single: &gloov1.Destination{
-										DestinationType: &gloov1.Destination_Kube{
-											Kube: &gloov1.KubernetesServiceDestination{
-												Ref: &core.ResourceRef{
-													Namespace: appService.Namespace,
-													Name:      appService.Name,
-												},
-												Port: 5678,
-											},
+			// required to prevent gateway webhook from rejecting
+			virtualService.Metadata.Annotations = map[string]string{k8sadmisssion.SkipValidationKey: k8sadmisssion.SkipValidationValue}
+
+			virtualService.VirtualHost.Routes = append(virtualService.VirtualHost.Routes, &gatewayv1.Route{
+				Matchers: []*matchers.Matcher{{
+					PathSpecifier: &matchers.Matcher_Prefix{
+						Prefix: "/3",
+					},
+				}},
+				Action: &gatewayv1.Route_RouteAction{
+					RouteAction: &gloov1.RouteAction{
+						Destination: &gloov1.RouteAction_Single{
+							Single: &gloov1.Destination{
+								DestinationType: &gloov1.Destination_Kube{
+									Kube: &gloov1.KubernetesServiceDestination{
+										Ref: &core.ResourceRef{
+											Namespace: testHelper.InstallNamespace,
+											Name:      "non-existent-svc",
 										},
+										Port: 1234,
 									},
 								},
 							},
 						},
 					},
 				},
-			},
-		}, clients.WriteOpts{Ctx: ctx})
-		Expect(err).NotTo(HaveOccurred())
+			})
 
-		By("wait for proxy to be accepted")
-		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-			if err != nil {
-				return err
-			}
-			if proxy.GetStatus().GetState() == core.Status_Accepted {
-				return nil
-			}
-			return eris.Errorf("waiting for proxy to be accepted, but status is %v", proxy.Status)
-		}, 60*time.Second, 1*time.Second).Should(BeNil())
+			virtualServiceReconciler := gatewayv1.NewVirtualServiceReconciler(virtualServiceClient)
+			err = virtualServiceReconciler.Reconcile(testHelper.InstallNamespace, gatewayv1.VirtualServiceList{virtualService}, nil, clients.ListOpts{})
+			Expect(err).NotTo(HaveOccurred())
 
-		By("verify that we can route to the service")
-		time.Sleep(1 * time.Second) // sleep a sec to save us some unnecessary polling
-		testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{
-			Protocol:          "http",
-			Path:              "/1",
-			Method:            "GET",
-			Host:              gatewayProxy,
-			Service:           gatewayProxy,
-			Port:              gatewayPort,
-			ConnectionTimeout: 1,
-			WithoutStats:      true,
-		}, expectedResponse(appName), 1, 30*time.Second, 1*time.Second)
+			helpers.EventuallyResourceWarning(func() (resources.InputResource, error) {
+				return proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+			}, 20*time.Second, 1*time.Second)
+		}
 
-		// Break config
-		By("add conflicting domains to the virtual service")
-		virtualService, err = virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
-		Expect(err).NotTo(HaveOccurred())
+		It("works", func() {
+			By("force proxy into warning state")
+			forceProxyIntoWarningState(virtualService)
 
-		// conflicting domains
-		virtualService.VirtualHost.Domains = []string{"*", "*"}
+			By("force an update of the service endpoints")
+			initialEndpointIPs := endpointIPsForKubeService(kubeClient, appService)
 
-		// required to prevent gateway webhook from rejecting
-		virtualService.Metadata.Annotations = map[string]string{k8sadmisssion.SkipValidationKey: k8sadmisssion.SkipValidationValue}
-
-		virtualServiceReconciler := gatewayv1.NewVirtualServiceReconciler(virtualServiceClient)
-		err = virtualServiceReconciler.Reconcile(testHelper.InstallNamespace, gatewayv1.VirtualServiceList{virtualService}, nil, clients.ListOpts{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("wait for proxy to enter rejected state")
-		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-			if err != nil {
-				return err
-			}
-			if proxy.GetStatus().GetState() == core.Status_Rejected {
-				return nil
-			}
-			return eris.Errorf("waiting for proxy to be rejected, but status is %v", proxy.Status)
-		}, 20*time.Second, 1*time.Second).Should(BeNil())
-
-		By("reset snapshot cache")
-		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"gloo": "gloo"}).String()})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(len(pods.Items)).To(Equal(1))
-		oldGlooPod := pods.Items[0]
-
-		err = kubeClient.CoreV1().Pods(namespace).Delete(ctx, oldGlooPod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointerToInt64(0)})
-		Expect(err).ToNot(HaveOccurred())
-
-		// check deleted and recreated
-		Eventually(func() bool {
-			pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"gloo": "gloo"}).String()})
-			Expect(err).ToNot(HaveOccurred())
-			if len(pods.Items) > 0 {
-				// new pod name will not match old gloo pod
-				return pods.Items[0].Name == oldGlooPod.Name
-			}
-			return true
-		}, 80*time.Second, 2*time.Second).Should(BeFalse())
-
-		By("force an update of the service endpoints")
-		initialIps := endpointsFor(kubeClient, appService)
-		var newIps []string
-		// Scale to 0 and back to 1 replicas until we have a different IP for the endpoint
-		Eventually(func() []string {
 			scaleDeploymentTo(kubeClient, appDeployment, 0)
 			scaleDeploymentTo(kubeClient, appDeployment, 1)
-			newIps = endpointsFor(kubeClient, appService)
-			return newIps
-		}, 20*time.Second, 1*time.Second).Should(And(
-			HaveLen(len(initialIps)),
-			Not(BeEquivalentTo(initialIps)),
-		))
 
-		By("verify that the new endpoints have been propagated to Envoy")
-		Eventually(func() bool {
-			clusters := testutils.CurlWithEphemeralPod(ctx, ioutil.Discard, kubeCtx, "gloo-system", gatewayProxyPodName, clustersPath)
-			testOldClusterEndpoints := regexp.MustCompile(initialIps[0] + ":")
-			oldEndpointMatches := testOldClusterEndpoints.FindAllStringIndex(clusters, -1)
-			testNewClusterEndpoints := regexp.MustCompile(newIps[0] + ":")
-			newEndpointMatches := testNewClusterEndpoints.FindAllStringIndex(clusters, -1)
-			fmt.Println(fmt.Sprintf("Number of cluster stats for old endpoint on clusters page: %d", len(oldEndpointMatches)))
-			fmt.Println(fmt.Sprintf("Number of cluster stats for new endpoint on clusters page: %d", len(newEndpointMatches)))
-			return len(oldEndpointMatches) == 0 && len(newEndpointMatches) > 0
-		}, 20*time.Second, 1*time.Second).Should(BeTrue())
+			Eventually(func() []string {
+				return endpointIPsForKubeService(kubeClient, appService)
+			}, 20*time.Second, 1*time.Second).Should(And(
+				HaveLen(len(initialEndpointIPs)),
+				Not(BeEquivalentTo(initialEndpointIPs)),
+			))
+
+			By("verify that the new endpoints have been propagated to Envoy")
+			testHelper.CurlEventuallyShouldRespond(helper.CurlOpts{
+				Protocol:          "http",
+				Path:              "/1",
+				Method:            "GET",
+				Host:              gatewayProxy,
+				Service:           gatewayProxy,
+				Port:              gatewayPort,
+				ConnectionTimeout: 1,
+				WithoutStats:      true,
+			}, expectedResponse(appName), 1, 30*time.Second, 1*time.Second)
+		})
+
+		It("works, even when snapshot cache is reset", func() {
+			By("force proxy into warning state")
+			forceProxyIntoWarningState(virtualService)
+
+			By("delete gloo pod, ensuring the snapshot cache is reset")
+			pods, err := kubeClient.CoreV1().Pods(testHelper.InstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"gloo": "gloo"}).String()})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(len(pods.Items)).To(Equal(1))
+			oldGlooPod := pods.Items[0]
+
+			err = kubeClient.CoreV1().Pods(testHelper.InstallNamespace).Delete(ctx, oldGlooPod.Name, metav1.DeleteOptions{GracePeriodSeconds: pointerToInt64(0)})
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				pods, err := kubeClient.CoreV1().Pods(testHelper.InstallNamespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"gloo": "gloo"}).String()})
+				Expect(err).ToNot(HaveOccurred())
+				if len(pods.Items) > 0 {
+					// new pod name will not match old gloo pod
+					return pods.Items[0].Name == oldGlooPod.Name
+				}
+				return true
+			}, 80*time.Second, 2*time.Second).Should(BeFalse())
+
+			By("force an update of the service endpoints")
+			var initialEndpointIPs, newEndpointIPs []string
+			initialEndpointIPs = endpointIPsForKubeService(kubeClient, appService)
+
+			scaleDeploymentTo(kubeClient, appDeployment, 0)
+			scaleDeploymentTo(kubeClient, appDeployment, 1)
+
+			Eventually(func() []string {
+				newEndpointIPs = endpointIPsForKubeService(kubeClient, appService)
+				return newEndpointIPs
+			}, 20*time.Second, 1*time.Second).Should(And(
+				HaveLen(len(initialEndpointIPs)),
+				Not(BeEquivalentTo(initialEndpointIPs)),
+			))
+
+			By("verify that the new endpoints have been propagated to Envoy")
+			gatewayProxyPodName := testutils.FindPodNameByLabel(cfg, ctx, testHelper.InstallNamespace, "gloo=gateway-proxy")
+			envoyClustersPath := "http://localhost:19000/clusters" // TODO - this should live in envoy test service
+			Eventually(func() bool {
+				clusters := testutils.CurlWithEphemeralPod(ctx, ioutil.Discard, "", testHelper.InstallNamespace, gatewayProxyPodName, envoyClustersPath)
+
+				testOldClusterEndpoints := regexp.MustCompile(initialEndpointIPs[0] + ":")
+				oldEndpointMatches := testOldClusterEndpoints.FindAllStringIndex(clusters, -1)
+				fmt.Println(fmt.Sprintf("Number of cluster stats for old endpoint on clusters page: %d", len(oldEndpointMatches)))
+
+				testNewClusterEndpoints := regexp.MustCompile(newEndpointIPs[0] + ":")
+				newEndpointMatches := testNewClusterEndpoints.FindAllStringIndex(clusters, -1)
+				fmt.Println(fmt.Sprintf("Number of cluster stats for new endpoint on clusters page: %d", len(newEndpointMatches)))
+
+				return len(oldEndpointMatches) == 0 && len(newEndpointMatches) > 0
+			}, 60*time.Second, 1*time.Second).Should(BeTrue())
+
+		})
 
 	})
+
 })
 
 func expectedResponse(appName string) string {
 	return fmt.Sprintf("Hello from %s!", appName)
 }
 
-func createDeploymentAndService(kubeClient kubernetes.Interface, namespace, appName string) (
+func createEchoDeploymentAndService(kubeClient kubernetes.Interface, namespace, appName string) (
 	*appsv1.Deployment, *corev1.Service, error,
 ) {
 	deployment, err := kubeClient.AppsV1().Deployments(namespace).Create(ctx, &appsv1.Deployment{
@@ -534,7 +387,7 @@ func pointerToInt64(value int64) *int64 {
 	return &value
 }
 
-func endpointsFor(kubeClient kubernetes.Interface, svc *corev1.Service) []string {
+func endpointIPsForKubeService(kubeClient kubernetes.Interface, svc *corev1.Service) []string {
 	var endpoints *corev1.EndpointsList
 	listOpts := metav1.ListOptions{LabelSelector: labels.SelectorFromSet(svc.Spec.Selector).String()}
 	endpoints, err := kubeClient.CoreV1().Endpoints(svc.Namespace).List(ctx, listOpts)

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -159,18 +159,34 @@ func UpdateRestEdsSetting(ctx context.Context, enableRestEds bool, installNamesp
 	}, ctx, installNamespace)
 }
 
-func UpdateSettings(f func(settings *v1.Settings), ctx context.Context, installNamespace string) {
+func UpdateReplaceInvalidRoutes(ctx context.Context, replaceInvalidRoutes bool, installNamespace string) {
+	UpdateSettings(func(settings *v1.Settings) {
+		Expect(settings.Gloo).NotTo(BeNil())
+		Expect(settings.Gloo.InvalidConfigPolicy).NotTo(BeNil())
+		settings.Gloo.InvalidConfigPolicy.ReplaceInvalidRoutes = replaceInvalidRoutes
+	}, ctx, installNamespace)
+}
+
+func UpdateSettings(updateSettings func(settings *v1.Settings), ctx context.Context, installNamespace string) {
+	// when validation config changes, the validation server restarts -- give time for it to come up again.
+	// without the wait, the validation webhook may temporarily fallback to it's failurePolicy, which is not
+	// what we want to test.
+	// TODO (samheilbron) We should avoid relying on time.Sleep in our tests as these tend to cause flakes
+	waitForSettingsToPropagate := func() {
+		time.Sleep(3 * time.Second)
+	}
+	UpdateSettingsWithPropagationDelay(updateSettings, waitForSettingsToPropagate, ctx, installNamespace)
+}
+
+func UpdateSettingsWithPropagationDelay(updateSettings func(settings *v1.Settings), waitForSettingsToPropagate func(), ctx context.Context, installNamespace string) {
 	settingsClient := clienthelpers.MustSettingsClient(ctx)
 	settings, err := settingsClient.Read(installNamespace, "default", clients.ReadOpts{})
 	Expect(err).NotTo(HaveOccurred())
 
-	f(settings)
+	updateSettings(settings)
 
 	_, err = settingsClient.Write(settings, clients.WriteOpts{OverwriteExisting: true})
 	Expect(err).NotTo(HaveOccurred())
 
-	// when validation config changes, the validation server restarts -- give time for it to come up again.
-	// without the wait, the validation webhook may temporarily fallback to it's failurePolicy, which is not
-	// what we want to test.
-	time.Sleep(3 * time.Second)
+	waitForSettingsToPropagate()
 }

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -143,6 +143,14 @@ func getSnapOut(metricsPort string) string {
 	return snapOut
 }
 
+func UpdateDisableTransformationValidationSetting(ctx context.Context, shouldDisable bool, installNamespace string) {
+	UpdateSettings(func(settings *v1.Settings) {
+		Expect(settings.Gateway).NotTo(BeNil())
+		Expect(settings.Gateway.Validation).NotTo(BeNil())
+		settings.Gateway.Validation.DisableTransformationValidation = &wrappers.BoolValue{Value: shouldDisable}
+	}, ctx, installNamespace)
+}
+
 // enable/disable strict validation
 func UpdateAlwaysAcceptSetting(ctx context.Context, alwaysAccept bool, installNamespace string) {
 	UpdateSettings(func(settings *v1.Settings) {


### PR DESCRIPTION
# Description
- Fixed logic in our proxy reconciler, which allowed invalid virtual hosts to be added to a proxy twice. 
- Add some utility methods for our Kube2e tests, to make it easier for developers to add logic around waiting for resources to be accepted and cleaned up
- Fix test pollution that did lead to flakes
- Fix robustness_test, which was written in a way that relied on the exact bug that this PR fixes, to be present
- Fix disable_transformation_test (https://github.com/solo-io/gloo/issues/4900) which would flake occasionally, and did during the development of this PR 

# Context

### Mix of valid and invalid virtual services
Example logs: https://console.cloud.google.com/cloud-build/builds/a13c32e3-fddf-4263-b28a-e931933d9f87;step=14?project=solo-public

This test flake was due to a bug in our proxy_reconciler. We incorrectly were duplicating virtual hosts on the proxy object. The proxy only transitioned in certain situations (depending on metadata of the object) which is why this didn't occur more frequently. However, when it did happen, it caused this flaking test.

I added a unit test to verify the change that I made fixes the problem. 
I also added a comment to the code so that future developers would understand the reason for the change.

### Does not equal length of map
Sometimes, I ran into a Gateway test (I don't have the logs handy) that produced the following error:
```
[
gloo-system-gateway-443_gloo-system-16567209401833135566:true 
gloo-system-gateway-proxy-443_gloo-system-7590740161429284937:true 
gloo-system-gateway-proxy-80_gloo-system-7992917100079133684:true 
gloo-system-gloo-9976_gloo-system-12285151928708083525:true 
gloo-system-gloo-9977_gloo-system-7484856654061583909:true 
gloo-system-gloo-9979_gloo-system-5451814594336066521:true 
gloo-system-gloo-9988_gloo-system-1559281721111094449:true 
gloo-system-testrunner-1234_gloo-system-10782942849661275980:true 
kube-svc:gloo-system-gateway-443_gloo-system-10160320302259603858:true 
kube-svc:gloo-system-gateway-proxy-443_gloo-system-13361889343733600589:true 
kube-svc:gloo-system-gateway-proxy-80_gloo-system-15324810366434219216:true 
kube-svc:gloo-system-gloo-9976_gloo-system-6098176559075073065:true 
kube-svc:gloo-system-gloo-9977_gloo-system-8667782289304402933:true
 kube-svc:gloo-system-gloo-9979_gloo-system-1598973103534690965:true
 kube-svc:gloo-system-gloo-9988_gloo-system-6721171892144873845:true 
kube-svc:gloo-system-testrunner-1234_gloo-system-1741026987556571732:true
] 

does not equal length of map

[
gloo-system-gateway-443_gloo-system-16567209401833135566:0xc0008e6ce0 
gloo-system-gateway-proxy-443_gloo-system-7590740161429284937:0xc0008e6da0 
gloo-system-gateway-proxy-80_gloo-system-7992917100079133684:0xc0008e6e50 
gloo-system-gloo-9976_gloo-system-12285151928708083525:0xc0008e6ec0 
gloo-system-gloo-9977_gloo-system-7484856654061583909:0xc0008e6f30 
gloo-system-gloo-9979_gloo-system-5451814594336066521:0xc0008e6fa0
gloo-system-gloo-9988_gloo-system-1559281721111094449:0xc0008e7010 
gloo-system-redbluezqw6b-5678_gloo-system-6470157035427515329:0xc0008e74b0
gloo-system-testrunner-1234_gloo-system-10782942849661275980:0xc0008e7060 
kube-svc:gloo-system-gateway-443_gloo-system-10160320302259603858:0xc0008e70d0 
kube-svc:gloo-system-gateway-proxy-443_gloo-system-13361889343733600589:0xc0008e7190 
kube-svc:gloo-system-gateway-proxy-80_gloo-system-15324810366434219216:0xc0008e7270 
kube-svc:gloo-system-gloo-9976_gloo-system-6098176559075073065:0xc0008e72f0 
kube-svc:gloo-system-gloo-9977_gloo-system-8667782289304402933:0xc0008e7360 
kube-svc:gloo-system-gloo-9979_gloo-system-1598973103534690965:0xc0008e73d0 
kube-svc:gloo-system-gloo-9988_gloo-system-6721171892144873845:0xc0008e7440 
kube-svc:gloo-system-redbluezqw6b-5678_gloo-system-5865765942139567028:0xc0008e74d0 
kube-svc:gloo-system-testrunner-1234_gloo-system-1741026987556571732:0xc0008e7490
]
```
I believe this is just due to test pollution, since the mismatched service (ie the service in one map but not the other) is `gloo-system-redbluezqw6b-5678_gloo-system-6470157035427515329:0xc0008e74b0`. There is only one test that uses this service, so I added an Eventually to ensure it is cleaned up after the test 

### Gateway robustness test changes
This test intentionally wrote a virtual service with duplicate domains, which triggers the exact bug that this PR fixes. After introducing the fix, and not changing the test at all, the test consistently fails, because it expects the proxy to enter a Rejected state. This would happen before, but with the fix, invalid virtual hosts are stripped properly, and not duplicated, so the proxy no longer enters a rejected state.

I updated the test, and simplified some of the logic to make it consistent with another test that is validating similar behavior.

### Disable transformation validation kube2e test flake

This flake was due to behavior of the gateway validation server. When the gateway validation settings change (as we do in this test), the server restarts and we need to afford it enough time to reboot. I re-used a pattern we have relied on in other tests, to ensure that the settings are given enough time to propagate before moving forward with the test execution.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

# Testing
I have another branch with the tests re-written in a way to make running a single test over and over easier/faster. As of now, we can supply the `untilItFails` flag to ginkgo, but since Kube2e tests install gloo and uninstall it before/after Suites, I re-wrote the tests so that I could repeat tests without having to re-install gloo each time. This was just useful for debugging, and I didn't add the code to the PR. If we're interested in a true debugging utility for kube2e tests, there are likely better ways to set that up. The branch is: https://github.com/solo-io/gloo/tree/regression-test-flakes

Here are the steps you can run to run these tests quickly:
1. Checkout code from testing branch: `git checkout regression-test-flakes`
1. Checkout code from this branch: `git checkout fix-regression-test-flakes`
1.  Build images with version, and push to kind cluster. `VERSION=v1.8.2 CLUSTER_NAME=regression-flakes CLUSTER_NODE_VERSION=v1.21.1 ./ci/deploy-to-kind-cluster.sh`
1. Checkout files from test branch: `git checkout regression-test-flakes test/kube2e/util.go`,  `git checkout regression-test-flakes test/kube2e/gateway/gateway_test.go`
1. Run focused regression tests: ` KUBE2E_TESTS=gateway TEAR_DOWN=true WAIT_ON_FAIL=1 make run-ci-regression-tests
`

This will run the previously flaking test 100 times in a row. Before this change (you can verify for yourself), if I ran this, most times a flake would occur within the 100 times. However, with this change, I consistently complete all 100 without an error.