### PR TITLE
Added example to disableKuberetesDestination for Production Deploymen…

### DIFF
--- a/changelog/v1.9.0-beta7/product-deploy-doc-fix.yaml
+++ b/changelog/v1.9.0-beta7/product-deploy-doc-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Clarify how to set disableKubernetesDestination in production deployment doc and give examples with Helm and editing the CRD directly

--- a/docs/content/operations/production_deployment/_index.md
+++ b/docs/content/operations/production_deployment/_index.md
@@ -17,6 +17,25 @@ For example, Gloo Edge's data plane (the `gateway-proxy` pod) has ReadOnly file 
 * **Disable Kubernetes destinations**
     - Gloo Edge out of the box routes to upstreams. It can also route directly to Kubernetes destinations (bypassing upstreams). Upstreams is the recommended abstraction to which to route in VirtualServices, and you can disable the Kubernetes destinations with the `settings.gloo.disableKubernetesDestinations`. This saves on memory overhead so Gloo Edge pod doesn't cache both upstreams and Kubernetes destinations. 
 
+    You can set this value in the default `Settings` CRD by adding the following content:   
+    ```
+    apiVersion: gloo.solo.io/v1
+    kind: Settings
+    metadata:
+      name: default
+      namespace: gloo-system
+    spec:
+      gloo:
+        disableKubernetesDestinations: true
+        ...
+    ```
+
+    You can set this value helm overrides by setting
+    ```
+    settings:
+      disableKubernetesDestinations: true
+    ```
+
 ## Enable replacing invalid routes
 
 * **Configure invalidConfigPolicy**

--- a/docs/content/operations/production_deployment/_index.md
+++ b/docs/content/operations/production_deployment/_index.md
@@ -15,7 +15,7 @@ For example, Gloo Edge's data plane (the `gateway-proxy` pod) has ReadOnly file 
 * **Disable service account token mount**
     - For example, when integrating with Istio's SDS (see integration with Istio), you need to have a service account token mounted. If you're not integrating with Istio, you can eliminate the need for the service account token. When installing Gloo Edge, set the `gateway.proxyServiceAccount.disableAutomount` field. 
 * **Disable Kubernetes destinations**
-    - Gloo Edge out of the box routes to upstreams. It can also route directly to Kubernetes destinations (bypassing upstreams). Upstreams is the recommended abstraction to which to route in VirtualServices, and you can disable the Kubernetes destinations with the `settings.gloo.disableKubernetesDestinations`. This saves on memory overhead so Gloo Edge pod doesn't cache both upstreams and Kubernetes destinations. 
+    - Gloo Edge out of the box routes to upstreams. It can also route directly to Kubernetes destinations (bypassing upstreams). Upstreams is the recommended abstraction to which to route in VirtualServices, and you can disable the Kubernetes destinations with the `settings.disableKubernetesDestinations`. This saves on memory overhead so Gloo Edge pod doesn't cache both upstreams and Kubernetes destinations. 
 
     You can set this value in the default `Settings` CRD by adding the following content:   
     ```


### PR DESCRIPTION
# Description

Clarify how to set `disableKubernetesDestination` in production deployment doc and give examples with Helm and editing the CRD directly

This fix clarifies a question that came from a client around setting `disableKubernetesDestinations`

# Context

A client ran into this when preparing for deployment and thought the docs were wrong because the docs explain how to directly set `disableKubernetesDestinations` on the settings object, the client though it was referring to the helm overrides values. This fix explains how to do it both ways.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

Closes #5080 