### PR TITLE
Run gzip compression after transformation

### DIFF
--- a/changelog/v1.12.0-beta4/gzip-early.yaml
+++ b/changelog/v1.12.0-beta4/gzip-early.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: Run the gzip compression filter after the transformation filter on responses.
+    issueLink: https://github.com/solo-io/gloo/issues/6206
+    resolvesIssue: false

--- a/projects/gloo/pkg/plugins/gzip/plugin.go
+++ b/projects/gloo/pkg/plugins/gzip/plugin.go
@@ -26,7 +26,7 @@ const (
 )
 
 // filter should be called after routing decision has been made
-var pluginStage = plugins.DuringStage(plugins.RouteStage)
+var pluginStage = plugins.DuringStage(plugins.FaultStage)
 
 type plugin struct{}
 

--- a/projects/gloo/pkg/plugins/gzip/plugin.go
+++ b/projects/gloo/pkg/plugins/gzip/plugin.go
@@ -25,7 +25,10 @@ const (
 	GzipLibrary          = "envoy.compression.gzip.compressor"
 )
 
-// filter should be called after routing decision has been made
+// filter should be called during the final stage on the response path, to ensure
+// compression happens after any transformations. this means that we need to put it
+// in the first stage of the request path (since filters are executed in the reverse
+// order on the response path)
 var pluginStage = plugins.DuringStage(plugins.FaultStage)
 
 type plugin struct{}

--- a/projects/gloo/pkg/plugins/gzip/plugin_test.go
+++ b/projects/gloo/pkg/plugins/gzip/plugin_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Plugin", func() {
 						TypedConfig: utils.MustMessageToAny(compressorConfig),
 					},
 				},
-				Stage: plugins.DuringStage(plugins.RouteStage),
+				Stage: plugins.DuringStage(plugins.FaultStage),
 			},
 		}))
 
@@ -83,7 +83,7 @@ var _ = Describe("Plugin", func() {
 						TypedConfig: utils.MustMessageToAny(compressorConfig),
 					},
 				},
-				Stage: plugins.DuringStage(plugins.RouteStage),
+				Stage: plugins.DuringStage(plugins.FaultStage),
 			},
 		}))
 	})
@@ -123,7 +123,7 @@ var _ = Describe("Plugin", func() {
 						TypedConfig: utils.MustMessageToAny(compressorConfig),
 					},
 				},
-				Stage: plugins.DuringStage(plugins.RouteStage),
+				Stage: plugins.DuringStage(plugins.FaultStage),
 			},
 		}))
 
@@ -153,7 +153,7 @@ var _ = Describe("Plugin", func() {
 						TypedConfig: utils.MustMessageToAny(compressorConfig),
 					},
 				},
-				Stage: plugins.DuringStage(plugins.RouteStage),
+				Stage: plugins.DuringStage(plugins.FaultStage),
 			},
 		}))
 	})


### PR DESCRIPTION
# Description

Currently, the gzip compression filter runs before the transformation filter on the response path (gzip does not run on the request path). This can result in corrupt data when the transformation filter modifies the gzip blob. To fix this, we now run gzip after transformation on the response path. This means that we need to configure gzip to run *before* transformation on the request path (even though gzip isn't actually used on the request path). Since the earliest stage that the transformation filter can run is the [stage after the FaultStage](https://github.com/solo-io/gloo/blob/081423f6837f7c6ad4be4ac8f4eaf5e98b074beb/projects/gloo/pkg/plugins/transformation/plugin.go#L44), gzip needs to run during the FaultStage.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
