### PR TITLE
[1.11.x] Disabled discovery empty subjects fix (#6249)

### DIFF
--- a/changelog/v1.11.1/helm-fix-discovery-empty-subjects.yaml
+++ b/changelog/v1.11.1/helm-fix-discovery-empty-subjects.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5866
+    description: Correct syntax of empty Subjects array in helm when discovery is disabled
+    resolvesIssue: false

--- a/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
+++ b/install/helm/gloo/templates/23-namespace-clusterrolebinding-gateway.yaml
@@ -36,10 +36,12 @@ metadata:
     app: gloo
     gloo: rbac
 subjects:
-  {{- if .Values.discovery.enabled }}
+{{- if .Values.discovery.enabled }}
 - kind: ServiceAccount
   name: discovery
   namespace: {{ .Release.Namespace }}
+{{- else }}
+  []
 {{- end}}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}
@@ -148,6 +150,8 @@ subjects:
   - kind: ServiceAccount
     name: discovery
     namespace: {{ .Release.Namespace }}
+{{- else }}
+  []
 {{- end}}
 roleRef:
   kind: {{ include "gloo.roleKind" . }}


### PR DESCRIPTION
* Adding else clause in case discovery is disabled, because it fails if not empty list.

* Follow-up to contribution by vladimir-cmd

- add else statement to a second empty subjects array
- add changelog

Co-authored-by: Vladimir Bundalo <vbundalo@repay.com>
Co-authored-by: soloio-bulldozer[bot] <48420018+soloio-bulldozer[bot]@users.noreply.github.com>

# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
