### PR TITLE
issue-4491-doc

### DIFF
--- a/docs/content/guides/observability/_index.md
+++ b/docs/content/guides/observability/_index.md
@@ -3,14 +3,16 @@ title: Observability
 weight: 40
 description: Monitoring, metrics, and logging for Gloo Edge
 ---
+{{% notice note %}}
+Gloo Edge default prometheus server and grafana instance are not meant to be used `as-is` in production. Please provide your own instance or configure the provided one with production values
+{{% /notice %}}
 
 Gloo Edge exposes a lot of metrics from both the data plane (Envoy) as well as the control plane components. 
 These metrics are available in Open Source Gloo Edge, and can be scraped into a standard metrics backend like Prometheus. 
 
 Enterprise Gloo Edge comes with a few extra enhancements around observability. First, it installs by default with a prometheus 
 server to scrape all of the Gloo Edge metrics, and a Grafana instance to provide dashboards from those metrics. Alternatively, 
-customers may wish to use their own Prometheus and Grafana deployments and integrate Gloo Edge with those. 
-
+customers may wish to use their own Prometheus and Grafana deployments and integrate Gloo Edge with those.
 
 Gloo Edge Enterprise comes with a built-in grafana dashboard to show a high-level health of the Envoy proxy, 
 and also comes with a component called `observability` that dynamically creates a new Grafana dashboard for each Gloo Edge `Upstream`. 

--- a/docs/content/guides/observability/grafana/deployment/_index.md
+++ b/docs/content/guides/observability/grafana/deployment/_index.md
@@ -3,14 +3,23 @@ title: Deployment Configuration
 weight: 2
 description: How to configure your Grafana installation
 ---
