### PR TITLE
oneway tls npe fix

### DIFF
--- a/changelog/v1.9.0-beta15/fix-onewaytls-npe.yaml
+++ b/changelog/v1.9.0-beta15/fix-onewaytls-npe.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/5262
+    description: >
+      Fix NPE when Gateway CR is defined to enable oneWayTls, but a VirtualService does not define an sslConfig

--- a/projects/gateway/pkg/translator/http.go
+++ b/projects/gateway/pkg/translator/http.go
@@ -105,7 +105,7 @@ func applyGlobalVirtualServiceSettings(ctx context.Context, virtualServices v1.V
 	// If oneWayTls is not defined on virtual service, use default value from global settings if defined there
 	if val := settingsutil.MaybeFromContext(ctx).GetGateway().GetVirtualServiceOptions().GetOneWayTls(); val != nil {
 		for _, vs := range virtualServices {
-			if vs.GetSslConfig().GetOneWayTls() == nil {
+			if vs.GetSslConfig() != nil && vs.GetSslConfig().GetOneWayTls() == nil {
 				vs.GetSslConfig().OneWayTls = &wrappers.BoolValue{Value: val.GetValue()}
 			}
 		}


### PR DESCRIPTION
# Description

NPE in gateway when gateway defines oneWayTls but virtualservice does not have an sslConfig

# Context

Resolves: https://github.com/solo-io/gloo/issues/5262

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5262