### PR TITLE
Test flake fixes

### DIFF
--- a/changelog/v1.12.0-beta9/staged-transformation-flake.yaml
+++ b/changelog/v1.12.0-beta9/staged-transformation-flake.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/6356
+    description: Make the upstream reachable check more robust in the transformation test.

--- a/test/e2e/staged_transformation_test.go
+++ b/test/e2e/staged_transformation_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -304,7 +305,10 @@ var _ = Describe("Staged Transformation", func() {
 	Context("with auth", func() {
 		TestUpstreamReachable := func() {
 			Eventually(func() error {
-				_, err := http.DefaultClient.Get(fmt.Sprintf("http://localhost:%d/1", envoyPort))
+				resp, err := http.DefaultClient.Get(fmt.Sprintf("http://localhost:%d/1", envoyPort))
+				if resp != nil && resp.StatusCode != 403 {
+					return errors.New("Expected status 403")
+				}
 				return err
 			}, "30s", "1s").ShouldNot(HaveOccurred())
 		}


### PR DESCRIPTION
# Description
The test sets up an upstream and some additional configuration and expects to get a 403 when all the config is propagated. The previous readiness check also succeeded on 503 which would sometimes happen before the config was finished propagating (I think as a result of config from a previous test). In this change the test looks for a 403. 
Running with `untilItFails` locally, it would fail after <7 runs before the fix and did not fail after 15 runs after the fix.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6356