### PR TITLE
ci(regression-tests): added opt-in slack notify-on-failure step (#6024)

### DIFF
--- a/.github/workflows/notify-on-regression-failure-list.json
+++ b/.github/workflows/notify-on-regression-failure-list.json
@@ -1,0 +1,19 @@
+{
+    "github_id": "slack_id",
+    "__artberger": "U02BQ7EF3LY",
+    "ben-taussig-solo": "U024KB026P7",
+    "bewebi": "U01LDKSG4TW",
+    "elcasteel": "U0239CFLF3M",
+    "gunnar-solo": "U02GW11FVJP",
+    "inFocus7": "U032J2NT4CF",
+    "__jameshbarton" : "U017SFK32D8",
+    "__jenshu": "U016LC0Q70A",
+    "__jmunozro" : "U0214QV6L3Y",
+    "kdorosh": "ULE7TSJ12",
+    "__MitchAman": "U01TH9ZJP3N",
+    "mkazin": "U02JFCX4YAE",
+    "__nfuden": "U02JCDBKEDT",
+    "__Rachael-Graham": "U02BQ7E7W3S",
+    "__saiskee": "U01D06A9NVA",
+    "sam-heilbron": "U01DAPLBEBG"
+}

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -87,3 +87,18 @@ jobs:
         # see what's in the cluster if we failed
         kubectl get all -A
         kubectl get configmaps -A
+    - name: Set pull_request_url
+      if: ${{ github.event_name == 'pull_request' && failure() }}
+      run: echo "pull_request_url=$(cat ${{ github.event_path }} | jq --raw-output .pull_request._links.html.href)" >> $GITHUB_ENV
+    - name: Set direct_message_id
+      if: ${{ github.event_name == 'pull_request' && failure() }}
+      run: echo "direct_message_id=$(cat ./.github/workflows/notify-on-regression-failure-list.json | jq -r '."${{ github.actor }}"')" >> $GITHUB_ENV
+    - name: Send Message
+      id: message-on-fail
+      if: ${{ github.event_name == 'pull_request' && failure() }}
+      shell: bash
+      run: |
+        curl -X POST https://slack.com/api/chat.postMessage\
+              -H "Content-Type: application/json; charset=utf-8"\
+              -H "Authorization: Bearer ${{ secrets.SLACKBOT_BEARER }}"\
+              -d '{"channel":"${{ env.direct_message_id }}","text":"Hey, `${{ github.actor }}`!  The <https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}|regression tests> for your <${{ env.pull_request_url }}|${{ github.head_ref }} PR> have failed."}'

--- a/changelog/v1.8.26/notify-on-failure.yaml
+++ b/changelog/v1.8.26/notify-on-failure.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Send slack notifications on regression test failure on an opt-in basis.


### PR DESCRIPTION
* ci(regression-tests): added opt-in slack notify-on-failure step

* enabled bewebi

* enabled ben-taussig-solo, kdorosh

* enabled inFocus7, mkazin

* enabled elcasteel

* enabled `sam-heilbron`

Co-authored-by: soloio-bulldozer[bot] <48420018+soloio-bulldozer[bot]@users.noreply.github.com>

# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
