### PR TITLE
fix: compress: dropped errors

### DIFF
--- a/projects/gloo/pkg/api/compress/compress.go
+++ b/projects/gloo/pkg/api/compress/compress.go
@@ -95,8 +95,14 @@ func uncompressSpec(s v1.Spec) (v1.Spec, error) {
 
 	var b bytes.Buffer
 	r, err := zlib.NewReader(bytes.NewBuffer(compressedData))
-	io.Copy(&b, r)
-	r.Close()
+	if err != nil {
+		return nil, eris.Wrap(err, "error creating buffer")
+	}
+	defer r.Close()
+	_, err = io.Copy(&b, r)
+	if err != nil {
+		return nil, eris.Wrap(err, "error copying buffer")
+	}
 
 	err = json.Unmarshal(b.Bytes(), &spec)
 	if err != nil {


### PR DESCRIPTION
# Description

This fixes an error that was being dropped and an error that should have been checked, but was not in `pkg/api/compress`.

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
