### PR TITLE
Avoid stackdumps in glooctl check (v1.10.x backport)

### DIFF
--- a/changelog/v1.10.8/glooctl-check-fix.yaml
+++ b/changelog/v1.10.8/glooctl-check-fix.yaml
@@ -2,3 +2,4 @@ changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/5061
     description: Prevent glooctl check from producing stackdumps.
+    resolvesIssue: false

--- a/changelog/v1.11.0-beta11/glooctl-check-fix.yaml
+++ b/changelog/v1.11.0-beta11/glooctl-check-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5061
+    description: Prevent glooctl check from producing stackdumps.

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -504,14 +504,14 @@ func MustSecretClient(ctx context.Context) v1.SecretClient {
 }
 
 func MustSecretClientWithOptions(ctx context.Context, timeout time.Duration, namespaces []string) v1.SecretClient {
-	client, err := getSecretClient(ctx, timeout, namespaces)
+	client, err := GetSecretClient(ctx, timeout, namespaces)
 	if err != nil {
 		log.Fatalf("failed to create Secret client: %v", err)
 	}
 	return client
 }
 
-func getSecretClient(ctx context.Context, timeout time.Duration, namespaces []string) (v1.SecretClient, error) {
+func GetSecretClient(ctx context.Context, timeout time.Duration, namespaces []string) (v1.SecretClient, error) {
 	customFactory := getSecretClientFactory()
 	if customFactory != nil {
 		return v1.NewSecretClient(ctx, customFactory)


### PR DESCRIPTION
# Description

Prevent glooctl check from producing stackdumps by removing usages of Must.

# Context

v1.10.x backport of https://github.com/solo-io/gloo/pull/5907

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
