### PR TITLE
Small CONTRIBUTING.md updates to better match Gloo's current state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ For significant changes to the repository, it’s important to settle on a desig
 1. **Open an issue.** Open an issue about your bug in this repo.
 2. **Message us on Slack.** Reach out to us to discuss your proposed changes.
 3. **Agree on implementation plan.** Write a plan for how this feature or bug fix should be implemented. Should this be one pull request or multiple incremental improvements? Who is going to do each part?
-4. **Submit a work-in-progress PR** It's important to get feedback as early as possible to ensure that any big improvements end up being merged. Submit a pull request and label it `wip` to start getting feedback.
+4. **Submit a work-in-progress PR** It's important to get feedback as early as possible to ensure that any big improvements end up being merged. Submit a pull request and label it `work in progress` to start getting feedback.
 5. **Review.** At least one Solo team member should sign off on the change before it’s merged. Look at the “code review” section below to learn about what we're looking for.
 6. **A Solo team member will merge and release!**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,8 @@ Useful make commands:
 | ---                                                       |   ---      |
 | make install-go-tools generated-code -B                   | Makes all generated code which is required to get past CI. |
 | make glooctl                                              | Makes glooctl binary and places it in _output/glooctl |
-| make build-kind-chart                                     | Makes the .tgz helm file that locally built instances of glooctl require to install gloo |
 | make docker TAGGED_VERSION=(version)                      | Builds the docker images needed for the helm charts and tests |
 | make clean build-test-assets -B TAGGED_VERSION=v(version) | Builds a zipped helm chart for gloo that is configured to use the specified gloo version. This version must be a valid image in quay. This can include non-standard versions used for testing. |
-| make update-deps                                          | Updates the go dependencies |
 
 ### Small bug fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@ Useful make commands:
 | make build-test-chart                                     | Makes the .tgz helm file that locally-built instances of glooctl require to install gloo |
 | make docker TAGGED_VERSION=(version)                      | Builds the docker images needed for the helm charts and tests |
 | make clean build-test-assets -B TAGGED_VERSION=v(version) | Builds a zipped helm chart for gloo that is configured to use the specified gloo version. This version must be a valid image in quay. This can include non-standard versions used for testing. |
+| make install-go-tools                                     | Updates the go dependencies |
 
 ### Small bug fixes
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,7 @@ Useful make commands:
 | ---                                                       |   ---      |
 | make install-go-tools generated-code -B                   | Makes all generated code which is required to get past CI. |
 | make glooctl                                              | Makes glooctl binary and places it in _output/glooctl |
+| make build-test-chart                                     | Makes the .tgz helm file that locally-built instances of glooctl require to install gloo |
 | make docker TAGGED_VERSION=(version)                      | Builds the docker images needed for the helm charts and tests |
 | make clean build-test-assets -B TAGGED_VERSION=v(version) | Builds a zipped helm chart for gloo that is configured to use the specified gloo version. This version must be a valid image in quay. This can include non-standard versions used for testing. |
 


### PR DESCRIPTION
# Description

Updating CONTRIBUTING.md.

- Updated the label shown for work-in-progress tickets to `work in progress`.
- Removed `make update-deps` from the "Useful make commands" subsection, since it's been removed/replaced since [this commit](https://github.com/solo-io/gloo/commit/f2f718dd8e30c740b46a0fca1feecd584264a79e)
  - Might worth to instead replace with `make install-go-tools`.
- Updated `make build-kind-chart` from the "Useful make commands" subsection, since it's been removed since [this commit](https://github.com/solo-io/gloo/commit/5fc8480eba37446516c8f291c2d66c840fc96724). It's now `make build-test-chart`

# Context

While starting to work in contributions these small nits threw me off a bit, so best to keep them updated for any future contributor.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
