### PR TITLE
V1 vwh

### DIFF
--- a/changelog/v1.9.0-beta19/upgrade-vwh.yaml
+++ b/changelog/v1.9.0-beta19/upgrade-vwh.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5339
+    resolvesIssue: true
+    description: Update Gloo Edge's validating webhook to v1 from v1beta1 to support k8s 1.22.

--- a/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
+++ b/install/helm/gloo/templates/5-gateway-validation-webhook-configuration.yaml
@@ -1,6 +1,6 @@
 {{- define "gateway.validationWebhookSpec" }}
 {{- if and (and .Values.gateway.enabled .Values.gateway.validation.enabled) .Values.gateway.validation.webhook.enabled }}
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: gloo-gateway-validation-webhook-{{ .Release.Namespace }}
@@ -29,6 +29,9 @@ webhooks:
     apiVersions: ["v1"]
     resources: ["*"]
   sideEffects: None
+  matchPolicy: Exact
+  admissionReviewVersions:
+    - v1beta1 # v1beta1 still live in 1.22 https://github.com/kubernetes/api/blob/release-1.22/admission/v1beta1/types.go#L33
 {{- if .Values.gateway.validation.failurePolicy }}
   failurePolicy: {{ .Values.gateway.validation.failurePolicy }}
 {{- end }} {{/* if .Values.gateway.validation.failurePolicy */}}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2884,7 +2884,7 @@ spec:
 					It("creates the validating webhook configuration", func() {
 						vwc := makeUnstructured(`
 
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: gloo-gateway-validation-webhook-` + namespace + `
@@ -2908,6 +2908,9 @@ webhooks:
        apiVersions: ["v1"]
        resources: ["*"]
    sideEffects: None
+   matchPolicy: Exact
+   admissionReviewVersions:
+     - v1beta1
    failurePolicy: Ignore
 
 `)


### PR DESCRIPTION
# Description

Opted to configure the v1 api with the same defaults as v1beta1 to keep the behavior the same.

As indicated by https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/ , all we need to do is allow for the new version to be installed because we can still read objects written using v1beta1 using the v1 api

# Context

Necessary for Gloo Edge 1.9 to support k8s 1.22, the latest stable release.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5339