### PR TITLE
Add CI check for DO_NOT_SUBMIT comments in go files.

### DIFF
--- a/.github/workflows/do-not-submit.yaml
+++ b/.github/workflows/do-not-submit.yaml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+    name: Test changed-files
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v1.1.2
+      - name: Check for DO_NOT_SUBMIT
+        run: ./ci/do-not-submit.sh "${{ steps.changed-files.outputs.all_modified_files }}"

--- a/.github/workflows/do-not-submit.yaml
+++ b/.github/workflows/do-not-submit.yaml
@@ -16,4 +16,4 @@ jobs:
         id: changed-files
         uses: tj-actions/changed-files@v1.1.2
       - name: Check for DO_NOT_SUBMIT
-        run: ./ci/do-not-submit.sh "${{ steps.changed-files.outputs.all_modified_files }}"
+        run: ./ci/do-not-submit.sh ${{ steps.changed-files.outputs.all_modified_files }}

--- a/changelog/v1.9.0-beta19/do-not-submit.yaml
+++ b/changelog/v1.9.0-beta19/do-not-submit.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add a CI check which fails when `// DO_NOT_SUBMIT` is found in *.go files that were modified in a PR.

--- a/ci/do-not-submit.sh
+++ b/ci/do-not-submit.sh
@@ -22,7 +22,7 @@ DO_NOT_SUBMIT_REGEX="[[:space:]]*//[[:space:]]*DO_NOT_SUBMIT"
 file_count=0
 for filename in "$@"; do
   # Only check *.go files for now
-  if [[ "$filename" == *".go" ]]; then
+  if [[ "$filename" == *".go" || "$filename" == *"go.mod" ]]; then
     ((file_count++))
     line_number=1
     while IFS= read -r line; do
@@ -35,7 +35,7 @@ for filename in "$@"; do
 done
 
 if [[ "$OUTPUT" == "" ]]; then
-  echo "$file_count *.go files check, none contain DO_NOT_SUBMIT"
+  echo "$file_count go files checked, none contain DO_NOT_SUBMIT"
   exit 0
 else
   echo "$OUTPUT"

--- a/ci/do-not-submit.sh
+++ b/ci/do-not-submit.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# do-not-submit.sh takes one or more file paths as arguments, then checks each
+# of those files for comments including the DO_NOT_SUBMIT keyword. If the
+# keyword is present, the script exits with -1.
+#
+# This initial implementation only checks *.go files for single-line comments
+# (i.e. starting with // rather than /* ... */).
+#
+# This script is invoked by .github/workflows/do-not-submit.yaml
+
+if [[ "$#" -lt 1 ]]; then
+  echo "Usage: $0 filename [filenames ...]"
+  exit -1
+fi
+
+NEWLINE=$'\n'
+OUTPUT=""
+DO_NOT_SUBMIT_REGEX="[[:space:]]*//[[:space:]]*DO_NOT_SUBMIT"
+
+# Keeps track of number of *.go files (as opposed to all files provided)
+file_count=0
+for filename in "$@"; do
+  # Only check *.go files for now
+  if [[ "$filename" == *".go" ]]; then
+    ((file_count++))
+    line_number=1
+    while IFS= read -r line; do
+      if [[ "$line" =~ $DO_NOT_SUBMIT_REGEX ]]; then
+        OUTPUT="${OUTPUT}$filename:$line_number contains DO_NOT_SUBMIT${NEWLINE}"
+      fi
+      ((line_number++))
+    done <"$filename"
+  fi
+done
+
+if [[ "$OUTPUT" == "" ]]; then
+  echo "$file_count *.go files check, none contain DO_NOT_SUBMIT"
+  exit 0
+else
+  echo "$OUTPUT"
+  exit -1
+fi

--- a/ci/tools.go
+++ b/ci/tools.go
@@ -15,7 +15,8 @@ limitations under the License.
 
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies
 package tools
-
+// DO_NOT_SUBMIT
+// DO_NOT_SUBMIT
 import (
 	_ "github.com/cratonica/2goarray"
 	_ "github.com/envoyproxy/protoc-gen-validate"

--- a/ci/tools.go
+++ b/ci/tools.go
@@ -15,8 +15,7 @@ limitations under the License.
 
 // This package imports things required by build scripts, to force `go mod` to see them as dependencies
 package tools
-// DO_NOT_SUBMIT
-// DO_NOT_SUBMIT
+
 import (
 	_ "github.com/cratonica/2goarray"
 	_ "github.com/envoyproxy/protoc-gen-validate"


### PR DESCRIPTION
# Description

Add a CI check which fails when `// DO_NOT_SUBMIT` is found in *.go files that were modified in a PR.

Example failure: https://github.com/solo-io/gloo/runs/3654089442?check_suite_focus=true

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
