### PR TITLE
Fix indentation for custom HTTPS Gateway settings

### DIFF
--- a/changelog/v1.11.0-beta9/fix-helm-indentation-https-gw.yaml
+++ b/changelog/v1.11.0-beta9/fix-helm-indentation-https-gw.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    description: Fix indentation for custom HTTPS Gateway settings
+    issueLink: https://github.com/solo-io/gloo/issues/5874
+    resolvesIssue: true

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -70,7 +70,7 @@ spec:
   bindPort: {{ $spec.podTemplate.httpsPort }}
 {{- if $gatewaySettings.customHttpsGateway }}
   httpGateway:
-{{ toYaml $gatewaySettings.customHttpsGateway | indent 6}}
+{{ toYaml $gatewaySettings.customHttpsGateway | indent 4}}
 {{- else if $spec.tracing }}
 {{- if $spec.tracing.provider }}
   httpGateway:


### PR DESCRIPTION
# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5874