### PR TITLE
fix: helm: gateway proxy service annotations

### DIFF
--- a/changelog/v1.9.0-beta7/helm-fix-proxy-service-annotations.yaml
+++ b/changelog/v1.9.0-beta7/helm-fix-proxy-service-annotations.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/4914
+    description: Fix gateway proxy service annotation rendering

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -122,9 +122,9 @@ spec:
 
 {{- if .Values.gateway.enabled }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
 {{- $defaultGatewayProxySafe := deepCopy $gatewayProxy -}}
 {{- $_ := unset $defaultGatewayProxySafe.service "extraAnnotations" -}}
-{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
 {{- $spec := deepCopy $gatewaySpec | mergeOverwrite $defaultGatewayProxySafe -}}
 {{/* Render each gatewayProxy template with it's yaml overrides */}}
 {{- $serviceYamlOverride := dict -}}


### PR DESCRIPTION
# Description

Fixes the incorrect service annotation being rendered for gateway proxies. I've tried adding some unit tests to reproduce, but cannot get a failing test case... This occurs with helm version `v3.5.4`

Fixes https://github.com/solo-io/gloo/issues/4914

# Context

The following values.yaml results in the incorrect annotations being added to `gatewayProxyPublic`

```yaml
gloo:
  gatewayProxies:
    gatewayProxy:
      disabled: true

    gatewayProxyPublic:
      disabled: false

    gatewayProxyInternal:
      disabled: false
      service:
        extraAnnotations:
          a: b
```

```yaml
# Source: gloo-ee/charts/gloo/templates/8-gateway-proxy-service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: gloo
    gloo: gateway-proxy
    gateway-proxy-id: gateway-proxy-internal
  name: gateway-proxy-internal
  namespace: default
  annotations:
    a: "b"
    prometheus.io/path: "/metrics"
    prometheus.io/port: "8081"
    prometheus.io/scrape: "true"
spec:

---
# Source: gloo-ee/charts/gloo/templates/8-gateway-proxy-service.yaml
apiVersion: v1
kind: Service
metadata:
  labels:
    app: gloo
    gloo: gateway-proxy
    gateway-proxy-id: gateway-proxy-public
  name: gateway-proxy-public
  namespace: default
  annotations:
    a: "b"
    prometheus.io/path: "/metrics"
    prometheus.io/port: "8081"
    prometheus.io/scrape: "true"
spec:
```

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4914