### PR TITLE
Discovered Upstream Annotation Config Casing Clarification

### DIFF
--- a/changelog/v1.11.0-beta3/upstream-template-config-casing.yaml
+++ b/changelog/v1.11.0-beta3/upstream-template-config-casing.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/3717
+    resolvesIssue: false
+    description: >-
+      Adds testing and documentation updates to clarify casing conventions used when customizing discovered upstreams via annotations.

--- a/docs/content/guides/traffic_management/destination_types/discovered_upstream/discovered-upstream-configuration.md
+++ b/docs/content/guides/traffic_management/destination_types/discovered_upstream/discovered-upstream-configuration.md
@@ -14,7 +14,7 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    gloo.solo.io/upstream_config: '{"initial_stream_window_size": 2048}'
+    gloo.solo.io/upstream_config: '{"initialStreamWindowSize": 2048}'
   name: petstore
   namespace: default
   labels:
@@ -69,9 +69,9 @@ apiVersion: gloo.solo.io/v1
 kind: Upstream
 metadata:
   annotations:
-    gloo.solo.io/upstream_config: '{"initial_stream_window_size": 2048}'
+    gloo.solo.io/upstream_config: '{"initialStreamWindowSize": 2048}'
     kubectl.kubernetes.io/last-applied-configuration: |
-      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{"gloo.solo.io/upstream_config":" {\"initial_stream_window_size\": 2048}"},"labels":{"service":"petstore"},"name":"petstore","namespace":"default"},"spec":{"ports":[{"port":8080,"protocol":"TCP"}],"selector":{"app":"petstore"}}}
+      {"apiVersion":"v1","kind":"Service","metadata":{"annotations":{"gloo.solo.io/upstream_config":" {\"initialStreamWindowSize\": 2048}"},"labels":{"service":"petstore"},"name":"petstore","namespace":"default"},"spec":{"ports":[{"port":8080,"protocol":"TCP"}],"selector":{"app":"petstore"}}}
   creationTimestamp: "2021-10-14T13:22:12Z"
   generation: 2
   labels:


### PR DESCRIPTION
# Description

https://github.com/solo-io/gloo/pull/5452 introduced the ability to configure discovered upstreams via annotations on the service corresponding to the discovered upstream. Since the introduction of this feature, there have been some questions about the form that this configuration should take.

 - The documentation introduced around this feature suggests that users use `snake_case` field names to configure discovered upstreams, i.e.:
   - `gloo.solo.io/upstream_config: '{"initial_stream_window_size": 2048}'`
 - This is not ideal UX, as our documentation provides these values in `camelCase`
 - `camelCase` configuration is also valid -- this PR proposes that we center this configuration format in our documentation.
   - e.g.: `gloo.solo.io/upstream_config: '{"initialStreamWindowSize": 2048}'`

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
