### PR TITLE
fix translator syncer test flake

### DIFF
--- a/changelog/v1.12.0-beta9/fix-translator-syncer-flake.yaml
+++ b/changelog/v1.12.0-beta9/fix-translator-syncer-flake.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix translator syncer test flake by waiting for status to be ready.
+    issueLink: https://github.com/solo-io/gloo/issues/6388

--- a/projects/gateway/pkg/syncer/translator_syncer_test.go
+++ b/projects/gateway/pkg/syncer/translator_syncer_test.go
@@ -182,8 +182,10 @@ var _ = Describe("TranslatorSyncer", func() {
 		reportedKey := getMapOnlyKey(mockReporter.Reports())
 		Expect(reportedKey).To(Equal(translator.UpstreamToClusterName(vs.GetMetadata().Ref())))
 		Expect(mockReporter.Reports()[reportedKey]).To(BeEquivalentTo(errs[vs]))
-		s := mockReporter.Statuses()[reportedKey]["*v1.Proxy.test_gloo-system"]
-		Expect(s.State).To(BeEquivalentTo(core.Status_Accepted))
+		m := map[string]*core.Status{
+			"*v1.Proxy.test_gloo-system": {State: core.Status_Accepted},
+		}
+		Eventually(func() map[string]*core.Status { return mockReporter.Statuses()[reportedKey] }, "5s", "0.5s").Should(BeEquivalentTo(m))
 	})
 
 	It("should retry setting the status if it first fails", func() {
@@ -215,7 +217,10 @@ var _ = Describe("TranslatorSyncer", func() {
 		reportedKey := getMapOnlyKey(mockReporter.Reports())
 		Expect(reportedKey).To(Equal(translator.UpstreamToClusterName(vs.GetMetadata().Ref())))
 		Expect(mockReporter.Reports()[reportedKey]).To(BeEquivalentTo(errs[vs]))
-		Expect(mockReporter.Statuses()[reportedKey]["*v1.Proxy.test_gloo-system"].State).To(BeEquivalentTo(core.Status_Accepted))
+		m := map[string]*core.Status{
+			"*v1.Proxy.test_gloo-system": {State: core.Status_Accepted},
+		}
+		Eventually(func() map[string]*core.Status { return mockReporter.Statuses()[reportedKey] }, "5s", "0.5s").Should(BeEquivalentTo(m))
 	})
 
 	It("should set status correctly when one proxy errors", func() {


### PR DESCRIPTION
# Description

Revert a previous change that removed the Eventually when waiting for status to update

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6388