### PR TITLE
Node selector overwrite (#5421)

### DIFF
--- a/changelog/v1.7.23/nodeselector-override.yaml
+++ b/changelog/v1.7.23/nodeselector-override.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    description: |
+      Ensure nodeSelectors set for custom gateway-proxy services are not overwritten
+      by default gateway-proxy nodeSelectors
+    issueLink: https://github.com/solo-io/gloo/issues/5286
+    resolvesIssue: true

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -6,9 +6,15 @@
 {{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- range $name, $spec := .Values.gatewayProxies }}
+{{- range $name, $gatewaySpec := .Values.gatewayProxies }}
+{{- $spec := $gatewaySpec -}}
 {{ if not $.Values.settings.helm2 }}
-{{- $spec = deepCopy $spec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{- $spec = deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+  {{- if not (empty $gatewaySpec.podTemplate) }}
+  {{- if not (empty $gatewaySpec.podTemplate.nodeSelector) }}
+  {{- $_ := set $spec.podTemplate "nodeSelector" $gatewaySpec.podTemplate.nodeSelector }}
+  {{- end }}
+  {{- end }}
 {{- end}}
 {{- $image := $spec.podTemplate.image }}
 {{- if $global }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -963,6 +963,72 @@ var _ = Describe("Helm Test", func() {
 						proxyNames = []string{defaults.GatewayProxyName}
 					)
 
+					It("does not overwrite nodeSelectors specified for custom gateway proxy", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"gatewayProxies.gatewayProxy.podTemplate.nodeSelector.default=true",
+								// anotherGatewayProxy should have its own nodeSelector and not the default
+								"gatewayProxies.anotherGatewayProxy.podTemplate.nodeSelector.custom=true",
+							},
+						})
+						gwpUns := testManifest.ExpectCustomResource("Deployment", namespace, "another-gateway-proxy")
+						gwp, err := kuberesource.ConvertUnstructured(gwpUns)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(gwp).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
+						gwpStr := *gwp.(*appsv1.Deployment)
+						Expect(gwpStr.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"custom": "true"}))
+					})
+
+					It("uses default nodeSelectors for custom gateway proxy when none is specified", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"gatewayProxies.gatewayProxy.podTemplate.nodeSelector.default=true",
+								// anotherGatewayProxy should get the default nodeSelector
+								"gatewayProxies.anotherGatewayProxy.loopbackAddress=127.0.0.1",
+							},
+						})
+						gwpUns := testManifest.ExpectCustomResource("Deployment", namespace, "another-gateway-proxy")
+						gwp, err := kuberesource.ConvertUnstructured(gwpUns)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(gwp).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
+						gwpStr := *gwp.(*appsv1.Deployment)
+						Expect(gwpStr.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"default": "true"}))
+					})
+
+					It("uses appropriate nodeSelectors for custom gateway proxies depending on whether any is specified", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								// unspecifiedGatewayProxy should get the default nodeSelector
+								"gatewayProxies.unspecifiedGatewayProxy.loopbackAddress=127.0.0.1",
+								// specifiedGatewayProxy should keep its specified nodeSelector
+								"gatewayProxies.specifiedGatewayProxy.podTemplate.nodeSelector.custom=true",
+								// default specified last to catch accidental overwriting
+								"gatewayProxies.gatewayProxy.podTemplate.nodeSelector.default=true",
+							},
+						})
+
+						unspecifiedUns := testManifest.ExpectCustomResource("Deployment", namespace, "unspecified-gateway-proxy")
+						unspecified, err := kuberesource.ConvertUnstructured(unspecifiedUns)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(unspecified).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
+						unspecifiedStr := *unspecified.(*appsv1.Deployment)
+						Expect(unspecifiedStr.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"default": "true"}))
+
+						specifiedUns := testManifest.ExpectCustomResource("Deployment", namespace, "specified-gateway-proxy")
+						specified, err := kuberesource.ConvertUnstructured(specifiedUns)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(specified).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
+						specifiedStr := *specified.(*appsv1.Deployment)
+						Expect(specifiedStr.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"custom": "true"}))
+
+						gwpUns := testManifest.ExpectCustomResource("Deployment", namespace, "gateway-proxy")
+						gwp, err := kuberesource.ConvertUnstructured(gwpUns)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(gwp).To(BeAssignableToTypeOf(&appsv1.Deployment{}))
+						gwpStr := *gwp.(*appsv1.Deployment)
+						Expect(gwpStr.Spec.Template.Spec.NodeSelector).To(Equal(map[string]string{"default": "true"}))
+					})
+
 					It("renders with http/https gateways by default", func() {
 						prepareMakefile(namespace, helmValues{})
 						gatewayUns := testManifest.ExpectCustomResource("Gateway", namespace, defaults.GatewayProxyName)


### PR DESCRIPTION
# Description

Backport of #5421


# Context

Added helm logic to preserve initial custom GatewayConfig spec after the mergeOverwrite call which did not previously exist on this version
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5286