### PR TITLE
Client server glooctl check

### DIFF
--- a/changelog/v1.11.0-beta23/glooctl-check-versions.yaml
+++ b/changelog/v1.11.0-beta23/glooctl-check-versions.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/6112
+  description: > 
+    Glooctl check will now check to make sure that the client and server versions match.
+    If they do not match, it will display a WARN and suggest you update your client.

--- a/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/golang/protobuf/jsonpb"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/version"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	glooinstancev1 "github.com/solo-io/solo-apis/pkg/api/fed.solo.io/v1"
 	"github.com/solo-io/solo-apis/pkg/api/fed.solo.io/v1/types"
@@ -21,6 +22,29 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
+
+func CheckVersionsMatch(opts *options.Options) {
+	vrs, _ := version.GetClientServerVersions(opts.Top.Ctx, version.NewKube(opts.Metadata.GetNamespace()))
+
+	clientVersionStr := vrs.GetClient().GetVersion()
+
+	serverVersionStr := ""
+	for _, v := range vrs.GetServer() {
+		for _, cvr := range v.GetKubernetes().Containers {
+			if cvr.GetName() == "gateway" {
+				serverVersionStr = cvr.GetTag()
+				break
+			}
+		}
+		if serverVersionStr != "" {
+			break
+		}
+	}
+
+	if clientVersionStr != serverVersionStr {
+		printer.AppendMessage(fmt.Sprintf("\nWARN: %s\n", "Client and Server versions do not match. Consider running `glooctl upgrade --release=v"+serverVersionStr+"`"))
+	}
+}
 
 func CheckMulticlusterResources(opts *options.Options) {
 	// check if the gloo fed deployment exists

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -77,6 +77,8 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 
 			CheckMulticlusterResources(opts)
 
+			CheckVersionsMatch(opts)
+
 			if opts.Top.Output.IsJSON() {
 				printer.PrintChecks(new(bytes.Buffer))
 			}


### PR DESCRIPTION
# Description

Add extra check to verify that the client and server versions match. If they do not match, display a warn and suggest updating the client to match the server versions. Right now I am checking the gateway version as its the only container tag that is open source and thus should be the oss equivalent for Gloo ee.

```sh
Checking deployments... OK
Checking pods... OK
Checking upstreams... OK
Checking upstream groups... OK
Checking auth configs... OK
Checking rate limit configs... OK
Checking VirtualHostOptions... OK
Checking RouteOptions... OK
Checking secrets... OK
Checking virtual services... OK
Checking gateways... OK
Checking proxies... OK
Checking rate limit server... OK
No problems detected.
Skipping Gloo Instance check -- Gloo Federation not detected

WARN: Client and Server versions do not match. Consider running `glooctl upgrade --release=v1.9.6`
```

# Context

Fixes: https://github.com/solo-io/gloo/issues/6112

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
