### PR TITLE
V1.10.x: Rename DeepMergeAnnotationPrefix to be a valid Annotation (#6094)

### DIFF
--- a/changelog/v1.11.0-beta21/fix-annotation-config-merge-annotation.yaml
+++ b/changelog/v1.11.0-beta21/fix-annotation-config-merge-annotation.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: Rename the serviceconverter DeepMergeAnnotationPrefix from "gloo.solo.io/upstream_config/deep_merge" to "gloo.solo.io/upstream_config.deep_merge", as the former is not a valid k8s annotation.
+    issueLink: https://github.com/solo-io/gloo/issues/6005

--- a/docs/content/guides/traffic_management/destination_types/discovered_upstream/discovered-upstream-configuration.md
+++ b/docs/content/guides/traffic_management/destination_types/discovered_upstream/discovered-upstream-configuration.md
@@ -104,4 +104,4 @@ As you can see, the configuration set `spec.initialStreamWindowSize` to `2048` o
 
 By default, discovered upstreams configured via the `gloo.solo.io/upstream_config` annotation will completely overwrite top-level upstream fields for which configuration has been specified.
 
-By setting the `gloo.solo.io/upstream_config/deep_merge` annotation to `true` on the service for which an upstream is to be discovered, you can configure Gloo Edge to merge the provided configuration with the default upstream config. This can be useful if you rely on certain default values present when a new upstream is discovered.
+By setting the `gloo.solo.io/upstream_config.deep_merge` annotation to `true` on the service for which an upstream is to be discovered, you can configure Gloo Edge to merge the provided configuration with the default upstream config. This can be useful if you rely on certain default values present when a new upstream is discovered.

--- a/projects/gloo/pkg/plugins/kubernetes/serviceconverter/general_annotation_converter.go
+++ b/projects/gloo/pkg/plugins/kubernetes/serviceconverter/general_annotation_converter.go
@@ -12,7 +12,7 @@ import (
 )
 
 const GlooAnnotationPrefix = "gloo.solo.io/upstream_config"
-const DeepMergeAnnotationPrefix = "gloo.solo.io/upstream_config/deep_merge"
+const DeepMergeAnnotationPrefix = "gloo.solo.io/upstream_config.deep_merge"
 
 type GeneralServiceConverter struct{}
 


### PR DESCRIPTION
# Description

Backport #6094 to v1.10.x
