### PR TITLE
fix the glooctl gloo fed check to use deployment

### DIFF
--- a/changelog/v1.9.0-rc2/fix-glooctl-check-gloo-fed.yaml
+++ b/changelog/v1.9.0-rc2/fix-glooctl-check-gloo-fed.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5386
+    description: Check for Gloo Fed using deployment in glooctl check.


### PR DESCRIPTION
Use the existence of the gloo-fed deployment to determine whether Gloo Fed is installed, since the lack of gloo instances doesn't necessarily mean Gloo Fed isn't installed - only means no clusters with gloo instances on them have been registered.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5386