-
-> **Note**: This page details configuration for the Grafana deployment packaged with Gloo Edge Enterprise
+This functionality is turned on by default, and can be turned off a couple of different ways: through [Helm chart install
+options]({{< versioned_link_path fromRoot="/installation/gateway/kubernetes/#installing-the-gloo-gateway-on-kubernetes" >}}); and through environment variables.
 
  * [Default Installation](#default-installation)
     * [Credentials](#credentials)
  * [Custom Deployment](#custom-deployment)
  
 ### Default Installation
+
+{{% notice warning %}}
+Gloo is shipped by default with grafana 5.x charts, and provides a set of default values that are not suitable for production usage in most cases. Please provide your own instance of grafana or configure the helm chart options with production values
+{{% /notice %}}
+
+{{% notice note %}}
+For a complete set of options, please refer to: https://github.com/grafana/helm-charts/tree/main/charts/grafana
+{{% /notice %}}
+
 No special configuration is needed to use the instance of Grafana that ships by default with Gloo Edge. Find the deployment and port-forward to it:
 
 ```bash

--- a/docs/content/guides/observability/prometheus/_index.md
+++ b/docs/content/guides/observability/prometheus/_index.md
@@ -3,8 +3,20 @@ title: Prometheus
 weight: 2
 description: Info about Gloo Edge's Prometheus Instance
 ---
+{{% notice note %}}
+Observability features are available only in Gloo Edge Enterprise
+{{% /notice %}}
+This functionality is turned on by default, and can be turned off a couple of different ways: through [Helm chart install
+options]({{< versioned_link_path fromRoot="/installation/gateway/kubernetes/#installing-the-gloo-gateway-on-kubernetes" >}}); and through environment variables.
 
-> **Note**: Observability features are available only in Gloo Edge Enterprise
+## Default Installation
+{{% notice warning %}}
+Gloo is shipped by default with prometheus 11.x charts, and provides a set of default values that are not suitable for production usage in most cases. Please provide your own instance of prometheus or configure the helm chart options with production values
+{{% /notice %}}
+
+{{% notice note %}}
+For a complete set of options, please refer to: https://github.com/prometheus-community/helm-charts/blob/main/charts/prometheus/values.yaml, or run `helm show values prometheus-community/prometheus`
+{{% /notice %}}
 
 ## Run Your Own Prometheus
 A common setup may be to run your own prometheus, separate from the gloo-provided one. The Gloo Edge Enterprise UI makes use of its own grafana to display dashboards for Envoy and Kubernetes, leveraging gloo custom resources such as `Upstreams`. You can point gloo's system grafana toward your prometheus by overriding grafana's datasources tag, i.e.

--- a/docs/content/operations/production_deployment/_index.md
+++ b/docs/content/operations/production_deployment/_index.md
@@ -77,10 +77,6 @@ Some metrics that may be useful to monitor (listed in Prometheus format):
 
 ### Troubleshooting monitoring components
 
-needed_disk_space = retention_time_seconds * ingested_samples_per_second * bytes_per_sample
-prometheus.server.retention
-prometheus.server.persistentVolume.size
-
 A common issue in production (or environments with high traffic) is to have sizing issues. This will result in an abnormal number of restarts like this:
 ```shell
 $ kubectl get all -n gloo-system

--- a/docs/content/operations/production_deployment/_index.md
+++ b/docs/content/operations/production_deployment/_index.md
@@ -61,6 +61,10 @@ See the [helm chart value reference]({{%versioned_link_path fromRoot="/reference
 
 ## Metrics and monitoring
 
+{{% notice note %}}
+Gloo Edge default prometheus server and grafana instance are not meant to be used `as-is` in production. Please provide your own instance or configure the provided one with production values
+{{% /notice %}}
+
 When running Gloo Edge (or any application for that matter) in a production environment, it is important to have a monitoring solution in place.
 Gloo Edge Enterprise provides a simple deployment of Prometheus and Grafana to assist with this necessity.
 However, depending on the requirements on your organization you may require a more robust solution, in which case you should make sure the metrics from the Gloo Edge components (especially Envoy) are available in whatever solution you are using.
@@ -70,6 +74,106 @@ Some metrics that may be useful to monitor (listed in Prometheus format):
 * `envoy_control_plane_connected_state` -- This metric shows whether or not a given Envoy instance is connected to the control plane, i.e. the Gloo pod.
  This metric should have a value of `1` otherwise it indicates that Envoy is having trouble connecting to the Gloo pod.
 * `container_cpu_cfs_throttled_seconds_total / container_cpu_cfs_throttled_periods_total` -- This is a generic expression that will show whether or not a given container is being throttled for CPU, which will result is performance issues and service degradation. If the Gloo Edge containers are being throttled, it is important to understand why and given the underlying cause, increase the resources allocated.
+
+### Troubleshooting monitoring components
+
+needed_disk_space = retention_time_seconds * ingested_samples_per_second * bytes_per_sample
+prometheus.server.retention
+prometheus.server.persistentVolume.size
+
+A common issue in production (or environments with high traffic) is to have sizing issues. This will result in an abnormal number of restarts like this:
+```shell
+$ kubectl get all -n gloo-system
+NAME                                                       READY   STATUS             RESTARTS   AGE
+pod/discovery-9d4c7fb4c-5wq5m                              1/1     Running            13         35d
+pod/extauth-77bb4fc79b-dsl6q                               1/1     Running            0          35d
+pod/gateway-f774b4d5b-jfhwn                                1/1     Running            0          35d
+pod/gateway-proxy-7656d9df87-qtn2s                         1/1     Running            0          35d
+pod/gloo-db4fb8c4-lfcrp                                    1/1     Running            13         35d
+pod/glooe-grafana-78c6f96db-wgl5k                          1/1     Running            0          41d
+pod/glooe-prometheus-kube-state-metrics-5dd77b76fc-s8prb   1/1     Running            0          41d
+pod/glooe-prometheus-server-59dcf7bc5b-jt654               1/2     CrashLoopBackOff   10692      41d
+pod/observability-656d47787-2fskq                          0/1     CrashLoopBackOff   9558       33d
+pod/rate-limit-7d6cf64fbf-ldgbp                            1/1     Running            0          35d
+pod/redis-55d6dbb6b7-ql89p                                 1/1     Running            0          41d
+```
+
+Looking at the cause of these restarts, we can see that the PV is exhausted:
+```shell
+kubectl logs -f pod/glooe-prometheus-server-59dcf7bc5b-jt654 -n gloo-system -c glooe-prometheus-server
+evel=info ts=2021-07-07T05:12:29.474Z caller=main.go:574 msg="Stopping scrape discovery manager..."
+level=info ts=2021-07-07T05:12:29.474Z caller=main.go:588 msg="Stopping notify discovery manager..."
+level=info ts=2021-07-07T05:12:29.474Z caller=main.go:610 msg="Stopping scrape manager..."
+level=info ts=2021-07-07T05:12:29.474Z caller=manager.go:908 component="rule manager" msg="Stopping rule manager..."
+level=info ts=2021-07-07T05:12:29.474Z caller=manager.go:918 component="rule manager" msg="Rule manager stopped"
+level=info ts=2021-07-07T05:12:29.474Z caller=notifier.go:601 component=notifier msg="Stopping notification manager..."
+level=info ts=2021-07-07T05:12:29.474Z caller=main.go:778 msg="Notifier manager stopped"
+level=info ts=2021-07-07T05:12:29.474Z caller=main.go:604 msg="Scrape manager stopped"
+level=info ts=2021-07-07T05:12:29.474Z caller=main.go:570 msg="Scrape discovery manager stopped"
+level=info ts=2021-07-07T05:12:29.474Z caller=main.go:584 msg="Notify discovery manager stopped"
+level=error ts=2021-07-07T05:12:29.474Z caller=main.go:787 err="opening storage failed: open /data/wal/00000721: no space left on device"
+```
+
+Next step is to check the pv size and the retention time:
+```shell
+kubectl get deploy/glooe-prometheus-server -n gloo-system -oyaml|grep "image: prom/prometheus" -C 10
+        - mountPath: /etc/config
+          name: config-volume
+          readOnly: true
+      - args:
+        - --storage.tsdb.retention.time=15d
+        - --config.file=/etc/config/prometheus.yml
+        - --storage.tsdb.path=/data
+        - --web.console.libraries=/etc/prometheus/console_libraries
+        - --web.console.templates=/etc/prometheus/consoles
+        - --web.enable-lifecycle
+        image: prom/prometheus:v2.21.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /-/healthy
+            port: 9090
+            scheme: HTTP
+          initialDelaySeconds: 30
+          periodSeconds: 15
+          successThreshold: 1
+```
+```shell
+kubectl get pv -oyaml|grep "glooe-prometheus-server" -C 10
+    selfLink: /api/v1/persistentvolumes/pvc-a616d9c6-9733-428f-bac5-c054ca8a025b
+    uid: 816c7e99-55e3-4888-83f0-2f31a8314b47
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    capacity:
+      storage: 16Gi
+    claimRef:
+      apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: glooe-prometheus-server
+      namespace: gloo-system
+      resourceVersion: "36337"
+      uid: a616d9c6-9733-428f-bac5-c054ca8a025b
+    gcePersistentDisk:
+      fsType: ext4
+      pdName: gke-jesus-lab-observability-9bc1029-pvc-a616d9c6-9733-428f-bac5-c054ca8a025b
+    nodeAffinity:
+      required:
+        nodeSelectorTerms:
+        - matchExpressions:
+```
+
+In this case, 16Gi volume size and 15d retention is not working well, so we must tune one or both parameters using these helm values:
+```
+prometheus.server.retention
+prometheus.server.persistentVolume.size
+```
+
+Choosing the right values requires some business knowledge, but as a rule of thumb a fair approach is:
+```
+persistentVolume.size = retention_in_seconds * ingested_samples_per_second * bytes_per_sample
+```
 
 ## Access Logging
 

--- a/docs/content/reference/helm_chart_values/enterprise_helm_chart_values.md
+++ b/docs/content/reference/helm_chart_values/enterprise_helm_chart_values.md
@@ -5,7 +5,7 @@ weight: 30
 ---
 
 The table below describes all the values that you can override in your custom values file when working with the Helm 
-chart for Open Source Gloo Edge. More information on using a Helm chart to install the Gloo Edge can be found 
+chart for Enterprise Gloo Edge. More information on using a Helm chart to install the Gloo Edge can be found 
 [here]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/#installing-on-kubernetes-with-helm" %}}).
 
 {{< readfile file="static/content/glooe-values.docgen" markdown="true" >}}


### PR DESCRIPTION
# Description

Fixes https://github.com/solo-io/gloo/issues/4991

# Context

There are some default values like `persistentVolumeSize=16GB +RetentionTime=15d` that are not suitable for production. In general, users should be warned that they must provide their own production-ready instance of prometheus/grafana, or fine-tune the helm chart for production usage.

Recently, there have been several customers reporting weird issues that resulted in 'no disk space' in observability pods. A clearer documentation could mitigate these kind of scenarios.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
