### PR TITLE
close grpcreflect.Client to gracefully close grpc stream

### DIFF
--- a/projects/discovery/pkg/fds/discoveries/grpc/grpc.go
+++ b/projects/discovery/pkg/fds/discoveries/grpc/grpc.go
@@ -86,6 +86,7 @@ func (f *UpstreamFunctionDiscovery) DetectType(ctx context.Context, url *url.URL
 	}
 
 	defer closeConn()
+	defer refClient.Reset()
 
 	_, err = refClient.ListServices()
 	if err != nil {
@@ -105,7 +106,6 @@ func (f *UpstreamFunctionDiscovery) DetectFunctions(ctx context.Context, url *ur
 	err := contextutils.NewExponentioalBackoff(contextutils.ExponentioalBackoff{}).Backoff(ctx, func(ctx context.Context) error {
 		return f.DetectFunctionsOnce(ctx, url, updatecb)
 	})
-
 	if err != nil {
 		if ctx.Err() != nil {
 			return multierror.Append(err, ctx.Err())
@@ -136,6 +136,7 @@ func (f *UpstreamFunctionDiscovery) DetectFunctionsOnce(ctx context.Context, url
 		return err
 	}
 	defer closeConn()
+	defer refClient.Reset()
 
 	services, err := refClient.ListServices()
 	if err != nil {


### PR DESCRIPTION
# Description

We started using function discovery feature with grpc services and noticed that the discovery process does not properly close the connection to grpc services when it disconnects from Reflection service which results in errors in our services. This happens because grpcreflect library opens bi-directional stream which needs to be closed properly. 

This bugfix closes the bi-directional stream by calling `Reset` method.

# Context

we're using grpc c# that reports errors when connections are not being closed properly.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
