### PR TITLE
fix issue with glooctl upgrade on windows

### DIFF
--- a/changelog/v1.12.0-beta2/glooctl-upgrade-windows-fix.yaml
+++ b/changelog/v1.12.0-beta2/glooctl-upgrade-windows-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6255
+    description: Fix issue where glooctl upgrade on windows would not find the release assets
+    resolvesIssue: false

--- a/projects/gloo/cli/pkg/cmd/upgrade/cmd.go
+++ b/projects/gloo/cli/pkg/cmd/upgrade/cmd.go
@@ -56,7 +56,14 @@ func upgradeGlooCtl(ctx context.Context, upgrade options.Upgrade) error {
 		Timeout: time.Duration(timeoutSeconds) * time.Second,
 	}
 
-	glooctlBinaryName := fmt.Sprintf("glooctl-%v-%v", runtime.GOOS, runtime.GOARCH)
+	glooctlBinaryName := ""
+	if runtime.GOOS != "windows" {
+		glooctlBinaryName = fmt.Sprintf("glooctl-%v-%v", runtime.GOOS, runtime.GOARCH)
+	} else {
+		//Windows binaries have .exe in asset name
+		glooctlBinaryName = fmt.Sprintf("glooctl-%v-%v%s", runtime.GOOS, runtime.GOARCH, ".exe")
+	}
+
 	release, err := getReleaseWithAsset(ctx, httpClient, upgrade.ReleaseTag, glooctlBinaryName)
 	if err != nil {
 		return errors.Wrapf(err, "getting release '%v' from solo-io/gloo repository", upgrade.ReleaseTag)


### PR DESCRIPTION
# Description

Please include a summary of the changes.

fix issue with glooctl upgrade on windows not finding assets

# Context

Fixes https://github.com/solo-io/gloo/issues/6255

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
