### PR TITLE
v1.8.x: bump solo-kit dependency to v0.20.4

### DIFF
--- a/changelog/v1.8.20/bump-solo-kit.yaml
+++ b/changelog/v1.8.20/bump-solo-kit.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: solo-kit
+    dependencyTag: v0.20.4
+    description: Pull in Solo-kit changes that allow us to ignore ownerReferences

--- a/changelog/v1.8.20/bump-solo-kit.yaml
+++ b/changelog/v1.8.20/bump-solo-kit.yaml
@@ -4,3 +4,6 @@ changelog:
     dependencyRepo: solo-kit
     dependencyTag: v0.20.4
     description: Pull in Solo-kit changes that allow us to ignore ownerReferences
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4790
+    description: Remove ownerReference mapping for upstreams created by UDS

--- a/changelog/v1.9.0-beta19/remove-ownerref-mapping-for-uds.yaml
+++ b/changelog/v1.9.0-beta19/remove-ownerref-mapping-for-uds.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/4790
+    description: Remove ownerReference mapping for upstreams created by UDS

--- a/changelog/v1.9.0-beta19/remove-ownerref-mapping-for-uds.yaml
+++ b/changelog/v1.9.0-beta19/remove-ownerref-mapping-for-uds.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/gloo/issues/4790
-    description: Remove ownerReference mapping for upstreams created by UDS

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	github.com/solo-io/skv2 v0.17.2
 	// Pinned to the `rate-limiter-v0.1.8` tag of solo-apis
 	github.com/solo-io/solo-apis v0.0.0-20210122162349-0e170e74af10
-	github.com/solo-io/solo-kit v0.20.3
+	github.com/solo-io/solo-kit v0.20.4
 	github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3
 	github.com/spf13/afero v1.3.4
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -1323,8 +1323,8 @@ github.com/solo-io/skv2 v0.17.2/go.mod h1:8Mo/EqmRGTu3UWb6ldnbN/9QyzI788MyG3SSpP
 github.com/solo-io/solo-apis v0.0.0-20210122162349-0e170e74af10 h1:Qbq966MqBQ2hlvrg0RuoB2rWXJOwSJq+kT5z4P3Nk50=
 github.com/solo-io/solo-apis v0.0.0-20210122162349-0e170e74af10/go.mod h1:pAKKsh7pWK1nkzSfSV67RlmiynYzZlu+IWAylvEqkUI=
 github.com/solo-io/solo-kit v0.16.0/go.mod h1:zf+vof9HAavbFKRgL80jJ24SeE9PvoB8ooQ7DACtK8I=
-github.com/solo-io/solo-kit v0.20.3 h1:WgfJqupfvBK41XeFqyWvficMCo9Te6z64O8ZUxP4ZYo=
-github.com/solo-io/solo-kit v0.20.3/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
+github.com/solo-io/solo-kit v0.20.4 h1:CgTuPVQwpVQRWjaG5UsJ3UMJQospiseB9qY2AmVPiJk=
+github.com/solo-io/solo-kit v0.20.4/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
 github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3 h1:Am1RMaWH7jOug0ys4gUeBCgwR/94NSfZqu90j9u8eTA=
 github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3/go.mod h1:3lckq1wF8I6I2a1Jx5IsEG+PQArE57Jp3wBE2rQnKmw=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=

