### PR TITLE
(Backport 1.10.x) - Add GLOO_LICENSE_KEY env var to gloo and discovery pods.

### DIFF
--- a/changelog/v1.10.0-rc5/add-license-env-var.yaml
+++ b/changelog/v1.10.0-rc5/add-license-env-var.yaml
@@ -3,6 +3,5 @@ changelog:
   description: Allows for GLOO_LICENSE_KEY env var to be automatically populated from generated license secret in the gloo and discovery pods.
 - type: NON_USER_FACING
   issueLink: https://github.com/solo-io/gloo/issues/5751
-  resolvesIssue: false
   description: |
     `license_secret_name` should now be under `gloo.license_secret_name` in the helm `values.yaml` file if it is used.

--- a/changelog/v1.11.0-beta3/add-license-env-var.yaml
+++ b/changelog/v1.11.0-beta3/add-license-env-var.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: NON_USER_FACING
+  description: Allows for GLOO_LICENSE_KEY env var to be automatically populated from generated license secret in the gloo and discovery pods.
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/5751
+  resolvesIssue: false
+  description: |
+    `license_secret_name` should now be under `gloo.license_secret_name` in the helm `values.yaml` file if it is used.

--- a/docs/content/operations/upgrading/1.10.0.md
+++ b/docs/content/operations/upgrading/1.10.0.md
@@ -1,0 +1,73 @@
+---
+title: 1.10.0+ Upgrade Notice
+weight: 40
+description: Migrating to Gloo Edge 1.10.x and Gloo Edge Enterprise 1.10.x
+---
+
+Follow these steps to upgrade your Gloo Edge or Gloo Edge Enterprise deployments to version 1.10 from previous verisions. 
+
+This upgrade guide assumes that you installed Gloo Edge with Helm or `glooctl`. You can verify this installation by checking for a Helm chart release named `gloo` in the output of `helm ls --all-namespaces`.
+
+For steps to avoid downtime during upgrades, check out the [Recommended settings]({{< versioned_link_path fromRoot="/operations/upgrading/upgrade_steps#upgrading-the-server-components" >}}).
+
+## Helm Breaking Changes
+- Prior to Gloo Edge Enterprise version v1.10, `license_secret_name` could be specified at the top level of your helm
+`values.yaml` file. However, in order to use this option now, this must be specified under `gloo.license_secret_name`.
+```yaml
+--- values.yaml ---
+license_secret_name: some-license-secret
+
+# the above becomes
+--- new-values.yaml ---
+gloo:
+  license_secret_name: some-license-secret
+```
+
+## Upgrade Gloo Edge
+
+Upgrade Gloo Edge.
+
+{{< tabs >}}
+{{% tab name="Gloo Edge - Helm 3" codelang="shell" %}}
+helm repo update
+helm upgrade -n gloo-system gloo gloo/gloo --version=1.10.0
+{{% /tab %}}
+{{% tab name="Gloo Edge Enterprise - Helm 3" codelang="shell"%}}
+helm repo update
+helm upgrade -n gloo-system gloo glooe/gloo-ee --version=1.10.0
+{{% /tab %}}
+{{< /tabs >}}
+
+
+## Verify upgrade
+To verify that your upgrade was successful, let's first check the version:
+
+```shell script
+glooctl version
+```
+
+You should see the expected version for all the server components.
+
+Let's also check that your Gloo Edge installation is healthy by running:
+
+```shell script
+glooctl check
+```
+
+If everything went well, you should see the following output:
+
+```shell script
+Checking deployments... OK
+Checking pods... OK
+Checking upstreams... OK
+Checking upstream groups... OK
+Checking auth configs... OK
+Checking rate limit configs... OK
+Checking VirtualHostOptions... OK
+Checking RouteOptions... OK
+Checking secrets... OK
+Checking virtual services... OK
+Checking gateways... OK
+Checking proxies... OK
+No problems detected.
+```

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -167,6 +167,13 @@ spec:
           mountPath: /etc/gloo
           readOnly: true
         env:
+{{- if .Values.license_secret_name }}
+          - name: GLOO_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.license_secret_name }}
+                key: license-key
+{{- end }}
 {{- if .Values.gloo.deployment.customEnv }}
 {{ toYaml .Values.gloo.deployment.customEnv | indent 10 }}
 {{- end }}

--- a/install/helm/gloo/templates/3-discovery-deployment.yaml
+++ b/install/helm/gloo/templates/3-discovery-deployment.yaml
@@ -67,6 +67,13 @@ spec:
             drop:
             - ALL
         env:
+{{- if .Values.license_secret_name }}
+          - name: GLOO_LICENSE_KEY
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.license_secret_name }}
+                key: license-key
+{{- end }}
 {{- if .Values.discovery.deployment.customEnv }}
 {{ toYaml .Values.discovery.deployment.customEnv | indent 10 }}
 {{- end }}


### PR DESCRIPTION

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5751