### PR TITLE
change ui readonly default to false

### DIFF
--- a/changelog/v1.11.0-rc4/readonly-default-false.yaml
+++ b/changelog/v1.11.0-rc4/readonly-default-false.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/3116
+  description: Change the readOnly default to false in UI settings.
+  resolvesIssue: false

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/settings.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/settings.proto.sk.md
@@ -713,7 +713,7 @@ Settings used by the Enterprise Console (UI)
 
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
-| `readOnly` | [.google.protobuf.BoolValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/bool-value) | If true, then custom resources can only be viewed in read-only mode in the UI. If false, then resources can be created, updated, and deleted via the UI. Currently, create/update/delete operations are only supported for GraphQL resources. This feature requires a Gloo Edge Enterprise license with GraphQL enabled. Defaults to true. |
+| `readOnly` | [.google.protobuf.BoolValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/bool-value) | If true, then custom resources can only be viewed in read-only mode in the UI. If false, then resources can be created, updated, and deleted via the UI. Currently, create/update/delete operations are only supported for GraphQL resources. This feature requires a Gloo Edge Enterprise license with GraphQL enabled. Defaults to false. |
 | `apiExplorerEnabled` | [.google.protobuf.BoolValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/bool-value) | Whether to enable the GraphQL API Explorer. This feature requires a Gloo Edge Enterprise license with GraphQL enabled. Defaults to true. |
 
 

--- a/projects/gloo/api/v1/settings.proto
+++ b/projects/gloo/api/v1/settings.proto
@@ -649,7 +649,7 @@ message ConsoleOptions {
     // If false, then resources can be created, updated, and deleted via the UI.
     // Currently, create/update/delete operations are only supported for GraphQL resources.
     // This feature requires a Gloo Edge Enterprise license with GraphQL enabled.
-    // Defaults to true.
+    // Defaults to false.
     google.protobuf.BoolValue read_only = 1;
 
     // Whether to enable the GraphQL API Explorer. This feature requires a Gloo Edge Enterprise license with GraphQL enabled.

--- a/projects/gloo/pkg/api/v1/settings.pb.go
+++ b/projects/gloo/pkg/api/v1/settings.pb.go
@@ -936,7 +936,7 @@ type ConsoleOptions struct {
 	// If false, then resources can be created, updated, and deleted via the UI.
 	// Currently, create/update/delete operations are only supported for GraphQL resources.
 	// This feature requires a Gloo Edge Enterprise license with GraphQL enabled.
-	// Defaults to true.
+	// Defaults to false.
 	ReadOnly *wrappers.BoolValue `protobuf:"bytes,1,opt,name=read_only,json=readOnly,proto3" json:"read_only,omitempty"`
 	// Whether to enable the GraphQL API Explorer. This feature requires a Gloo Edge Enterprise license with GraphQL enabled.
 	// Defaults to true.


### PR DESCRIPTION
# Description

Updating the proto comments to indicate that the default value of the console readOnly setting is false

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
