### PR TITLE
makefile: Upgrade envoy-gloo version for aws fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.20.0-patch3
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.20.0-patch6
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.11.0-beta19/bump-envoy.yaml
+++ b/changelog/v1.11.0-beta19/bump-envoy.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: envoy-gloo
+    dependencyRepo: solo-io
+    dependencyTag: v1.20.0-patch6
+    description: >-
+      Upgrade envoy-gloo version to contain aws filter changes. Transform order and sts race condition.

--- a/changelog/v1.11.0-beta19/bump-envoy.yaml
+++ b/changelog/v1.11.0-beta19/bump-envoy.yaml
@@ -1,7 +1,0 @@
-changelog:
-  - type: DEPENDENCY_BUMP
-    dependencyOwner: envoy-gloo
-    dependencyRepo: solo-io
-    dependencyTag: v1.20.0-patch6
-    description: >-
-      Upgrade envoy-gloo version to contain aws filter changes. Transform order and sts race condition.

--- a/changelog/v1.11.0-beta20/bump-envoy.yaml
+++ b/changelog/v1.11.0-beta20/bump-envoy.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: envoy-gloo
+    dependencyRepo: solo-io
+    dependencyTag: v1.20.0-patch6
+    description: >-
+      Upgrade envoy-gloo version to contain aws filter changes. Transform order and sts race condition.


### PR DESCRIPTION
# Description

Bump envoy-gloo to support aws sts fixes.

# Context

Intermittent 403s in aws sts filter was tracked down to race condition with upstream functionality working as expected. This envoy-gloo version has a workaround.


