### PR TITLE
10/fix(ssl.go): prevent isValidSslKeyPair with only rootCa

### DIFF
--- a/changelog/v1.10.18/less-strict-ssl-validation.yaml
+++ b/changelog/v1.10.18/less-strict-ssl-validation.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6021
+    resolvesIssue: false
+    description: When providing _only_ a `rootCa` file, no longer fail by validating nonexistent `certChain` and `privateKey`

--- a/projects/gloo/pkg/utils/ssl_test.go
+++ b/projects/gloo/pkg/utils/ssl_test.go
@@ -82,6 +82,14 @@ var _ = Describe("Ssl", func() {
 				vctx := c.ValidationContextType.(*envoyauth.CommonTlsContext_ValidationContext).ValidationContext
 				Expect(vctx.MatchSubjectAltNames).To(Equal(verifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
 			})
+
+			It("should _not_ error with only a rootca", func() {
+				// rootca, tlscert, and tlskey are set in a beforeEach.  Explicitly UNsetting cert+key:
+				upstreamCfg.SslSecrets.(*v1.UpstreamSslConfig_SslFiles).SslFiles.TlsCert = ""
+				upstreamCfg.SslSecrets.(*v1.UpstreamSslConfig_SslFiles).SslFiles.TlsKey = ""
+				_, err := resolveCommonSslConfig(upstreamCfg, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 	})
 	Context("secret", func() {


### PR DESCRIPTION
related https://github.com/solo-io/gloo/issues/6021

# Description
Avoid validating `certChain` and `privateKey` when _only_ a `rootCa` is present

# Context
Per [Gloo's Upstream TLS docs](https://docs.solo.io/gloo-edge/latest/guides/security/tls/client_tls/#trusted-mode), users should be able to provide _only_ a rootCa file (as in `glooctl create secret tls --rootca=...`).  However, the [current validation method](https://github.com/solo-io/gloo/commit/ee2e1115631e36a6b6136101f5d330dde810be74) in `ResolveCommonSslConfig` is overly restrictive, enforcing `tls.X509KeyPair` checks against empty files, even if said empty files aren't meant to be used.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
