### PR TITLE
Update broken link to Gloo Edge installation opts

### DIFF
--- a/install/helm/README.md
+++ b/install/helm/README.md
@@ -8,7 +8,7 @@ to generate the following files:
 - `Chart.yaml`: contains information about the Gloo Edge chart
 - `values.yaml`: default configuration values for the chart
 
-Check the [Gloo Edge docs](https://gloo.solo.io/installation/quick_start/#2-choosing-a-deployment-option)
+Check the [Gloo Edge docs](https://docs.solo.io/gloo-edge/latest/installation/)
 for a description of the different installation options.
 
 ## /crds


### PR DESCRIPTION
# Description

Broken link in README updated - points to docs for installation options.

# Context

Reading about the Helm Chart.

# Checklist:

## Relevant

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I included a concise, user-facing changelog (for details, see
  https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
  (❓~Is this required for docs changes?~ Thanks changelog-bot ✅)

## N/A

- [ ] N/A ~If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff~
- [ ] N/A ~I opened a draft PR or added the work in progress label if my PR is not ready for review~
- [ ] N/A ~I have commented my code, particularly in hard-to-understand areas~
- [ ] N/A ~I have added tests that prove my fix is effective or that my feature works~
