### PR TITLE
Backport change to use correct map key when deleting endpoints in san…

### DIFF
--- a/changelog/v1.9.0-beta17/upstream-sanitizer-fix.yaml
+++ b/changelog/v1.9.0-beta17/upstream-sanitizer-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5022
+    resolvesIssue: true
+    description: Ensure that endpoints for invalid upstreams are deleted from snapshots and invalid upstreams are not accepted.

--- a/projects/gloo/pkg/syncer/envoy_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/envoy_translator_syncer.go
@@ -141,7 +141,6 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1.ApiSnapshot, 
 		if err != nil {
 			logger.Warnf("proxy %v was rejected due to invalid config: %v\n"+
 				"Attempting to update only EDS information", proxy.Metadata.Ref().Key(), err)
-
 			// If the snapshot is invalid, attempt at least to update the EDS information. This is important because
 			// endpoints are relatively ephemeral entities and the previous snapshot Envoy got might be stale by now.
 			sanitizedSnapshot, err = s.updateEndpointsOnly(key, xdsSnapshot)
@@ -152,7 +151,8 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1.ApiSnapshot, 
 			}
 			logger.Infof("successfully updated EDS information for proxy %v", proxy.Metadata.Ref().Key())
 		}
-
+		// Merge reports after sanitization to capture changes made by the sanitizers
+		allReports.Merge(reports)
 		if err := s.xdsCache.SetSnapshot(key, sanitizedSnapshot); err != nil {
 			err := eris.Wrapf(err, "failed while updating xDS snapshot cache")
 			logger.DPanicw("", zap.Error(err))

--- a/projects/gloo/pkg/syncer/sanitizer/upstream_removing_sanitizer_test.go
+++ b/projects/gloo/pkg/syncer/sanitizer/upstream_removing_sanitizer_test.go
@@ -3,7 +3,8 @@ package sanitizer_test
 import (
 	"context"
 
-	envoyapi "github.com/envoyproxy/go-control-plane/envoy/api/v2"
+	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoyclusterapi "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/rotisserie/eris"
@@ -26,9 +27,19 @@ var _ = Describe("UpstreamRemovingSanitizer", func() {
 				Namespace: "upstream",
 			},
 		}
+		clusterType = &envoy_config_cluster_v3.Cluster_Type{
+			Type: envoy_config_cluster_v3.Cluster_EDS,
+		}
 		goodClusterName = translator.UpstreamToClusterName(us.Metadata.Ref())
-		goodCluster     = &envoyapi.Cluster{
-			Name: goodClusterName,
+		goodCluster     = &envoyclusterapi.Cluster{
+			Name:                 goodClusterName,
+			ClusterDiscoveryType: clusterType,
+			EdsClusterConfig: &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+				ServiceName: goodClusterName + "-123",
+			},
+		}
+		goodEndpoint = &envoyclusterapi.Cluster{
+			Name: goodClusterName + "-123",
 		}
 
 		badUs = &v1.Upstream{
@@ -38,22 +49,31 @@ var _ = Describe("UpstreamRemovingSanitizer", func() {
 			},
 		}
 		badClusterName = translator.UpstreamToClusterName(badUs.Metadata.Ref())
-		badCluster     = &envoyapi.Cluster{
-			Name: badClusterName,
+		badCluster     = &envoyclusterapi.Cluster{
+			Name:                 badClusterName,
+			ClusterDiscoveryType: clusterType,
+			EdsClusterConfig: &envoy_config_cluster_v3.Cluster_EdsClusterConfig{
+				ServiceName: badClusterName + "-123",
+			},
+		}
+		badEndpoint = &envoyclusterapi.Cluster{
+			Name: badClusterName + "-123",
 		}
 	)
 	It("removes upstreams whose reports have an error, and changes the error to a warning", func() {
 
 		xdsSnapshot := xds.NewSnapshotFromResources(
-			envoycache.NewResources("", nil),
-			envoycache.NewResources("clusters", []envoycache.Resource{
+			envoycache.NewResources("unit_test", []envoycache.Resource{
+				resource.NewEnvoyResource(goodEndpoint),
+				resource.NewEnvoyResource(badEndpoint),
+			}),
+			envoycache.NewResources("unit_test", []envoycache.Resource{
 				resource.NewEnvoyResource(goodCluster),
 				resource.NewEnvoyResource(badCluster),
 			}),
 			envoycache.NewResources("", nil),
 			envoycache.NewResources("", nil),
 		)
-
 		sanitizer := NewUpstreamRemovingSanitizer()
 
 		reports := reporter.ResourceReports{


### PR DESCRIPTION
…itizer (#5307)

* Use the correct map key to delete endpoints in upstream_removing_sanitizer
* remove unused test
* Clean up teat and add changelog
* Merge branch 'master' into missing-kube-service
* codegen, remove debug printing and log level changes
* codegen again
* default endpoint name

# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
