### PR TITLE
Enable to add 'pre-upgrade' hook to Certgen Job

### DIFF
--- a/changelog/v1.11.0-beta9/certgen-preupgrade.yaml
+++ b/changelog/v1.11.0-beta9/certgen-preupgrade.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/4638
+    description: Add a helm option to support running the certgen job on upgrades and installs

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -307,6 +307,7 @@
 |gateway.certGenJob.resources.limits.cpu|string||amount of CPUs|
 |gateway.certGenJob.resources.requests.memory|string||amount of memory|
 |gateway.certGenJob.resources.requests.cpu|string||amount of CPUs|
+|gateway.certGenJob.runOnUpdate|bool|false|enable to run the job also on pre-upgrade|
 |gateway.updateValues|bool||if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions|
 |gateway.proxyServiceAccount.extraAnnotations.NAME|string||extra annotations to add to the service account|
 |gateway.proxyServiceAccount.disableAutomount|bool||disable automunting the service account to the gateway proxy. not mounting the token hardens the proxy container, but may interfere with service mesh integrations|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -312,6 +312,7 @@ type CertGenJob struct {
 	FloatingUserId          *bool                 `json:"floatingUserId,omitempty" desc:"set to true to allow the cluster to dynamically assign a user ID"`
 	RunAsUser               *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the container to run as. Default is 10101"`
 	Resources               *ResourceRequirements `json:"resources,omitempty"`
+	RunOnUpdate             *bool                 `json:"runOnUpdate,omitempty" desc:"enable to run the job also on pre-upgrade"`
 }
 
 type GatewayProxy struct {

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -4,6 +4,7 @@
 {{- $image = merge .Values.gateway.certGenJob.image .Values.global.image }}
 {{- end }}
 {{- if .Values.global.glooMtls.enabled }}
+{{- $secretExist := lookup "v1" "Secret" .Release.Namespace "gloo-mtls-certs" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -13,7 +14,12 @@ metadata:
   name: gloo-mtls-certgen
   namespace: {{ .Release.Namespace }}
   annotations:
+    annotations:
+    {{- if $secretExist }}
     "helm.sh/hook": pre-install
+    {{- else }}
+    "helm.sh/hook": pre-install, pre-upgrade
+    {{- end }}
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -4,7 +4,6 @@
 {{- $image = merge .Values.gateway.certGenJob.image .Values.global.image }}
 {{- end }}
 {{- if .Values.global.glooMtls.enabled }}
-{{- $secretExist := lookup "v1" "Secret" .Release.Namespace "gloo-mtls-certs" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -14,11 +13,10 @@ metadata:
   name: gloo-mtls-certgen
   namespace: {{ .Release.Namespace }}
   annotations:
-    annotations:
-    {{- if $secretExist }}
-    "helm.sh/hook": pre-install
-    {{- else }}
+    {{- if .Values.gateway.certGenJob.runOnUpdate }}
     "helm.sh/hook": pre-install, pre-upgrade
+    {{- else }}
+    "helm.sh/hook": pre-install
     {{- end }}
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": hook-succeeded

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -89,6 +89,7 @@ gateway:
     setTtlAfterFinished: true
     ttlSecondsAfterFinished: 60
     runAsUser: 10101
+    runOnUpdate: false
   proxyServiceAccount: {}
   serviceAccount: {}
 gatewayProxies:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -406,7 +406,7 @@ var _ = Describe("Helm Test", func() {
 							Secret: &v1.SecretVolumeSource{
 								SecretName:  "gloo-mtls-certs",
 								Items:       nil,
-								DefaultMode: proto.Int(420),
+								DefaultMode: proto.Int32(420),
 							},
 						},
 					}
@@ -531,6 +531,52 @@ var _ = Describe("Helm Test", func() {
 						if structuredConfigMap.GetName() == "gateway-proxy-envoy-config" {
 							expectedPrefixRewrite := "prefix_rewrite: /stats?format=json"
 							Expect(structuredConfigMap.Data["envoy.yaml"]).To(ContainSubstring(expectedPrefixRewrite))
+						}
+					})
+				})
+
+				It("Should have 'pre-install' and 'pre-upgrade' hook if gateway.certGenJob.runOnUpdate is true", func() {
+					prepareMakefile(namespace, helmValues{
+						valuesArgs: []string{"gateway.certGenJob.runOnUpdate=true"},
+					})
+
+					testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+						return resource.GetKind() == "Job"
+					}).ExpectAll(func(job *unstructured.Unstructured) {
+						jobObject, err := kuberesource.ConvertUnstructured(job)
+						Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Job %+v should be able to convert from unstructured", job))
+						structuredDeployment, ok := jobObject.(*jobsv1.Job)
+						Expect(ok).To(BeTrue(), fmt.Sprintf("Job %+v should be able to cast to a structured job", job))
+
+						if structuredDeployment.GetName() == "gloo-mtls-certgen" {
+							for annotation_name, annotation_value := range structuredDeployment.GetAnnotations() {
+								if annotation_name == "helm.sh/hook" {
+									Expect(annotation_value).To(Equal("pre-install, pre-upgrade"))
+								}
+							}
+						}
+					})
+				})
+
+				It("Should have only 'pre-install' hook if gateway.certGenJob.runOnUpdate is false", func() {
+					prepareMakefile(namespace, helmValues{
+						valuesArgs: []string{"gateway.certGenJob.runOnUpdate=false"},
+					})
+
+					testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+						return resource.GetKind() == "Job"
+					}).ExpectAll(func(job *unstructured.Unstructured) {
+						jobObject, err := kuberesource.ConvertUnstructured(job)
+						Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Job %+v should be able to convert from unstructured", job))
+						structuredDeployment, ok := jobObject.(*jobsv1.Job)
+						Expect(ok).To(BeTrue(), fmt.Sprintf("Job %+v should be able to cast to a structured job", job))
+
+						if structuredDeployment.GetName() == "gloo-mtls-certgen" {
+							for annotation_name, annotation_value := range structuredDeployment.GetAnnotations() {
+								if annotation_name == "helm.sh/hook" {
+									Expect(annotation_value).To(Equal("pre-install"))
+								}
+							}
 						}
 					})
 				})

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -537,7 +537,9 @@ var _ = Describe("Helm Test", func() {
 
 				It("Should have 'pre-install' and 'pre-upgrade' hook if gateway.certGenJob.runOnUpdate is true", func() {
 					prepareMakefile(namespace, helmValues{
-						valuesArgs: []string{"gateway.certGenJob.runOnUpdate=true"},
+						valuesArgs: []string{
+							"global.glooMtls.enabled=true",
+							"gateway.certGenJob.runOnUpdate=true"},
 					})
 
 					testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
@@ -560,7 +562,9 @@ var _ = Describe("Helm Test", func() {
 
 				It("Should have only 'pre-install' hook if gateway.certGenJob.runOnUpdate is false", func() {
 					prepareMakefile(namespace, helmValues{
-						valuesArgs: []string{"gateway.certGenJob.runOnUpdate=false"},
+						valuesArgs: []string{
+							"global.glooMtls.enabled=true",
+							"gateway.certGenJob.runOnUpdate=false"},
 					})
 
 					testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3546,7 +3546,7 @@ metadata:
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
 									SecretName:  "gateway-validation-certs",
-									DefaultMode: proto.Int(420),
+									DefaultMode: proto.Int32(420),
 								},
 							},
 						}}


### PR DESCRIPTION
# Description

This new feature can be used to support upgrading Gloo with mTLS enabled if Gloo was initially installed without mTLS.
Relevant open issues:

1. https://github.com/solo-io/gloo/issues/4638
2. https://github.com/solo-io/gloo/issues/5855

# Context

Users needed this feature to so on upgrade the certgen job will run also on pre-upgrade hook if the secret doesn't exist.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4638