### PR TITLE
(hybrid gateway) unique matcher name

### DIFF
--- a/projects/gloo/pkg/translator/names.go
+++ b/projects/gloo/pkg/translator/names.go
@@ -1,9 +1,8 @@
 package translator
 
 import (
-	"crypto/md5"
 	"fmt"
-	"io"
+	"hash/fnv"
 	"sort"
 
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -29,8 +28,8 @@ func matcherID(matcher *v1.Matcher) string {
 	sort.Strings(matcher.GetSslConfig().GetSniDomains())
 	sort.Strings(matcher.GetSslConfig().GetVerifySubjectAltName())
 
-	h := md5.New()
-	io.WriteString(h, matcher.String())
+	h := fnv.New64()
+	h.Write([]byte(matcher.String()))
 
 	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/projects/gloo/pkg/translator/names.go
+++ b/projects/gloo/pkg/translator/names.go
@@ -1,7 +1,9 @@
 package translator
 
 import (
+	"crypto/md5"
 	"fmt"
+	"io"
 	"sort"
 
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -27,5 +29,8 @@ func matcherID(matcher *v1.Matcher) string {
 	sort.Strings(matcher.SslConfig.SniDomains)
 	sort.Strings(matcher.SslConfig.VerifySubjectAltName)
 
-	return matcher.String()
+	h := md5.New()
+	io.WriteString(h, matcher.String())
+
+	return fmt.Sprintf("%x", h.Sum(nil))
 }

--- a/projects/gloo/pkg/translator/names.go
+++ b/projects/gloo/pkg/translator/names.go
@@ -1,7 +1,31 @@
 package translator
 
-import v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+import (
+	"fmt"
+	"sort"
+
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+)
 
 func routeConfigName(listener *v1.Listener) string {
 	return listener.GetName() + "-routes"
+}
+
+func matchedRouteConfigName(listener *v1.Listener, matcher *v1.Matcher) string {
+	return fmt.Sprintf("%s-%s", routeConfigName(listener), matcherID(matcher))
+}
+
+func matcherID(matcher *v1.Matcher) string {
+	sort.Slice(matcher.SourcePrefixRanges, func(i, j int) bool {
+		if matcher.SourcePrefixRanges[i].AddressPrefix != matcher.SourcePrefixRanges[j].AddressPrefix {
+			return matcher.SourcePrefixRanges[i].AddressPrefix < matcher.SourcePrefixRanges[j].AddressPrefix
+		}
+		return matcher.SourcePrefixRanges[i].PrefixLen.Value < matcher.SourcePrefixRanges[j].PrefixLen.Value
+	})
+
+	sort.Strings(matcher.SslConfig.AlpnProtocols)
+	sort.Strings(matcher.SslConfig.SniDomains)
+	sort.Strings(matcher.SslConfig.VerifySubjectAltName)
+
+	return matcher.String()
 }

--- a/projects/gloo/pkg/translator/names.go
+++ b/projects/gloo/pkg/translator/names.go
@@ -18,16 +18,16 @@ func matchedRouteConfigName(listener *v1.Listener, matcher *v1.Matcher) string {
 }
 
 func matcherID(matcher *v1.Matcher) string {
-	sort.Slice(matcher.SourcePrefixRanges, func(i, j int) bool {
-		if matcher.SourcePrefixRanges[i].AddressPrefix != matcher.SourcePrefixRanges[j].AddressPrefix {
-			return matcher.SourcePrefixRanges[i].AddressPrefix < matcher.SourcePrefixRanges[j].AddressPrefix
+	sort.Slice(matcher.GetSourcePrefixRanges(), func(i, j int) bool {
+		if matcher.GetSourcePrefixRanges()[i].GetAddressPrefix() != matcher.GetSourcePrefixRanges()[j].GetAddressPrefix() {
+			return matcher.GetSourcePrefixRanges()[i].GetAddressPrefix() < matcher.GetSourcePrefixRanges()[j].GetAddressPrefix()
 		}
-		return matcher.SourcePrefixRanges[i].PrefixLen.Value < matcher.SourcePrefixRanges[j].PrefixLen.Value
+		return matcher.GetSourcePrefixRanges()[i].GetPrefixLen().GetValue() < matcher.GetSourcePrefixRanges()[j].GetPrefixLen().GetValue()
 	})
 
-	sort.Strings(matcher.SslConfig.AlpnProtocols)
-	sort.Strings(matcher.SslConfig.SniDomains)
-	sort.Strings(matcher.SslConfig.VerifySubjectAltName)
+	sort.Strings(matcher.GetSslConfig().GetAlpnProtocols())
+	sort.Strings(matcher.GetSslConfig().GetSniDomains())
+	sort.Strings(matcher.GetSslConfig().GetVerifySubjectAltName())
 
 	h := md5.New()
 	io.WriteString(h, matcher.String())

--- a/projects/gloo/pkg/translator/names_test.go
+++ b/projects/gloo/pkg/translator/names_test.go
@@ -95,7 +95,7 @@ var _ = Describe("matcherID", func() {
 				},
 			},
 			SslConfig: &v1.SslConfig{
-				SniDomains: []string{"def","abc"},
+				SniDomains: []string{"def", "abc"},
 			},
 		}
 		matcher2 := &v1.Matcher{

--- a/projects/gloo/pkg/translator/names_test.go
+++ b/projects/gloo/pkg/translator/names_test.go
@@ -11,6 +11,30 @@ import (
 )
 
 var _ = Describe("matcherID", func() {
+	When("we get a matcher ID", func() {
+		matcher := &v1.Matcher{
+			SourcePrefixRanges: []*v3.CidrRange{
+				{
+					AddressPrefix: "foo",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 123,
+					},
+				},
+				{
+					AddressPrefix: "bar",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 456,
+					},
+				},
+			},
+			SslConfig: &v1.SslConfig{
+				SniDomains: []string{"abc", "def"},
+			},
+		}
+		It("produces a deterministic unique ID", func() {
+			Expect(matcherID(matcher)).To(Equal("8380e12a0f262b4a49d84e9e2b322160"))
+		})
+	})
 	When("matchers are identical", func() {
 		matcher1 := &v1.Matcher{
 			SourcePrefixRanges: []*v3.CidrRange{

--- a/projects/gloo/pkg/translator/names_test.go
+++ b/projects/gloo/pkg/translator/names_test.go
@@ -1,8 +1,9 @@
 package translator
 
 import (
-	v3 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/core/v3"
 	"reflect"
+
+	v3 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/core/v3"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo"

--- a/projects/gloo/pkg/translator/names_test.go
+++ b/projects/gloo/pkg/translator/names_test.go
@@ -2,6 +2,7 @@ package translator
 
 import (
 	v3 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/core/v3"
+	"reflect"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo"
@@ -32,7 +33,7 @@ var _ = Describe("matcherID", func() {
 			},
 		}
 		It("produces a deterministic unique ID", func() {
-			Expect(matcherID(matcher)).To(Equal("8380e12a0f262b4a49d84e9e2b322160"))
+			Expect(matcherID(matcher)).To(Equal("3107de82d662fb9a452ba47fa401f1c8"))
 		})
 	})
 	When("matchers are identical", func() {
@@ -151,5 +152,11 @@ var _ = Describe("matcherID", func() {
 		It("produces different IDs", func() {
 			Expect(matcherID(matcher1)).NotTo(Equal(matcherID(matcher2)))
 		})
+	})
+	It("does not have new fields", func() {
+		Expect(reflect.TypeOf(v1.Matcher{}).NumField()).To(
+			Equal(5),
+			"wrong number of fields found",
+		)
 	})
 })

--- a/projects/gloo/pkg/translator/names_test.go
+++ b/projects/gloo/pkg/translator/names_test.go
@@ -1,0 +1,131 @@
+package translator
+
+import (
+	v3 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/core/v3"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+)
+
+var _ = Describe("matcherID", func() {
+	When("matchers are identical", func() {
+		matcher1 := &v1.Matcher{
+			SourcePrefixRanges: []*v3.CidrRange{
+				{
+					AddressPrefix: "foo",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 123,
+					},
+				},
+				{
+					AddressPrefix: "bar",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 456,
+					},
+				},
+			},
+			SslConfig: &v1.SslConfig{
+				SniDomains: []string{"abc", "def"},
+			},
+		}
+		matcher2 := &v1.Matcher{
+			SourcePrefixRanges: []*v3.CidrRange{
+				{
+					AddressPrefix: "foo",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 123,
+					},
+				},
+				{
+					AddressPrefix: "bar",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 456,
+					},
+				},
+			},
+			SslConfig: &v1.SslConfig{
+				SniDomains: []string{"abc", "def"},
+			},
+		}
+		It("produces the same ID", func() {
+			Expect(matcherID(matcher1)).To(Equal(matcherID(matcher2)))
+		})
+	})
+	When("matchers are equivalent", func() {
+		matcher1 := &v1.Matcher{
+			SourcePrefixRanges: []*v3.CidrRange{
+				{
+					AddressPrefix: "bar",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 456,
+					},
+				},
+				{
+					AddressPrefix: "foo",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 123,
+					},
+				},
+			},
+			SslConfig: &v1.SslConfig{
+				SniDomains: []string{"def","abc"},
+			},
+		}
+		matcher2 := &v1.Matcher{
+			SourcePrefixRanges: []*v3.CidrRange{
+				{
+					AddressPrefix: "foo",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 123,
+					},
+				},
+				{
+					AddressPrefix: "bar",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 456,
+					},
+				},
+			},
+			SslConfig: &v1.SslConfig{
+				SniDomains: []string{"abc", "def"},
+			},
+		}
+		It("produces the same ID", func() {
+			Expect(matcherID(matcher1)).To(Equal(matcherID(matcher2)))
+		})
+	})
+	When("matchers are different", func() {
+		matcher1 := &v1.Matcher{
+			SourcePrefixRanges: []*v3.CidrRange{
+				{
+					AddressPrefix: "foo",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 123,
+					},
+				},
+			},
+			SslConfig: &v1.SslConfig{
+				SniDomains: []string{"abc"},
+			},
+		}
+		matcher2 := &v1.Matcher{
+			SourcePrefixRanges: []*v3.CidrRange{
+				{
+					AddressPrefix: "foo",
+					PrefixLen: &wrappers.UInt32Value{
+						Value: 123,
+					},
+				},
+			},
+			SslConfig: &v1.SslConfig{
+				SniDomains: []string{"def"},
+			},
+		}
+		It("produces different IDs", func() {
+			Expect(matcherID(matcher1)).NotTo(Equal(matcherID(matcher2)))
+		})
+	})
+})

--- a/projects/gloo/pkg/translator/names_test.go
+++ b/projects/gloo/pkg/translator/names_test.go
@@ -33,7 +33,7 @@ var _ = Describe("matcherID", func() {
 			},
 		}
 		It("produces a deterministic unique ID", func() {
-			Expect(matcherID(matcher)).To(Equal("3107de82d662fb9a452ba47fa401f1c8"))
+			Expect(matcherID(matcher)).To(Equal("d91ebade3dc8b77d"))
 		})
 	})
 	When("matchers are identical", func() {


### PR DESCRIPTION
Add a function to return a constant sized unique identifier for matchers instead of the `.String()` function

Unclear, though seemingly unlikely, that we require the standardization of equivalent matchers, but it's unlikely to be harmful either