### PR TITLE
Ensure invalid virtual hosts are not duplicated on proxy (1.6)

### DIFF
--- a/changelog/v1.6.32/fix-regression-flakes.yaml
+++ b/changelog/v1.6.32/fix-regression-flakes.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3247
+    resolvesIssue: false
+    description: Ensure proxy reconciliaton does not duplicate virtual hosts

--- a/go.sum
+++ b/go.sum
@@ -411,7 +411,6 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjr
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v0.0.0-20210511163231-5b2d2b5f6c34/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
-github.com/form3tech-oss/jwt-go v3.2.2+incompatible h1:TcekIExNqud5crz4xD2pavyTgWiPvpYe4Xau31I0PRk=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible h1:7ZaBxOI7TMoYBfyA3cQHErNNyAWIKUMIwqxEtgHOs5c=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -831,7 +830,6 @@ github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5 h1:lrdPtrORjGv1HbbE
 github.com/jmoiron/sqlx v1.2.1-0.20190826204134-d7d95172beb5/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
-github.com/jonboulle/clockwork v0.1.0 h1:VKV+ZcuP6l3yW9doeqz6ziZGgcynBVQO+obU0+0hcPo=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/jonboulle/clockwork v0.2.1 h1:S/EaQvW6FpWMYAvYvY+OBDvpaM+izu0oiwo5y0MH7U0=
@@ -878,7 +876,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -154,6 +154,56 @@ var _ = Describe("Robustness tests", func() {
 		cancel()
 	})
 
