### PR TITLE
expose envoy clusters endpoint

### DIFF
--- a/changelog/v1.10.0-beta6/gateway-proxy-envoy-clusters.yaml
+++ b/changelog/v1.10.0-beta6/gateway-proxy-envoy-clusters.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/5447
+    resolvesIssue: false
+    description: Expose the clusters envoy admin endpoint in the gateway-proxy-envoy-config configmap.

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -129,6 +129,13 @@ data:
                                      exact_match: GET
                               route:
                                 cluster: admin_port_cluster
+                            - match:
+                                prefix: "/clusters"
+                                headers:
+                                  - name: ":method"
+                                    exact_match: GET
+                              route:
+                                cluster: admin_port_cluster
                     http_filters:
                       - name: envoy.filters.http.router
 {{- end}} {{- /* if $spec.readConfig */}}

--- a/install/test/fixtures.go
+++ b/install/test/fixtures.go
@@ -623,6 +623,13 @@ static_resources:
                   prefix: /config_dump
                 route:
                   cluster: admin_port_cluster
+              - match:
+                  headers:
+                  - exact_match: GET
+                    name: :method
+                  prefix: /clusters
+                route:
+                  cluster: admin_port_cluster
           stat_prefix: read_config
         name: envoy.filters.network.http_connection_manager
     name: read_config_listener


### PR DESCRIPTION
Expose the envoy admin clusters endpoint if readConfig is true. It will be used by the UI to display cluster info.