### PR TITLE
fix glooctl windows installer - 64 bit window server

### DIFF
--- a/changelog/v1.9.0-beta7/windows-server-installer-fix.yaml
+++ b/changelog/v1.9.0-beta7/windows-server-installer-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5062
+    description: Fix windows installer to more consistently work on 64-bit windows server

--- a/docs/content/getting_started/_index.md
+++ b/docs/content/getting_started/_index.md
@@ -14,7 +14,7 @@ curl -sL https://run.solo.io/gloo/install | sh
 export PATH=$HOME/.gloo/bin:$PATH
 
 ## Windows
-curl -sL https://run.solo.io/gloo/windows/install | pwsh
+(New-Object System.Net.WebClient).DownloadString("https://run.solo.io/gloo/windows/install") | iex
 $env:Path += ";$env:userprofile/.gloo/bin/"
 
 # Install Gloo Edge

--- a/docs/content/installation/glooctl_setup.md
+++ b/docs/content/installation/glooctl_setup.md
@@ -18,7 +18,7 @@ The `glooctl` command line provides useful functions to install, configure, and 
 * To install on windows you can use this install script. Openssl is required for installation to execute properly.
   
   ```pwsh
-  curl -sL https://run.solo.io/gloo/windows/install | pwsh
+  (New-Object System.Net.WebClient).DownloadString("https://run.solo.io/gloo/windows/install") | iex
   $env:Path += ";$env:userprofile/.gloo/bin/"
   ```
 

--- a/projects/clusteringress/README.md
+++ b/projects/clusteringress/README.md
@@ -25,7 +25,7 @@ To install the CLI, run:
 
 ##### Windows
 
-`curl -sL https://run.solo.io/gloo/windows/install | pwsh`
+`(New-Object System.Net.WebClient).DownloadString("https://run.solo.io/gloo/windows/install") | iex`
 
 Alternatively, you can download the CLI directly via the github releases page. 
 

--- a/projects/gloo/cli/install.ps1
+++ b/projects/gloo/cli/install.ps1
@@ -1,18 +1,17 @@
 Param(
     [Parameter(Mandatory = $false,
         ParameterSetName = "GLOO_VERSION")]
-    [String[]]
+    [String]
     $GLOO_VERSION
 )
 
-$currentLocation = $MyInvocation.MyCommand.Path
+$currentLocation = (Resolve-Path .\).Path
 
 $openssl_version = & { openssl version } 2>&1
 
 if ($openssl_version -is [System.Management.Automation.ErrorRecord]) {
     $openssl_version.Exception.Message
     Write-Output "Openssl is required to install glooctl"
-    exit 1
 }
 
 if ([string]::IsNullOrEmpty($GLOO_VERSION)) {
@@ -64,7 +63,6 @@ Foreach ($gloo_version IN $GLOO_VERSIONS) {
     $checksum = $checksum.Substring($checksum.IndexOf(' '), ($checksum.Length - $checksum.IndexOf(' '))).TrimStart(" ")
     if ($checksum -ne $SHA) {
         Write-Output "Checksum validation failed."
-        exit 1
     }
 
     Write-Output "Checksum valid."
@@ -90,10 +88,8 @@ if ($glooctlDownloaded -eq $true) {
     Write-Output "  glooctl install ingress     # install very basic Kubernetes Ingress support with Gloo into namespace gloo-system"
     Write-Output "  glooctl install knative     # install Knative serving with Gloo configured as the default cluster ingress"
     Write-Output "Please see visit the Gloo Installation guides for more:  https://docs.solo.io/gloo-edge/latest/installation/"
-    exit 0
 }
 else {
     Set-Location (Get-Item $currentLocation).DirectoryName
     Write-Output "No versions of glooctl found."
-    exit 1
 }

--- a/projects/knative/README.md
+++ b/projects/knative/README.md
@@ -25,7 +25,7 @@ To install the CLI, run:
 
 ##### Windows
 
-`curl -sL https://run.solo.io/gloo/windows/install | pwsh`
+`(New-Object System.Net.WebClient).DownloadString("https://run.solo.io/gloo/windows/install") | iex`
 
 Alternatively, you can download the CLI directly via the github releases page. 
 


### PR DESCRIPTION
# Description
Fix the glooctl windows install and docs to work more consistently on windows server 64bit

Update docs

Add change log

# Context

Fix implementation from: https://github.com/solo-io/gloo/pull/5086

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5062