### PR TITLE
fix: cmd/istio dropped errors

### DIFF
--- a/projects/gloo/cli/pkg/cmd/istio/inject.go
+++ b/projects/gloo/cli/pkg/cmd/istio/inject.go
@@ -102,6 +102,9 @@ func istioInject(args []string, opts *options.Options) error {
 	// To get around this, we write the gateway_proxy_sds cluster into the configmap that
 	// gateway-proxy loads at bootstrap time.
 	configMaps, err := client.CoreV1().ConfigMaps(glooNS).List(opts.Top.Ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
 	for _, configMap := range configMaps.Items {
 		if configMap.Name == gatewayProxyConfigMap {
 			// Make sure we don't already have the gateway_proxy_sds cluster set up

--- a/projects/gloo/cli/pkg/cmd/istio/uninject.go
+++ b/projects/gloo/cli/pkg/cmd/istio/uninject.go
@@ -87,6 +87,9 @@ func istioUninject(args []string, opts *options.Options) error {
 
 	// Remove gateway_proxy_sds cluster from the gateway-proxy configmap
 	configMaps, err := client.CoreV1().ConfigMaps(glooNS).List(opts.Top.Ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
 	for _, configMap := range configMaps.Items {
 		if configMap.Name == gatewayProxyConfigMap {
 			// Make sure we don't already have the gateway_proxy_sds cluster set up


### PR DESCRIPTION
# Description

Please include a summary of the changes.

This fixes two dropped `err` variables in the `istio` cmd.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
