### PR TITLE
10/feat(docker-compose): repair docker-compose launch script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.20.0-patch6
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.20.0-patch7
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.10.17/docker-compose-repair.yaml
+++ b/changelog/v1.10.17/docker-compose-repair.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add missing directory to docker compose setup script.  Allows `gateway` container to spin up correctly on previously-broken versions v1.10.8+.
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: envoy-gloo
+    dependencyRepo: solo-io
+    dependencyTag: v1.20.0-patch7
+    description: >-
+      Upgrade envoy-gloo version to contain fixed base image.  Resolves docker-compose envoy build issues.
+    issueLink: https://github.com/solo-io/gloo/issues/5980

--- a/install/docker-compose-file/docker-compose.yaml
+++ b/install/docker-compose-file/docker-compose.yaml
@@ -3,7 +3,7 @@ version: '3'
 services:
 
   gloo:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.10.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo:${GLOO_VERSION:-1.10.16}
     working_dir: /
     command:
     - "--dir=/data/"
@@ -14,7 +14,7 @@ services:
     restart: always
 
   gateway:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.10.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gateway:${GLOO_VERSION:-1.10.16}
     working_dir: /
     command:
     - "--dir=/data/"
@@ -23,7 +23,7 @@ services:
     restart: always
 
   gateway-proxy:
-    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.10.0}
+    image: ${GLOO_REPO:-quay.io/solo-io}/gloo-envoy-wrapper:${GLOO_VERSION:-1.10.16}
     entrypoint: ["envoy"]
     command: ["-c", "/config/envoy.yaml", "--disable-hot-restart"]
     volumes:

--- a/install/docker-compose-file/prepare-directories.sh
+++ b/install/docker-compose-file/prepare-directories.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 mkdir -p ./data/artifact/artifacts/gloo-system
-mkdir -p ./data/config/{authconfigs,gateways,graphqlschemas,proxies,ratelimitconfigs,routeoptions,routetables,upstreamgroups,upstreams,virtualhostoptions,virtualservices}/gloo-system
+mkdir -p ./data/config/{authconfigs,gateways,graphqlschemas,proxies,ratelimitconfigs,routeoptions,routetables,upstreamgroups,upstreams,virtualhostoptions,virtualservices,httpgateways}/gloo-system
 mkdir -p ./data/secret/secrets/{default,gloo-system}


### PR DESCRIPTION
# Description

* bump envoy version
* repair missing setup directory to docker-compose script

related https://github.com/solo-io/gloo/issues/5980

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5980