### PR TITLE
Rename DeepMergeAnnotationPrefix to be a valid Annotation

### DIFF
--- a/changelog/v1.11.0-beta21/fix-annotation-config-merge-annotation.yaml
+++ b/changelog/v1.11.0-beta21/fix-annotation-config-merge-annotation.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Rename the serviceconverter DeepMergeAnnotationPrefix from "gloo.solo.io/upstream_config/deep_merge" to "gloo.solo.io/upstream_config.deep_merge", as the former is not a valid k8s annotation.
+    issueLink: https://github.com/solo-io/gloo/issues/6005

--- a/docs/content/guides/traffic_management/destination_types/discovered_upstream/discovered-upstream-configuration.md
+++ b/docs/content/guides/traffic_management/destination_types/discovered_upstream/discovered-upstream-configuration.md
@@ -104,4 +104,4 @@ As you can see, the configuration set `spec.initialStreamWindowSize` to `2048` o
 
 By default, discovered upstreams configured via the `gloo.solo.io/upstream_config` annotation will completely overwrite top-level upstream fields for which configuration has been specified.
 
-By setting the `gloo.solo.io/upstream_config/deep_merge` annotation to `true` on the service for which an upstream is to be discovered, you can configure Gloo Edge to merge the provided configuration with the default upstream config. This can be useful if you rely on certain default values present when a new upstream is discovered.
+By setting the `gloo.solo.io/upstream_config.deep_merge` annotation to `true` on the service for which an upstream is to be discovered, you can configure Gloo Edge to merge the provided configuration with the default upstream config. This can be useful if you rely on certain default values present when a new upstream is discovered.

--- a/projects/gloo/pkg/plugins/kubernetes/serviceconverter/general_annotation_converter.go
+++ b/projects/gloo/pkg/plugins/kubernetes/serviceconverter/general_annotation_converter.go
@@ -12,7 +12,7 @@ import (
 )
 
 const GlooAnnotationPrefix = "gloo.solo.io/upstream_config"
-const DeepMergeAnnotationPrefix = "gloo.solo.io/upstream_config/deep_merge"
+const DeepMergeAnnotationPrefix = "gloo.solo.io/upstream_config.deep_merge"
 
 type GeneralServiceConverter struct{}
 


### PR DESCRIPTION
# Description

Pr #6036 introduces the ability to deep merge discovered upstream config provided via annotation with default upstream configuration. [The annotation used to enable the feature in the initial implementation](https://github.com/solo-io/gloo/pull/6036/files#diff-d5cb4efdfb5e21818b5d7ddb469244d2bf54dba8a791263f3c1adc54c4f7ca61R15) is not a valid k8s annotation (only 1 `/` is allowed). This PR changes the name of the annotation from  `gloo.solo.io/upstream_config/deep_merge` to `gloo.solo.io/upstream_config.deep_merge`, allowing users to configure this feature in the way that the PR initially intended.

Specifically, attempting to apply the service below resulted in the following error:
```
apiVersion: v1
kind: Service
metadata:
  name: httpbin
  labels:
    app: httpbin
  annotations:
    gloo.solo.io/upstream_config: >
      {
        "kube": {
          "serviceSpec": {
            "rest": {
              "swaggerInfo": {
                "url":"http://newexample.com/"
              }
            }
          }
        }
      }
    gloo.solo.io/upstream_config/deep_merge: "true"
```
```
The Service "httpbin" is invalid: metadata.annotations: Invalid value: "gloo.solo.io/upstream_config/deep_merge": a qualified name must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]') with an optional DNS subdomain prefix and '/' (e.g. '[example.com/MyName](http://example.com/MyName)')
```

See the [k8s documentation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set) for clarification on this issue:
`Valid annotation keys have two segments: an optional prefix and name, separated by a slash (/).`


# Context

I encountered this bug while manually testing PR #6036 
