### PR TITLE
Fail loudly when docker push fails

### DIFF
--- a/changelog/v1.9.0-beta19/release-build-fails.yaml
+++ b/changelog/v1.9.0-beta19/release-build-fails.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Make releases fail when docker-push fails.

--- a/ci/extended-docker/extended-docker.sh
+++ b/ci/extended-docker/extended-docker.sh
@@ -5,6 +5,7 @@
 # also ensure we clean up the file once we're done
 TEMP_FILE=$(mktemp)
 make docker-push | tee ${TEMP_FILE}
+err=${PIPESTATUS[0]}
 
 cleanup() {
     echo ">> Removing ${TEMP_FILE}"
@@ -15,7 +16,7 @@ trap "cleanup" EXIT SIGINT
 echo ">> Temporary output file ${TEMP_FILE}"
 
 # grab the image names out of the `make docker` output
-sed -nE 's|Successfully tagged (.*$)|\1|p' ${TEMP_FILE} | while read f;
+sed -nE 's|Successfully tagged (.*$)|\1|p' ${TEMP_FILE} | grep -v "build-container" | while read f;
 do
   docker build ci/extended-docker --build-arg BASE_IMAGE=$f -t $f-extended;
   docker push $f-extended;


### PR DESCRIPTION
# Description

Use `${PIPESTATUS[0]}` to get the result of `make docker-push` so that we can fail builds when docker push fails.

# Context

Solo-projects releases were silently failing to push images to quay. Preemptively porting the same fix here.

