### PR TITLE
Glooctl check eventually healthy gives more descriptive error

### DIFF
--- a/test/kube2e/gloo-mtls/gloo_mtls_suite_test.go
+++ b/test/kube2e/gloo-mtls/gloo_mtls_suite_test.go
@@ -3,6 +3,7 @@ package gloo_mtls_test
 import (
 	"context"
 	"fmt"
+	"github.com/solo-io/gloo/test/kube2e"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -14,16 +15,12 @@ import (
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
-	errors "github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/pkg/cliutil"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/check"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/testutils"
 	"github.com/solo-io/go-utils/testutils/exec"
 	"github.com/solo-io/k8s-utils/testutils/helper"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/solo-kit/pkg/utils/statusutils"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
@@ -73,21 +70,7 @@ var _ = BeforeSuite(func() {
 
 	err = testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", values, "-v"))
 	Expect(err).NotTo(HaveOccurred())
-	Eventually(func() error {
-		opts := &options.Options{
-			Top: options.Top{
-				Ctx: context.Background(),
-			},
-			Metadata: core.Metadata{
-				Namespace: testHelper.InstallNamespace,
-			},
-		}
-		err := check.CheckResources(opts)
-		if err != nil {
-			return errors.Wrapf(err, "glooctl check detected a problem with the installation")
-		}
-		return nil
-	}, 2*time.Minute, "5s").Should(BeNil())
+	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "2m")
 
 	// Print out the versions of CLI and server components
 	glooctlVersionCommand := []string{

--- a/test/kube2e/gloo-mtls/gloo_mtls_suite_test.go
+++ b/test/kube2e/gloo-mtls/gloo_mtls_suite_test.go
@@ -3,12 +3,13 @@ package gloo_mtls_test
 import (
 	"context"
 	"fmt"
-	"github.com/solo-io/gloo/test/kube2e"
 	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/solo-io/gloo/test/kube2e"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -46,7 +46,7 @@ func GlooctlCheckEventuallyHealthy(offset int, testHelper *helper.SoloTestHelper
 		}
 		err := check.CheckResources(opts)
 		if err != nil {
-			return errors.New("glooctl check detected a problem with the installation")
+			return errors.Wrap(err, "glooctl check detected a problem with the installation")
 		}
 		return nil
 	}, timeoutInterval, "5s").Should(BeNil())


### PR DESCRIPTION
If the `glooctl check` fails in our e2e tests, we don't know why. This will provide a more descriptive error with the glooctl check error message.