### PR TITLE
Expose Request/Response details in ALS

### DIFF
--- a/changelog/v1.9.0-beta9/als-request-response-headers.yaml
+++ b/changelog/v1.9.0-beta9/als-request-response-headers.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Include request_headers, response_headers, and response_trailers in gloo access-logger.
+      These can be configured in the ALS plugin and therefore we should include them in the logs.

--- a/projects/accesslogger/pkg/runner/run.go
+++ b/projects/accesslogger/pkg/runner/run.go
@@ -142,7 +142,10 @@ func Run() {
 							zap.Any("request_path", v.GetRequest().GetPath()),
 							zap.Any("request_original_path", v.GetRequest().GetOriginalPath()),
 							zap.Any("request_method", v.GetRequest().GetRequestMethod().String()),
+							zap.Any("request_headers", v.GetRequest().GetRequestHeaders()),
 							zap.Any("response_code", v.GetResponse().GetResponseCode().String()),
+							zap.Any("response_headers", v.GetResponse().GetResponseHeaders()),
+							zap.Any("response_trailers", v.GetResponse().GetResponseTrailers()),
 							zap.Any("cluster", v.GetCommonProperties().GetUpstreamCluster()),
 							zap.Any("upstream_remote_address", v.GetCommonProperties().GetUpstreamRemoteAddress()),
 							zap.Any("issuer", issuer),                                     // requires jwt set up and jwt with 'iss' claim to be non-empty


### PR DESCRIPTION
# Description

Expose `request_headers`, `response_headers`, and `response_trailers` in the default access logger that ships with Gloo Edge.

# Context

The open source access logger that ships with Gloo Edge is intended as a template for customers to mirror when they build their own access logging service. However, some users rely directly on the open source access logging implemenation.

We allow users to configure including `additionalRequestHeadersToLog`, `additionalResponseHeadersToLog`, and `additionalResponseTrailersToLog` in the access logging configuration (https://github.com/solo-io/gloo/blob/master/projects/gloo/api/v1/options/als/als.proto#L52). However, our default access logger does not include these details.

# How did I test?
1. Install Gloo Edge with access logging enabled (https://docs.solo.io/gloo-edge/latest/guides/security/access_logging/#deploying-the-open-source-grpc-access-logger)
1. Followed the hello world tutorial to set up basic routing
1. Modifying the default gateway to include access logging
1. Confirm logs are send without request headers
1. Pushed up a change, rebuild the access logger image, and loaded that into the kind cluster 
1. Updated the access logger to point to the image with modifications
1. Sent requests and confirm that new fields were all null (since we hadn't configured any headers in the gateway)
1. Modified the gateway resource to include expected headers 
1. Sent requests, including a custom header (`custom-header`) and confirm that new fields were populated 

The final gateway resource that I used looked like: 

```
spec:
  bindAddress: '::'
  bindPort: 8080
  httpGateway: {}
  options:
    accessLoggingService:
      accessLog:
      - grpcService:
          additionalRequestHeadersToLog:
          - custom-header
          additionalResponseHeadersToLog:
          - content-length
          logName: example
          staticClusterName: access_log_cluster
``` 

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
