### PR TITLE
Fixed template to correctly use envoySidecarResources for istio-proxy

### DIFF
--- a/changelog/v1.12.0-beta5/fix-proxy-deployment-override.yaml
+++ b/changelog/v1.12.0-beta5/fix-proxy-deployment-override.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: HELM
+    description: Fix duplicate key in YAML.
+    issueLink: https://github.com/solo-io/gloo/pull/5350

--- a/changelog/v1.12.0-beta5/fix-proxy-deployment-override.yaml
+++ b/changelog/v1.12.0-beta5/fix-proxy-deployment-override.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: HELM
-    description: Fix duplicate key in YAML.
-    issueLink: https://github.com/solo-io/gloo/pull/5350

--- a/changelog/v1.12.0-beta6/fix-proxy-deployment-override.yaml
+++ b/changelog/v1.12.0-beta6/fix-proxy-deployment-override.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    description: Fix key in Helm template used to configure resources of istio-proxy sidecar
+    issueLink: https://github.com/solo-io/gloo/pull/6044
+    resolvesIssue: false

--- a/changelog/v1.12.0-beta6/fix-proxy-deployment-override.yaml
+++ b/changelog/v1.12.0-beta6/fix-proxy-deployment-override.yaml
@@ -1,5 +1,8 @@
 changelog:
   - type: HELM
     description: Fix key in Helm template used to configure resources of istio-proxy sidecar
+    description: >-
+      Corrects helm value of the gateway-proxy envoy sidecar ("istio-proxy") to use glooMtls.envoySidecarResources
+      instead of glooMtls.sdsResources, matching the sidecar in the gloo container ("envoy-sidecar")
     issueLink: https://github.com/solo-io/gloo/pull/6044
     resolvesIssue: false

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -351,9 +351,9 @@ spec:
 {{- if not $global.istioSDS.customSidecars }}
       - name: istio-proxy
         image: docker.io/istio/proxyv2:1.9.5
-        {{- if $global.glooMtls.sdsResources }}
+        {{- if $global.glooMtls.envoySidecarResources }}
         resources:
-{{ toYaml $global.glooMtls.sdsResources | indent 10}}
+{{ toYaml $global.glooMtls.envoySidecarResources | indent 10}}
         {{- end}}
         args:
         - proxy

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3323,7 +3323,7 @@ spec:
 								if container.Name == "envoy-sidecar" || container.Name == "sds" || container.Name == "istio-proxy" {
 									var expectedVals = sdsVals
 									// istio-proxy is another sds container
-									if container.Name == "envoy-sidecar" {
+									if container.Name == "envoy-sidecar" || container.Name == "istio-proxy" {
 										expectedVals = envoySidecarVals
 									}
 

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3322,7 +3322,9 @@ spec:
 								Expect(container.Resources).NotTo(BeNil(), "deployment/container %s/%s had nil resources", deployment.GetName(), container.Name)
 								if container.Name == "envoy-sidecar" || container.Name == "sds" || container.Name == "istio-proxy" {
 									var expectedVals = sdsVals
-									// istio-proxy is another sds container
+									// Two deployments employ proxy containers requiring the envoySidecar resources config:
+									// - gloo (whose sidecar container is named: "envoy-sidecar")
+									// - gateway-proxy (named: "istio-proxy")
 									if container.Name == "envoy-sidecar" || container.Name == "istio-proxy" {
 										expectedVals = envoySidecarVals
 									}


### PR DESCRIPTION
# Description

This change fixes a helm template so the envoySidecarResources value is used when generating the gateway proxy deployment.

# Context

The Helm template had been incorrectly using sdsResources.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
