### PR TITLE
fix regex route short circuiting check

### DIFF
--- a/changelog/v1.11.0-beta12/fix-regex-route-short-circuiting.yaml
+++ b/changelog/v1.11.0-beta12/fix-regex-route-short-circuiting.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5958
+    description: Fix bug where regex route short-circuiting was reported when it shouldn't have been.
+    resolvesIssue: false

--- a/projects/gateway/pkg/translator/http_translator.go
+++ b/projects/gateway/pkg/translator/http_translator.go
@@ -471,7 +471,7 @@ func regexShortCircuits(laterMatcher, earlierMatcher *matchers.Matcher) bool {
 	foundIndex := re.FindStringIndex(laterPath)
 	// later matcher is always non-regex. to validate against the regex, we need to ensure that it's either
 	// unset or set to false
-	return foundIndex != nil && laterMatcher.GetCaseSensitive() == nil || laterMatcher.GetCaseSensitive().GetValue() == false
+	return foundIndex != nil && (laterMatcher.GetCaseSensitive() == nil || laterMatcher.GetCaseSensitive().GetValue() == false)
 }
 
 // As future matcher APIs get added, this validation will need to be updated as well.

--- a/projects/gateway/pkg/translator/http_translator_test.go
+++ b/projects/gateway/pkg/translator/http_translator_test.go
@@ -698,6 +698,22 @@ var _ = Describe("Http Translator", func() {
 					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Regex{Regex: "["}},
 					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/"}},
 					InvalidRegexErr("gloo-system.name1", "error parsing regexp: missing closing ]: `[`")),
+				Entry("regex hijacking - handles lack of methods, headers, or query params",
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Regex{Regex: "/anything"}},
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/nomatch"}},
+					nil),
+				Entry("regex hijacking - handles later matcher with more specific methods",
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Regex{Regex: "/anything"}},
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/nomatch"}, Methods: []string{"GET", "POST"}},
+					nil),
+				Entry("regex hijacking - handles later matcher with more specific headers",
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Regex{Regex: "/anything"}},
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/nomatch"}, Headers: []*matchers.HeaderMatcher{{Name: "foo", Value: "bar"}}},
+					nil),
+				Entry("regex hijacking - handles later matcher with more specific query params",
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Regex{Regex: "/anything"}},
+					&matchers.Matcher{PathSpecifier: &matchers.Matcher_Prefix{Prefix: "/nomatch"}, QueryParameters: []*matchers.QueryParameterMatcher{{Name: "foo", Value: "bar"}}},
+					nil),
 			)
 		})
 	})


### PR DESCRIPTION
# Description

Fix a typo that was resulting in regex route short-circuiting being reported when it shouldn't have been.

# Context

See the linked issue for context.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
