### PR TITLE
Fix passthrough auth example repo link

### DIFF
--- a/docs/content/guides/security/auth/extauth/passthrough_auth/_index.md
+++ b/docs/content/guides/security/auth/extauth/passthrough_auth/_index.md
@@ -67,7 +67,7 @@ spec:
 EOF
 {{< /highlight >}}
 
-The source code for the gRPC service can be found in the Gloo Edge repository at `docs/examples/passthrough-auth`.
+The source code for the gRPC service can be found in the Gloo Edge repository [here](https://github.com/solo-io/gloo/tree/master/docs/examples/grpc-passthrough-auth).
 
 Once we create the authentication service, we also want to apply the following Service to assign it a static cluster IP.
 {{< highlight shell >}}


### PR DESCRIPTION
# Description

Fix link in passthrough auth [doc](https://docs.solo.io/gloo-edge/latest/guides/security/auth/extauth/passthrough_auth/#creating-an-authentication-service) to point to correct example in github.
