### PR TITLE
 Fix docs team name in codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-/docs/ @solo-docs
+/docs/ @solo-io/solo-docs


### PR DESCRIPTION
Previously left off the front half of `@solo-io/solo-docs`. This fixes the CODEOWNERS file to properly autotag docs team for changes to files in /docs/ directory.

# Checklist:

- NA I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- NA I have commented my code, particularly in hard-to-understand areas
- NA I have made corresponding changes to the documentation
- NA I have added tests that prove my fix is effective or that my feature works
