### PR TITLE
Docs: Exapnd GraphQL documentation

### DIFF
--- a/changelog/v1.11.0-rc7/docs-graphql.yaml
+++ b/changelog/v1.11.0-rc7/docs-graphql.yaml
@@ -1,3 +1,3 @@
 changelog:
   - type: NON_USER_FACING
-    description: Expands GraphQL documentatio to include UI and stitching pages.
+    description: Expands GraphQL documentation to include UI and stitching pages.

--- a/changelog/v1.11.0-rc7/docs-graphql.yaml
+++ b/changelog/v1.11.0-rc7/docs-graphql.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Expands GraphQL documentatio to include UI and stitching pages.

--- a/docs/content/guides/graphql/_index.md
+++ b/docs/content/guides/graphql/_index.md
@@ -10,10 +10,6 @@ Set up API gateway and GraphQL server functionality for your apps in the same pr
 This feature is available only in Gloo Edge Enterprise version 1.10.0 and later.
 {{% /notice %}}
 
-{{% notice warning %}}
-This is an alpha feature. Do not use this feature in a production environment.
-{{% /notice %}}
-
 ## Why GraphQL?
 
 GraphQL is a server-side query language and runtime you can use to expose your APIs as an alternative to REST APIs. GraphQL allows you to request only the data you want and handle any subsequent requests on the server side, saving numerous expensive origin-to-client requests by instead handling requests in your internal network.

--- a/docs/content/guides/graphql/automatic_discovery.md
+++ b/docs/content/guides/graphql/automatic_discovery.md
@@ -6,7 +6,7 @@ description: Explore automatic schema generation with GraphQL service discovery.
 
 <!-- **QUESTION do we need to add the behind-the-scenes info for this feature?** eg Sai has a great overview here: https://docs.google.com/presentation/d/1ArxEdVVAOowz4wYcXIYlg4Wd-psadUTrOYH9DPPWwpk/edit#slide=id.g10a8760f3dd_24_181 -->
 
-Gloo Edge can automatically discover API specifications and create GraphQL schemas. The generated `GraphQLApi` includes the configuration for REST <!--or gRPC -->resolvers and schema definitions for the types of data to return to graphQL queries.
+Gloo Edge can automatically discover API specifications and create GraphQL schemas. The generated `GraphQLApi` includes the configuration for REST or gRPC resolvers and schema definitions for the types of data to return to graphQL queries.
 
 Gloo Edge supports two modes of discovery: allowlist and blocklist. For more information about these discovery modes, see the [Function Discovery Service (FDS) guide]({{% versioned_link_path fromRoot="/installation/advanced_configuration/fds_mode/#function-discovery-service-fds" %}}).
 

--- a/docs/content/guides/graphql/getting_started.md
+++ b/docs/content/guides/graphql/getting_started.md
@@ -10,13 +10,9 @@ Set up API gateway and GraphQL server functionality for your apps in the same pr
 This feature is available only in Gloo Edge Enterprise version 1.10.0 and later.
 {{% /notice %}}
 
-{{% notice warning %}}
-This is an alpha feature. Do not use this feature in a production environment.
-{{% /notice %}}
-
 ## Step 1: Install GraphQL
 
