### PR TITLE
docs/glooctl fixes for header secrets

### DIFF
--- a/docs/content/guides/traffic_management/request_processing/append_remove_headers/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/append_remove_headers/_index.md
@@ -12,7 +12,7 @@ Header Manipulation is configured via the
 
 This struct can be added to {{< protobuf name="gloo.solo.io.RouteOptions" display="Route Options">}}, {{< protobuf name="gloo.solo.io.VirtualHostOptions" display="Virtual Host Options">}}, and {{< protobuf name="gloo.solo.io.WeightedDestinationOptions" display="Weighted Destination Options" >}}.
 
-The `headerManipulation` struct contains four optional fields `requestHeadersToAdd`, `requestHeadersToRemove`,  `responseHeadersToAdd`, and `responseHeadersToRemove`. The key and value for the header can be specified directly in the manifest, or in the case of `requestHeadersToAdd` it can be a reference to a secret of the type `gloo.solo.io/header`.
+The `headerManipulation` struct contains four optional fields `requestHeadersToAdd`, `requestHeadersToRemove`,  `responseHeadersToAdd`, and `responseHeadersToRemove`. The key and value for the header can be specified directly in the manifest, or in the case of `requestHeadersToAdd` it can be a reference to a secret of the type `gloo.solo.io/header` or `Opaque`.
 
 ```yaml
 headerManipulation:
@@ -34,7 +34,7 @@ headerManipulation:
   - headerSecretRef:
       name: SECRET_NAME
       namespace: SECRET_NAMESPACE
-    # The type of the secret must be gloo.solo.io/header
+    # The type of the secret must be gloo.solo.io/header or Opaque
     # Each key/value pair in the secret will be added
 
   # remove headers from request

--- a/docs/content/guides/traffic_management/request_processing/append_remove_headers/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/append_remove_headers/_index.md
@@ -90,7 +90,7 @@ The secret will be created in the same namespace as the Gloo Edge installation b
 ## Example: Manipulating Headers on a Route
 
 
-{{< highlight yaml "hl_lines=22-28" >}}
+{{< highlight yaml "hl_lines=24-30" >}}
 apiVersion: gateway.solo.io/v1
 kind: VirtualService
 metadata:
@@ -127,7 +127,7 @@ status: {}
 
 ## Example: Manipulating Headers on a VirtualHost
 
-{{< highlight yaml "hl_lines=23-28" >}}
+{{< highlight yaml "hl_lines=22-27" >}}
 apiVersion: gateway.solo.io/v1
 kind: VirtualService
 metadata:

--- a/projects/gloo/cli/pkg/printers/secret.go
+++ b/projects/gloo/cli/pkg/printers/secret.go
@@ -49,6 +49,8 @@ func SecretTable(list v1.SecretList, w io.Writer) {
 			secretType = "OAuth"
 		case *v1.Secret_ApiKey:
 			secretType = "ApiKey"
+		case *v1.Secret_Header:
+			secretType = "Header"
 		default:
 			secretType = "unknown"
 		}

--- a/projects/gloo/pkg/api/converters/kube/header_secret.go
+++ b/projects/gloo/pkg/api/converters/kube/header_secret.go
@@ -29,8 +29,11 @@ func (t *HeaderSecretConverter) FromKubeSecret(ctx context.Context, _ *kubesecre
 
 	if secret.Type == HeaderSecretType || secret.Type == kubev1.SecretTypeOpaque {
 		if len(secret.Data) == 0 {
-			contextutils.LoggerFrom(ctx).Warnw("skipping header secret with no headers",
-				zap.String("name", secret.Name), zap.String("namespace", secret.Namespace))
+			if secret.Type == HeaderSecretType {
+				// only log this warning for header secrets (we don't want it to show for all opaque secrets)
+				contextutils.LoggerFrom(ctx).Warnw("skipping header secret with no headers",
+					zap.String("name", secret.Name), zap.String("namespace", secret.Namespace))
+			}
 			return nil, nil
 		}
 


### PR DESCRIPTION
# Description

Update the Header Manipulation docs to indicate that we support secrets of type `gloo.solo.io/header` and `Opaque`.
Update glooctl to be able to print the type for header secrets.
Make logs less noisy on opaque secrets with no data fields.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
