### PR TITLE
Support PROXY Protocol listener filter (1.7 patch)

### DIFF
--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -61,6 +61,7 @@ jobs:
     - uses: engineerd/setup-kind@v0.5.0
       with:
         skipClusterCreation: true
+        version: v0.11.1
     - uses: azure/setup-kubectl@v1
       id: kubectl
       with:

--- a/.github/workflows/regression-tests-and-codegen.yaml
+++ b/.github/workflows/regression-tests-and-codegen.yaml
@@ -61,7 +61,6 @@ jobs:
     - uses: engineerd/setup-kind@v0.5.0
       with:
         skipClusterCreation: true
-        version: v0.11.1
     - uses: azure/setup-kubectl@v1
       id: kubectl
       with:

--- a/changelog/v1.7.8-patch2/proxy-protocol-listener-filter.yaml
+++ b/changelog/v1.7.8-patch2/proxy-protocol-listener-filter.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5116
+    resolvesIssue: false
+    description: >
+      Add PROXY protocol as listener filter, instead of relying on the deprecated
+      use_proxy_proto flag that Envoy exposes. We ensure the filter occurs before
+      the TLS inspector filter, to ensure that PROXY protocol and SNI can be used
+      together.

--- a/ci/kind.sh
+++ b/ci/kind.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # This config is roughly based on: https://kind.sigs.k8s.io/docs/user/ingress/
-cat <<EOF | kind create cluster --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00 --name kind --config=-
+cat <<EOF | kind create cluster --name kind --config=-
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 kubeadmConfigPatches:

--- a/ci/kind.sh
+++ b/ci/kind.sh
@@ -3,7 +3,7 @@
 # This config is roughly based on: https://kind.sigs.k8s.io/docs/user/ingress/
 cat <<EOF | kind create cluster --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00 --name kind --config=-
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha4
+apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta2

--- a/ci/kind.sh
+++ b/ci/kind.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 # This config is roughly based on: https://kind.sigs.k8s.io/docs/user/ingress/
-cat <<EOF | kind create cluster --name kind --config=-
+cat <<EOF | kind create cluster --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00 --name kind --config=-
 kind: Cluster
 apiVersion: kind.sigs.k8s.io/v1alpha3
 kubeadmConfigPatches:

--- a/ci/kind.sh
+++ b/ci/kind.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -ex
 
 # This config is roughly based on: https://kind.sigs.k8s.io/docs/user/ingress/
-cat <<EOF | kind create cluster --name kind --config=-
+cat <<EOF | kind create cluster --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00 --name kind --config=-
 kind: Cluster
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.sigs.k8s.io/v1alpha4
 kubeadmConfigPatches:
 - |
   apiVersion: kubeadm.k8s.io/v1beta2

--- a/projects/gloo/cli/pkg/cmd/demo/federation.go
+++ b/projects/gloo/cli/pkg/cmd/demo/federation.go
@@ -53,10 +53,10 @@ if [ "$4" == "" ]; then
   exit 1
 fi
 
-kind create cluster --name "$1"
+kind create cluster --name "$1" --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
 
 # Add locality labels to remote kind cluster for discovery
