### PR TITLE
Backport: Docs: Fix GraphQL links 1.10.x

### DIFF
--- a/changelog/v1.10.21/doc-fix-links.yaml
+++ b/changelog/v1.10.21/doc-fix-links.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Backports fix for GraphQL links.

--- a/docs/content/guides/graphql/getting_started.md
+++ b/docs/content/guides/graphql/getting_started.md
@@ -313,7 +313,7 @@ EOF
 
 Now that you've tried out GraphQL with Gloo Edge, check out the following pages to configure your own services for GraphQL integration.
 <!--* [Visualize your GraphQL services in the UI]({{% versioned_link_path fromRoot="/guides/traffic_management/request_processing/graphql/graphql_ui/" %}})-->
-* [Explore automatic schema generation with GraphQL service discovery]({{% versioned_link_path fromRoot="/guides/traffic_management/request_processing/graphql/automatic_discovery/" %}})
-* [Manually configure resolvers and schema for your GraphQL API]({{% versioned_link_path fromRoot="/guides/traffic_management/request_processing/graphql/resolver_config/" %}})
+* [Explore automatic schema generation with GraphQL service discovery]({{% versioned_link_path fromRoot="/guides/graphql/automatic_discovery/" %}})
+* [Manually configure resolvers and schema for your GraphQL API]({{% versioned_link_path fromRoot="/guides/graphql/resolver_config/" %}})
 <!--* [Monitor your GraphQL services]({{% versioned_link_path fromRoot="/guides/traffic_management/request_processing/graphql/observability/" %}})-->
 * [Gloo Edge API reference for GraphQL]({{% versioned_link_path fromRoot="/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/graphql/v1alpha1/graphql.proto.sk/" %}})


### PR DESCRIPTION
Backport of https://github.com/solo-io/gloo/pull/6323/files