### PR TITLE
Add line about draft PRs to github actions readme

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,6 +4,8 @@
  - This workflow is used to open a PR in Solo-APIs which corresponds to a set of changes in Gloo OSS
  - The workflow is run when a Gloo OSS release is published
  - The workflow can be run manually from the "Actions" tab in Github while viewing the Gloo OSS repo
+   - Ensure that PRs created from manual workflow runs are not merged by adding the "Work in Progress" tag or by making 
+     the PR a draft.
    - The user must specify three arguments, which should take the following values:
    - `Use workflow from`: The branch in Gloo OSS which the generated Solo-APIs PR should mirror
    - `Release Tag Name`: The specific commit hash/tag in Gloo OSS from which the Solo-APIs PR should be generated


### PR DESCRIPTION
I added a reminder about not merging solo-apis PRs to the readme in github actions. We were discussing this in slack and this readme seems like a good place to ensure it is found in the future.