### PR TITLE
Backport 1.8 upgrade docs

### DIFF
--- a/changelog/v1.8.16/upgrade-docs-backport.yaml
+++ b/changelog/v1.8.16/upgrade-docs-backport.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Backport 1.8 upgrade docs from master to 1.8.x

--- a/docs/content/operations/upgrading/1.8.0.md
+++ b/docs/content/operations/upgrading/1.8.0.md
@@ -28,10 +28,24 @@ Helm maintainers, given the risk associated with changing CRDs. Given this limit
 You can add the new CRDs to your cluster in two ways. The first is to supply a URL that points to the CRD template in the public
 [Gloo Edge GitHub repository](https://github.com/solo-io/gloo)
 
+{{< tabs >}}
+{{% tab name="Gloo Edge - Helm 3" %}}
 ```shell script
 kubectl apply -f https://raw.githubusercontent.com/solo-io/gloo/v1.8.0/install/helm/gloo/crds/gateway.solo.io_v1_VirtualHostOption.yaml
 kubectl apply -f https://raw.githubusercontent.com/solo-io/gloo/v1.8.0/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
+helm repo update
+helm upgrade -n gloo-system gloo gloo/gloo --version=1.8.0
 ```
+{{% /tab %}}
+{{% tab name="Gloo Edge Enterprise - Helm 3" %}}
+```shell script
+kubectl apply -f https://raw.githubusercontent.com/solo-io/gloo/v1.8.0/install/helm/gloo/crds/gateway.solo.io_v1_VirtualHostOption.yaml
+kubectl apply -f https://raw.githubusercontent.com/solo-io/gloo/v1.8.0/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
+helm repo update
+helm upgrade -n gloo-system glooe gloo/gloo-ee --version=1.8.0
+```
+{{% /tab %}}
+{{< /tabs >}}
 
 The second option involves using the template that is shipped in the Gloo Edge and Gloo Edge enterprise charts.
 
@@ -100,6 +114,19 @@ spec:
 If you do not make this change, you will see the following type of error:
 `ValidationError(Upstream.spec.kube): unknown field "service_name" in io.solo.gloo.v1.Upstream.spec.kube`
 
+##### Settings CRD
+
+In v1.8.8 the `validationServerGrpcMaxSize` was replaced by `validationServerGrpcMaxSizeBytes` in the settings CRD.
+If the new settings CRD is not applied, you will see the following type of error:
+
+`Error: UPGRADE FAILED: error validating "": error validating data: ValidationError(Settings.spec.gateway.validation): unknown field "validationServerGrpcMaxSizeBytes" in io.solo.gloo.v1.Settings.spec.gateway.validation`
+
+To apply the new settings CRD:
+```
+helm pull gloo/gloo --version 1.8.8 --untar
+kubectl apply -f gloo/crds/gloo.solo.io_v1_Settings.yaml
+```
+
 #### Enterprise Gloo Edge
 
 ##### Gloo Federation
@@ -130,9 +157,12 @@ helm install gloo glooe/gloo-ee --namespace gloo-system --set gloo-fed.enabled=f
 {{% /tab %}}
 {{< /tabs >}}
 
-##### Gloo Federation UI
+##### Enterprise UI
 
-Note that the Gloo Fed UI (which [replaced the Gloo UI]({{< versioned_link_path fromRoot="/operations/upgrading/1.7.0#enterprise" >}}) in the 1.7.0 release), will not show any data until you [register one or more clusters]({{< versioned_link_path fromRoot="/guides/gloo_federation/cluster_registration/" >}}). In future releases, we plan to make explicit cluster registration unnecessary if you only want access to local Gloo instances in your UI.
+Prior to Gloo Edge Enterprise v1.8.9, the Enterprise UI was only available if Gloo Federation was enabled.
+Starting in v1.8.9, the UI is included by default for all Gloo Edge Enterprise users as well.
+
+Note that if you have Gloo Federation enabled, the UI does not show any data until you [register one or more clusters]({{< versioned_link_path fromRoot="/guides/gloo_federation/cluster_registration/" >}}). If Gloo Federation is disabled, the UI shows the installed Gloo Edge instance automatically without cluster registration.
 
 ### Verify upgrade
 To verify that your upgrade was successful, let's first check the version:


### PR DESCRIPTION
# Description

Backport the 1.8 upgrade docs from master to 1.8.

# Context

There is information present in master (https://docs.solo.io/gloo-edge/master/operations/upgrading/1.8.0/) that is not present in the 1.8 ("latest") version (https://docs.solo.io/gloo-edge/latest/operations/upgrading/1.8.0/).

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
