### PR TITLE
Fixes indentation error in access logging example

### DIFF
--- a/docs/content/guides/security/access_logging/_index.md
+++ b/docs/content/guides/security/access_logging/_index.md
@@ -129,27 +129,27 @@ keys is defined:
 
 ```yaml
 apiVersion: gateway.solo.io/v1
-   kind: Gateway
-   metadata:
-     name: gateway-proxy
-     namespace: gloo-system
-   spec:
-     bindAddress: '::'
-     bindPort: 8080
-     proxyNames:
-       - gateway-proxy
-     httpGateway: {}
-     useProxyProto: false
-     options:
-       accessLoggingService:
-         accessLog:
-           - fileSink:
-               path: /dev/stdout
-               jsonFormat:
-                 protocol: "%PROTOCOL%"
-                 duration: "%DURATION%"
-                 upstreamCluster: "%UPSTREAM_CLUSTER%"
-                 upstreamHost: "%UPSTREAM_HOST%"
+kind: Gateway
+metadata:
+  name: gateway-proxy
+  namespace: gloo-system
+spec:
+  bindAddress: '::'
+  bindPort: 8080
+  proxyNames:
+    - gateway-proxy
+  httpGateway: {}
+  useProxyProto: false
+  options:
+    accessLoggingService:
+      accessLog:
+        - fileSink:
+            path: /dev/stdout
+            jsonFormat:
+              protocol: "%PROTOCOL%"
+              duration: "%DURATION%"
+              upstreamCluster: "%UPSTREAM_CLUSTER%"
+              upstreamHost: "%UPSTREAM_HOST%"
 ```
 
 This will cause requests to the HTTP port to be logged to the application logs of the `gateway-proxy` deployment:


### PR DESCRIPTION
# Description
This bug fixes an indentation error in one of the access logging examples.

Issue: #6092 

# Context
Was not able to apply the example in our own cluster.

# Checklist:
- [yes] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [N/A] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [yes] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [N/A] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [yes] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [yes] I have made corresponding changes to the documentation
- [N/A] I have added tests that prove my fix is effective or that my feature works

