### PR TITLE
feat(docker-compose) add missing setup directory

### DIFF
--- a/changelog/v1.11.0-beta19/docker-compose-repair.yaml
+++ b/changelog/v1.11.0-beta19/docker-compose-repair.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add missing directory to docker compose setup script.  Allows `gateway` container to spin up correctly on previously-broken versions v1.10.8+.

--- a/install/docker-compose-file/prepare-directories.sh
+++ b/install/docker-compose-file/prepare-directories.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 mkdir -p ./data/artifact/artifacts/gloo-system
-mkdir -p ./data/config/{authconfigs,gateways,graphqlschemas,proxies,ratelimitconfigs,routeoptions,routetables,upstreamgroups,upstreams,virtualhostoptions,virtualservices}/gloo-system
+mkdir -p ./data/config/{authconfigs,gateways,graphqlschemas,proxies,ratelimitconfigs,routeoptions,routetables,upstreamgroups,upstreams,virtualhostoptions,virtualservices,httpgateways}/gloo-system
 mkdir -p ./data/secret/secrets/{default,gloo-system}


### PR DESCRIPTION
# Description
Modified the filesystem prep script referenced in [this guide](https://docs.solo.io/gloo-edge/master/installation/gateway/development/docker-compose-file/).  It stopped being functional after `v1.10.7`, as it expects a `config/httpgateways/gloo-system` directory to exist.  This allows the `gateway` container to spin up correctly

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
