### PR TITLE
add graphql to fed clusterrole

### DIFF
--- a/changelog/v1.11.0-beta11/graphql-fed-cluster-reg.yaml
+++ b/changelog/v1.11.0-beta11/graphql-fed-cluster-reg.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/3006
+    description: Add graphql to the gloo fed clusterrole.

--- a/projects/gloo/cli/pkg/cmd/federation/register/root.go
+++ b/projects/gloo/cli/pkg/cmd/federation/register/root.go
@@ -12,7 +12,7 @@ import (
 var glooFederationPolicyRules = []v1.PolicyRule{
 	{
 		Verbs:     []string{"*"},
-		APIGroups: []string{"gloo.solo.io", "gateway.solo.io", "enterprise.gloo.solo.io", "ratelimit.solo.io"},
+		APIGroups: []string{"gloo.solo.io", "gateway.solo.io", "enterprise.gloo.solo.io", "graphql.gloo.solo.io", "ratelimit.solo.io"},
 		Resources: []string{"*"},
 	},
 	{


### PR DESCRIPTION
# Description

We need this to be able to read/list graphqlschemas when Gloo Fed is enabled.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