+	forceProxyIntoWarningState := func(virtualService *gatewayv1.VirtualService) {
+		By("add an invalid route to the virtual service")
+		virtualService, err = virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+		Expect(err).NotTo(HaveOccurred())
+
+		virtualService.VirtualHost.Routes = append(virtualService.VirtualHost.Routes, &gatewayv1.Route{
+			Matchers: []*matchers.Matcher{{
+				PathSpecifier: &matchers.Matcher_Prefix{
+					Prefix: "/3",
+				},
+			}},
+			Action: &gatewayv1.Route_RouteAction{
+				RouteAction: &gloov1.RouteAction{
+					Destination: &gloov1.RouteAction_Single{
+						Single: &gloov1.Destination{
+							DestinationType: &gloov1.Destination_Kube{
+								Kube: &gloov1.KubernetesServiceDestination{
+									Ref: &core.ResourceRef{
+										Namespace: namespace,
+										Name:      "non-existent-svc",
+									},
+									Port: 1234,
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		// required to prevent gateway webhook from rejecting
+		virtualService.Metadata.Annotations = map[string]string{k8sadmisssion.SkipValidationKey: k8sadmisssion.SkipValidationValue}
+
+		virtualServiceReconciler := gatewayv1.NewVirtualServiceReconciler(virtualServiceClient)
+		err = virtualServiceReconciler.Reconcile(testHelper.InstallNamespace, gatewayv1.VirtualServiceList{virtualService}, nil, clients.ListOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("wait for proxy to enter warning state")
+		Eventually(func() error {
+			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+			if err != nil {
+				return err
+			}
+			if proxy.GetStatus().GetState() == core.Status_Warning {
+				return nil
+			}
+			return eris.Errorf("waiting for proxy to be warning, but status is %v", proxy.Status)
+		}, 20*time.Second, 1*time.Second).Should(BeNil())
+	}
+
 	It("updates Envoy endpoints even if proxy is rejected", func() {
 
 		By("create a virtual service routing to the service")
@@ -219,53 +269,7 @@ var _ = Describe("Robustness tests", func() {
 			WithoutStats:      true,
 		}, expectedResponse(appName), 1, 30*time.Second, 1*time.Second)
 
-		By("add an invalid route to the virtual service")
-		virtualService, err = virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
-		Expect(err).NotTo(HaveOccurred())
-
-		virtualService.VirtualHost.Routes = append(virtualService.VirtualHost.Routes, &gatewayv1.Route{
-			Matchers: []*matchers.Matcher{{
-				PathSpecifier: &matchers.Matcher_Prefix{
-					Prefix: "/3",
-				},
-			}},
-			Action: &gatewayv1.Route_RouteAction{
-				RouteAction: &gloov1.RouteAction{
-					Destination: &gloov1.RouteAction_Single{
-						Single: &gloov1.Destination{
-							DestinationType: &gloov1.Destination_Kube{
-								Kube: &gloov1.KubernetesServiceDestination{
-									Ref: &core.ResourceRef{
-										Namespace: namespace,
-										Name:      "non-existent-svc",
-									},
-									Port: 1234,
-								},
-							},
-						},
-					},
-				},
-			},
-		})
-
-		// required to prevent gateway webhook from rejecting
-		virtualService.Metadata.Annotations = map[string]string{k8sadmisssion.SkipValidationKey: k8sadmisssion.SkipValidationValue}
-
-		virtualServiceReconciler := gatewayv1.NewVirtualServiceReconciler(virtualServiceClient)
-		err = virtualServiceReconciler.Reconcile(testHelper.InstallNamespace, gatewayv1.VirtualServiceList{virtualService}, nil, clients.ListOpts{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("wait for proxy to enter warning state")
-		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-			if err != nil {
-				return err
-			}
-			if proxy.GetStatus().GetState() == core.Status_Warning {
-				return nil
-			}
-			return eris.Errorf("waiting for proxy to be warning, but status is %v", proxy.Status)
-		}, 20*time.Second, 1*time.Second).Should(BeNil())
+		forceProxyIntoWarningState(virtualService)
 
 		By("force an update of the service endpoints")
 		initialIps := endpointsFor(kubeClient, appService)
@@ -386,32 +390,7 @@ var _ = Describe("Robustness tests", func() {
 			WithoutStats:      true,
 		}, expectedResponse(appName), 1, 30*time.Second, 1*time.Second)
 
-		// Break config
-		By("add conflicting domains to the virtual service")
-		virtualService, err = virtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
-		Expect(err).NotTo(HaveOccurred())
-
-		// conflicting domains
-		virtualService.VirtualHost.Domains = []string{"*", "*"}
-
-		// required to prevent gateway webhook from rejecting
-		virtualService.Metadata.Annotations = map[string]string{k8sadmisssion.SkipValidationKey: k8sadmisssion.SkipValidationValue}
-
-		virtualServiceReconciler := gatewayv1.NewVirtualServiceReconciler(virtualServiceClient)
-		err = virtualServiceReconciler.Reconcile(testHelper.InstallNamespace, gatewayv1.VirtualServiceList{virtualService}, nil, clients.ListOpts{})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("wait for proxy to enter rejected state")
-		Eventually(func() error {
-			proxy, err := proxyClient.Read(namespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
-			if err != nil {
-				return err
-			}
-			if proxy.GetStatus().GetState() == core.Status_Rejected {
-				return nil
-			}
-			return eris.Errorf("waiting for proxy to be rejected, but status is %v", proxy.Status)
-		}, 20*time.Second, 1*time.Second).Should(BeNil())
+		forceProxyIntoWarningState(virtualService)
 
 		By("reset snapshot cache")
 		pods, err := kubeClient.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{LabelSelector: labels.SelectorFromSet(map[string]string{"gloo": "gloo"}).String()})


### PR DESCRIPTION
Partial backport of: https://github.com/solo-io/gloo/pull/5033 (Only included bug fix, since there were merge conflicts)

# Description
Fixed logic in our proxy reconciler, which allowed invalid virtual hosts to be added to a proxy twice. 

# Context
Example logs: https://console.cloud.google.com/cloud-build/builds/a13c32e3-fddf-4263-b28a-e931933d9f87;step=14?project=solo-public

This test flake was due to a bug in our proxy_reconciler. We incorrectly were duplicating virtual hosts on the proxy object. The proxy only transitioned in certain situations (depending on metadata of the object) which is why this didn't occur more frequently. However, when it did happen, it caused this flaking test.

I added a unit test to verify the change that I made fixes the problem. 
I also added a comment to the code so that future developers would understand the reason for the change.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
