### PR TITLE
Bump solo-kit dependency to v0.20.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/solo-io/skv2 v0.17.2
 	// Pinned to the `rate-limiter-v0.1.8` tag of solo-apis
 	github.com/solo-io/solo-apis v0.0.0-20210122162349-0e170e74af10
-	github.com/solo-io/solo-kit v0.20.3
+	github.com/solo-io/solo-kit v0.20.4
 	github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3
 	github.com/spf13/afero v1.3.4
 	github.com/spf13/cobra v1.1.3


### PR DESCRIPTION
Bump solo-kit dependency to v0.20.4, which includes at recent backport of https://github.com/solo-io/solo-kit/pull/446 to v0.20.x. This is being done with the intention of introducing the fix for solo-io/gloo#4790 to Gloo EE v1.8.x
