### PR TITLE
Resolve HybridListener marshal panic

### DIFF
--- a/changelog/v1.11.0-beta4/hybrid-gateway-panic.yaml
+++ b/changelog/v1.11.0-beta4/hybrid-gateway-panic.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5785
+    resolvesIssue: false
+    description: |
+      When a Gateway with a HybridListener defined contained invalid Ssl configuration,
+      a panic would occur while generating the FilterChain, preventing other updates
+      from being processed by the control plane.
+
+

--- a/docs/content/operations/upgrading/1.10.0.md
+++ b/docs/content/operations/upgrading/1.10.0.md
@@ -10,6 +10,58 @@ This upgrade guide assumes that you installed Gloo Edge with Helm or `glooctl`. 
 
 For steps to avoid downtime during upgrades, check out the [Recommended settings]({{< versioned_link_path fromRoot="/operations/upgrading/upgrade_steps#upgrading-the-server-components" >}}).
 
+##### New GraphqlSchema CRD
+
+Gloo Edge v1.10.0 introduces {{< protobuf name="graphql.gloo.solo.io.GraphQlSchema" display="The GraphQLSchema CRD">}}. This CRD is automatically applied to your cluster when performing a `helm install` operation.
+However, the CRD is not be applied when performing an `helm upgrade` operation. This is a [deliberate design choice](https://helm.sh/docs/topics/charts/#limitations-on-crds) on the part of the
+Helm maintainers, given the risk associated with changing CRDs. Given this limitation, you need to apply the new CRD to the cluster before upgrading.
+
+## Installing the new GraphqlSchema CRD
+You can add the new CRD to your cluster in two ways. The first is to supply a URL that points to the CRD template in the public
+[Gloo Edge GitHub repository](https://github.com/solo-io/gloo).
+
+{{< tabs >}}
+{{% tab name="Gloo Edge - Helm 3" %}}
+```shell script
+kubectl apply -f https://raw.githubusercontent.com/solo-io/gloo/v1.10.0/install/helm/gloo/crds/graphql_schema.yaml
+helm repo update
+helm upgrade -n gloo-system gloo gloo/gloo --version=1.10.0
+```
+{{% /tab %}}
+{{% tab name="Gloo Edge Enterprise - Helm 3" %}}
+```shell script
+kubectl apply -f https://raw.githubusercontent.com/solo-io/gloo/v1.10.0/install/helm/gloo/crds/graphql_schema.yaml
+helm repo update
+helm upgrade -n gloo-system glooe gloo/gloo-ee --version=1.10.0
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+The second option involves using the template that is shipped in the Gloo Edge and Gloo Edge enterprise charts.
+
+{{< tabs >}}
+{{% tab name="Gloo Edge - Helm 3" %}}
+```shell script
+helm repo update
+helm pull gloo/gloo --version 1.10.0 --untar
+kubectl apply -f gloo/crds/graphql_schema.yaml
+```
+{{% /tab %}}
+{{% tab name="Gloo Edge Enterprise - Helm 3" %}}
+```shell script
+helm repo update
+helm pull glooe/gloo-ee --version 1.10.0 --untar
+kubectl apply -f gloo-ee/charts/gloo/crds/graphql_schema.yaml
+```
+{{% /tab %}}
+{{< /tabs >}}
+
+You can verify that the new CRD has been successfully applied by running the following command:
+
+```shell script
+kubectl get crds graphqlschemas.graphql.gloo.solo.io
+```
+
 ## Helm Breaking Changes
 - Prior to Gloo Edge Enterprise version v1.10, `license_secret_name` could be specified at the top level of your helm
 `values.yaml` file. However, in order to use this option now, this must be specified under `gloo.license_secret_name`.

--- a/projects/gloo/pkg/plugins/plugin_interface.go
+++ b/projects/gloo/pkg/plugins/plugin_interface.go
@@ -287,4 +287,11 @@ type PluginRegistry interface {
 	GetTcpFilterChainPlugins() []TcpFilterChainPlugin
 	GetHttpFilterPlugins() []HttpFilterPlugin
 	GetHttpConnectionManagerPlugins() []HttpConnectionManagerPlugin
+	GetVirtualHostPlugins() []VirtualHostPlugin
+	GetResourceGeneratorPlugins() []ResourceGeneratorPlugin
+	GetUpstreamPlugins() []UpstreamPlugin
+	GetEndpointPlugins() []EndpointPlugin
+	GetRoutePlugins() []RoutePlugin
+	GetRouteActionPlugins() []RouteActionPlugin
+	GetWeightedDestinationPlugins() []WeightedDestinationPlugin
 }

--- a/projects/gloo/pkg/plugins/plugin_interface.go
+++ b/projects/gloo/pkg/plugins/plugin_interface.go
@@ -278,9 +278,6 @@ type ResourceGeneratorPlugin interface {
 // Historically, all plugins were passed around as an argument, and each translator
 // would iterate over all plugins, and only apply the relevant ones.
 // This interface enables translators to only know of the relevant plugins
-// NOTE:
-// 	This is not complete. As translators are modified, we can gradually expose
-//	more methods on a PluginRegistry
 type PluginRegistry interface {
 	GetPlugins() []Plugin
 	GetListenerPlugins() []ListenerPlugin

--- a/projects/gloo/pkg/plugins/registry/registry.go
+++ b/projects/gloo/pkg/plugins/registry/registry.go
@@ -115,6 +115,13 @@ type pluginRegistry struct {
 	tcpFilterChainPlugins        []plugins.TcpFilterChainPlugin
 	httpFilterPlugins            []plugins.HttpFilterPlugin
 	httpConnectionManagerPlugins []plugins.HttpConnectionManagerPlugin
+	virtualHostPlugins           []plugins.VirtualHostPlugin
+	resourceGeneratorPlugins     []plugins.ResourceGeneratorPlugin
+	upstreamPlugins              []plugins.UpstreamPlugin
+	endpointPlugins              []plugins.EndpointPlugin
+	routePlugins                 []plugins.RoutePlugin
+	routeActionPlugins           []plugins.RouteActionPlugin
+	weightedDestinationPlugins   []plugins.WeightedDestinationPlugin
 }
 
 func NewPluginRegistry(registeredPlugins []plugins.Plugin) *pluginRegistry {
@@ -122,6 +129,13 @@ func NewPluginRegistry(registeredPlugins []plugins.Plugin) *pluginRegistry {
 	var tcpFilterChainPlugins []plugins.TcpFilterChainPlugin
 	var httpFilterPlugins []plugins.HttpFilterPlugin
 	var httpConnectionManagerPlugins []plugins.HttpConnectionManagerPlugin
+	var virtualHostPlugins []plugins.VirtualHostPlugin
+	var resourceGeneratorPlugins []plugins.ResourceGeneratorPlugin
+	var upstreamPlugins []plugins.UpstreamPlugin
+	var endpointPlugins []plugins.EndpointPlugin
+	var routePlugins []plugins.RoutePlugin
+	var routeActionPlugins []plugins.RouteActionPlugin
+	var weightedDestinationPlugins []plugins.WeightedDestinationPlugin
 
 	// Process registered plugins once
 	for _, plugin := range registeredPlugins {
@@ -144,6 +158,41 @@ func NewPluginRegistry(registeredPlugins []plugins.Plugin) *pluginRegistry {
 		if ok {
 			httpConnectionManagerPlugins = append(httpConnectionManagerPlugins, httpConnectionManagerPlugin)
 		}
+
+		virtualHostPlugin, ok := plugin.(plugins.VirtualHostPlugin)
+		if ok {
+			virtualHostPlugins = append(virtualHostPlugins, virtualHostPlugin)
+		}
+
+		resourceGeneratorPlugin, ok := plugin.(plugins.ResourceGeneratorPlugin)
+		if ok {
+			resourceGeneratorPlugins = append(resourceGeneratorPlugins, resourceGeneratorPlugin)
+		}
+
+		upstreamPlugin, ok := plugin.(plugins.UpstreamPlugin)
+		if ok {
+			upstreamPlugins = append(upstreamPlugins, upstreamPlugin)
+		}
+
+		endpointPlugin, ok := plugin.(plugins.EndpointPlugin)
+		if ok {
+			endpointPlugins = append(endpointPlugins, endpointPlugin)
+		}
+
+		routePlugin, ok := plugin.(plugins.RoutePlugin)
+		if ok {
+			routePlugins = append(routePlugins, routePlugin)
+		}
+
+		routeActionPlugin, ok := plugin.(plugins.RouteActionPlugin)
+		if ok {
+			routeActionPlugins = append(routeActionPlugins, routeActionPlugin)
+		}
+
+		weightedDestinationPlugin, ok := plugin.(plugins.WeightedDestinationPlugin)
+		if ok {
+			weightedDestinationPlugins = append(weightedDestinationPlugins, weightedDestinationPlugin)
+		}
 	}
 
 	return &pluginRegistry{
@@ -152,6 +201,12 @@ func NewPluginRegistry(registeredPlugins []plugins.Plugin) *pluginRegistry {
 		tcpFilterChainPlugins:        tcpFilterChainPlugins,
 		httpFilterPlugins:            httpFilterPlugins,
 		httpConnectionManagerPlugins: httpConnectionManagerPlugins,
+		resourceGeneratorPlugins:     resourceGeneratorPlugins,
+		upstreamPlugins:              upstreamPlugins,
+		endpointPlugins:              endpointPlugins,
+		routePlugins:                 routePlugins,
+		routeActionPlugins:           routeActionPlugins,
+		weightedDestinationPlugins:   weightedDestinationPlugins,
 	}
 }
 
@@ -173,4 +228,32 @@ func (p *pluginRegistry) GetHttpFilterPlugins() []plugins.HttpFilterPlugin {
 
 func (p *pluginRegistry) GetHttpConnectionManagerPlugins() []plugins.HttpConnectionManagerPlugin {
 	return p.httpConnectionManagerPlugins
+}
+
+func (p *pluginRegistry) GetVirtualHostPlugins() []plugins.VirtualHostPlugin {
+	return p.virtualHostPlugins
+}
+
+func (p *pluginRegistry) GetResourceGeneratorPlugins() []plugins.ResourceGeneratorPlugin {
+	return p.resourceGeneratorPlugins
+}
+
+func (p *pluginRegistry) GetUpstreamPlugins() []plugins.UpstreamPlugin {
+	return p.upstreamPlugins
+}
+
+func (p *pluginRegistry) GetEndpointPlugins() []plugins.EndpointPlugin {
+	return p.endpointPlugins
+}
+
+func (p *pluginRegistry) GetRoutePlugins() []plugins.RoutePlugin {
+	return p.routePlugins
+}
+
+func (p *pluginRegistry) GetRouteActionPlugins() []plugins.RouteActionPlugin {
+	return p.routeActionPlugins
+}
+
+func (p *pluginRegistry) GetWeightedDestinationPlugins() []plugins.WeightedDestinationPlugin {
+	return p.weightedDestinationPlugins
 }

--- a/projects/gloo/pkg/plugins/registry/registry.go
+++ b/projects/gloo/pkg/plugins/registry/registry.go
@@ -201,6 +201,7 @@ func NewPluginRegistry(registeredPlugins []plugins.Plugin) *pluginRegistry {
 		tcpFilterChainPlugins:        tcpFilterChainPlugins,
 		httpFilterPlugins:            httpFilterPlugins,
 		httpConnectionManagerPlugins: httpConnectionManagerPlugins,
+		virtualHostPlugins:           virtualHostPlugins,
 		resourceGeneratorPlugins:     resourceGeneratorPlugins,
 		upstreamPlugins:              upstreamPlugins,
 		endpointPlugins:              endpointPlugins,

--- a/projects/gloo/pkg/translator/endpoints.go
+++ b/projects/gloo/pkg/translator/endpoints.go
@@ -31,12 +31,8 @@ func (t *translatorInstance) computeClusterEndpoints(
 		// if there are any endpoints for this upstream, it's using eds and we need to create a load assignment for it
 		if len(clusterEndpoints) > 0 {
 			loadAssignment := loadAssignmentForUpstream(upstream, clusterEndpoints)
-			for _, plug := range t.pluginRegistry.GetPlugins() {
-				upstreamPlug, ok := plug.(plugins.EndpointPlugin)
-				if !ok {
-					continue
-				}
-				if err := upstreamPlug.ProcessEndpoints(params, upstream, loadAssignment); err != nil {
+			for _, plugin := range t.pluginRegistry.GetEndpointPlugins() {
+				if err := plugin.ProcessEndpoints(params, upstream, loadAssignment); err != nil {
 					reports.AddError(upstream, err)
 				}
 			}

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -2251,7 +2251,9 @@ var _ = Describe("Translator", func() {
 			Expect(listener.GetListenerFilters()[0].GetName()).To(Equal(wellknown.TlsInspector))
 		})
 	})
+
 	Context("Hybrid", func() {
+
 		It("can properly create a hybrid listener", func() {
 			translate()
 			listeners := snapshot.GetResources(resource.ListenerTypeV3).Items
@@ -2288,6 +2290,9 @@ var _ = Describe("Translator", func() {
 			Expect(hcmTypedCfg.GetRds().RouteConfigName).To(Equal(glooutils.MatchedRouteConfigName(proxy.GetListeners()[2], proxy.GetListeners()[2].GetHybridListener().GetMatchedListeners()[1].GetMatcher())))
 			Expect(hcmTypedCfg.GetHttpFilters()).To(HaveLen(6)) // TODO: is this the right number? is there more we can/should do to ensure correctness?
 		})
+
+		It("skips listeners with invalid downstream ssl config", func() {})
+
 	})
 
 	Context("Ssl - cluster", func() {


### PR DESCRIPTION
# Description

Ensure that invalid configuration defined on a HybridListener does not cause the translation loop to panic

# Context

## How did we notice this?
Our CI pipeline failed: https://storage.googleapis.com/solo-public-build-logs/logs.html?buildid=2ae522e9-cca1-4d87-9257-36deb08a1258

## What is the bug?
During the generation of the FilterChain, we convert a user defined SslConfig, into the definition for a FilterChainMatch. If the SslConfig is invalid (for example, an invalid secret reference) we should catch the error, write it to a report, skip the config and continue processing.

We do this for HttpListeners: https://github.com/solo-io/gloo/blob/fccf272cb170ba4f1531013bacaa915d98e2e99d/projects/gloo/pkg/translator/filter_chain.go#L99

However, we did not do this for HybridListeners: https://github.com/solo-io/gloo/blob/fccf272cb170ba4f1531013bacaa915d98e2e99d/projects/gloo/pkg/translator/filter_chain.go#L265. Instead we were processing the error, writing it to a report and then processing that config. It would then panic when trying to marshal a nil value: https://github.com/solo-io/gloo/blob/fccf272cb170ba4f1531013bacaa915d98e2e99d/projects/gloo/pkg/translator/filter_chain.go#L274

## What is the fix?
We identify the invalid config, and do not create a FilterChain if the config is invalid. This mirrors the behavior of our HttpListener.

## PluginRegistry Changes
In earlier PRs, we introduce the concept of a PluginRegistry, as a way to process plugins ahead of time, and provide specific types to translators. Previously each translator would have to process all plugins and decide for itself which implemented the required interface. In this PR, we extend the usage of the registry to other translators that were still iterating over all plugins.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
