### PR TITLE
Fix helm chart values description ...gatewaySettings.option to ...gatewaySettings.gatewayOptions

### DIFF
--- a/changelog/v1.10.0-beta2/fix-helm-values.yaml
+++ b/changelog/v1.10.0-beta2/fix-helm-values.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Fix helm chart values documentation. change `gloo.gatewayProxies.NAME.gatewaySettings.options` to `gloo.gatewayProxies.NAME.gatewaySettings.gatewayOptions` and `gloo.gatewayProxies.gatewayProxy.gatewaySettings.options` to gloo.gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -430,14 +430,14 @@
 |gatewayProxies.NAME.gatewaySettings.customHttpGateway|string||custom yaml to use for http gateway settings|
 |gatewayProxies.NAME.gatewaySettings.customHttpsGateway|string||custom yaml to use for https gateway settings|
 |gatewayProxies.NAME.gatewaySettings.accessLoggingService.access_log[]|interface|||
-|gatewayProxies.NAME.gatewaySettings.options.access_logging_service.access_log[]|interface|||
-|gatewayProxies.NAME.gatewaySettings.options.extensions.configs.NAME.fields.NAME|interface|||
-|gatewayProxies.NAME.gatewaySettings.options.per_connection_buffer_limit_bytes.value|uint32|||
-|gatewayProxies.NAME.gatewaySettings.options.socket_options[].description|string|||
-|gatewayProxies.NAME.gatewaySettings.options.socket_options[].level|int64|||
-|gatewayProxies.NAME.gatewaySettings.options.socket_options[].name|int64|||
-|gatewayProxies.NAME.gatewaySettings.options.socket_options[]|interface|||
-|gatewayProxies.NAME.gatewaySettings.options.socket_options[].state|int32|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.access_logging_service.access_log[]|interface|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.extensions.configs.NAME.fields.NAME|interface|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.per_connection_buffer_limit_bytes.value|uint32|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.socket_options[].description|string|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.socket_options[].level|int64|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.socket_options[].name|int64|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.socket_options[]|interface|||
+|gatewayProxies.NAME.gatewaySettings.gatewayOptions.socket_options[].state|int32|||
 |gatewayProxies.NAME.gatewaySettings.httpGatewayKubeOverride.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.NAME.gatewaySettings.httpsGatewayKubeOverride.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.NAME.gatewaySettings.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
@@ -596,14 +596,14 @@
 |gatewayProxies.gatewayProxy.gatewaySettings.customHttpGateway|string||custom yaml to use for http gateway settings|
 |gatewayProxies.gatewayProxy.gatewaySettings.customHttpsGateway|string||custom yaml to use for https gateway settings|
 |gatewayProxies.gatewayProxy.gatewaySettings.accessLoggingService.access_log[]|interface|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.access_logging_service.access_log[]|interface|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.extensions.configs.NAME.fields.NAME|interface|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.per_connection_buffer_limit_bytes.value|uint32|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.socket_options[].description|string|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.socket_options[].level|int64|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.socket_options[].name|int64|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.socket_options[]|interface|||
-|gatewayProxies.gatewayProxy.gatewaySettings.options.socket_options[].state|int32|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.access_logging_service.access_log[]|interface|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.extensions.configs.NAME.fields.NAME|interface|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.per_connection_buffer_limit_bytes.value|uint32|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.socket_options[].description|string|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.socket_options[].level|int64|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.socket_options[].name|int64|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.socket_options[]|interface|||
+|gatewayProxies.gatewayProxy.gatewaySettings.gatewayOptions.socket_options[].state|int32|||
 |gatewayProxies.gatewayProxy.gatewaySettings.httpGatewayKubeOverride.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.gatewayProxy.gatewaySettings.httpsGatewayKubeOverride.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.gatewayProxy.gatewaySettings.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -353,7 +353,7 @@ type GatewayProxyGatewaySettings struct {
 	CustomHttpGateway        *string                  `json:"customHttpGateway,omitempty" desc:"custom yaml to use for http gateway settings"`
 	CustomHttpsGateway       *string                  `json:"customHttpsGateway,omitempty" desc:"custom yaml to use for https gateway settings"`
 	AccessLoggingService     als.AccessLoggingService `json:"accessLoggingService,omitempty"`
-	GatewayOptions           v1.ListenerOptions       `json:"options,omitempty" desc:"custom options for http(s) gateways"`
+	GatewayOptions           v1.ListenerOptions       `json:"gatewayOptions,omitempty" desc:"custom options for http(s) gateways"`
 	HttpGatewayOverride      *KubeResourceOverride    `json:"httpGatewayKubeOverride,omitempty"`
 	HttpsGatewayOverride     *KubeResourceOverride    `json:"httpsGatewayKubeOverride,omitempty"`
 	*KubeResourceOverride


### PR DESCRIPTION
# Description

Please include a summary of the changes.

This pr fixes wrong documentation of the helm chart values.

# Context

When trying to modify the `per_connection_buffer_limit_bytes` as documented here: https://docs.solo.io/gloo-edge/1.8.18/reference/helm_chart_values/enterprise_helm_chart_values/

I got an error: `Error: UPGRADE FAILED: error validating "": error validating data: [ValidationError(Gateway.spec.options): unknown field "per_connection_buffer_limit_bytes" in io.solo.gateway.v1.Gateway.spec.options, ValidationError(Gateway.spec.options): unknown field "socket_options" in io.solo.gateway.v1.Gateway.spec.options]
`

After a quick look i saw [here](https://github.com/solo-io/gloo/blob/master/install/helm/gloo/generate/values.go#L356) that it should be `gatewayOptions` instead of `options`
# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
