### PR TITLE
(v1.8.x) Initialize the validation_gateway_solo_io_valid_config metric

### DIFF
--- a/changelog/v1.8.27/initialize-valid-config-metric.yaml
+++ b/changelog/v1.8.27/initialize-valid-config-metric.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5949
+    resolvesIssue: false
+    description: Initialize the validation_gateway_solo_io_valid_config metric after the first snapshot Translation.

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -125,6 +125,18 @@ func (v *validator) Sync(ctx context.Context, snap *v1.ApiSnapshot) error {
 	v.lock.Lock()
 	defer v.lock.Unlock()
 
+	// When the pod is first starting (aka the first snapshot is received),
+	// set the value of mValidConfig with respect to the translation loop above.
+	// Without this, mValidConfig will not be exported on /metrics until a new
+	// resource is applied (https://github.com/solo-io/gloo/issues/5949).
+	if v.latestSnapshot == nil {
+		if errs == nil {
+			utils2.MeasureOne(ctx, mValidConfig)
+		} else {
+			utils2.MeasureZero(ctx, mValidConfig)
+		}
+	}
+
 	v.latestSnapshotErr = errs
 	v.latestSnapshot = &snapCopy
 

--- a/projects/gateway/pkg/validation/validator_test.go
+++ b/projects/gateway/pkg/validation/validator_test.go
@@ -33,17 +33,57 @@ var _ = Describe("Validator", func() {
 		ns string
 		v  *validator
 	)
+
 	BeforeEach(func() {
 		t = translator.NewDefaultTranslator(translator.Opts{})
 		vc = &mockValidationClient{}
 		ns = "my-namespace"
 		v = NewValidator(NewValidatorConfig(t, vc, ns, false, false))
+		mValidConfig = utils.MakeGauge("validation.gateway.solo.io/valid_config", "A boolean indicating whether gloo config is valid")
 	})
+
 	It("returns error before sync called", func() {
 		_, err := v.ValidateVirtualService(nil, nil, false)
 		Expect(err).To(testutils.HaveInErrorChain(NotReadyErr))
 		err = v.Sync(context.Background(), &gatewayv1.ApiSnapshot{})
 		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("has mValidConfig=1 after Sync is called with valid snapshot", func() {
+		err := v.Sync(context.TODO(), &gatewayv1.ApiSnapshot{})
+		Expect(err).NotTo(HaveOccurred())
+
+		rows, err := view.RetrieveData("validation.gateway.solo.io/valid_config")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rows).NotTo(BeEmpty())
+		Expect(rows[0].Data.(*view.LastValueData).Value).To(BeEquivalentTo(1))
+	})
+
+	It("has mValidConfig=0 after Sync is called with invalid snapshot", func() {
+		us := samples.SimpleUpstream()
+		snap := samples.SimpleGatewaySnapshot(us.Metadata.Ref(), ns)
+		snap.Gateways.Each(func(element *gatewayv1.Gateway) {
+			http, ok := element.GatewayType.(*gatewayv1.Gateway_HttpGateway)
+			if !ok {
+				return
+			}
+			http.HttpGateway.VirtualServiceExpressions = &gatewayv1.VirtualServiceSelectorExpressions{
+				Expressions: []*gatewayv1.VirtualServiceSelectorExpressions_Expression{
+					{
+						Key:      "a",
+						Operator: gatewayv1.VirtualServiceSelectorExpressions_Expression_Equals,
+						Values:   []string{"b", "c"},
+					},
+				},
+			}
+		})
+		err := v.Sync(context.TODO(), snap)
+		Expect(err).To(HaveOccurred())
+
+		rows, err := view.RetrieveData("validation.gateway.solo.io/valid_config")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rows).NotTo(BeEmpty())
+		Expect(rows[0].Data.(*view.LastValueData).Value).To(BeEquivalentTo(0))
 	})
 
 	Context("validating a route table", func() {
@@ -482,14 +522,21 @@ var _ = Describe("Validator", func() {
 				err := v.Sync(context.TODO(), snap)
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0], true)
-				Expect(err).To(HaveOccurred())
-
-				// there should be no metric value written, since dryRun was true
+				// Metric should be valid after successful Sync
 				rows, err := view.RetrieveData("validation.gateway.solo.io/valid_config")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(rows).NotTo(BeEmpty())
-				Expect(rows[0].Data.(*view.LastValueData).Value).To(BeEquivalentTo(-1))
+				Expect(rows[0].Data.(*view.LastValueData).Value).To(BeEquivalentTo(1))
+
+				// Run a failed validation
+				_, err = v.ValidateVirtualService(context.TODO(), snap.VirtualServices[0], true)
+				Expect(err).To(HaveOccurred())
+
+				// The metric should still be valid, since dryRun was true
+				rows, err = view.RetrieveData("validation.gateway.solo.io/valid_config")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(rows).NotTo(BeEmpty())
+				Expect(rows[0].Data.(*view.LastValueData).Value).To(BeEquivalentTo(1))
 			})
 		})
 		Context("dry-run", func() {


### PR DESCRIPTION
# Description

v1.8.x backport of https://github.com/solo-io/gloo/pull/6132

Initialize the `validation_gateway_solo_io_valid_config` metric when the gateway pod starts up.

# Context

`validation_gateway_solo_io_valid_config` will not appear on the gateway pod's `/metrics` endpoint until a value is assigned to it. This PR initializes the metric based on the first snapshot that the gateway pod receives after starting. Previously, the metric would not have been initialized until a resource was applied and validated by the webhook.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works