### PR TITLE
Fix tab to fix link

### DIFF
--- a/docs/content/guides/observability/prometheus/metrics.md
+++ b/docs/content/guides/observability/prometheus/metrics.md
@@ -46,7 +46,7 @@ helm install gloo gloo/gloo --namespace gloo-system -f stats-values.yaml
 {{< /tab >}}
 {{< /tabs >}}
 
-{{% notice warning %}} 
+{{% notice warning %}}
 Using Helm 2 is not supported in Gloo Edge v1.8.0.
 {{% /notice %}}
 

--- a/docs/content/guides/observability/prometheus/metrics.md
+++ b/docs/content/guides/observability/prometheus/metrics.md
@@ -43,9 +43,10 @@ glooctl install gateway --values stats-values.yaml
 {{< /tab >}}
 {{< tab name="Helm 3" codelang="shell">}}
 helm install gloo gloo/gloo --namespace gloo-system -f stats-values.yaml
+{{< /tab >}}
 {{< /tabs >}}
 
-{{% notice warning %}}
+{{% notice warning %}} 
 Using Helm 2 is not supported in Gloo Edge v1.8.0.
 {{% /notice %}}
 


### PR DESCRIPTION
For https://github.com/solo-io/gloo/issues/5171, the tab wasn't closed so I think that none of the content on the rest of the page was rendering, which caused the broken link.

# Checklist:

- N/A I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- N/A If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- N/A I have added tests that prove my fix is effective or that my feature works
