### PR TITLE
Backport change to use correct map key when deleting endpoints in san…

### DIFF
--- a/changelog/v1.8.15/upstream-sanitizer-fix.yaml
+++ b/changelog/v1.8.15/upstream-sanitizer-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5022
+    resolvesIssue: true
+    description: Ensure that endpoints for invalid upstreams are deleted from snapshots and invalid upstreams are not accepted.

--- a/projects/gloo/pkg/syncer/envoy_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/envoy_translator_syncer.go
@@ -137,14 +137,14 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1.ApiSnapshot, 
 
 		sanitizedSnapshot, err := s.sanitizer.SanitizeSnapshot(ctx, snap, xdsSnapshot, reports)
 		if err != nil {
-			logger.Warnf("proxy %v was rejected due to invalid config: %v\n"+
+			logger.Errorf("proxy %v was rejected due to invalid config: %v\n"+
 				"Attempting to update only EDS information", proxy.GetMetadata().Ref().Key(), err)
 
 			// If the snapshot is invalid, attempt at least to update the EDS information. This is important because
 			// endpoints are relatively ephemeral entities and the previous snapshot Envoy got might be stale by now.
 			sanitizedSnapshot, err = s.updateEndpointsOnly(key, xdsSnapshot)
 			if err != nil {
-				logger.Warnf("endpoint update failed. xDS snapshot for proxy %v will not be updated. "+
+				logger.Errorf("endpoint update failed. xDS snapshot for proxy %v will not be updated. "+
 					"Error is: %s", proxy.GetMetadata().Ref().Key(), err)
 				continue
 			}
@@ -153,7 +153,6 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1.ApiSnapshot, 
 
 		// Merge reports after sanitization to capture changes made by the sanitizers
 		allReports.Merge(reports)
-
 		if err := s.xdsCache.SetSnapshot(key, sanitizedSnapshot); err != nil {
 			err := eris.Wrapf(err, "failed while updating xDS snapshot cache")
 			logger.DPanicw("", zap.Error(err))


### PR DESCRIPTION
…itizer (#5307)

* Use the correct map key to delete endpoints in upstream_removing_sanitizer
* remove unused test
* Clean up teat and add changelog
* Merge branch 'master' into missing-kube-service
* codegen, remove debug printing and log level changes
* codegen again
* default endpoint name

# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5022