-GraphQL resolution is an alpha feature included in Gloo Edge Enterprise version 1.10.0 and later.
+GraphQL resolution is included in Gloo Edge Enterprise version 1.10.0 and later.
 
 1. [Contact your account representative](https://www.solo.io/company/talk-to-an-expert/) to request a Gloo Edge Enterprise license that specifically enables the GraphQL capability.
 
@@ -155,7 +151,7 @@ In Gloo Edge, you can create GraphQL resolvers to fetch the data from your backe
    kubectl get upstream -n gloo-system
    ```
 
-3. Check out the contents of the following Gloo Edge GraphQL API CRD. Specifically, take a look at the `restResolver` and `schema_definition` sections.
+3. Check out the contents of the following Gloo Edge GraphQL API CRD. Specifically, take a look at the `restResolver` and `schemaDefinition` sections.
    ```sh
    curl https://raw.githubusercontent.com/solo-io/graphql-bookinfo/main/kubernetes/bookinfo-gql.yaml
    ```
@@ -172,9 +168,9 @@ In Gloo Edge, you can create GraphQL resolvers to fetch the data from your backe
              name: default-productpage-9080
              namespace: gloo-system
      ```
-   * `schema_definition`: A schema definition determines what kind of data can be returned to a client that makes a GraphQL query to your endpoint. The schema specifies the data that a particular `type`, or service, returns in response to a GraphQL query. In this example, fields are defined for the three Bookinfo services, Product, Review, and Rating. Additionally, the schema definition indicates which services reference the resolvers. In this example, the Product service references the `Query|productForHome` resolver. 
+   * `schemaDefinition`: A schema definition determines what kind of data can be returned to a client that makes a GraphQL query to your endpoint. The schema specifies the data that a particular `type`, or service, returns in response to a GraphQL query. In this example, fields are defined for the three Bookinfo services, Product, Review, and Rating. Additionally, the schema definition indicates which services reference the resolvers. In this example, the Product service references the `Query|productForHome` resolver. 
      ```yaml
-     schema_definition: |
+     schemaDefinition: |
        type Query {
          productsForHome: [Product] @resolve(name: "Query|productsForHome")
        }

--- a/docs/content/guides/graphql/graphql_ui.md
+++ b/docs/content/guides/graphql/graphql_ui.md
@@ -1,0 +1,56 @@
+---
+title: GraphQL UI
+weight: 20
+description: Visualize your GraphQL API and services in the GraphQL UI.
+---
+
+## List GraphQL APIs in the Gloo Edge UI
+
+The Gloo Edge UI is served from the `gloo-fed-console` service on port 8090. For more information about how to use the UI, see [Read-only Console]({{< versioned_link_path fromRoot="/guides/gloo_federation/read_only_console/" >}}).
+
+1. Open the Gloo Mesh UI.
+   * `glooctl`: For more information, see the [CLI documentation]({{< versioned_link_path fromRoot="/reference/cli/glooctl_dashboard/" >}}).
+     ```shell
+     glooctl dashboard
+     ```
+   * `kubectl`: Port-forward the `gloo-mesh-ui` service on 8090.
+     ```shell
+     kubectl port-forward svc/gloo-fed-console -n gloo-system 8090:8090
+     ```
+2. Open your browser and connect to [http://localhost:8090](http://localhost:8090).
+3. Optional: If authentication is enabled, sign in.
+4. In the navigation bar, click **APIs**. The GraphQL API schemas in your Gloo Edge environment are listed.
+5. Review the overview details for each API, such as the namespace it is deployed in, the number of resolvers defined in the API, and the current status of the API.
+6. In the **Actions** column, you can optionally download the configuration files for the API, or delete the API configuration from your environment.
+
+![GraphQL APIs overview screenshot]({{% versioned_link_path fromRoot="/img/screenshots/TODO.png" %}})
+
+## Review GraphQL API details
+
+Review the details of a GraphQL API, including its configuration, the resolvers for each query, and more.
+
+1. From the list of GraphQL APIs, click the name of a GraphQL API schema.
+2. In the **API Details** tab, you can view the _Configuration_ and the _Upstreams_ for the API.
+   * _Configuration_: To review the defined fields and values, click to expand each section. For example, you can expand a "Query" section to review the field names that are defined in the GraphQL query, the type of data returned by each field, and the resolver that processes the request and returns the data. You can also click the **View Raw Config** button to view the raw configuration in the UI, and the **<file-name>.yaml** button to download the configuration YAML file.
+   * _Upstreams_: To review the upstream services that the GraphQL server exposes, click the name of one of the listed services. The **Upstreams** page for the service opens. For more information about the upstream services page, see [Exploring Virtual Services and Upstreams]({{< versioned_link_path fromRoot="/guides/gloo_federation/read_only_console/#exploring-virtual-services-and-upstreams" >}}).
+
+## Explore GraphQL API functionality
+
+Explorer - invoking an API (similar to Try It Now in Portal)
+
+## Create a GraphQL API
+
+Define a new GraphQL API by using the UI.
+
+1. From the **APIs** overview page, click **Create API**.
+2. Enter a name for the API, and click **Upload Schema** to add a `.gql` configuration file.
+3. Click **Create API**. The details page for the API opens.
+4. If no resolvers are defined, you might see a warning. To define a resolver:
+   1. In the **API Details** tab, expand a configuration section.
+   2. In the **Resolver** column, click **Define Resolver**.
+   3. For the Resolver Type, choose a REST or gRPC resolver. 
+   4. For the Upstream, choose a service for the upstream reference. The drop-down list is populated by the upstream services that are currently defined in your Gloo Edge environment.
+   5. For the Resolver Config, fill out values for the provided fields. Note that you might not require all provided fields, and you can validate the syntax at any time by clicking **Validate**. For more information about how to configure each type of resolver, see [Manual schema configuration]({{< versioned_link_path fromRoot="/guides/graphql/resolver_config/" >}}).
+   6. Click **Submit**.
+   7. Repeat these steps to define a resolver for each configuration field.
+5. To apply changes to your API configuration, toggle **Schema Introspection**, and click **Update**.

--- a/docs/content/guides/graphql/graphql_ui.md
+++ b/docs/content/guides/graphql/graphql_ui.md
@@ -4,11 +4,13 @@ weight: 20
 description: Visualize your GraphQL API and services in the GraphQL UI.
 ---
 
+Use the Gloo Edge UI to review the health and configuration of your GraphQL APIs, test out your GraphQL API functionality, and create new GraphQL APIs.
+
 ## List GraphQL APIs in the Gloo Edge UI
 
-The Gloo Edge UI is served from the `gloo-fed-console` service on port 8090. For more information about how to use the UI, see [Read-only Console]({{< versioned_link_path fromRoot="/guides/gloo_federation/read_only_console/" >}}).
+The Gloo Edge UI is served from the `gloo-fed-console` service on port 8090. For more information about how to use the UI, see the [UI documentation]({{< versioned_link_path fromRoot="/guides/gloo_federation/read_only_console/" >}}).
 
-1. Open the Gloo Mesh UI.
+1. Open the Gloo Edge UI.
    * `glooctl`: For more information, see the [CLI documentation]({{< versioned_link_path fromRoot="/reference/cli/glooctl_dashboard/" >}}).
      ```shell
      glooctl dashboard
@@ -34,9 +36,14 @@ Review the details of a GraphQL API, including its configuration, the resolvers 
    * _Configuration_: To review the defined fields and values, click to expand each section. For example, you can expand a "Query" section to review the field names that are defined in the GraphQL query, the type of data returned by each field, and the resolver that processes the request and returns the data. You can also click the **View Raw Config** button to view the raw configuration in the UI, and the **<file-name>.yaml** button to download the configuration YAML file.
    * _Upstreams_: To review the upstream services that the GraphQL server exposes, click the name of one of the listed services. The **Upstreams** page for the service opens. For more information about the upstream services page, see [Exploring Virtual Services and Upstreams]({{< versioned_link_path fromRoot="/guides/gloo_federation/read_only_console/#exploring-virtual-services-and-upstreams" >}}).
 
-## Explore GraphQL API functionality
+## Test GraphQL API functionality
 
-Explorer - invoking an API (similar to Try It Now in Portal)
+Explore the functionality of an API by sending sample queries.
+
+1. From the **APIs** overview page, click the name of a GraphQL API schema.
+2. Click the **Explore** tab.
+3. In the query panel, you can specify example requests to send to the GraphQL API. The GraphiQL interface includes autocomplete based on the fields defined in your API configuration. For example, you might select one of your defined queries, and the fields within the query that you want data for.
+4. Click the play button, which sends the request, and returns the response in the middle panel.
 
 ## Create a GraphQL API
 

--- a/docs/content/guides/graphql/observability.md
+++ b/docs/content/guides/graphql/observability.md
@@ -1,0 +1,46 @@
+---
+title: Observability
+weight: 60
+description: Gather metrics for your GraphQL services in Prometheus and Grafana.
+---
+
+Gather metrics for your GraphQL APIs in Prometheus and Grafana.
+
+## Access Envoy logs in Prometheus and Grafana
+
+Review the Gloo Edge [Observability documentation]({{< versioned_link_path fromRoot="/guides/observability/" >}}) to access the dashboards default Prometheus and Grafana deployments that are installed with Gloo Edge, or configure your own Promethus or Grafana instances.
+
+For example, you can use the following commands to access the Envoy pod logs in the default Prometheus and Grafana dashboards:
+* Prometheus:
+  ```sh
+  kubectl -n gloo-system port-forward deployment/gateway-proxy 19000
+
+  curl http://localhost:19000/stats/prometheus
+  ```
+* Grafana:
+  ```
+  kubectl -n gloo-system port-forward deployment/glooe-grafana 3000
+
+  open http://localhost:3000/
+  ```
+
+## Envoy metrics for GraphQL
+
+The following Envoy metrics are collected for GraphQL APIs in your Gloo Edge environment.
+
+```
+envoy_gloo_system_bookinfo_graphql_graphql_Query_productsForHome_rest_resolver_failed_resolutions
+envoy_gloo_system_bookinfo_graphql_graphql_Query_productsForHome_rest_resolver_total_resolutions
+envoy_gloo_system_bookinfo_graphql_graphql_author_rest_resolver_failed_resolutions 
+envoy_gloo_system_bookinfo_graphql_graphql_author_rest_resolver_total_resolutions
+envoy_gloo_system_bookinfo_graphql_graphql_pages_rest_resolver_failed_resolutions
+envoy_gloo_system_bookinfo_graphql_graphql_pages_rest_resolver_total_resolutions
+envoy_gloo_system_bookinfo_graphql_graphql_review_rest_resolver_failed_resolutions envoy_gloo_system_bookinfo_graphql_graphql_review_rest_resolver_total_resolutions
+envoy_gloo_system_bookinfo_graphql_graphql_rq_error
+envoy_gloo_system_bookinfo_graphql_graphql_rq_invalid_query_error
+envoy_gloo_system_bookinfo_graphql_graphql_rq_parse_json_error
+envoy_gloo_system_bookinfo_graphql_graphql_rq_parse_query_error
+envoy_gloo_system_bookinfo_graphql_graphql_rq_total
+envoy_gloo_system_bookinfo_graphql_graphql_year_rest_resolver_failed_resolutions
+envoy_gloo_system_bookinfo_graphql_graphql_year_rest_resolver_total_resolutions
+```

--- a/docs/content/guides/graphql/resolver_config.md
+++ b/docs/content/guides/graphql/resolver_config.md
@@ -4,9 +4,11 @@ weight: 40
 description: Manually configure resolvers and schema for your GraphQL API.
 ---
 
-You can deploy your own GraphQL API, which might not leverage automatic service discovery and registration. To manually configure GraphQL resolvers, you create a Gloo Edge GraphQL API CRD. The following sections describe the configuration for REST <!--or gRPC -->resolvers, schema definitions for the types of data to return to graphQL queries, and an in-depth example.
+You can deploy your own GraphQL API, which might not leverage automatic service discovery and registration. To manually configure GraphQL resolvers, you create a Gloo Edge GraphQL API CRD. The following sections describe the configuration for REST or gRPC resolvers, schema definitions for the types of data to return to graphQL queries, and an in-depth example.
 
 ## REST resolvers
+
+Configure a REST resolver as a section within your `GraphQLApi` YAML file.
 
 ```yaml
 resolutions:
@@ -41,6 +43,7 @@ resolutions:
 
 This example REST resolver, `Query|productsForHome`, specifies the path and the method that are needed to request the data.
 ```yaml
+...
 resolutions:
   Query|productsForHome:
     restResolver:
@@ -51,19 +54,27 @@ resolutions:
       upstreamRef:
         name: default-productpage-9080
         namespace: gloo-system
+...
 ```
-<!--
+
 ## gRPC resolvers
 
-**QUESTION need the actual fields for a grpcResolver** Relevant section in the Proto: https://github.com/solo-io/gloo/blob/master/projects/gloo/api/v1/enterprise/options/graphql/v1alpha1/graphql.proto#L171
+Configure a REST resolver as a section within your `GraphQLApi` YAML file.
 
 ```yaml
 resolutions:
   # Resolver name
   Query|nameOfResolver:
     grpcResolver:
-      requestTransform: <need fields>
-      spanName: <need fields>
+      # Configuration for generating outgoing requests to a gRPC API
+      requestTransform:
+        # JSON representation of outgoing gRPC message to be sent to JSON service
+        outgoingMessageJson:
+          <key>: <value>
+        # The full name of the JSON service
+        serviceName:
+        # Method on the gRPC service defined in serviceName to make request to 
+        methodName:
       upstreamRef:
         # Name of the upstream resource associated with the REST API  
         name:
@@ -71,8 +82,23 @@ resolutions:
         namespace:
 ```
 
-**QUESTION need example grpcResolver**
--->
+This example gRPC resolver, `Query|UserService.GetUser`, specifies the `GetUser` method on the `user.UserService`, and the `default-users-8080` upstream service.
+```yaml
+...
+resolutions:
+  Query|UserService.GetUser:
+    grpcResolver:
+      requestTransform:
+        methodName: GetUser
+        outgoingMessageJson:
+          username: '{$args.UserSearch.username}'
+        serviceName: user.UserService
+      upstreamRef:
+        name: default-users-8080
+        namespace: gloo-system
+...
+```
+
 ## Schema definitions
 
 A schema definition determines what kind of data can be returned to a client that makes a GraphQL query to your endpoint. The schema specifies the data that a particular `type`, or service, returns in response to a GraphQL query.

--- a/docs/content/guides/graphql/resolver_config.md
+++ b/docs/content/guides/graphql/resolver_config.md
@@ -80,7 +80,7 @@ A schema definition determines what kind of data can be returned to a client tha
 In this example, fields are defined for the three Bookinfo services, Product, Review, and Rating. Additionally, the schema definition indicates which services reference the resolvers. In this example, the Product service references the `Query|productForHome` REST resolver.
 
 ```yaml
-schema_definition: |
+schemaDefinition: |
   type Query {
     productsForHome: [Product] @resolve(name: "Query|productsForHome")
   }

--- a/docs/content/guides/graphql/stitching.md
+++ b/docs/content/guides/graphql/stitching.md
@@ -1,0 +1,173 @@
+---
+title: Schema stitching
+weight: 50
+description: Use Gloo Edge to stitch together schemas for multiple GraphQL services.
+---
+
+{{% notice warning %}}
+Stitching is a beta feature. Do not use this feature in a production environment.
+{{% /notice %}}
+
+When you use GraphQL in Gloo Edge, you can stitch multiple schemas together to expose one unified GraphQL server to your clients.
+
+For example, consider a cluster to which the `user` and `product` services are deployed. These services are either native GraphQL servers, or have been converted to GraphQL via automatic schema discovery. However, both of these services contribute to a unified data model, which clients must typically stitch together in the frontend. With Gloo Edge, you can instead stitch the GraphQL schemas for these services together in the backend, and expose a unified GraphQL server to your clients. This frees your clients to consider only what data that they want to fetch, not how to fetch the data.
+
+To understand how stitching occurs, consider both of the services, starting with the user service. The user service provides a partial type definition for the `User` type, and a query for how to get the full name of a user given the username.
+```yaml
+type User {
+  username: String!
+  fullName: String
+}
+
+type Query {
+  getUserWithFullName(username: String!): User
+}
+```
+
+Example query to the user service:
+```yaml
+query {
+  getUserWithFullName(username: "akeith") {
+    fullName
+  }
+}
+```
+
+Example response from the user service:
+```json
+{
+  "getUserWithFullName": "Abigail Keith"
+}
+```
+
+The product service also provides a partial type definition for the `User` type, and a query for how to get the product name and the seller's username given the product ID.
+```yaml
+type User {
+  username: String!
+}
+
+
+type Product{
+  id: ID!
+  name: String!
+  seller: User!
+}
+
+type Query {
+  getProductById(id: ID!): Product!
+}
+```
+
+Example query to the product service:
+```yaml
+query {
+  getProductById(id: 125) {
+    name
+    seller {
+      username
+    }
+  }
+}
+```
+
+Example response from the product service:
+```json
+{
+  "getProductById": {
+    "name": "Narnia",
+    "seller": {
+      "username": "akeith"
+    }
+  }
+}
+```
+
+But consider a client that wants the full name of the seller for a given product, instead the username of the seller. Given the product ID, the client cannot get the seller's full name from the product service. However, the full name of any user _is_ provided by the user service. 
+
+To solve this problem, you can specify a configuration file to merge the types between the services. In the `merge_config` section for a `user-service` configuration file, you can specify which fields are unique to the `User` type, and how to get these fields. If a client provides the username for a user and wants the full name, Gloo Edge can use the `getUserWithFullName` query to provide the full name from the user service.
+**QUESTION is the user providing this merging config somewhere? Sounds like in **
+```yaml
+name: user-service
+namespace: products-app
+merge_config:
+  User:
+    query_field: getUserWithFullName
+    key: username
+...
+```
+
+Similarly, in the `merge_config` section for a `product-service` configuration file, you can specify which fields are unique to the `User` type, and how to get these fields. If a client provides the product ID and wants the product name, Gloo Edge can use the `getProductByID` query to provide the product ID from the product service.
+```yaml
+name: product-service
+namespace: products-app
+mergeConfig:
+  Product:
+    queryName: getProductById
+    key: id
+...
+```
+
+As a result, Gloo Edge generates a **stitched service**. From this one stitched service, a client can provide the product ID, and recieve the product name, the full name of the seller, and the username of the seller.
+```yaml
+type User {
+  username: String!
+  fullName: String
+}
+
+
+type Product{
+  id: ID!
+  name: String!
+  seller: User!
+}
+
+type Query {
+  getProductById(id: ID!): Product!
+}
+```
+
+Based on this stitched service information, the following schema definition is generated, which incorporates all the types and queries from each of the respective services. In the background, Gloo Edge uses this schema to create the requests to the stitched service, and then stitches the responses back together into one response to the client.
+```yaml
+schemaDefinition: |
+  type Query {
+    getUserWithFullName(username: String!): User
+    getProductById(productId: ID!): Product!
+  }
+
+  type User {
+    username: String!
+    fullName: String
+  }
+
+  type Product {
+    id: ID!
+    name: String!
+    seller: User!
+  }
+```
+
+Example query to the stitched service:
+```yaml
+query {
+  getProductById(id: 125) {
+    name
+    seller {
+      username
+      fullName
+    }
+  }
+}
+```
+
+Example response from the stitched service:
+```json
+{
+  "getProductById": {
+    "name": "Narnia",
+    "seller": {
+      "username": "akeith"
+      "fullName": "Abigail Keith"
+    }
+  }
+}
+```


### PR DESCRIPTION
Expands the GraphQL documentation by adding a UI overview, a stitching example, and a metrics reference.