### PR TITLE
Make default gateways disable-able

### DIFF
--- a/changelog/v1.11.0-beta17/disable-default-gateways.yaml
+++ b/changelog/v1.11.0-beta17/disable-default-gateways.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: HELM
+    description: >-
+      Allow users to disable the default gateways, which can be helpful for users who configure the validation webhook
+      to strict failures (i.e. `gloo.gateway.validation.failurePolicy: Fail`) so validation works on installation and
+      upgrades. Once the gateway pod is running and healthy, the user can then apply the default gateways.
+    issueLink: https://github.com/solo-io/gloo/issues/4468

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -444,6 +444,7 @@
 |gatewayProxies.NAME.affinity.NAME|interface|||
 |gatewayProxies.NAME.tracing.provider.NAME|interface|||
 |gatewayProxies.NAME.tracing.cluster[].NAME|interface|||
+|gatewayProxies.NAME.gatewaySettings.enabled|bool||enable/disable default gateways|
 |gatewayProxies.NAME.gatewaySettings.disableGeneratedGateways|bool||set to true to disable the gateway generation for a gateway proxy|
 |gatewayProxies.NAME.gatewaySettings.disableHttpGateway|bool||Set to true to disable http gateway generation.|
 |gatewayProxies.NAME.gatewaySettings.disableHttpsGateway|bool||Set to true to disable https gateway generation.|
@@ -606,6 +607,7 @@
 |gatewayProxies.gatewayProxy.affinity.NAME|interface|||
 |gatewayProxies.gatewayProxy.tracing.provider.NAME|interface|||
 |gatewayProxies.gatewayProxy.tracing.cluster[].NAME|interface|||
+|gatewayProxies.gatewayProxy.gatewaySettings.enabled|bool|true|enable/disable default gateways|
 |gatewayProxies.gatewayProxy.gatewaySettings.disableGeneratedGateways|bool||set to true to disable the gateway generation for a gateway proxy|
 |gatewayProxies.gatewayProxy.gatewaySettings.disableHttpGateway|bool||Set to true to disable http gateway generation.|
 |gatewayProxies.gatewayProxy.gatewaySettings.disableHttpsGateway|bool||Set to true to disable https gateway generation.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -380,6 +380,7 @@ type GatewayProxy struct {
 }
 
 type GatewayProxyGatewaySettings struct {
+	Enabled                  *bool                  `json:"enabled,omitempty" desc:"enable/disable default gateways"`
 	DisableGeneratedGateways *bool                  `json:"disableGeneratedGateways,omitempty" desc:"set to true to disable the gateway generation for a gateway proxy"`
 	DisableHttpGateway       *bool                  `json:"disableHttpGateway,omitempty" desc:"Set to true to disable http gateway generation."`
 	DisableHttpsGateway      *bool                  `json:"disableHttpsGateway,omitempty" desc:"Set to true to disable https gateway generation."`

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -3,6 +3,7 @@
 {{- $spec := (index . 2) }}
 {{- with (first .) }}
 {{- $gatewaySettings := $spec.gatewaySettings }}
+{{- if $gatewaySettings.enabled }}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:
@@ -45,6 +46,7 @@ spec:
   ssl: false
   proxyNames:
   - {{ $name | kebabcase }}
+{{- end }}{{/* $gatewaySettings.enabled */}}
 {{- end }}{{/* with */}}
 {{- end }}{{/* define "defaultGateway.gateway" */}}
 
@@ -54,6 +56,7 @@ spec:
 {{- $spec := (index . 2) }}
 {{- with (first .) }}
 {{- $gatewaySettings := $spec.gatewaySettings }}
+{{- if $gatewaySettings.enabled }}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:
@@ -96,6 +99,7 @@ spec:
   ssl: true
   proxyNames:
   - {{ $name | kebabcase }}
+{{- end }}{{/* $gatewaySettings.enabled */}}
 {{- end }}{{/* with */}}
 {{- end }}{{/* define "defaultGatway.sslGateway" */}}
 
@@ -104,6 +108,7 @@ spec:
 {{- $spec := (index . 2) }}
 {{- with (first .) }}
 {{- $gatewaySettings := $spec.gatewaySettings }}
+{{- if $gatewaySettings.enabled }}
 apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:
@@ -129,6 +134,7 @@ spec:
         forwardSniClusterName: {}
   proxyNames:
   - {{ $name | kebabcase }}
+{{- end }}{{/* $gatewaySettings.enabled */}}
 {{- end }}{{/* with */}}
 {{- end }}{{/* define "defaultGateway.failoverGateway" */}}
 

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -99,6 +99,7 @@ gatewayProxies:
   gatewayProxy:
     envoyApiVersion: V3
     gatewaySettings:
+      enabled: true
       useProxyProto: false
     failover:
       enabled: false

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1067,6 +1067,21 @@ var _ = Describe("Helm Test", func() {
 
 				Context("default gateways", func() {
 
+					It("does not render when disabled", func() {
+						prepareMakefile(namespace, helmValues{})
+						testManifest.ExpectCustomResource("Gateway", namespace, defaults.GatewayProxyName)
+
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gatewayProxies.gatewayProxy.gatewaySettings.enabled=true"},
+						})
+						testManifest.ExpectCustomResource("Gateway", namespace, defaults.GatewayProxyName)
+
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gatewayProxies.gatewayProxy.gatewaySettings.enabled=false"},
+						})
+						testManifest.Expect("Gateway", namespace, defaults.GatewayProxyName).To(BeNil())
+					})
+
 					It("does not render when gatewayProxy is disabled", func() {
 						prepareMakefile(namespace, helmValues{})
 						testManifest.ExpectCustomResource("Gateway", namespace, defaults.GatewayProxyName)


### PR DESCRIPTION
# Description

Allow users to disable the default gateways, which can be helpful for users who configure the validation webhook to strict failures (i.e. `gloo.gateway.validation.failurePolicy: Fail`) so validation works on installation and upgrades. Once the gateway pod is running and healthy, the user can then apply the default gateways.

# Testing

In addition to unit tests, validated locally with the following helm values:
```yaml
cat << EOF > values.yaml
gloo:
  gateway:
    validation:
      allowWarnings: false
      alwaysAcceptResources: false
      failurePolicy: Fail
gatewayProxies:
  gatewayProxy:
    gatewaySettings:
      enabled: false
EOF
```

then build a new chart with `TAGGED_VERSION=v1.9.0 make build-test-chart -B` and validate the installation is successful via `glooctl install gateway --values values.yaml -f _test/gloo-1.9.0.tgz`

Once installed / upgraded, the user can deploy the default or any custom gateways (e.g. gitops)

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4468