### PR TITLE
Allow header secrets to be of type Opaque.

### DIFF
--- a/changelog/v1.11.0-beta7/opaque-header-secrets.yaml
+++ b/changelog/v1.11.0-beta7/opaque-header-secrets.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/5323
+  resolvesIssue: false
+  description: |
+    Accept opaque header secrets in addition to `gloo.solo.io/header`.

--- a/projects/gloo/pkg/api/converters/kube/header_secret.go
+++ b/projects/gloo/pkg/api/converters/kube/header_secret.go
@@ -27,7 +27,7 @@ func (t *HeaderSecretConverter) FromKubeSecret(ctx context.Context, _ *kubesecre
 		return nil, nil
 	}
 
-	if secret.Type == HeaderSecretType {
+	if secret.Type == HeaderSecretType || secret.Type == kubev1.SecretTypeOpaque {
 		if len(secret.Data) == 0 {
 			contextutils.LoggerFrom(ctx).Warnw("skipping header secret with no headers",
 				zap.String("name", secret.Name), zap.String("namespace", secret.Namespace))

--- a/projects/gloo/pkg/api/converters/kube/header_secret_test.go
+++ b/projects/gloo/pkg/api/converters/kube/header_secret_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Header Secret Converter", func() {
 				Data: map[string][]byte{
 					"foo": {0, 1, 2},
 				},
-				Type: corev1.SecretTypeOpaque,
+				Type: corev1.SecretTypeTLS,
 			}
 			glooSecret, err := converter.FromKubeSecret(ctx, resourceClient, secret)
 			Expect(err).NotTo(HaveOccurred())
@@ -77,6 +77,22 @@ var _ = Describe("Header Secret Converter", func() {
 					"bat": []byte("baz"),
 				},
 				Type: kubeconverters.HeaderSecretType,
+			}
+			actual, err := converter.FromKubeSecret(ctx, resourceClient, secret)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(actual).To(Equal(glooSecret))
+		})
+
+		It("correctly converts opaque header secrets", func() {
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Data: map[string][]byte{
+					"bat": []byte("baz"),
+				},
+				Type: corev1.SecretTypeOpaque,
 			}
 			actual, err := converter.FromKubeSecret(ctx, resourceClient, secret)
 			Expect(err).NotTo(HaveOccurred())

--- a/projects/gloo/pkg/api/converters/kube/secretconverter.go
+++ b/projects/gloo/pkg/api/converters/kube/secretconverter.go
@@ -21,9 +21,9 @@ const (
 var GlooSecretConverterChain = NewSecretConverterChain(
 	new(TLSSecretConverter),
 	new(AwsSecretConverter),
-	new(HeaderSecretConverter),
 	new(APIKeySecretConverter),
 	new(OAuthSecretConverter),
+	new(HeaderSecretConverter),
 )
 
 type SecretConverterChain struct {


### PR DESCRIPTION
# Description

Allow header secrets to be Opaque.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
