### PR TITLE
rename ratelimit back to rateLimit

### DIFF
--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -118,7 +118,7 @@ spec:
 {{- end }}
 
 {{- if .Values.settings.rateLimit }}
-  ratelimit:
+  rateLimit:
 {{- toYaml .Values.settings.rateLimit | nindent 4 }}
 {{- end }}
 

--- a/install/test/fixtures/settings/ratelimit_descriptors.yaml
+++ b/install/test/fixtures/settings/ratelimit_descriptors.yaml
@@ -33,7 +33,7 @@ spec:
  kubernetesSecretSource: {}
  refreshRate: 60s
  discoveryNamespace: {{ . }}
- rateLimit:
+ ratelimit:
    descriptors:
      - key: generic_key
        value: "per-second"

--- a/install/test/fixtures/settings/ratelimit_descriptors.yaml
+++ b/install/test/fixtures/settings/ratelimit_descriptors.yaml
@@ -33,7 +33,7 @@ spec:
  kubernetesSecretSource: {}
  refreshRate: 60s
  discoveryNamespace: {{ . }}
- ratelimit:
+ rateLimit:
    descriptors:
      - key: generic_key
        value: "per-second"


### PR DESCRIPTION
# Description

Revert accidental rename from rateLimit to ratelimit in settings helm template

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
