### PR TITLE
Resolve data race in setup syncer test

### DIFF
--- a/changelog/v1.12.0-beta3/setup-syncer-data-race.yaml
+++ b/changelog/v1.12.0-beta3/setup-syncer-data-race.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/5860
+    resolvesIssue: false
+    description: Fix a data race that occurs during our setup syncer tests


### PR DESCRIPTION
# Description

Resolve a data race that occurs in our setup syncer test

# Context

I think this data race is due to our tests and not due to our implementation. Per https://github.com/kubernetes/kubernetes/pull/89019#issuecomment-600278461, we do setup schemes at construction time, as we should. Moreover, this flake has only occurred in this specific test. If this were a bug in our Gloo code, I would have expected to see it fail in other tests.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
