### PR TITLE
Adding else clause in case discovery is disabled, because it fails if…

### DIFF
--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -148,6 +148,8 @@ subjects:
   - kind: ServiceAccount
     name: discovery
     namespace: {{ .Release.Namespace }}
+{{- else }}
+  []
 {{- end}}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}


### PR DESCRIPTION
… not empty list.

# Description

- added else clause for Discovery feature if disabled to add an empty list
- this bug fixes the issue with an empty value under subjects, in case .Values.discovery.enabled = false

# Context

Users needed this feature when doing an upgrade of gloo to 1.10.18
