### PR TITLE
utils/regexutils: Re-allow nil engine types in regex.

### DIFF
--- a/changelog/v1.11.0-rc7/regex-rewrite-engine.yaml
+++ b/changelog/v1.11.0-rc7/regex-rewrite-engine.yaml
@@ -1,5 +1,5 @@
-hangelog:
-  - type: fix
+changelog:
+  - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/5448
     resolvesIssue: true
     description: Allows for engine to not be set.

--- a/changelog/v1.11.0-rc7/regex-rewrite-engine.yaml
+++ b/changelog/v1.11.0-rc7/regex-rewrite-engine.yaml
@@ -1,0 +1,5 @@
+hangelog:
+  - type: fix
+    issueLink: https://github.com/solo-io/gloo/issues/5448
+    resolvesIssue: true
+    description: Allows for engine to not be set.

--- a/pkg/utils/regexutils/regex.go
+++ b/pkg/utils/regexutils/regex.go
@@ -44,6 +44,9 @@ func NewRegexWithProgramSize(regex string, programsize *uint32) *envoy_type_matc
 	}
 }
 
+//ConvertRegexMatchAndSubstitute into safe variant consumable by envoy.
+// By default we use the RegexMatcher_GoogleRe2 matcher which as of
+// envoy 1.21 is the only engine supported.
 func ConvertRegexMatchAndSubstitute(ctx context.Context, in *v32.RegexMatchAndSubstitute) (*envoy_type_matcher_v3.RegexMatchAndSubstitute, error) {
 	if in == nil {
 		return nil, nil
@@ -54,12 +57,19 @@ func ConvertRegexMatchAndSubstitute(ctx context.Context, in *v32.RegexMatchAndSu
 		Substitution: in.GetSubstitution(),
 	}
 	switch inET := in.GetPattern().GetEngineType().(type) {
+	case nil:
+		// we do nothing here as it defaults to googleRe2 but we dont have any of the extra settings on it.
 	case *v32.RegexMatcher_GoogleRe2:
+		// note that this is likely to be deprecated soon anyways... So if engines no longer matter we may eventually
+		// be able to remove most of this.
 		outET := out.GetPattern().GetEngineType().(*envoy_type_matcher_v3.RegexMatcher_GoogleRe2)
 		if inET.GoogleRe2.GetMaxProgramSize() != nil && (outET.GoogleRe2.GetMaxProgramSize() == nil || inET.GoogleRe2.GetMaxProgramSize().GetValue() < outET.GoogleRe2.GetMaxProgramSize().GetValue()) {
 			out.Pattern = NewRegexWithProgramSize(in.GetPattern().GetRegex(), &inET.GoogleRe2.GetMaxProgramSize().Value)
 		}
+
 	default:
+		// this will only happen if there is a new type of engine that our current envoy implementation does not know how to handle.
+		// This should be thrown as we are unsure that we are passing the right info to envoy which could cause crashes.
 		return nil, errors.Errorf("Invalid regex EngineType: %v", in.GetPattern().GetEngineType())
 	}
 

--- a/pkg/utils/regexutils/regex_test.go
+++ b/pkg/utils/regexutils/regex_test.go
@@ -9,6 +9,7 @@ import (
 
 	. "github.com/solo-io/gloo/pkg/utils/regexutils"
 	"github.com/solo-io/gloo/pkg/utils/settingsutil"
+	v32 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/type/matcher/v3"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 )
 
@@ -37,5 +38,21 @@ var _ = Describe("Regex", func() {
 		regex := NewRegex(ctx, "foo")
 		Expect(regex.GetRegex()).To(Equal("foo"))
 		Expect(regex.GetGoogleRe2().GetMaxProgramSize().GetValue()).To(BeEquivalentTo(123))
+	})
+	It("should create regex even without engine", func() {
+		ctx := settingsutil.WithSettings(context.Background(), &v1.Settings{
+			Gloo: &v1.GlooOptions{RegexMaxProgramSize: &wrappers.UInt32Value{Value: 123}},
+		})
+		subPattern := v32.RegexMatcher{
+			Regex: "(.*)",
+		}
+		in := v32.RegexMatchAndSubstitute{
+			Substitution: "123",
+			Pattern:      &subPattern,
+		}
+		out, err := ConvertRegexMatchAndSubstitute(ctx, &in)
+		Expect(err).To(BeNil())
+		Expect(out.Pattern.Regex).To(Equal(in.Pattern.Regex))
+		Expect(out.Substitution).To(Equal(in.Substitution))
 	})
 })


### PR DESCRIPTION
We have documents showing how to setup regex rewrites without requiring engine.
We stopped allowing this behavior but will once more respect this.

It makes sense to not require the engine as envoy has moved away from interacting with the engine (only field on it is now deprecated). It does raise questions as to whether there needs to be more regex validation on the control plane prior to translation but this minimally fixes the issue seen in 1.11.0-rc5/rc6 of gloo
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/5448