### PR TITLE
Run tests releases only 1.8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,9 @@ install-go-tools: mod-download
 
 .PHONY: run-tests
 run-tests:
+ifneq ($(RELEASE), "true")
 	$(DEPSGOBIN)/ginkgo -ldflags=$(LDFLAGS) -r -failFast -trace -progress -race -compilers=4 -failOnPending -noColor $(TEST_PKG)
+endif
 
 .PHONY: run-ci-regression-tests
 run-ci-regression-tests: TEST_PKG=./test/kube2e/...

--- a/changelog/v1.8.26/improve-ci-times.yaml
+++ b/changelog/v1.8.26/improve-ci-times.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/3201
+    resolvesIssue: false
+    description: Disable tests on release builds to improve ci times and reliability


### PR DESCRIPTION
# Description

backport of https://github.com/solo-io/gloo/pull/6030

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
