### PR TITLE
feat(docs): split vulnerabillity scans to render in smaller chunks

### DIFF
--- a/changelog/v1.8.25/hotfix-docs-gen.yaml
+++ b/changelog/v1.8.25/hotfix-docs-gen.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Vulnerability detection docs are now rendered on a per-subversion basis

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,9 @@ HUGO_VERSION := 0.69.2
 
 SOLO_HUGO_THEME_REVISION := 41587dc9dc719bd22cedd9803994f756e25f571f
 
+SECURITY_SCAN_MIN_VERSION ?= v1.7.0
+
+
 #----------------------------------------------------------------------------------
 # Docs
 #----------------------------------------------------------------------------------
@@ -20,14 +23,19 @@ SOLO_HUGO_THEME_REVISION := 41587dc9dc719bd22cedd9803994f756e25f571f
 site-common: clean gloo-enterprise-version
 	if [ ! -d themes/hugo-theme-soloio ]; then git clone https://github.com/solo-io/hugo-theme-soloio themes/hugo-theme-soloio; fi
 	git -C themes/hugo-theme-soloio checkout $(SOLO_HUGO_THEME_REVISION)
-	GO111MODULE=on go run cmd/generate_docs.go gen-releases gloo > opensource.out
-	GO111MODULE=on go run cmd/generate_docs.go gen-releases glooe > enterprise.out
-	GO111MODULE=on go run cmd/generate_docs.go gen-changelog-md gloo > content/static/content/gloo-changelog.docgen
-	GO111MODULE=on go run cmd/generate_docs.go gen-changelog-md glooe > content/static/content/glooe-changelog.docgen
-	GO111MODULE=on go run cmd/generate_docs.go gen-security-scan-md gloo > content/static/content/gloo-security-scan.docgen
-	GO111MODULE=on go run cmd/generate_docs.go gen-security-scan-md glooe > content/static/content/glooe-security-scan.docgen
+	GO111MODULE=on go run cmd/generate_docs.go gen-releases -r gloo > opensource.out
+	GO111MODULE=on go run cmd/generate_docs.go gen-releases -r glooe > enterprise.out
+	GO111MODULE=on go run cmd/generate_docs.go gen-changelog-md -r gloo > content/static/content/gloo-changelog.docgen
+	GO111MODULE=on go run cmd/generate_docs.go gen-changelog-md -r glooe > content/static/content/glooe-changelog.docgen
+
+	# generate split security scans for gloo versions which HAVE recieved new split-templating updates
+	MIN_SCANNED_VERSION=$(SECURITY_SCAN_MIN_VERSION) GO111MODULE=on go run cmd/generate_docs.go gen-security-scan-md -r gloo > content/static/content/gloo-security-scan.docgen
+	MIN_SCANNED_VERSION=$(SECURITY_SCAN_MIN_VERSION) GO111MODULE=on go run cmd/generate_docs.go gen-security-scan-md -r glooe > content/static/content/glooe-security-scan.docgen
+	./split-file-by-delimiter.sh content/static/content/gloo-security-scan.docgen \\\*\\\*\\\*
+	./split-file-by-delimiter.sh content/static/content/glooe-security-scan.docgen \\\*\\\*\\\*
 	GO111MODULE=on go run cmd/generate_docs.go get-enterprise-helm-values > content/static/content/glooe-values.docgen
 	rm -f opensource.out enterprise.out
+
 
 .PHONY: site-test
 site-test: site-common

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -123,6 +123,15 @@ function generateSiteForVersion() {
   mkdir $repoDir/docs/content
   cp -a $tempContentDir/$version/. $repoDir/docs/content/
 
+  # Remove the file responsible for the "security scan too large" bug if necessary
+  guilty_path="./content/reference/security-updates"
+  if cat $guilty_path/enterprise/_index.md | grep -q "glooe-security-scan-0"; then
+    echo "$version contains the updated security scan template"
+  else
+    echo "$version does not contain the updated security scan template"
+    rm -rf $guilty_path
+  fi
+
   # Generate the versioned static site.
   make site-release
 

--- a/docs/content/reference/security-updates/enterprise/_index.md
+++ b/docs/content/reference/security-updates/enterprise/_index.md
@@ -6,4 +6,7 @@ description: Security Updates and CVEs
 
 Gloo container images are scanned using [Trivy](https://github.com/aquasecurity/trivy) for HIGH and CRITICAL vulnerabilities.
 
-{{< readfile file="static/content/glooe-security-scan.docgen" markdown="true" >}}
+{{< readfile file="static/content/glooe-security-scan-0.docgen" markdown="true" >}}
+{{< readfile file="static/content/glooe-security-scan-1.docgen" markdown="true" >}}
+{{< readfile file="static/content/glooe-security-scan-2.docgen" markdown="true" >}}
+{{< readfile file="static/content/glooe-security-scan-3.docgen" markdown="true" >}}

--- a/docs/content/reference/security-updates/open_source/_index.md
+++ b/docs/content/reference/security-updates/open_source/_index.md
@@ -6,4 +6,7 @@ description: Security Updates and CVEs
 
 Gloo container images are scanned using [Trivy](https://github.com/aquasecurity/trivy) for HIGH and CRITICAL vulnerabilities.
 
-{{< readfile file="static/content/gloo-security-scan.docgen" markdown="true" >}}
+{{< readfile file="static/content/gloo-security-scan-0.docgen" markdown="true" >}}
+{{< readfile file="static/content/gloo-security-scan-1.docgen" markdown="true" >}}
+{{< readfile file="static/content/gloo-security-scan-2.docgen" markdown="true" >}}
+{{< readfile file="static/content/gloo-security-scan-3.docgen" markdown="true" >}}

--- a/docs/split-file-by-delimiter.sh
+++ b/docs/split-file-by-delimiter.sh
@@ -1,0 +1,31 @@
+# turn off glob expansion, since default use-case is splitting by lines containing "***""
+set -f
+
+# simple parse of input values
+file_in=$1      # in expected use-case, is "content/static/content/gloo-security-scan.docgen"
+delimiter=$2    # in expected use-case, is "***"
+
+# split file_in to useful components
+filename=$(basename -- "$1")
+directory_out=$(dirname $1)
+base_file_name=`echo "$filename" | cut -d'.' -f1`         # won't work if there are multiple extensions (a.b.js)
+file_extension=`echo "$filename" | cut -d'.' -f2`         # won't work if there are multiple extensions (a.b.js)
+
+# do the actual by-line splitting
+echo "splitting $1 by $2\n"
+
+i=0
+cur_out="$directory_out/$base_file_name-$i.$file_extension"
+rm -f $cur_out
+cat $file_in | while read line 
+do
+    if echo "$line" | grep -q "$delimiter"; then
+        cur_out="$directory_out/$base_file_name-$i.$file_extension"
+        i=$(($i+1))
+        rm -f $cur_out
+        echo "Generating File: $cur_out"
+    fi
+    echo $line >> $cur_out
+done
+
+echo "\nFinished splitting $file_in into subfiles.  Results are all located in $directory_out."


### PR DESCRIPTION
# Description

When running CI, we've found that our vulnerability reports are too large to process.  This PR splits the reports into smaller sections, as well as renders said sections individually