### PR TITLE
Use link syntax to avoid ambiguous linking behavior

### DIFF
--- a/changelog/v1.12.0-beta7/docs-link-fix.yaml
+++ b/changelog/v1.12.0-beta7/docs-link-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/6372
+    resolvesIssue: true
+    description: Fixes broken link to Helm hooks page.

--- a/docs/content/installation/gateway/kubernetes/_index.md
+++ b/docs/content/installation/gateway/kubernetes/_index.md
@@ -87,7 +87,7 @@ Once you've installed Gloo Edge, please be sure [to verify your installation]({{
 
 {{% notice note %}}
 You can run the command with the flag `--dry-run` to output the Kubernetes manifests (as `yaml`) that `glooctl` will apply to the cluster instead of installing them.
-Note that a proper Gloo Edge installation depends on Helm Chart Hooks (https://helm.sh/docs/topics/charts_hooks/), so the behavior of your installation
+Note that a proper Gloo Edge installation depends on [Helm Chart Hooks](https://helm.sh/docs/topics/charts_hooks/), so the behavior of your installation
 may not be correct if you install by directly applying the dry run manifests, e.g. `glooctl install gateway --dry-run | kubectl apply -f -`.
 {{% /notice %}}
 


### PR DESCRIPTION
# Description

On the latest Firefox the link for "Helm Chart Hooks" goes to `https://helm.sh/docs/topics/charts_hooks/),` with the parenthesis and comma at the end. This should resolve that as well as make the format more in-line with the rest of the page.

# Context

https://docs.solo.io/gloo-edge/latest/installation/gateway/kubernetes/#installing-gloo-edge-on-kubernetes

Affects Chrome 102, Firefox 100, and Edge 100. This closes #6372.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6372