### PR TITLE
Resolve panic in gateway validation client

### DIFF
--- a/changelog/v1.12.0-beta2/robust-client-panic.yaml
+++ b/changelog/v1.12.0-beta2/robust-client-panic.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6237
+    resolvesIssue: true
+    description: Ensure that the validation client is nevel nil, even after the connection has been refreshed.

--- a/changelog/v1.12.0-beta2/robust-client-panic.yaml
+++ b/changelog/v1.12.0-beta2/robust-client-panic.yaml
@@ -2,4 +2,4 @@ changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/6237
     resolvesIssue: true
-    description: Ensure that the validation client is nevel nil, even after the connection has been refreshed.
+    description: Ensure that the validation client is never nil, even after the connection has been refreshed. 

--- a/projects/gateway/pkg/validation/robust_client.go
+++ b/projects/gateway/pkg/validation/robust_client.go
@@ -99,8 +99,15 @@ func (c *connectionRefreshingValidationClient) retryWithNewClient(ctx context.Co
 		c.lock.Lock()
 		defer c.lock.Unlock()
 		// if someone already changed my client, do not replace it
-		if validationClient == c.validationClient {
-			c.validationClient, reinstantiateClientErr = c.constructValidationClient()
+		if validationClient != c.validationClient {
+			return
+		}
+
+		// if someone has not already changed my client, replace it if successful
+		var newValidationClient validation.GlooValidationServiceClient
+		newValidationClient, reinstantiateClientErr = c.constructValidationClient()
+		if newValidationClient != nil {
+			c.validationClient = newValidationClient
 		}
 	}))
 }

--- a/projects/gateway/pkg/validation/robust_client_test.go
+++ b/projects/gateway/pkg/validation/robust_client_test.go
@@ -3,9 +3,10 @@ package validation
 import (
 	"context"
 	"fmt"
-	"github.com/rotisserie/eris"
 	"net"
 	"time"
+
+	"github.com/rotisserie/eris"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"

--- a/projects/gateway/pkg/validation/robust_client_test.go
+++ b/projects/gateway/pkg/validation/robust_client_test.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"context"
 	"fmt"
+	"github.com/rotisserie/eris"
 	"net"
 	"time"
 
@@ -92,6 +93,7 @@ var _ = Describe("RetryOnUnavailableClientConstructor", func() {
 		Expect(resp).To(Equal(res))
 
 	})
+
 })
 
 type mockWrappedValidationClient struct {
@@ -108,6 +110,7 @@ func (c *mockWrappedValidationClient) Validate(ctx context.Context, in *validati
 }
 
 var _ = Describe("RobustClient", func() {
+
 	It("swaps out the client when it returns a connection error", func() {
 		original := &mockWrappedValidationClient{name: "original"}
 		robustClient, _ := NewConnectionRefreshingValidationClient(func() (client validation.GlooValidationServiceClient, e error) {
@@ -135,6 +138,35 @@ var _ = Describe("RobustClient", func() {
 
 		robustClient.lock.RLock()
 		Expect(robustClient.validationClient).To(Equal(replacement))
+		robustClient.lock.RUnlock()
+	})
+
+	FIt("does not swap out the client when new client returns a connection error", func() {
+		original := &mockWrappedValidationClient{name: "original"}
+		robustClient, _ := NewConnectionRefreshingValidationClient(func() (client validation.GlooValidationServiceClient, e error) {
+			return original, nil
+		})
+
+		rootCtx := context.Background()
+
+		resp, err := robustClient.Validate(rootCtx, &validation.GlooValidationServiceRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(Equal(res))
+
+		// make the original client return an error
+		original.err = status.Error(codes.Unavailable, "oh no, an error")
+		// update the constructor func with a new client, that also returns an error
+		robustClient.constructValidationClient = func() (client validation.GlooValidationServiceClient, e error) {
+			return nil, eris.New("intentionally failed to connect")
+		}
+
+		// robust client should not replace with the replacement client since it could not be constructed
+		resp, err = robustClient.Validate(rootCtx, &validation.GlooValidationServiceRequest{})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(ContainElement(original.err))
+
+		robustClient.lock.RLock()
+		Expect(robustClient.validationClient).To(Equal(original))
 		robustClient.lock.RUnlock()
 	})
 })

--- a/projects/gateway/pkg/validation/robust_client_test.go
+++ b/projects/gateway/pkg/validation/robust_client_test.go
@@ -141,7 +141,7 @@ var _ = Describe("RobustClient", func() {
 		robustClient.lock.RUnlock()
 	})
 
-	FIt("does not swap out the client when new client returns a connection error", func() {
+	It("does not swap out the client when new client returns a connection error", func() {
 		original := &mockWrappedValidationClient{name: "original"}
 		robustClient, _ := NewConnectionRefreshingValidationClient(func() (client validation.GlooValidationServiceClient, e error) {
 			return original, nil


### PR DESCRIPTION
# Description

Ensure that the gateway validation client is never set to nil

# Context

We encountered this bug in tests that would occasionally panic, however the bug itself could impact customers

## Verification

I wrote a test first, and add that as the first commit. If you checkout just that test (no other changes) it will panic in the way that we noticed in some e2e tests. If you then checkout my fix and re-run the same test, it will pass.

## General Thoughts

I believe this issue arises because we have a local variable for clientReinstantiateError and a class variable for constructorClient. This means that we can ensure that on a clientReinstantiateError we do not retry, but we do set the client to nil which could be picked up on the subsequent request.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6237