### PR TITLE
Fix indent in discovery service template

### DIFF
--- a/changelog/v1.11.0-beta18/helm-fix-discovery-service.yaml
+++ b/changelog/v1.11.0-beta18/helm-fix-discovery-service.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    resolvesIssue: false
+    issueLink: https://github.com/solo-io/gloo/issues/6041
+    description: Fix indentation with selector in discovery service

--- a/install/helm/gloo/templates/3-discovery-service.yaml
+++ b/install/helm/gloo/templates/3-discovery-service.yaml
@@ -13,6 +13,6 @@ spec:
   ports:
     - name: http-monitoring
       port: 9091
-selector:
-  gloo: discovery
+  selector:
+    gloo: discovery
 {{- end -}}


### PR DESCRIPTION
# Description

Fix indent in helm template

# Context

The issue was introduced in https://github.com/solo-io/gloo/pull/6001 

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
