### PR TITLE
Add configuration status metric support for UpstreamGroups (v1.10.x backport)

### DIFF
--- a/changelog/v1.10.9/upstream-group-status-metrics.yaml
+++ b/changelog/v1.10.9/upstream-group-status-metrics.yaml
@@ -1,4 +1,4 @@
 changelog:
-  - type: NEW_FEATURE
+  - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/5935
     description: Add configuration status metric support for UpstreamGroup CRs

--- a/changelog/v1.11.0-beta12/upstream-group-status-metrics.yaml
+++ b/changelog/v1.11.0-beta12/upstream-group-status-metrics.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/5935
+    description: Add configuration status metric support for UpstreamGroup CRs

--- a/projects/gateway/pkg/utils/metrics/metrics.go
+++ b/projects/gateway/pkg/utils/metrics/metrics.go
@@ -21,21 +21,23 @@ import (
 type Labels = gloov1.Settings_ObservabilityOptions_MetricLabels
 
 var Names = map[schema.GroupVersionKind]string{
-	gwv1.GatewayGVK:        "validation.gateway.solo.io/gateway_config_status",
-	gwv1.RouteTableGVK:     "validation.gateway.solo.io/route_table_config_status",
-	gwv1.VirtualServiceGVK: "validation.gateway.solo.io/virtual_service_config_status",
-	gloov1.ProxyGVK:        "validation.gateway.solo.io/proxy_config_status",
-	gloov1.SecretGVK:       "validation.gateway.solo.io/secret_config_status",
-	gloov1.UpstreamGVK:     "validation.gateway.solo.io/upstream_config_status",
+	gwv1.GatewayGVK:         "validation.gateway.solo.io/gateway_config_status",
+	gwv1.RouteTableGVK:      "validation.gateway.solo.io/route_table_config_status",
+	gwv1.VirtualServiceGVK:  "validation.gateway.solo.io/virtual_service_config_status",
+	gloov1.ProxyGVK:         "validation.gateway.solo.io/proxy_config_status",
+	gloov1.SecretGVK:        "validation.gateway.solo.io/secret_config_status",
+	gloov1.UpstreamGVK:      "validation.gateway.solo.io/upstream_config_status",
+	gloov1.UpstreamGroupGVK: "validation.gateway.solo.io/upsteam_group_config_status",
 }
 
 var descriptions = map[schema.GroupVersionKind]string{
-	gwv1.GatewayGVK:        "The health status of gateway resources in the system. A value of 0 indicates that there are no issues.",
-	gwv1.RouteTableGVK:     "The health status of route table resources in the system. A value of 0 indicates that there are no issues.",
-	gwv1.VirtualServiceGVK: "The health status of virtual service resources in the system. A value of 0 indicates that there are no issues.",
-	gloov1.ProxyGVK:        "The health status of proxy resources in the system. A value of 0 indicates that there are no issues.",
-	gloov1.SecretGVK:       "The health status of secret resources in the system. A value of 0 indicates that there are no issues.",
-	gloov1.UpstreamGVK:     "The health status of upstream resources in the system. A value of 0 indicates that there are no issues.",
+	gwv1.GatewayGVK:         "The health status of gateway resources in the system. A value of 0 indicates that there are no issues.",
+	gwv1.RouteTableGVK:      "The health status of route table resources in the system. A value of 0 indicates that there are no issues.",
+	gwv1.VirtualServiceGVK:  "The health status of virtual service resources in the system. A value of 0 indicates that there are no issues.",
+	gloov1.ProxyGVK:         "The health status of proxy resources in the system. A value of 0 indicates that there are no issues.",
+	gloov1.SecretGVK:        "The health status of secret resources in the system. A value of 0 indicates that there are no issues.",
+	gloov1.UpstreamGVK:      "The health status of upstream resources in the system. A value of 0 indicates that there are no issues.",
+	gloov1.UpstreamGroupGVK: "The health status of upstream group resources in the system. A value of 0 indicates that there are no issues.",
 }
 
 // ConfigStatusMetrics is a collection of metrics, each of which records if the configuration for
@@ -102,6 +104,8 @@ func resourceToGVK(resource resources.Resource) (schema.GroupVersionKind, error)
 		return gloov1.SecretGVK, nil
 	case *gloov1.Upstream:
 		return gloov1.UpstreamGVK, nil
+	case *gloov1.UpstreamGroup:
+		return gloov1.UpstreamGroupGVK, nil
 	default:
 		return schema.GroupVersionKind{}, errors.Errorf("config status metric reporting is not supported for resource type: %T", resource)
 	}

--- a/projects/gateway/pkg/utils/metrics/metrics_test.go
+++ b/projects/gateway/pkg/utils/metrics/metrics_test.go
@@ -54,6 +54,15 @@ func makeUpstream(nameSuffix string) resources.Resource {
 	}
 }
 
+func makeUpstreamGroup(nameSuffix string) resources.Resource {
+	return &gloov1.UpstreamGroup{
+		Metadata: &core.Metadata{
+			Namespace: namespace,
+			Name:      "usg-" + nameSuffix,
+		},
+	}
+}
+
 func makeSecret(nameSuffix string) resources.Resource {
 	return &gloov1.Secret{
 		Metadata: &core.Metadata{
@@ -119,6 +128,7 @@ var _ = Describe("ConfigStatusMetrics Test", func() {
 		Entry("Gateway", "Gateway.v1.gateway.solo.io", metrics.Names[gwv1.GatewayGVK], makeGateway),
 		Entry("RouteTable", "RouteTable.v1.gateway.solo.io", metrics.Names[gwv1.RouteTableGVK], makeRouteTable),
 		Entry("Upstream", "Upstream.v1.gloo.solo.io", metrics.Names[gloov1.UpstreamGVK], makeUpstream),
+		Entry("UpstreamGroup", "UpstreamGroup.v1.gloo.solo.io", metrics.Names[gloov1.UpstreamGroupGVK], makeUpstreamGroup),
 		Entry("Secret", "Secret.v1.gloo.solo.io", metrics.Names[gloov1.SecretGVK], makeSecret),
 		Entry("Proxy", "Proxy.v1.gloo.solo.io", metrics.Names[gloov1.ProxyGVK], makeProxy),
 	)


### PR DESCRIPTION
# Description

Add configuration status metric support for UpstreamGroup CRs.

# Context

v1.10.x Backport of https://github.com/solo-io/gloo/pull/5939

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
