### PR TITLE
Ensure invalid virtual hosts are not duplicated on proxy (1.7)

### DIFF
--- a/changelog/v1.7.14/fix-regression-flakes.yaml
+++ b/changelog/v1.7.14/fix-regression-flakes.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/3247
+    resolvesIssue: false
+    description: Ensure proxy reconciliaton does not duplicate virtual hosts


### PR DESCRIPTION
Partial backport of: https://github.com/solo-io/gloo/pull/5033 (Only included bug fix, since there were merge conflicts)

# Description
Fixed logic in our proxy reconciler, which allowed invalid virtual hosts to be added to a proxy twice. 

# Context
Example logs: https://console.cloud.google.com/cloud-build/builds/a13c32e3-fddf-4263-b28a-e931933d9f87;step=14?project=solo-public

This test flake was due to a bug in our proxy_reconciler. We incorrectly were duplicating virtual hosts on the proxy object. The proxy only transitioned in certain situations (depending on metadata of the object) which is why this didn't occur more frequently. However, when it did happen, it caused this flaking test.

I added a unit test to verify the change that I made fixes the problem. 
I also added a comment to the code so that future developers would understand the reason for the change.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
