### PR TITLE
CI(docs): cat out security utils file

### DIFF
--- a/changelog/v1.11.0-rc5/docs-debug.yaml
+++ b/changelog/v1.11.0-rc5/docs-debug.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: cat out security utils file

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -31,6 +31,7 @@ site-common: clean gloo-enterprise-version
 	# generate split security scans for gloo versions which HAVE recieved new split-templating updates
 	MIN_SCANNED_VERSION=$(SECURITY_SCAN_MIN_VERSION) GO111MODULE=on go run cmd/generate_docs.go gen-security-scan-md -r gloo > content/static/content/gloo-security-scan.docgen
 	MIN_SCANNED_VERSION=$(SECURITY_SCAN_MIN_VERSION) GO111MODULE=on go run cmd/generate_docs.go gen-security-scan-md -r glooe > content/static/content/glooe-security-scan.docgen
+	cat content/static/content/gloo-security-scan.docgen
 	./split-file-by-delimiter.sh content/static/content/gloo-security-scan.docgen \\\*\\\*\\\*
 	./split-file-by-delimiter.sh content/static/content/glooe-security-scan.docgen \\\*\\\*\\\*
 	GO111MODULE=on go run cmd/generate_docs.go get-enterprise-helm-values > content/static/content/glooe-values.docgen


### PR DESCRIPTION
# Description

(temporary) github action update to docs gen.  Debugging `cat` to trace security-scan generation issue