### PR TITLE
prefix enum field with Gzip

### DIFF
--- a/projects/gloo/api/external/envoy/config/filter/http/gzip/v2/gzip.proto
+++ b/projects/gloo/api/external/envoy/config/filter/http/gzip/v2/gzip.proto
@@ -51,7 +51,7 @@ message Gzip {
     // higher latency, "SPEED" provides lower compression with minimum impact on response time.
     // "DEFAULT" provides an optimal result between speed and compression. This field will be set to
     // "DEFAULT" if not specified.
-    CompressionLevel.Enum compression_level = 3 [(validate.rules).enum = {defined_only: true}];
+    Gzip.CompressionLevel.Enum compression_level = 3 [(validate.rules).enum = {defined_only: true}];
 
     // A value used for selecting the zlib compression strategy which is directly related to the
     // characteristics of the content. Most of the time "DEFAULT" will be the best choice, though


### PR DESCRIPTION
# Description

Cue has issues parsing the `CompressionLevel.Enum` field in gzip.proto. Prefixing with the parent message name i.e. `Gzip.CompressionLevel.Enum` makes cue happy.

# Context

Needed in a dependent project to generate validation schemas using skv2.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
