### PR TITLE
Pin setup-gcloud to v0 instead of master

### DIFF
--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Setup - gcloud / gsutil
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GLOO_VULN_REPORTER }}
           project_id: solo-public


### PR DESCRIPTION
# Description

setup-gcloud will be updating the branch name from master to main in
a future release. Even though GitHub will establish redirects, this
will break any GitHub Actions workflows that pin to master. This PR
updates your GitHub Actions workflows to pin to v0, which is the
recommended best practice.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved. N/A
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff N/A
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas N/A
- [x] I have made corresponding changes to the documentation N/A
- [x] I have added tests that prove my fix is effective or that my feature works N/A
