### PR TITLE
Add support for istio 1.11+ for `glooctl istio inject`

### DIFF
--- a/changelog/v1.9.0-beta14/add-istio-1-11-support.yaml
+++ b/changelog/v1.9.0-beta14/add-istio-1-11-support.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/5224
+    description: Add support for `glooctl istio inject` for istio 1.11.x

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7-1.19.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/istio1.7-1.19.go
@@ -6,7 +6,7 @@ import (
 )
 
 // Sidecar for Istio 1.7.x releases, also works for Istio 1.8.x, 1.9.x and 1.10.x releases
-func generateIstio17or18or19or10Sidecar(version, jwtPolicy string, istioMetaMeshID string, istioMetaClusterID string) *corev1.Container {
+func generateIstio17to119Sidecar(version, jwtPolicy string, istioMetaMeshID string, istioMetaClusterID string) *corev1.Container {
 	sidecar := &corev1.Container{
 		Name:  "istio-proxy",
 		Image: "docker.io/istio/proxyv2:" + version,

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/matcher.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/matcher.go
@@ -3,6 +3,7 @@ package sidecars
 import (
 	"errors"
 	"strings"
+	"regexp"
 
 	corev1 "k8s.io/api/core/v1"
 )
@@ -14,8 +15,11 @@ var ErrNoSupportedSidecar = errors.New("no valid istio sidecar found for this is
 // version of Istio, with the given jwtPolicy, to run
 // in the gateway-proxy pod
 func GetIstioSidecar(istioVersion, jwtPolicy string, istioMetaMeshID string, istioMetaClusterID string) (*corev1.Container, error) {
-	if strings.HasPrefix(istioVersion, "1.7.") || strings.HasPrefix(istioVersion, "1.8.") || strings.HasPrefix(istioVersion, "1.9.") || strings.HasPrefix(istioVersion, "1.10.") {
-		return generateIstio17or18or19or10Sidecar(istioVersion, jwtPolicy, istioMetaMeshID, istioMetaClusterID), nil
+
+	istio17to119Match, _ := regexp.MatchString("1.(7|8|9|1[0-9]).[0-9]*", istioVersion)
+
+	if istio17to119Match {
+		return generateIstio17to119Sidecar(istioVersion, jwtPolicy, istioMetaMeshID, istioMetaClusterID), nil
 	} else if strings.HasPrefix(istioVersion, "1.6.") {
 		return generateIstio16Sidecar(istioVersion, jwtPolicy, istioMetaMeshID, istioMetaClusterID), nil
 	}


### PR DESCRIPTION
# Description

temporarily add support for istio 1.11+ until istio injection code is reworked

# Context
Long term this code needs to be reworked, but adding a more generic regexp matcher we can stop chasing istio release support.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
