### PR TITLE
Fix multitenancy routetables

### DIFF
--- a/changelog/v1.11.0-beta22/fix-function-signature.yaml
+++ b/changelog/v1.11.0-beta22/fix-function-signature.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/5721
+  resolvesIssue: false
+  description: update function signature to make bugs harder to write for future devs

--- a/projects/gateway/pkg/translator/http_translator.go
+++ b/projects/gateway/pkg/translator/http_translator.go
@@ -327,13 +327,7 @@ func (t *HttpTranslator) computeHttpListenerVirtualHosts(params Params, parentGa
 func (t *HttpTranslator) virtualServiceToVirtualHost(vs *v1.VirtualService, gateway *v1.Gateway, proxyName string, snapshot *v1.ApiSnapshot, reports reporter.ResourceReports) (*gloov1.VirtualHost, error) {
 	converter := NewRouteConverter(NewRouteTableSelector(snapshot.RouteTables), NewRouteTableIndexer())
 	t.mergeDelegatedVirtualHostOptions(vs, snapshot.VirtualHostOptions, reports)
-
-	routes, err := converter.ConvertVirtualService(vs, gateway, proxyName, snapshot, reports)
-	if err != nil {
-		// internal error, should never happen
-		return nil, err
-	}
-
+	routes := converter.ConvertVirtualService(vs, gateway, proxyName, snapshot, reports)
 	vh := &gloov1.VirtualHost{
 		Name:    VirtualHostName(vs),
 		Domains: vs.GetVirtualHost().GetDomains(),


### PR DESCRIPTION
# Description

To support multi-tenancy, route tables should not be able to invalidate the parent virtual service. Thus, `ConvertVirtualService` cannot return an error.

# Context

No need to backport this as the only error path that could have been returned should be impossible to hit.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
