### PR TITLE
Docs - Adding tabs for Linux base64 option

### DIFF
--- a/changelog/v1.10.0-beta5/docs-base64-fix.yaml
+++ b/changelog/v1.10.0-beta5/docs-base64-fix.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update base64 commands for macOS vs. Linux options.

--- a/docs/content/guides/security/auth/extauth/basic_auth/_index.md
+++ b/docs/content/guides/security/auth/extauth/basic_auth/_index.md
@@ -174,9 +174,14 @@ Authorization: basic <base64_encoded_credentials>
 
 To encode the credentials, just run:
 
-```shell
+{{< tabs >}}
+{{< tab name="macOS" codelang="shell" >}}
 echo -n "user:password" | base64
-```
+{{< /tab >}}
+{{< tab name="Linux" codelang="shell">}}
+echo -n "user:password" | base64 -w 0
+{{< /tab >}}
+{{< /tabs >}}
 
 This outputs `dXNlcjpwYXNzd29yZA==`. Let's include the header with this value in our request:
 

--- a/docs/content/guides/traffic_management/destination_types/grpc_to_rest_advanced/_index.md
+++ b/docs/content/guides/traffic_management/destination_types/grpc_to_rest_advanced/_index.md
@@ -95,9 +95,14 @@ which is responsible for generating our binary descriptors and writing them out 
 
 Next we need to configure our `Gateway` to handle gRPC to JSON transcoding using our generated descriptors. Since yaml can't handle binary data, we need to encode the binary descriptor set for our gRPC service in base64 (standard encoding). From the root of the Gloo Edge repo:
 
-```shell script
+{{< tabs >}}
+{{< tab name="macOS" codelang="shell" >}}
 cat docs/examples/grpc-json-transcoding/bookstore/descriptors/proto.pb | base64
-```
+{{< /tab >}}
+{{< tab name="Linux" codelang="shell">}}
+cat docs/examples/grpc-json-transcoding/bookstore/descriptors/proto.pb | base64 -w 0
+{{< /tab >}}
+{{< /tabs >}}
 
 Taking the output from that, we can now configure our gateway (`kubectl apply` this gateway) using the base64 encoded descriptor and setting it on `spec.httpGateway.options.grpc_json_transcoder.proto_descriptor_bin`:
 

--- a/docs/content/operations/updating_license/_index.md
+++ b/docs/content/operations/updating_license/_index.md
@@ -68,10 +68,16 @@ If you're a new user whose trial license has expired, contact your Solo.io Accou
 
 The Gloo Edge Enterprise license is installed by default into a Kubernetes `Secret` named `license` in the `gloo-system` namespace. If that is the case for your installation, then you can use a simple bash script to replace the expired key by patching the `license` secret:
 
-```bash
+{{< tabs >}}
+{{< tab name="macOS" codelang="shell" >}}
 GLOO_KEY=your-new-enterprise-key-string
 echo $GLOO_KEY | base64 | read output;kubectl patch secret license -n gloo-system -p="{\"data\":{\"license-key\": \"$output\"}}" -v=1
-```
+{{< /tab >}}
+{{< tab name="Linux codelang="shell">}}
+GLOO_KEY=your-new-enterprise-key-string
+echo $GLOO_KEY | base64 -w 0 | read output;kubectl patch secret license -n gloo-system -p="{\"data\":{\"license-key\": \"$output\"}}" -v=1
+{{< /tab >}}
+{{< /tabs >}}
 
 If successful, this script should respond with: `secret/license patched`.
 


### PR DESCRIPTION
Better to use the -w 0 option to suppress newlines for Kube. MacOS does this by default.

Based on discussion in Slack: https://solo-io-corp.slack.com/archives/CHJV572TG/p1636444750056800

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- N/A If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- N/A I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- N/A I have added tests that prove my fix is effective or that my feature works