-(cat <<EOF | kind create cluster --name "$2" --config=-
+(cat <<EOF | kind create cluster --name "$2" --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/projects/gloo/cli/pkg/cmd/demo/federation.go
+++ b/projects/gloo/cli/pkg/cmd/demo/federation.go
@@ -53,10 +53,10 @@ if [ "$4" == "" ]; then
   exit 1
 fi
 
-kind create cluster --name "$1" --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00
+kind create cluster --name "$1"
 
 # Add locality labels to remote kind cluster for discovery
-(cat <<EOF | kind create cluster --name "$2" --image kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00 --config=-
+(cat <<EOF | kind create cluster --name "$2" --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/projects/gloo/pkg/plugins/proxyprotocol/plugin.go
+++ b/projects/gloo/pkg/plugins/proxyprotocol/plugin.go
@@ -1,0 +1,49 @@
+package proxyprotocol
+
+import (
+	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	envoy_listener_proxy_protocol "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/proxy_protocol/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
+)
+
+func NewPlugin() *plugin {
+	return &plugin{}
+}
+
+// Compile-time assertion
+var (
+	_ plugins.Plugin         = new(plugin)
+	_ plugins.ListenerPlugin = new(plugin)
+)
+
+type plugin struct{}
+
+func (p *plugin) Init(params plugins.InitParams) error {
+	return nil
+}
+
+func (p *plugin) ProcessListener(params plugins.Params, in *v1.Listener, out *envoy_config_listener_v3.Listener) error {
+	if !in.GetUseProxyProto().GetValue() {
+		// If UseProxyProto is not defined on the listener or it is false, do not append the filter
+		return nil
+	}
+
+	envoyProxyProtocol := &envoy_listener_proxy_protocol.ProxyProtocol{}
+	msg, err := utils.MessageToAny(envoyProxyProtocol)
+	if err != nil {
+		return err
+	}
+
+	listenerFilter := &envoy_config_listener_v3.ListenerFilter{
+		Name: wellknown.ProxyProtocol,
+		ConfigType: &envoy_config_listener_v3.ListenerFilter_TypedConfig{
+			TypedConfig: msg,
+		},
+	}
+
+	out.ListenerFilters = append(out.ListenerFilters, listenerFilter)
+	return nil
+}

--- a/projects/gloo/pkg/plugins/proxyprotocol/plugin_test.go
+++ b/projects/gloo/pkg/plugins/proxyprotocol/plugin_test.go
@@ -1,0 +1,80 @@
+package proxyprotocol
+
+import (
+	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
+)
+
+var _ = Describe("Plugin", func() {
+
+	var (
+		p      *plugin
+		params plugins.Params
+
+		in  *v1.Listener
+		out *envoy_config_listener_v3.Listener
+	)
+
+	BeforeEach(func() {
+		p = NewPlugin()
+
+		err := p.Init(plugins.InitParams{})
+		Expect(err).NotTo(HaveOccurred())
+
+		in = &v1.Listener{}
+		out = &envoy_config_listener_v3.Listener{}
+	})
+
+	When("UseProxyProto=true is defined on the listener", func() {
+
+		BeforeEach(func() {
+			in.UseProxyProto = &wrappers.BoolValue{Value: true}
+		})
+
+		It("appends ProxyProtocol listener filter", func() {
+			err := p.ProcessListener(params, in, out)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(out.ListenerFilters).To(HaveLen(1))
+			Expect(out.ListenerFilters).To(HaveLen(1))
+			Expect(out.ListenerFilters[0].GetName()).To(Equal(wellknown.ProxyProtocol))
+		})
+
+	})
+
+	When("UseProxyProto=false is defined on the listener", func() {
+
+		BeforeEach(func() {
+			in.UseProxyProto = &wrappers.BoolValue{Value: false}
+		})
+
+		It("does not append ProxyProtocol listener filter", func() {
+			err := p.ProcessListener(params, in, out)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(out.ListenerFilters).To(HaveLen(0))
+		})
+
+	})
+
+	When("UseProxyProto is not defined on the listener", func() {
+
+		BeforeEach(func() {
+			in.UseProxyProto = nil
+		})
+
+		It("does not append ProxyProtocol listener filter", func() {
+			err := p.ProcessListener(params, in, out)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(out.ListenerFilters).To(HaveLen(0))
+		})
+
+	})
+
+})

--- a/projects/gloo/pkg/plugins/proxyprotocol/proxyprotocol_suite_test.go
+++ b/projects/gloo/pkg/plugins/proxyprotocol/proxyprotocol_suite_test.go
@@ -1,0 +1,15 @@
+package proxyprotocol_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/onsi/ginkgo/reporters"
+	. "github.com/onsi/gomega"
+)
+
+func TestProxyProtocol(t *testing.T) {
+	RegisterFailHandler(Fail)
+	junitReporter := reporters.NewJUnitReporter("junit.xml")
+	RunSpecsWithDefaultAndCustomReporters(t, "Proxy Protocol Suite", []Reporter{junitReporter})
+}

--- a/projects/gloo/pkg/plugins/registry/registry.go
+++ b/projects/gloo/pkg/plugins/registry/registry.go
@@ -28,6 +28,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/metadata"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/pipe"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/protocoloptions"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/proxyprotocol"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/ratelimit"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/rest"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/shadowing"
@@ -61,6 +62,7 @@ var globalRegistry = func(opts bootstrap.Opts, pluginExtensions ...func() plugin
 		rest.NewPlugin(&transformationPlugin.RequireTransformationFilter),
 		hcmPlugin,
 		als.NewPlugin(),
+		proxyprotocol.NewPlugin(),
 		tls_inspector.NewPlugin(),
 		pipe.NewPlugin(),
 		tcp.NewPlugin(utils.NewSslConfigTranslator()),

--- a/projects/gloo/pkg/plugins/tcp/plugin.go
+++ b/projects/gloo/pkg/plugins/tcp/plugin.go
@@ -7,7 +7,6 @@ import (
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/hashicorp/go-multierror"
 	"github.com/rotisserie/eris"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -193,8 +192,7 @@ func (p *Plugin) computerTcpFilterChain(
 	sslConfig := host.GetSslConfig()
 	if sslConfig == nil {
 		return &envoy_config_listener_v3.FilterChain{
-			Filters:       listenerFilters,
-			UseProxyProto: listener.GetUseProxyProto(),
+			Filters: listenerFilters,
 		}, nil
 	}
 
@@ -202,17 +200,12 @@ func (p *Plugin) computerTcpFilterChain(
 	if err != nil {
 		return nil, InvalidSecretsError(err, listener.GetName())
 	}
-	return p.newSslFilterChain(downstreamConfig,
-		sslConfig.GetSniDomains(),
-		listener.GetUseProxyProto(),
-		listenerFilters,
-	), nil
+	return p.newSslFilterChain(downstreamConfig, sslConfig.GetSniDomains(), listenerFilters), nil
 }
 
 func (p *Plugin) newSslFilterChain(
 	downstreamConfig *envoyauth.DownstreamTlsContext,
 	sniDomains []string,
-	useProxyProto *wrappers.BoolValue,
 	listenerFilters []*envoy_config_listener_v3.Filter,
 ) *envoy_config_listener_v3.FilterChain {
 
@@ -231,7 +224,6 @@ func (p *Plugin) newSslFilterChain(
 			Name:       wellknown.TransportSocketTls,
 			ConfigType: &envoy_config_core_v3.TransportSocket_TypedConfig{TypedConfig: utils.MustMessageToAny(downstreamConfig)},
 		},
-		UseProxyProto: useProxyProto,
 	}
 }
 

--- a/projects/gloo/pkg/translator/listener.go
+++ b/projects/gloo/pkg/translator/listener.go
@@ -10,7 +10,6 @@ import (
 	envoyauth "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes/wrappers"
 	validationapi "github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
@@ -152,8 +151,7 @@ func (t *translatorInstance) computeFilterChainsFromSslConfig(
 	// if no ssl config is provided, return a single insecure filter chain
 	if len(listener.SslConfigurations) == 0 {
 		return []*envoy_config_listener_v3.FilterChain{{
-			Filters:       listenerFilters,
-			UseProxyProto: listener.GetUseProxyProto(),
+			Filters: listenerFilters,
 		}}
 	}
 
@@ -167,7 +165,7 @@ func (t *translatorInstance) computeFilterChainsFromSslConfig(
 				validationapi.ListenerReport_Error_SSLConfigError, err.Error())
 			continue
 		}
-		filterChain := newSslFilterChain(downstreamConfig, sslConfig.SniDomains, listener.UseProxyProto, listenerFilters)
+		filterChain := newSslFilterChain(downstreamConfig, sslConfig.GetSniDomains(), listenerFilters)
 
 		secureFilterChains = append(secureFilterChains, filterChain)
 	}
@@ -246,7 +244,6 @@ func validateListenerPorts(proxy *v1.Proxy, listenerReport *validationapi.Listen
 func newSslFilterChain(
 	downstreamConfig *envoyauth.DownstreamTlsContext,
 	sniDomains []string,
-	useProxyProto *wrappers.BoolValue,
 	listenerFilters []*envoy_config_listener_v3.Filter,
 ) *envoy_config_listener_v3.FilterChain {
 
@@ -266,8 +263,6 @@ func newSslFilterChain(
 			Name:       wellknown.TransportSocketTls,
 			ConfigType: &envoy_config_core_v3.TransportSocket_TypedConfig{TypedConfig: utils.MustMessageToAny(downstreamConfig)},
 		},
-
-		UseProxyProto: useProxyProto,
 	}
 }
 

--- a/test/e2e/proxy_protocol_test.go
+++ b/test/e2e/proxy_protocol_test.go
@@ -1,0 +1,347 @@
+package e2e_test
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+
+	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
+	gloohelpers "github.com/solo-io/gloo/test/helpers"
+	"github.com/solo-io/gloo/test/services"
+	"github.com/solo-io/gloo/test/v1helpers"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+)
+
+var _ = Describe("Proxy Protocol", func() {
+
+	var (
+		err           error
+		ctx           context.Context
+		cancel        context.CancelFunc
+		testClients   services.TestClients
+		envoyInstance *services.EnvoyInstance
+
+		gateway        *gatewayv1.Gateway
+		virtualService *gatewayv1.VirtualService
+		testUpstream   *v1helpers.TestUpstream
+		secret         *gloov1.Secret
+
+		requestScheme      string
+		rootCACert         string
+		proxyProtocolBytes []byte
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+		defaults.HttpPort = services.NextBindPort()
+		defaults.HttpsPort = services.NextBindPort()
+
+		// run gloo
+		ro := &services.RunOptions{
+			NsToWrite: defaults.GlooSystem,
+			NsToWatch: []string{
+				"default",
+				defaults.GlooSystem,
+			},
+			WhatToRun: services.What{
+				DisableFds: true,
+				DisableUds: true,
+			},
+		}
+		testClients = services.RunGlooGatewayUdsFds(ctx, ro)
+
+		// run envoy
+		envoyInstance, err = envoyFactory.NewEnvoyInstance()
+		Expect(err).NotTo(HaveOccurred())
+		err = envoyInstance.RunWithRole(defaults.GlooSystem+"~"+gatewaydefaults.GatewayProxyName, testClients.GlooPort)
+		Expect(err).NotTo(HaveOccurred())
+
+		// prepare default resources
+		secret = &gloov1.Secret{
+			Metadata: &core.Metadata{
+				Name:      "secret",
+				Namespace: "default",
+			},
+			Kind: &gloov1.Secret_Tls{
+				Tls: &gloov1.TlsSecret{
+					CertChain:  gloohelpers.Certificate(),
+					PrivateKey: gloohelpers.PrivateKey(),
+				},
+			},
+		}
+
+		testUpstream = v1helpers.NewTestHttpUpstream(ctx, envoyInstance.LocalAddr())
+
+		// https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt
+		proxyProtocolBytes = []byte("PROXY TCP4 1.2.3.4 1.2.3.4 123 123\r\n")
+	})
+
+	JustBeforeEach(func() {
+		// Write Secret
+		_, err = testClients.SecretClient.Write(secret, clients.WriteOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Write Upstream
+		_, err = testClients.UpstreamClient.Write(testUpstream.Upstream, clients.WriteOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Write VirtualService
+		_, err = testClients.VirtualServiceClient.Write(virtualService, clients.WriteOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Write Gateway
+		_, err = testClients.GatewayClient.Write(gateway, clients.WriteOpts{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Wait for a proxy to be generated
+		gloohelpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+			return testClients.ProxyClient.Read(defaults.GlooSystem, gatewaydefaults.GatewayProxyName, clients.ReadOpts{})
+		})
+	})
+
+	AfterEach(func() {
+		if envoyInstance != nil {
+			_ = envoyInstance.Clean()
+		}
+		cancel()
+	})
+
+	EventuallyGatewayReturnsOk := func(client *http.Client) {
+		EventuallyWithOffset(1, func() (int, error) {
+			var buf bytes.Buffer
+			res, err := client.Post(fmt.Sprintf("%s://%s:%d/1", requestScheme, "localhost", gateway.BindPort), "application/octet-stream", &buf)
+			if err != nil {
+				return 0, err
+			}
+			return res.StatusCode, nil
+
+		}, "15s", "1s").Should(Equal(http.StatusOK))
+	}
+
+	Context("HttpGateway", func() {
+
+		Context("without TLS", func() {
+
+			BeforeEach(func() {
+				requestScheme = "http"
+				rootCACert = ""
+				// http gateway
+				gateway = gatewaydefaults.DefaultGateway(defaults.GlooSystem)
+				// vs without sslConfig
+				virtualService = getVirtualServiceToUpstream(testUpstream.Upstream.Metadata.Ref(), nil)
+			})
+
+			Context("without PROXY protocol", func() {
+
+				BeforeEach(func() {
+					gateway.UseProxyProto = &wrappers.BoolValue{Value: false}
+				})
+
+				It("works", func() {
+					client := getHttpClientWithoutProxyProtocol(rootCACert)
+					EventuallyGatewayReturnsOk(client)
+				})
+
+			})
+
+			Context("with PROXY protocol", func() {
+
+				BeforeEach(func() {
+					gateway.UseProxyProto = &wrappers.BoolValue{Value: true}
+				})
+
+				It("works", func() {
+					client := getHttpClientWithProxyProtocol(rootCACert, proxyProtocolBytes)
+					EventuallyGatewayReturnsOk(client)
+				})
+
+			})
+
+		})
+
+		Context("with TLS", func() {
+
+			BeforeEach(func() {
+				requestScheme = "https"
+				rootCACert = gloohelpers.Certificate()
+				// https gateway
+				gateway = gatewaydefaults.DefaultSslGateway(defaults.GlooSystem)
+				// vs with sslConfig
+				sslConfig := &gloov1.SslConfig{
+					SslSecrets: &gloov1.SslConfig_SecretRef{
+						SecretRef: secret.Metadata.Ref(),
+					},
+				}
+				virtualService = getVirtualServiceToUpstream(testUpstream.Upstream.Metadata.Ref(), sslConfig)
+			})
+
+			Context("without PROXY protocol", func() {
+
+				BeforeEach(func() {
+					gateway.UseProxyProto = &wrappers.BoolValue{Value: false}
+				})
+
+				It("works", func() {
+					client := getHttpClientWithoutProxyProtocol(rootCACert)
+					EventuallyGatewayReturnsOk(client)
+				})
+
+			})
+
+			Context("with PROXY protocol", func() {
+
+				BeforeEach(func() {
+					gateway.UseProxyProto = &wrappers.BoolValue{Value: true}
+				})
+
+				It("works", func() {
+					client := getHttpClientWithProxyProtocol(rootCACert, proxyProtocolBytes)
+					EventuallyGatewayReturnsOk(client)
+				})
+
+			})
+
+			Context("with PROXY protocol and SNI", func() {
+
+				BeforeEach(func() {
+					gateway.UseProxyProto = &wrappers.BoolValue{Value: true}
+
+					sslConfig := &gloov1.SslConfig{
+						SslSecrets: &gloov1.SslConfig_SecretRef{
+							SecretRef: secret.Metadata.Ref(),
+						},
+						SniDomains: []string{"gateway-proxy"},
+					}
+					virtualService = getVirtualServiceToUpstream(testUpstream.Upstream.Metadata.Ref(), sslConfig)
+				})
+
+				It("works", func() {
+					client := getHttpClientWithProxyProtocol(rootCACert, proxyProtocolBytes)
+					EventuallyGatewayReturnsOk(client)
+				})
+
+			})
+
+		})
+
+	})
+
+})
+
+func getHttpClientWithoutProxyProtocol(rootCACert string) *http.Client {
+	client, err := getHttpClient(rootCACert, nil)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return client
+}
+
+func getHttpClientWithProxyProtocol(rootCACert string, proxyProtocolBytes []byte) *http.Client {
+	client, err := getHttpClient(rootCACert, proxyProtocolBytes)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return client
+}
+
+func getHttpClient(rootCACert string, proxyProtocolBytes []byte) (*http.Client, error) {
+
+	var (
+		client          http.Client
+		tlsClientConfig *tls.Config
+		dialContext     func(ctx context.Context, network, addr string) (net.Conn, error)
+	)
+
+	// If the rootCACert is provided, configure the client to use TLS
+	if rootCACert != "" {
+		caCertPool := x509.NewCertPool()
+		ok := caCertPool.AppendCertsFromPEM([]byte(rootCACert))
+		if !ok {
+			return nil, fmt.Errorf("ca cert is not OK")
+		}
+
+		tlsClientConfig = &tls.Config{
+			InsecureSkipVerify: false,
+			ServerName:         "gateway-proxy",
+			RootCAs:            caCertPool,
+		}
+	}
+
+	// If the proxyProtocolBytes are provided, configure the dialContext to prepend
+	//	the bytes at the beginning of the connection
+	if len(proxyProtocolBytes) > 0 {
+		dialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			var zeroDialer net.Dialer
+			c, err := zeroDialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+
+			// inject proxy protocol bytes
+			// example: []byte("PROXY TCP4 1.2.3.4 1.2.3.5 443 443\r\n")
+			_, err = c.Write(proxyProtocolBytes)
+			if err != nil {
+				_ = c.Close()
+				return nil, err
+			}
+
+			return c, nil
+		}
+
+	}
+
+	client.Transport = &http.Transport{
+		TLSClientConfig: tlsClientConfig,
+		DialContext:     dialContext,
+	}
+
+	return &client, nil
+
+}
+
+func getVirtualServiceToUpstream(upstreamRef *core.ResourceRef, sslConfig *gloov1.SslConfig) *gatewayv1.VirtualService {
+	vs := &gatewayv1.VirtualService{
+		Metadata: &core.Metadata{
+			Name:      "vs",
+			Namespace: defaults.GlooSystem,
+		},
+		VirtualHost: &gatewayv1.VirtualHost{
+			Domains: []string{"*"},
+			Routes: []*gatewayv1.Route{{
+				Action: &gatewayv1.Route_RouteAction{
+					RouteAction: &gloov1.RouteAction{
+						Destination: &gloov1.RouteAction_Single{
+							Single: &gloov1.Destination{
+								DestinationType: &gloov1.Destination_Upstream{
+									Upstream: upstreamRef,
+								},
+							},
+						},
+					},
+				},
+				Matchers: []*matchers.Matcher{
+					{
+						PathSpecifier: &matchers.Matcher_Prefix{
+							Prefix: "/",
+						},
+					},
+				},
+			}},
+		},
+	}
+	if sslConfig != nil {
+		vs.SslConfig = sslConfig
+	}
+	return vs
+}


### PR DESCRIPTION
Backport of: https://github.com/solo-io/gloo/pull/5117 (PROXY protocol) and https://github.com/solo-io/gloo/pull/5092 (Fix CI)

# Description

Support PROXY Protocol listener filter and ensure it is executed before the TLS inspector listener filter.

# Context
https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/listener_filters/proxy_protocol.html

We previously relied on a now deprecated Envoy flag, `use_proxy_proto` defined on the Listener FilterChain: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto#config-listener-v3-filterchain. 

### SNI Context
Using the deprecated flag, the PROXY protocol listener filter is appended to the filter chain. However, we need the PROXY protocol listener filter to be executed before the TLS inspector filter. Since the PROXY protocol adds bytes to the beginning of the connection, the SNI will not be parsed correctly if the PROXY protocol listener filter is not executed first. Without SNI matching, you would get the wrong certificate, and traffic would drop.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
