### PR TITLE
Fix certgen upgrade

### DIFF
--- a/changelog/v1.12.0-beta8/fix-certgen-upgrade.yaml
+++ b/changelog/v1.12.0-beta8/fix-certgen-upgrade.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6384
+    description: Run gateway certgen job on upgrade and make sure the validation webhook gets an updated caBundle on upgrade.

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -14,7 +14,7 @@ metadata:
   name: gateway-certgen
   namespace: {{ .Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3516,7 +3516,7 @@ metadata:
   name: gateway-certgen
   namespace: ` + namespace + `
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-delete-policy": "hook-succeeded"
     "helm.sh/hook-weight": "10"
 spec:

--- a/jobs/pkg/kube/secret_test.go
+++ b/jobs/pkg/kube/secret_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Secret", func() {
 			CaBundle:           data,
 		}
 
-		err := CreateTlsSecret(context.TODO(), kube, secretCfg)
+		_, err := CreateTlsSecret(context.TODO(), kube, secretCfg)
 		Expect(err).NotTo(HaveOccurred())
 
 		ctx, cancel := context.WithCancel(context.Background())
@@ -54,7 +54,7 @@ var _ = Describe("Secret", func() {
 		}))
 	})
 
-	Context("SecretExistsAndIsValidTlsSecret", func() {
+	Context("Get existing valid TLS secret", func() {
 
 		generateCaCertBytes := func(notBefore, notAfter time.Time) []byte {
 			// CA cert
@@ -82,23 +82,11 @@ var _ = Describe("Secret", func() {
 		}
 
 		It("doesn't error on non-existing secret", func() {
-			data := []byte{1, 2, 3}
-
 			kube := fake.NewSimpleClientset()
-			secretCfg := TlsSecret{
-				SecretName:         "mysecret",
-				SecretNamespace:    "mynamespace",
-				PrivateKeyFileName: "tls.key",
-				CertFileName:       "tls.crt",
-				CaBundleFileName:   "ca.crt",
-				PrivateKey:         data,
-				Cert:               generateCaCertBytes(time.Now(), time.Now().Add(1*time.Minute)),
-				CaBundle:           data,
-			}
 
-			valid, err := SecretExistsAndIsValidTlsSecret(context.TODO(), kube, secretCfg)
+			secret, err := GetExistingValidTlsSecret(context.TODO(), kube, "mysecret", "mynamespace")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(valid).To(BeFalse())
+			Expect(secret).To(BeNil())
 		})
 
 		It("recognizes a tls secret that is still valid", func() {
@@ -116,12 +104,12 @@ var _ = Describe("Secret", func() {
 				CaBundle:           data,
 			}
 
-			err := CreateTlsSecret(context.TODO(), kube, secretCfg)
+			_, err := CreateTlsSecret(context.TODO(), kube, secretCfg)
 			Expect(err).NotTo(HaveOccurred())
 
-			valid, err := SecretExistsAndIsValidTlsSecret(context.TODO(), kube, secretCfg)
+			existing, err := GetExistingValidTlsSecret(context.TODO(), kube, "mysecret", "mynamespace")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(valid).To(BeTrue())
+			Expect(existing).NotTo(BeNil())
 		})
 
 		It("recognizes a tls secret that is invalid relative to now", func() {
@@ -139,12 +127,12 @@ var _ = Describe("Secret", func() {
 				CaBundle:           data,
 			}
 
-			err := CreateTlsSecret(context.TODO(), kube, secretCfg)
+			_, err := CreateTlsSecret(context.TODO(), kube, secretCfg)
 			Expect(err).NotTo(HaveOccurred())
 
-			valid, err := SecretExistsAndIsValidTlsSecret(context.TODO(), kube, secretCfg)
+			existing, err := GetExistingValidTlsSecret(context.TODO(), kube, "mysecret", "mynamespace")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(valid).To(BeFalse())
+			Expect(existing).To(BeNil())
 		})
 
 		It("recognizes a tls secret that is invalid relative to now, not first cert in chain", func() {
@@ -166,12 +154,12 @@ var _ = Describe("Secret", func() {
 				CaBundle:           data,
 			}
 
-			err := CreateTlsSecret(context.TODO(), kube, secretCfg)
+			_, err := CreateTlsSecret(context.TODO(), kube, secretCfg)
 			Expect(err).NotTo(HaveOccurred())
 
-			valid, err := SecretExistsAndIsValidTlsSecret(context.TODO(), kube, secretCfg)
+			existing, err := GetExistingValidTlsSecret(context.TODO(), kube, "mysecret", "mynamespace")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(valid).To(BeFalse())
+			Expect(existing).To(BeNil())
 		})
 	})
 })

--- a/jobs/pkg/run/run.go
+++ b/jobs/pkg/run/run.go
@@ -3,13 +3,13 @@ package run
 import (
 	"context"
 
-	"go.uber.org/zap"
-
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/jobs/pkg/certgen"
 	"github.com/solo-io/gloo/jobs/pkg/kube"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/go-utils/contextutils"
+	"go.uber.org/zap"
+	v1 "k8s.io/api/core/v1"
 )
 
 type Options struct {
@@ -50,38 +50,44 @@ func Run(ctx context.Context, opts Options) error {
 	if opts.ServerKeySecretFileName == "" {
 		return eris.Errorf("must provide name for the server key entry in the secret data")
 	}
-	certs, err := certgen.GenCerts(opts.SvcName, opts.SvcNamespace)
-	if err != nil {
-		return eris.Wrapf(err, "generating self-signed certs and key")
-	}
+
 	kubeClient := helpers.MustKubeClient()
 
-	caCert := append(certs.ServerCertificate, certs.CaCertificate...)
-	secretConfig := kube.TlsSecret{
-		SecretName:         opts.SecretName,
-		SecretNamespace:    opts.SecretNamespace,
-		PrivateKeyFileName: opts.ServerKeySecretFileName,
-		CertFileName:       opts.ServerCertSecretFileName,
-		CaBundleFileName:   opts.ServerCertAuthorityFileName,
-		PrivateKey:         certs.ServerCertKey,
-		Cert:               caCert,
-		CaBundle:           certs.CaCertificate,
-	}
-	existAndValid := false
+	var secret *v1.Secret
+	var err error
 	if !opts.ForceRotation {
-		existAndValid, err = kube.SecretExistsAndIsValidTlsSecret(ctx, kubeClient, secretConfig)
+		// check if there is an existing valid TLS secret
+		secret, err = kube.GetExistingValidTlsSecret(ctx, kubeClient, opts.SecretName, opts.SecretNamespace)
 		if err != nil {
 			return eris.Wrapf(err, "failed validating existing secret")
 		}
 
-		if existAndValid {
-			contextutils.LoggerFrom(ctx).Infow("existing TLS secret found, skipping update to TLS secret and ValidatingWebhookConfiguration since the old TLS secret is still existAndValid",
-				zap.String("secretName", secretConfig.SecretName),
-				zap.String("secretNamespace", secretConfig.SecretNamespace))
+		if secret != nil {
+			contextutils.LoggerFrom(ctx).Infow("existing TLS secret found, skipping update to TLS secret since the old TLS secret is still valid",
+				zap.String("secretName", opts.SecretName),
+				zap.String("secretNamespace", opts.SecretNamespace))
 		}
 	}
-	if !existAndValid {
-		if err := kube.CreateTlsSecret(ctx, kubeClient, secretConfig); err != nil {
+	// if ForceRotation=true or there is no existing valid secret, generate one
+	if secret == nil {
+		certs, err := certgen.GenCerts(opts.SvcName, opts.SvcNamespace)
+		if err != nil {
+			return eris.Wrapf(err, "generating self-signed certs and key")
+		}
+
+		caCert := append(certs.ServerCertificate, certs.CaCertificate...)
+		secretConfig := kube.TlsSecret{
+			SecretName:         opts.SecretName,
+			SecretNamespace:    opts.SecretNamespace,
+			PrivateKeyFileName: opts.ServerKeySecretFileName,
+			CertFileName:       opts.ServerCertSecretFileName,
+			CaBundleFileName:   opts.ServerCertAuthorityFileName,
+			PrivateKey:         certs.ServerCertKey,
+			Cert:               caCert,
+			CaBundle:           certs.CaCertificate,
+		}
+		secret, err = kube.CreateTlsSecret(ctx, kubeClient, secretConfig)
+		if err != nil {
 			return eris.Wrapf(err, "failed creating secret")
 		}
 	}
@@ -95,7 +101,7 @@ func Run(ctx context.Context, opts Options) error {
 	vwcConfig := kube.WebhookTlsConfig{
 		ServiceName:      opts.SvcName,
 		ServiceNamespace: opts.SvcNamespace,
-		CaBundle:         certs.CaCertificate,
+		CaBundle:         secret.Data[opts.ServerCertAuthorityFileName],
 	}
 
 	if err := kube.UpdateValidatingWebhookConfigurationCaBundle(ctx, kubeClient, vwcName, vwcConfig); err != nil {

--- a/test/kube2e/knative/knative_manual_tls_test.go
+++ b/test/kube2e/knative/knative_manual_tls_test.go
@@ -109,7 +109,7 @@ func addTLSSecret() {
 		// CaBundle:           certs.CaCertificate,
 	}
 
-	err = kube.CreateTlsSecret(context.Background(), kubeClient, secretConfig)
+	_, err = kube.CreateTlsSecret(context.Background(), kubeClient, secretConfig)
 	Expect(err).NotTo(HaveOccurred(), "it should create the tls secret")
 }
 


### PR DESCRIPTION
# Description

- Make sure the gateway certgen job runs on upgrade, since we now reinstall the validation webhook on upgrade and it needs the caBundle field to be populated by the certgen job.
- Fix a bug in the certgen job where if we don't create a new Secret (because the existing one is still valid), we were still setting a newly generated caBundle on the validation webhook (which was not attached to any persisted secret)


# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6384