### PR TITLE
Update docker-compose.yaml to reflect v1.10 config change

### DIFF
--- a/changelog/v1.11.0-beta4/prepare-directories.sh.yaml
+++ b/changelog/v1.11.0-beta4/prepare-directories.sh.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5777
+    description: Fix prepare-directories.sh for docker-compose use

--- a/docs/content/installation/gateway/development/docker-compose-file/_index.md
+++ b/docs/content/installation/gateway/development/docker-compose-file/_index.md
@@ -102,6 +102,8 @@ The updated `data` directory structure should look like this:
 │   ├── gateways
 │   │   └── gloo-system
 │   │       └── gateway-proxy.yaml
+│   ├── graphqlschemas
+│   │   └── gloo-system
 │   ├── proxies
 │   │   └── gloo-system
 │   ├── ratelimitconfigs

--- a/install/docker-compose-consul/docker-compose.yaml
+++ b/install/docker-compose-consul/docker-compose.yaml
@@ -6,7 +6,7 @@ services:
   # note: this consul instance is being run in dev mode
   # and should not be used in production
   consul:
-    image: "consul:${CONSUL_VERSION:-1.9.0}"
+    image: "consul:${CONSUL_VERSION:-1.10.0}"
     working_dir: /
     command:
       - "agent"
@@ -38,13 +38,13 @@ services:
   # example application, the swagger petstore
   petstore:
     image: ${PETSTORE_REPO:-quay.io/solo-io}/petstore:v1
-    ports: 
+    ports:
     - "8090:8080"
     restart: always
 
   # Gloo components
   gloo:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.9.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.10.0}
     working_dir: /
     command:
     - "--dir=/data/"
@@ -55,7 +55,7 @@ services:
     restart: always
 
   discovery:
-    image: ${GLOO_REPO:-quay.io/solo-io}/discovery:${GLOO_VERSION:-1.9.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/discovery:${GLOO_VERSION:-1.10.0}
     working_dir: /
     command:
     - "--dir=/data/"
@@ -64,7 +64,7 @@ services:
     restart: always
 
   gateway:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.9.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.10.0}
     working_dir: /
     command:
     - "--dir=/data/"
@@ -73,7 +73,7 @@ services:
     restart: always
 
   gateway-proxy:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.9.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.10.0}
     entrypoint: ["envoy"]
     command: ["-c", "/config/envoy.yaml", "--disable-hot-restart"]
     volumes:

--- a/install/docker-compose-file/docker-compose.yaml
+++ b/install/docker-compose-file/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   gloo:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.9.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.10.0}
     working_dir: /
     command:
     - "--dir=/data/"
@@ -14,7 +14,7 @@ services:
     restart: always
 
   gateway:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.9.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.10.0}
     working_dir: /
     command:
     - "--dir=/data/"
@@ -23,7 +23,7 @@ services:
     restart: always
 
   gateway-proxy:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.9.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.10.0}
     entrypoint: ["envoy"]
     command: ["-c", "/config/envoy.yaml", "--disable-hot-restart"]
     volumes:

--- a/install/docker-compose-file/prepare-directories.sh
+++ b/install/docker-compose-file/prepare-directories.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 mkdir -p ./data/artifact/artifacts/gloo-system
-mkdir -p ./data/config/{authconfigs,gateways,proxies,upstreams,upstreamgroups,ratelimitconfigs,routeoptions,routetables,virtualhostoptions,virtualservices}/gloo-system
+mkdir -p ./data/config/{authconfigs,gateways,graphqlschemas,proxies,ratelimitconfigs,routeoptions,routetables,upstreamgroups,upstreams,virtualhostoptions,virtualservices}/gloo-system
 mkdir -p ./data/secret/secrets/{default,gloo-system}


### PR DESCRIPTION
# Description

Address #5777

# Context

Running 1.10.0 is throwing `fatal` errors due to a missing folder

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5777