### PR TITLE
Backport: Docs: Move helm prefix warning (#5397)

### DIFF
--- a/docs/content/reference/helm_chart_values/enterprise_helm_chart_values.md
+++ b/docs/content/reference/helm_chart_values/enterprise_helm_chart_values.md
@@ -8,6 +8,13 @@ The table below describes all the values that you can override in your custom va
 chart for Open Source Gloo Edge. More information on using a Helm chart to install the Gloo Edge can be found 
 [here]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/#installing-on-kubernetes-with-helm" %}}).
 
+{{% notice warning %}}
+Because the Gloo Edge Enterprise Helm chart uses the open source chart as a dependency, 
+you must add the `gloo.` prefix to all open source Gloo Edge chart values.
+
+This applies to all values except for `global.*`. For example, when you install Gloo Edge Enterprise, `gateway.certGenJob.enabled` must be changed to `gloo.gateway.certGenJob.enabled`, but `global.glooRbac.create` remains unchanged.
+{{% /notice %}}
+
 {{< readfile file="static/content/glooe-values.docgen" markdown="true" >}}
 
 ## Helm Chart KubeResourceOverrides

--- a/docs/content/reference/helm_chart_values/open_source_helm_chart_values.md
+++ b/docs/content/reference/helm_chart_values/open_source_helm_chart_values.md
@@ -8,21 +8,6 @@ The table below describes all the values that you can override in your custom va
 chart for Open Source Gloo Edge. More information on using a Helm chart to install the Gloo Edge can be found 
 [here]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/#installing-on-kubernetes-with-helm" %}}).
 
-{{% notice warning %}}
-If you are using the **Gloo Edge Enterprise Helm** chart you will need to add a `gloo.` prefix to all the open source Gloo Edge 
-chart values. This is due to the fact that the Gloo Edge Enterprise Helm chart uses the open source one as a dependency; 
-therefore the sub-chart values have to be prefixed with the name of the sub-chart itself. 
-This applies to all values except:
-
-- `global.*`
-
-For example, if you are installing Gloo Edge Enterprise:
-
-- `gateway.certGenJob.enabled` needs to be `gloo.gateway.certGenJob.enabled`
-
-but `global.glooRbac.create` remains the same.
-{{% /notice %}}
-
 {{% notice note %}}
 If you need further customization of the Helm chart, please read our [advanced customization guide]({{% versioned_link_path fromRoot="/installation/gateway/kubernetes/helm_advanced/" %}}).
 {{% /notice %}}


### PR DESCRIPTION
* Docs: Move helm prefix warning

Fix to move the helm prefix warning to the correct page.
