### PR TITLE
Include app=gloo label on gateway proxy services

### DIFF
--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -107,6 +107,7 @@ metadata:
   name: {{ $name | kebabcase }}-config-dump-service
   namespace: {{ .Release.Namespace }}
   labels:
+    app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
 spec:
@@ -128,6 +129,7 @@ metadata:
   name: {{ $name | kebabcase }}-monitoring-service
   namespace: {{ .Release.Namespace }}
   labels:
+    app: gloo
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
 spec:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -466,6 +466,7 @@ var _ = Describe("Helm Test", func() {
 						ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("Service %+v should be able to convert from unstructured", service))
 						structuredService, ok := serviceObject.(*v1.Service)
 						ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("Service %+v should be able to cast to a structured service", service))
+						ExpectWithOffset(1, structuredService.Labels["app"]).To(Equal("gloo"), "Service has app=gloo label")
 
 						if serviceContainsMonitoringPort(structuredService) {
 							actualServicesWithHttpMonitoring = append(actualServicesWithHttpMonitoring, structuredService.GetName())
@@ -504,6 +505,7 @@ var _ = Describe("Helm Test", func() {
 						ExpectWithOffset(1, err).NotTo(HaveOccurred(), fmt.Sprintf("Deployment %+v should be able to convert from unstructured", deployment))
 						structuredDeployment, ok := deploymentObject.(*appsv1.Deployment)
 						ExpectWithOffset(1, ok).To(BeTrue(), fmt.Sprintf("Deployment %+v should be able to cast to a structured deployment", deployment))
+						ExpectWithOffset(1, structuredDeployment.Labels["app"]).To(Equal("gloo"), "Deployment has app=gloo label")
 
 						if deploymentContainsMonitoringPort(structuredDeployment) {
 							actualDeploymentsWithHttpMonitoring = append(actualDeploymentsWithHttpMonitoring, structuredDeployment.GetName())

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4431,10 +4431,17 @@ metadata:
 				Describe("gateway proxy -- readConfigMulticluster config", func() {
 					It("has a service for the gateway proxy config dump port", func() {
 						prepareMakefile(namespace, helmValues{
-							valuesArgs: []string{"gatewayProxies.gatewayProxy.readConfig=true",
-								"gatewayProxies.gatewayProxy.readConfigMulticluster=true"},
+							valuesArgs: []string{
+								"gatewayProxies.gatewayProxy.readConfig=true",
+								"gatewayProxies.gatewayProxy.readConfigMulticluster=true",
+							},
 						})
 						serviceLabels := map[string]string{
+							"app":              "gloo",
+							"gloo":             "gateway-proxy",
+							"gateway-proxy-id": "gateway-proxy",
+						}
+						serviceSelector := map[string]string{
 							"gloo":             "gateway-proxy",
 							"gateway-proxy-id": "gateway-proxy",
 						}
@@ -4445,7 +4452,7 @@ metadata:
 							Labels:    serviceLabels,
 						}
 						gatewayProxyConfigDumpService := rb.GetService()
-						gatewayProxyConfigDumpService.Spec.Selector = serviceLabels
+						gatewayProxyConfigDumpService.Spec.Selector = serviceSelector
 						gatewayProxyConfigDumpService.Spec.Ports = []v1.ServicePort{
 							{
 								Protocol: "TCP",


### PR DESCRIPTION
# Description

Include app=gloo label on all services and deployments

# Context

The dynamically generated dashboards for the upstreams has app=gloo defined for some panels. Without this label, the metrics will not appear properly on the dashboard.

Slack context: https://solo-io-corp.slack.com/archives/CEDCS8TAP/p1648154147487449

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