--- a/projects/clusteringress/api/external/knative/cluster_ingress.go
+++ b/projects/clusteringress/api/external/knative/cluster_ingress.go
@@ -11,7 +11,7 @@ import (
 type ClusterIngress v1alpha1.Ingress
 
 func (p *ClusterIngress) GetMetadata() *core.Metadata {
-	return kubeutils.FromKubeMeta(p.ObjectMeta)
+	return kubeutils.FromKubeMeta(p.ObjectMeta, true)
 }
 
 func (p *ClusterIngress) SetMetadata(meta *core.Metadata) {

--- a/projects/gloo/api/external/solo/ratelimit/rate_limit_config.go
+++ b/projects/gloo/api/external/solo/ratelimit/rate_limit_config.go
@@ -21,7 +21,7 @@ var _ resources.CustomInputResource = &RateLimitConfig{}
 type RateLimitConfig v1alpha1.RateLimitConfig
 
 func (r *RateLimitConfig) GetMetadata() *core.Metadata {
-	return kubeutils.FromKubeMeta(r.ObjectMeta)
+	return kubeutils.FromKubeMeta(r.ObjectMeta, true)
 }
 
 func (r *RateLimitConfig) SetMetadata(meta *core.Metadata) {

--- a/projects/gloo/pkg/api/converters/kube/api_key_secret.go
+++ b/projects/gloo/pkg/api/converters/kube/api_key_secret.go
@@ -54,7 +54,7 @@ func (c *APIKeySecretConverter) FromKubeSecret(ctx context.Context, _ *kubesecre
 		}
 
 		glooSecret := &v1.Secret{
-			Metadata: kubeutils.FromKubeMeta(secret.ObjectMeta),
+			Metadata: kubeutils.FromKubeMeta(secret.ObjectMeta, true),
 			Kind: &v1.Secret_ApiKey{
 				ApiKey: apiKeySecret,
 			},

--- a/projects/gloo/pkg/api/converters/kube/artifact_converter.go
+++ b/projects/gloo/pkg/api/converters/kube/artifact_converter.go
@@ -33,7 +33,7 @@ func (c *converter) FromKubeConfigMap(_ context.Context, rc *skcfgmap.ResourceCl
 func KubeConfigMapToArtifact(configMap *kubev1.ConfigMap) *v1.Artifact {
 	artifact := new(v1.Artifact)
 	artifact.Data = configMap.Data
-	artifact.SetMetadata(skkubeutils.FromKubeMeta(configMap.ObjectMeta))
+	artifact.SetMetadata(skkubeutils.FromKubeMeta(configMap.ObjectMeta, true))
 
 	return artifact
 }

--- a/projects/gloo/pkg/api/converters/kube/secretconverter.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter.go
@@ -77,7 +77,7 @@ func (t *TLSSecretConverter) FromKubeSecret(_ context.Context, _ *kubesecret.Res
 					RootCa:     string(secret.Data[kubev1.ServiceAccountRootCAKey]),
 				},
 			},
-			Metadata: kubeutils.FromKubeMeta(secret.ObjectMeta),
+			Metadata: kubeutils.FromKubeMeta(secret.ObjectMeta, true),
 		}
 		if glooSecret.GetMetadata().GetAnnotations() == nil {
 			glooSecret.GetMetadata().Annotations = make(map[string]string)

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
@@ -44,7 +44,7 @@ func (uc *KubeUpstreamConverter) UpstreamsForService(ctx context.Context, svc *k
 
 func (uc *KubeUpstreamConverter) CreateUpstream(ctx context.Context, svc *kubev1.Service, port kubev1.ServicePort) *v1.Upstream {
 	meta := svc.ObjectMeta
-	coremeta := kubeutils.FromKubeMeta(meta)
+	coremeta := kubeutils.FromKubeMeta(meta, false)
 	coremeta.ResourceVersion = ""
 	coremeta.Name = UpstreamName(meta.Namespace, meta.Name, port.Port)
 	labels := coremeta.GetLabels()

--- a/projects/ingress/pkg/api/ingress/resource_client.go
+++ b/projects/ingress/pkg/api/ingress/resource_client.go
@@ -62,7 +62,7 @@ func FromKube(ingress *v1beta1.Ingress) (*v1.Ingress, error) {
 		KubeIngressStatus: status,
 	}
 
-	resource.SetMetadata(kubeutils.FromKubeMeta(ingress.ObjectMeta))
+	resource.SetMetadata(kubeutils.FromKubeMeta(ingress.ObjectMeta, true))
 
 	return resource, nil
 }

--- a/projects/ingress/pkg/api/service/resource_client.go
+++ b/projects/ingress/pkg/api/service/resource_client.go
@@ -62,7 +62,7 @@ func FromKube(svc *kubev1.Service) (*v1.KubeService, error) {
 		KubeServiceStatus: status,
 	}
 
-	resource.SetMetadata(kubeutils.FromKubeMeta(svc.ObjectMeta))
+	resource.SetMetadata(kubeutils.FromKubeMeta(svc.ObjectMeta, true))
 
 	return resource, nil
 }

--- a/projects/knative/api/external/knative/ingress.go
+++ b/projects/knative/api/external/knative/ingress.go
@@ -11,7 +11,7 @@ import (
 type Ingress v1alpha1.Ingress
 
 func (p *Ingress) GetMetadata() *core.Metadata {
-	return kubeutils.FromKubeMeta(p.ObjectMeta)
+	return kubeutils.FromKubeMeta(p.ObjectMeta, true)
 }
 
 func (p *Ingress) SetMetadata(meta *core.Metadata) {

--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Gateway", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Create a virtual service with a route pointing to the above service
-				vs := getTrivialVirtualServiceForService("gloo-system", kubeutils.FromKubeMeta(svc.ObjectMeta).Ref(), uint32(svc.Spec.Ports[0].Port))
+				vs := getTrivialVirtualServiceForService("gloo-system", kubeutils.FromKubeMeta(svc.ObjectMeta, true).Ref(), uint32(svc.Spec.Ports[0].Port))
 				_, err = testClients.VirtualServiceClient.Write(vs, clients.WriteOpts{})
 				Expect(err).NotTo(HaveOccurred())
 
@@ -213,7 +213,7 @@ var _ = Describe("Gateway", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// Create a trivial, working service with a route pointing to the above service
-				vs1 := getTrivialVirtualServiceForService(defaults.GlooSystem, kubeutils.FromKubeMeta(svc.ObjectMeta).Ref(), uint32(svc.Spec.Ports[0].Port))
+				vs1 := getTrivialVirtualServiceForService(defaults.GlooSystem, kubeutils.FromKubeMeta(svc.ObjectMeta, true).Ref(), uint32(svc.Spec.Ports[0].Port))
 				vs1.VirtualHost.Domains = []string{"vs1"}
 				vs1.Metadata.Name = "vs1"
 				_, err = testClients.VirtualServiceClient.Write(vs1, clients.WriteOpts{})
@@ -230,7 +230,7 @@ var _ = Describe("Gateway", func() {
 				}, "60s", "2s").Should(BeTrue(), "first virtualservice should be accepted")
 
 				// Create a second vs with a bad authconfig
-				vs2 := getTrivialVirtualServiceForService(defaults.GlooSystem, kubeutils.FromKubeMeta(svc.ObjectMeta).Ref(), uint32(svc.Spec.Ports[0].Port))
+				vs2 := getTrivialVirtualServiceForService(defaults.GlooSystem, kubeutils.FromKubeMeta(svc.ObjectMeta, true).Ref(), uint32(svc.Spec.Ports[0].Port))
 				vs2.VirtualHost.Domains = []string{"vs2"}
 				vs2.Metadata.Name = "vs2"
 				vs2.VirtualHost.Options = &gloov1.VirtualHostOptions{
@@ -277,7 +277,7 @@ var _ = Describe("Gateway", func() {
 				}, "10s", "0.1s").Should(BeTrue(), "second virtualservice should not end up in the proxy (bad config)")
 
 				// Create a third trivial vs with valid config
-				vs3 := getTrivialVirtualServiceForService(defaults.GlooSystem, kubeutils.FromKubeMeta(svc.ObjectMeta).Ref(), uint32(svc.Spec.Ports[0].Port))
+				vs3 := getTrivialVirtualServiceForService(defaults.GlooSystem, kubeutils.FromKubeMeta(svc.ObjectMeta, true).Ref(), uint32(svc.Spec.Ports[0].Port))
 				vs3.Metadata.Name = "vs3"
 				vs3.VirtualHost.Domains = []string{"vs3"}
 				_, err = testClients.VirtualServiceClient.Write(vs3, clients.WriteOpts{})

--- a/test/e2e/happypath_test.go
+++ b/test/e2e/happypath_test.go
@@ -519,7 +519,7 @@ var _ = Describe("Happy path", func() {
 					})
 
 					It("correctly routes requests to a service destination", func() {
-						svcRef := skkubeutils.FromKubeMeta(svc.ObjectMeta).Ref()
+						svcRef := skkubeutils.FromKubeMeta(svc.ObjectMeta, true).Ref()
 						svcPort := svc.Spec.Ports[0].Port
 						proxy := getTrivialProxyForService(namespace, envoyPort, svcRef, uint32(svcPort))
 


### PR DESCRIPTION
Bump solo-kit dependency to v0.20.4, which includes at recent backport of https://github.com/solo-io/solo-kit/pull/446 to v0.20.x. This is being done with the intention of introducing the fix for solo-io/gloo#4790 to Gloo EE v1.8.x

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4790