### PR TITLE
Fix Envoy port-forward in prometheus docs

### DIFF
--- a/docs/content/guides/observability/prometheus/_index.md
+++ b/docs/content/guides/observability/prometheus/_index.md
@@ -38,7 +38,7 @@ grafana:
 The envoy pod publishes its fairly comprehensive metrics on port 19000. You can view the available ones by running:
 ```bash
 # Port-forward to envoy's admin port:
-kubectl port-forward deployment/gateway-proxy 19000
+kubectl -n gloo-system port-forward deployment/gateway-proxy 19000
 
 curl http://localhost:19000/stats/prometheus
 ```


### PR DESCRIPTION
# Description

A `port-forward` command in [this](https://docs.solo.io/gloo-edge/latest/guides/observability/prometheus/) doc does not indicate the default `gloo-system` namespace and thus fails for users with the most common configuration.