### PR TITLE
Disabled discovery empty subjects fix

### DIFF
--- a/changelog/v1.12.0-beta1/helm-fix-discovery-empty-subjects.yaml
+++ b/changelog/v1.12.0-beta1/helm-fix-discovery-empty-subjects.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5866
+    description: Correct syntax of empty Subjects array in helm when discovery is disabled
+    resolvesIssue: false

--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -36,10 +36,12 @@ metadata:
     app: gloo
     gloo: rbac
 subjects:
-  {{- if .Values.discovery.enabled }}
+{{- if .Values.discovery.enabled }}
 - kind: ServiceAccount
   name: discovery
   namespace: {{ .Release.Namespace }}
+{{- else }}
+  []
 {{- end}}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}

--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -148,6 +148,8 @@ subjects:
   - kind: ServiceAccount
     name: discovery
     namespace: {{ .Release.Namespace }}
+{{- else }}
+  []
 {{- end}}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}


### PR DESCRIPTION
# Description

Corrects syntax of empty `subjects` array in helm chart when two role bindings' only subject is `discovery` which is removed due to Discovery being disabled

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

# Testing

This change does not manifest in existing unit tests for this issue and is not testable. Debugging the Golang unit test showed the `makeRoleBindingFromUnstructured(resource).Subjects` field contains an empty array both before and after the change.

For the following manual tests I used a policy file named `values-discovery_disabled.yaml` which disables discovery as follows:
```
gloo:
  deployment:
    image:
      repository: gloo
      tag: $VERSION
gatewayProxies:
  gatewayProxy:
    service:
      type: NodePort
      httpPort: 31500
      httpsPort: 32500
      httpNodePort: 31500
      httpsNodePort: 32500
discovery:
  enabled: false
global:
  image:
    registry: $IMAGE_REPO
    pullPolicy: Always
```

1) Tested helm template rendering of a policy with disabled discovery, yielding the expected empty arrays:
```
❯ helm template gloo-$VERSION.tgz -f values-discovery_disabled.yaml | egrep -B4 -A9 "gloo-graphqlapi-mutator-binding|gloo-upstream-mutator-binding"
# Source: gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: gloo-upstream-mutator-binding-default
  labels:
    app: gloo
    gloo: rbac
subjects:
  []
roleRef:
  kind: ClusterRole
  name: gloo-upstream-mutator-default
  apiGroup: rbac.authorization.k8s.io
--
# Source: gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
kind: ClusterRoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: gloo-graphqlapi-mutator-binding-default
  labels:
    app: gloo
    gloo: rbac
subjects:
  []
roleRef:
  kind: ClusterRole
  name: gloo-graphqlapi-mutator-default
  apiGroup: rbac.authorization.k8s.io
```

2) Tested a manual local deployment with discovery enabled and observed the expected bindings. 
Then updated the deployment with the above policy:
```
>helm upgrade -n gloo-system gloo _output/helm/charts/gloo-$VERSION.tgz --values values-discovery_disabled.yaml
```
This removed the bindings, showing no subjects:
```
❯ k describe clusterrolebindings.rbac.authorization.k8s.io -n gloo-system gloo-graphqlapi-mutator-binding-gloo-system gloo-upstream-mutator-binding-gloo-system       
Name:         gloo-graphqlapi-mutator-binding-gloo-system
Labels:       app=gloo
              app.kubernetes.io/managed-by=Helm
              gloo=rbac
Annotations:  meta.helm.sh/release-name: gloo
              meta.helm.sh/release-namespace: gloo-system
Role:
  Kind:  ClusterRole
  Name:  gloo-graphqlapi-mutator-gloo-system
Subjects:
  Kind  Name  Namespace
  ----  ----  ---------


Name:         gloo-upstream-mutator-binding-gloo-system
Labels:       app=gloo
              app.kubernetes.io/managed-by=Helm
              gloo=rbac
Annotations:  meta.helm.sh/release-name: gloo
              meta.helm.sh/release-namespace: gloo-system
Role:
  Kind:  ClusterRole
  Name:  gloo-upstream-mutator-gloo-system
Subjects:
  Kind  Name  Namespace
  ----  ----  ---------
```
