### PR TITLE
backport(fix(gateway)): allow error clearing for gateways without children

### DIFF
--- a/changelog/v1.10.5/5578-orphaned-gateway.yaml
+++ b/changelog/v1.10.5/5578-orphaned-gateway.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5578
+    description: |
+      Gateways are no longer dependant on having an associated VirtualService to receive/clear their own resource statuses.

--- a/changelog/v1.10.5/5578-orphaned-gateway.yaml
+++ b/changelog/v1.10.5/5578-orphaned-gateway.yaml
@@ -3,3 +3,7 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/5578
     description: |
       Gateways are no longer dependant on having an associated VirtualService to receive/clear their own resource statuses.
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5323
+    description: |
+      Accept opaque header secrets in addition to `gloo.solo.io/header`.

--- a/changelog/v1.10.5/opaque-header-secrets.yaml
+++ b/changelog/v1.10.5/opaque-header-secrets.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5323
+    description: |
+      Accept opaque header secrets in addition to `gloo.solo.io/header`.

--- a/changelog/v1.10.5/opaque-header-secrets.yaml
+++ b/changelog/v1.10.5/opaque-header-secrets.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/gloo/issues/5323
-    description: |
-      Accept opaque header secrets in addition to `gloo.solo.io/header`.

--- a/projects/gateway/pkg/reconciler/proxy_reconciler.go
+++ b/projects/gateway/pkg/reconciler/proxy_reconciler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"sort"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	"github.com/solo-io/gloo/projects/gateway/pkg/reporting"
 	"github.com/solo-io/gloo/projects/gateway/pkg/utils"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
@@ -17,6 +19,8 @@ import (
 )
 
 type GeneratedProxies map[*gloov1.Proxy]reporter.ResourceReports
+
+type InvalidProxies map[*core.ResourceRef]reporter.ResourceReports
 
 type ProxyReconciler interface {
 	ReconcileProxies(ctx context.Context, proxiesToWrite GeneratedProxies, writeNamespace string, labels map[string]string) error

--- a/projects/gateway/pkg/syncer/translator_syncer_integration_test.go
+++ b/projects/gateway/pkg/syncer/translator_syncer_integration_test.go
@@ -150,7 +150,8 @@ var _ = Describe("TranslatorSyncer integration test", func() {
 			if subresource == nil {
 				return core.Status_Pending, fmt.Errorf("no status")
 			}
-			proxyState := subresource["*v1.Proxy.gloo-system.gateway-proxy"]
+			proxyState := subresource["*v1.Proxy.gateway-proxy_gloo-system"]
+
 			if proxyState == nil {
 				return core.Status_Pending, fmt.Errorf("no state")
 			}

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -194,6 +194,21 @@ var _ = Describe("Kube2e: gateway", func() {
 		cancel()
 	})
 
+	Context("tests with orphaned gateways", func() {
+		It("correctly sets a status to a single gateway", func() {
+			defaultGateway := defaults.DefaultGateway(testHelper.InstallNamespace)
+			// wait for default gateway to be created
+			Eventually(func() (*gatewayv1.Gateway, error) {
+				return gatewayClient.Read(testHelper.InstallNamespace, defaultGateway.Metadata.Name, clients.ReadOpts{})
+			}, "15s", "0.5s").Should(Not(BeNil()))
+
+			// demand that a created gateway _has_ a status.  This test is "good enough", as, prior to an orphaned gateway fix,
+			// https://github.com/solo-io/gloo/pull/5790, free-floating gateways would never be assigned a status at all (nil)
+			gw, _ := gatewayClient.Read(testHelper.InstallNamespace, defaultGateway.Metadata.Name, clients.ReadOpts{})
+			Expect(gw.NamespacedStatuses.GetStatuses()).NotTo(BeNil())
+		})
+	})
+
 	Context("tests with virtual service", func() {
 
 		AfterEach(func() {


### PR DESCRIPTION
backport of https://github.com/solo-io/gloo/commit/638755e32ee48bf98b7a63290219089689a4d766 to `v1.10.x`.

Beyond the backport, this also transfers the sorting logic implemented in https://github.com/solo-io/gloo/pull/5844/files#diff-120aa64c2663421cad34855e6614b279b92bb76b47816fb9172a4bc1e5a237a1R196-R207

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5578
resolves https://github.com/solo-io/gloo/issues/5323