### PR TITLE
RemoveUnusedFilters evaluated per HttpListener

### DIFF
--- a/changelog/v1.12.0-beta10/remove-cors-default-filter.yaml
+++ b/changelog/v1.12.0-beta10/remove-cors-default-filter.yaml
@@ -9,3 +9,10 @@ changelog:
       and there is no CORS configuration defined.
     issueLink: https://github.com/solo-io/gloo/issues/6042
     resolvesIssue: false
+  - type: FIX
+    description: |
+      Change the log level from WARN to DEBUG when a resource kind is processed that does
+      not yet support metrics reporting for statuses. This message would occur on all
+      translation runs and confuse users.
+    issueLink: https://github.com/solo-io/gloo/issues/3964
+    resolvesIssue: false

--- a/changelog/v1.12.0-beta10/remove-cors-default-filter.yaml
+++ b/changelog/v1.12.0-beta10/remove-cors-default-filter.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Allow CLI to cleanup Federated MatchableHttpGateway CRD
+    issueLink: https://github.com/solo-io/gloo/issues/5948
+    resolvesIssue: false
+  - type: FIX
+    description: |
+      Ensure CORS filter is not added to filter chain when removeUnusedFilters is enabled
+      and there is no CORS configuration defined.
+    issueLink: https://github.com/solo-io/gloo/issues/6042
+    resolvesIssue: false

--- a/changelog/v1.12.0-beta10/unused-filters-followup.yaml
+++ b/changelog/v1.12.0-beta10/unused-filters-followup.yaml
@@ -17,6 +17,7 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/3964
     resolvesIssue: false
   - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5651
     description: |
       Ensure that removeUnusedFilters is localized to an HttpListener instead of a Proxy.
       Previously, if a filter were configured for one listener, it would cause another listener to

--- a/changelog/v1.12.0-beta10/unused-filters-followup.yaml
+++ b/changelog/v1.12.0-beta10/unused-filters-followup.yaml
@@ -5,8 +5,8 @@ changelog:
     resolvesIssue: false
   - type: FIX
     description: |
-      Ensure CORS filter is not added to filter chain when removeUnusedFilters is enabled
-      and there is no CORS configuration defined.
+      Ensure CORS and GrpcWeb filters are not added to filter chain when removeUnusedFilters is enabled
+      and there is no filter configuration defined.
     issueLink: https://github.com/solo-io/gloo/issues/6042
     resolvesIssue: false
   - type: FIX
@@ -16,3 +16,8 @@ changelog:
       translation runs and confuse users.
     issueLink: https://github.com/solo-io/gloo/issues/3964
     resolvesIssue: false
+  - type: FIX
+    description: |
+      Ensure that removeUnusedFilters is localized to an HttpListener instead of a Proxy.
+      Previously, if a filter were configured for one listener, it would cause another listener to
+      render empty configuration.

--- a/projects/gateway/pkg/utils/metrics/metrics.go
+++ b/projects/gateway/pkg/utils/metrics/metrics.go
@@ -126,7 +126,7 @@ func (m *ConfigStatusMetrics) SetResourceValid(ctx context.Context, resource res
 	log := contextutils.LoggerFrom(ctx)
 	gvk, err := resourceToGVK(resource)
 	if err != nil {
-		log.Warnf(err.Error())
+		log.Debugf(err.Error())
 		return
 	}
 	if m.metrics[gvk] != nil {
@@ -143,7 +143,7 @@ func (m *ConfigStatusMetrics) SetResourceInvalid(ctx context.Context, resource r
 	log := contextutils.LoggerFrom(ctx)
 	gvk, err := resourceToGVK(resource)
 	if err != nil {
-		log.Warnf(err.Error())
+		log.Debugf(err.Error())
 		return
 	}
 	if m.metrics[gvk] != nil {

--- a/projects/gloo/cli/pkg/cmd/install/util.go
+++ b/projects/gloo/cli/pkg/cmd/install/util.go
@@ -54,6 +54,7 @@ func init() {
 		"failoverschemes.fed.solo.io",
 		"federatedauthconfigs.fed.enterprise.gloo.solo.io",
 		"federatedgateways.fed.gateway.solo.io",
+		"federatedmatchablehttpgateways.fed.gateway.solo.io",
 		"federatedroutetables.fed.gateway.solo.io",
 		"federatedsettings.fed.gloo.solo.io",
 		"federatedupstreamgroups.fed.gloo.solo.io",

--- a/projects/gloo/pkg/plugins/cors/plugin.go
+++ b/projects/gloo/pkg/plugins/cors/plugin.go
@@ -37,7 +37,7 @@ var (
 	pluginStage             = plugins.DuringStage(plugins.CorsStage)
 )
 
-type plugin struct{
+type plugin struct {
 	filterNeeded bool
 }
 

--- a/projects/gloo/pkg/plugins/csrf/plugin_test.go
+++ b/projects/gloo/pkg/plugins/csrf/plugin_test.go
@@ -197,6 +197,8 @@ var _ = Describe("plugin", func() {
 
 	It("allows vhost specific csrf config", func() {
 		p := NewPlugin()
+		p.Init(plugins.InitParams{Ctx: context.TODO(), Settings: &v1.Settings{Gloo: &v1.GlooOptions{RemoveUnusedFilters: &wrapperspb.BoolValue{Value: false}}}})
+
 		out := &envoy_config_route.VirtualHost{}
 		err := p.ProcessVirtualHost(plugins.VirtualHostParams{}, &v1.VirtualHost{
 			Options: &v1.VirtualHostOptions{
@@ -218,6 +220,8 @@ var _ = Describe("plugin", func() {
 
 	It("allows weighted destination specific csrf config", func() {
 		p := NewPlugin()
+		p.Init(plugins.InitParams{Ctx: context.TODO(), Settings: &v1.Settings{Gloo: &v1.GlooOptions{RemoveUnusedFilters: &wrapperspb.BoolValue{Value: false}}}})
+
 		out := &envoy_config_route.WeightedCluster_ClusterWeight{}
 		err := p.ProcessWeightedDestination(plugins.RouteParams{}, &v1.WeightedDestination{
 			Options: &v1.WeightedDestinationOptions{

--- a/projects/gloo/pkg/plugins/registry/registry_test.go
+++ b/projects/gloo/pkg/plugins/registry/registry_test.go
@@ -5,6 +5,21 @@ import (
 	"reflect"
 	"testing"
 
+	v2 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/filter/http/gzip/v2"
+	v3 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/buffer/v3"
+	v32 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/csrf/v3"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/proxylatency"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/dlp"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/waf"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/dynamic_forward_proxy"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc_json"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc_web"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/hcm"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/healthcheck"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/wasm"
+
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	gloov1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -38,19 +53,51 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 			Name:    "virt1",
 			Domains: []string{"*"},
 		}
+		emptyListener := &gloov1.Listener{
+			Name: "empty-listener",
+			ListenerType: &gloov1.Listener_HttpListener{
+				HttpListener: &gloov1.HttpListener{
+					Options:      &gloov1.HttpListenerOptions{},
+					VirtualHosts: []*gloov1.VirtualHost{virtualHost},
+				},
+			},
+		}
+		fullyConfiguredListener := &gloov1.Listener{
+			Name: "fully-configured-listener",
+			ListenerType: &gloov1.Listener_HttpListener{
+				HttpListener: &gloov1.HttpListener{
+					Options: &gloov1.HttpListenerOptions{
+						GrpcWeb:                       &grpc_web.GrpcWeb{},
+						HttpConnectionManagerSettings: &hcm.HttpConnectionManagerSettings{},
+						HealthCheck:                   &healthcheck.HealthCheck{},
+						Extensions:                    &gloov1.Extensions{},
+						Waf:                           &waf.Settings{},
+						Dlp:                           &dlp.FilterConfig{},
+						Wasm:                          &wasm.PluginSource{},
+						Extauth:                       &v1.Settings{},
+						RatelimitServer:               &ratelimit.Settings{},
+						Gzip:                          &v2.Gzip{},
+						ProxyLatency:                  &proxylatency.ProxyLatency{},
+						Buffer:                        &v3.Buffer{},
+						Csrf:                          &v32.CsrfPolicy{},
+						GrpcJsonTranscoder:            &grpc_json.GrpcJsonTranscoder{},
+						SanitizeClusterHeader:         &wrapperspb.BoolValue{},
+						LeftmostXffAddress:            &wrapperspb.BoolValue{},
+						DynamicForwardProxy:           &dynamic_forward_proxy.FilterConfig{},
+					},
+					VirtualHosts: []*gloov1.VirtualHost{virtualHost},
+				},
+			},
+		}
 		proxy := &gloov1.Proxy{
 			Metadata: &core.Metadata{
 				Name:      "proxy",
 				Namespace: "default",
 			},
-			Listeners: []*gloov1.Listener{{
-				Name: "default",
-				ListenerType: &gloov1.Listener_HttpListener{
-					HttpListener: &gloov1.HttpListener{
-						VirtualHosts: []*gloov1.VirtualHost{virtualHost},
-					},
-				},
-			}},
+			Listeners: []*gloov1.Listener{
+				emptyListener,
+				fullyConfiguredListener,
+			},
 		}
 
 		params := plugins.Params{
@@ -61,20 +108,16 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 		}
 		// Filters should not be added to this map without due consideration
 		// In general we should strive not to add any new default filters going forwards
-		knownBaseFilters := map[string]struct{}{
-			"envoy.filters.http.grpc_web": {},
-		}
-		t.Run("Http Filters without override value", func(t *testing.T) {
-			plugs := pluginRegistry.GetPlugins()
+		knownBaseFilters := map[string]struct{}{}
 
-			potentiallyNonConformingFilters := []plugins.StagedHttpFilter{}
-			for _, p := range plugs {
+		t.Run("Http Filters without override value", func(t *testing.T) {
+			for _, p := range pluginRegistry.GetPlugins() {
 				// Many plugins require safety via an init which is outside of the creation step
 				p.Init(plugins.InitParams{Ctx: ctx, Settings: &gloov1.Settings{Gloo: &gloov1.GlooOptions{RemoveUnusedFilters: &wrapperspb.BoolValue{Value: true}}}})
-				httpPlug, ok := p.(plugins.HttpFilterPlugin)
-				if !ok {
-					continue
-				}
+			}
+
+			potentiallyNonConformingFilters := []plugins.StagedHttpFilter{}
+			for _, httpPlug := range pluginRegistry.GetHttpFilterPlugins() {
 				filters, err := httpPlug.HttpFilters(params, nil)
 				if err != nil {
 					t.Fatalf("plugin http filter failed %v", err)
@@ -97,15 +140,13 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 			}
 		})
 		t.Run("Http Filters with override value", func(t *testing.T) {
-			plugs := pluginRegistry.GetPlugins()
-			filterCount := 0
-			for _, p := range plugs {
+			for _, p := range pluginRegistry.GetPlugins() {
 				// Many plugins require safety via an init which is outside of the creation step
 				p.Init(plugins.InitParams{Ctx: ctx, Settings: &gloov1.Settings{Gloo: &gloov1.GlooOptions{RemoveUnusedFilters: &wrapperspb.BoolValue{Value: false}}}})
-				httpPlug, ok := p.(plugins.HttpFilterPlugin)
-				if !ok {
-					continue
-				}
+			}
+
+			filterCount := 0
+			for _, httpPlug := range pluginRegistry.GetHttpFilterPlugins() {
 				filters, err := httpPlug.HttpFilters(params, nil)
 				if err != nil {
 					t.Fatalf("plugin http filter failed %v", err)

--- a/projects/gloo/pkg/plugins/registry/registry_test.go
+++ b/projects/gloo/pkg/plugins/registry/registry_test.go
@@ -62,7 +62,7 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 		// Filters should not be added to this map without due consideration
 		// In general we should strive not to add any new default filters going forwards
 		knownBaseFilters := map[string]struct{}{
-			"envoy.filters.http.grpc_web": {}, "envoy.filters.http.cors": {},
+			"envoy.filters.http.grpc_web": {},
 		}
 		t.Run("Http Filters without override value", func(t *testing.T) {
 			plugs := pluginRegistry.GetPlugins()

--- a/projects/gloo/pkg/plugins/registry/registry_test.go
+++ b/projects/gloo/pkg/plugins/registry/registry_test.go
@@ -5,23 +5,27 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/cors"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/headers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/protocol_upgrade"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/retries"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/shadowing"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/tracing"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
+
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
+
 	v2 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/filter/http/gzip/v2"
 	v3 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/buffer/v3"
 	v32 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/csrf/v3"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/proxylatency"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/dlp"
-	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/waf"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	gloov1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/dynamic_forward_proxy"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc_json"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc_web"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/hcm"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/healthcheck"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/wasm"
-
-	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
-	gloov1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/bootstrap"
@@ -49,43 +53,89 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 	t.Run("Http Filters are only added if needed", func(t *testing.T) {
 
 		ctx := context.Background()
-		virtualHost := &gloov1.VirtualHost{
-			Name:    "virt1",
+		emptyRoute := &gloov1.Route{
+			Name:    "empty-route",
+			Options: &gloov1.RouteOptions{},
+		}
+		emptyVirtualHost := &gloov1.VirtualHost{
+			Name:    "empty-virtual-host",
 			Domains: []string{"*"},
+			Routes:  []*gloov1.Route{emptyRoute},
+			Options: &gloov1.VirtualHostOptions{},
 		}
 		emptyListener := &gloov1.Listener{
 			Name: "empty-listener",
 			ListenerType: &gloov1.Listener_HttpListener{
 				HttpListener: &gloov1.HttpListener{
 					Options:      &gloov1.HttpListenerOptions{},
-					VirtualHosts: []*gloov1.VirtualHost{virtualHost},
+					VirtualHosts: []*gloov1.VirtualHost{emptyVirtualHost},
 				},
 			},
 		}
-		fullyConfiguredListener := &gloov1.Listener{
-			Name: "fully-configured-listener",
+
+		configuredRoute := &gloov1.Route{
+			Name:     "configured-route",
+			Matchers: []*matchers.Matcher{},
+			Action: &gloov1.Route_DirectResponseAction{
+				DirectResponseAction: &gloov1.DirectResponseAction{
+					Status: 200,
+					Body:   "ok",
+				},
+			},
+			Options: &gloov1.RouteOptions{
+				Retries:    &retries.RetryPolicy{},
+				Extensions: &gloov1.Extensions{},
+				Tracing:    &tracing.RouteTracingSettings{},
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream: &core.ResourceRef{
+						Name:      "upstream-name",
+						Namespace: "upstream-namespace",
+					},
+				},
+				HeaderManipulation: &headers.HeaderManipulation{},
+				Cors: &cors.CorsPolicy{
+					AllowOrigin: []string{"origin"},
+				},
+				Upgrades: []*protocol_upgrade.ProtocolUpgradeConfig{},
+
+				BufferPerRoute: &v3.BufferPerRoute{},
+				Csrf:           &v32.CsrfPolicy{},
+				StagedTransformations: &transformation.TransformationStages{
+					Early: &transformation.RequestResponseTransformations{
+						RequestTransforms:  []*transformation.RequestMatch{},
+						ResponseTransforms: []*transformation.ResponseMatch{},
+					},
+					Regular: &transformation.RequestResponseTransformations{
+						RequestTransforms:  []*transformation.RequestMatch{},
+						ResponseTransforms: []*transformation.ResponseMatch{},
+					},
+				},
+			},
+		}
+		configuredVirtualHost := &gloov1.VirtualHost{
+			Name:    "cofigured-virtual-host",
+			Domains: []string{"*"},
+			Routes:  []*gloov1.Route{configuredRoute},
+		}
+		configuredListener := &gloov1.Listener{
+			Name: "configured-listener",
 			ListenerType: &gloov1.Listener_HttpListener{
 				HttpListener: &gloov1.HttpListener{
 					Options: &gloov1.HttpListenerOptions{
+						// We do not include options that are only supported in enterprise
 						GrpcWeb:                       &grpc_web.GrpcWeb{},
 						HttpConnectionManagerSettings: &hcm.HttpConnectionManagerSettings{},
-						HealthCheck:                   &healthcheck.HealthCheck{},
-						Extensions:                    &gloov1.Extensions{},
-						Waf:                           &waf.Settings{},
-						Dlp:                           &dlp.FilterConfig{},
-						Wasm:                          &wasm.PluginSource{},
-						Extauth:                       &v1.Settings{},
-						RatelimitServer:               &ratelimit.Settings{},
-						Gzip:                          &v2.Gzip{},
-						ProxyLatency:                  &proxylatency.ProxyLatency{},
-						Buffer:                        &v3.Buffer{},
-						Csrf:                          &v32.CsrfPolicy{},
-						GrpcJsonTranscoder:            &grpc_json.GrpcJsonTranscoder{},
-						SanitizeClusterHeader:         &wrapperspb.BoolValue{},
-						LeftmostXffAddress:            &wrapperspb.BoolValue{},
-						DynamicForwardProxy:           &dynamic_forward_proxy.FilterConfig{},
+						HealthCheck: &healthcheck.HealthCheck{
+							Path: "/",
+						},
+						Extensions:          &gloov1.Extensions{},
+						Gzip:                &v2.Gzip{},
+						Buffer:              &v3.Buffer{},
+						Csrf:                &v32.CsrfPolicy{},
+						GrpcJsonTranscoder:  &grpc_json.GrpcJsonTranscoder{},
+						DynamicForwardProxy: &dynamic_forward_proxy.FilterConfig{},
 					},
-					VirtualHosts: []*gloov1.VirtualHost{virtualHost},
+					VirtualHosts: []*gloov1.VirtualHost{configuredVirtualHost},
 				},
 			},
 		}
@@ -96,7 +146,7 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 			},
 			Listeners: []*gloov1.Listener{
 				emptyListener,
-				fullyConfiguredListener,
+				configuredListener,
 			},
 		}
 
@@ -113,12 +163,24 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 		t.Run("Http Filters without override value", func(t *testing.T) {
 			for _, p := range pluginRegistry.GetPlugins() {
 				// Many plugins require safety via an init which is outside of the creation step
-				p.Init(plugins.InitParams{Ctx: ctx, Settings: &gloov1.Settings{Gloo: &gloov1.GlooOptions{RemoveUnusedFilters: &wrapperspb.BoolValue{Value: true}}}})
+				p.Init(plugins.InitParams{
+					Ctx: ctx,
+					Settings: &gloov1.Settings{
+						Gateway: &gloov1.GatewayOptions{
+							Validation: &gloov1.GatewayOptions_ValidationOptions{
+								DisableTransformationValidation: &wrapperspb.BoolValue{Value: true},
+							},
+						},
+						Gloo: &gloov1.GlooOptions{
+							RemoveUnusedFilters: &wrapperspb.BoolValue{Value: true},
+						},
+					},
+				})
 			}
 
 			potentiallyNonConformingFilters := []plugins.StagedHttpFilter{}
 			for _, httpPlug := range pluginRegistry.GetHttpFilterPlugins() {
-				filters, err := httpPlug.HttpFilters(params, nil)
+				filters, err := httpPlug.HttpFilters(params, emptyListener.GetHttpListener())
 				if err != nil {
 					t.Fatalf("plugin http filter failed %v", err)
 				}
@@ -142,12 +204,24 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 		t.Run("Http Filters with override value", func(t *testing.T) {
 			for _, p := range pluginRegistry.GetPlugins() {
 				// Many plugins require safety via an init which is outside of the creation step
-				p.Init(plugins.InitParams{Ctx: ctx, Settings: &gloov1.Settings{Gloo: &gloov1.GlooOptions{RemoveUnusedFilters: &wrapperspb.BoolValue{Value: false}}}})
+				p.Init(plugins.InitParams{
+					Ctx: ctx,
+					Settings: &gloov1.Settings{
+						Gateway: &gloov1.GatewayOptions{
+							Validation: &gloov1.GatewayOptions_ValidationOptions{
+								DisableTransformationValidation: &wrapperspb.BoolValue{Value: true},
+							},
+						},
+						Gloo: &gloov1.GlooOptions{
+							RemoveUnusedFilters: &wrapperspb.BoolValue{Value: false},
+						},
+					},
+				})
 			}
 
 			filterCount := 0
 			for _, httpPlug := range pluginRegistry.GetHttpFilterPlugins() {
-				filters, err := httpPlug.HttpFilters(params, nil)
+				filters, err := httpPlug.HttpFilters(params, emptyListener.GetHttpListener())
 				if err != nil {
 					t.Fatalf("plugin http filter failed %v", err)
 				}
@@ -156,6 +230,87 @@ func TestPluginsHttpFilterUsefulness(t *testing.T) {
 			if len(knownBaseFilters) >= filterCount {
 				t.Fatalf("reinstating to old behavior for unused filters failed with to have more filters than %d", filterCount)
 			}
+		})
+
+		t.Run("Http Filters with route configuration and multiple listeners", func(t *testing.T) {
+			for _, p := range pluginRegistry.GetPlugins() {
+				// Many plugins require safety via an init which is outside of the creation step
+				p.Init(plugins.InitParams{
+					Ctx: ctx,
+					Settings: &gloov1.Settings{
+						Gateway: &gloov1.GatewayOptions{
+							Validation: &gloov1.GatewayOptions_ValidationOptions{
+								DisableTransformationValidation: &wrapperspb.BoolValue{Value: true},
+							},
+						},
+						Gloo: &gloov1.GlooOptions{
+							RemoveUnusedFilters: &wrapperspb.BoolValue{Value: true},
+						},
+					},
+				})
+			}
+
+			// Process the configuredListener
+			configuredListenerFilterCount := 0
+			virtualHostParams := plugins.VirtualHostParams{
+				Params:       params,
+				Proxy:        proxy,
+				Listener:     configuredListener,
+				HttpListener: configuredListener.GetHttpListener(),
+			}
+			routeParams := plugins.RouteParams{
+				VirtualHostParams: virtualHostParams,
+				VirtualHost:       configuredVirtualHost,
+			}
+			for _, routePlugin := range pluginRegistry.GetRoutePlugins() {
+				err := routePlugin.ProcessRoute(routeParams, configuredRoute, &envoy_config_route_v3.Route{})
+				if err != nil {
+					t.Fatalf("plugin route filter failed %v", err)
+				}
+			}
+			for _, httpPlug := range pluginRegistry.GetHttpFilterPlugins() {
+				filters, err := httpPlug.HttpFilters(params, configuredListener.GetHttpListener())
+				if err != nil {
+					t.Fatalf("plugin http filter failed %v", err)
+				}
+				configuredListenerFilterCount += len(filters)
+			}
+
+			// Process the emptyListener
+			emptyListenerFilterCount := 0
+			virtualHostParams = plugins.VirtualHostParams{
+				Params:       params,
+				Proxy:        proxy,
+				Listener:     emptyListener,
+				HttpListener: emptyListener.GetHttpListener(),
+			}
+			routeParams = plugins.RouteParams{
+				VirtualHostParams: virtualHostParams,
+				VirtualHost:       emptyVirtualHost,
+			}
+			for _, routePlugin := range pluginRegistry.GetRoutePlugins() {
+				err := routePlugin.ProcessRoute(routeParams, emptyRoute, &envoy_config_route_v3.Route{})
+				if err != nil {
+					t.Fatalf("plugin route filter failed %v", err)
+				}
+			}
+			for _, httpPlug := range pluginRegistry.GetHttpFilterPlugins() {
+				filters, err := httpPlug.HttpFilters(params, emptyListener.GetHttpListener())
+				if err != nil {
+					t.Fatalf("plugin http filter failed %v", err)
+				}
+				emptyListenerFilterCount += len(filters)
+			}
+
+			// Validate that the emptyListener filter count and configuredListener filter count are different
+			if emptyListenerFilterCount != len(knownBaseFilters) {
+				t.Fatalf("Found %d filters that were configured, but expected %d", emptyListenerFilterCount, len(knownBaseFilters))
+			}
+
+			if configuredListenerFilterCount <= len(knownBaseFilters) {
+				t.Fatalf("Found %d filters that were configured, but expected at least %d", configuredListenerFilterCount, len(knownBaseFilters))
+			}
+
 		})
 
 	})

--- a/projects/gloo/pkg/plugins/transformation/plugin.go
+++ b/projects/gloo/pkg/plugins/transformation/plugin.go
@@ -56,8 +56,10 @@ type TranslateTransformationFn func(*transformation.Transformation) (*envoytrans
 // methods were exported.
 // Other plugins may
 type Plugin struct {
+	removeUnused              bool
+	filterRequiredForListener map[*v1.HttpListener]struct{}
+
 	RequireEarlyTransformation bool
-	filterNeeded               bool
 	TranslateTransformation    TranslateTransformationFn
 	settings                   *v1.Settings
 
@@ -79,7 +81,8 @@ func (p *Plugin) Name() string {
 // Init attempts to set the plugin back to a clean slate state.
 func (p *Plugin) Init(params plugins.InitParams) error {
 	p.RequireEarlyTransformation = false
-	p.filterNeeded = !params.Settings.GetGloo().GetRemoveUnusedFilters().GetValue()
+	p.removeUnused = !params.Settings.GetGloo().GetRemoveUnusedFilters().GetValue()
+	p.filterRequiredForListener = make(map[*v1.HttpListener]struct{})
 	p.settings = params.Settings
 	p.TranslateTransformation = TranslateTransformation
 	return nil
@@ -122,7 +125,7 @@ func (p *Plugin) ProcessVirtualHost(
 		return err
 	}
 
-	p.filterNeeded = true
+	p.filterRequiredForListener[params.HttpListener] = struct{}{}
 
 	return pluginutils.ModifyVhostPerFilterConfig(out, FilterName, mergeFunc(envoyTransformation))
 }
@@ -144,7 +147,7 @@ func (p *Plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *env
 		return err
 	}
 
-	p.filterNeeded = true
+	p.filterRequiredForListener[params.HttpListener] = struct{}{}
 	return pluginutils.ModifyRoutePerFilterConfig(out, FilterName, mergeFunc(envoyTransformation))
 }
 
@@ -169,7 +172,7 @@ func (p *Plugin) ProcessWeightedDestination(
 	if err != nil {
 		return err
 	}
-	p.filterNeeded = true
+	p.filterRequiredForListener[params.HttpListener] = struct{}{}
 	return pluginutils.ModifyWeightedClusterPerFilterConfig(out, FilterName, mergeFunc(envoyTransformation))
 }
 
@@ -178,7 +181,8 @@ func (p *Plugin) ProcessWeightedDestination(
 func (p *Plugin) HttpFilters(params plugins.Params, listener *v1.HttpListener) ([]plugins.StagedHttpFilter, error) {
 	var filters []plugins.StagedHttpFilter
 
-	if !p.filterNeeded {
+	_, ok := p.filterRequiredForListener[listener]
+	if !ok && p.removeUnused {
 		return filters, nil
 	}
 

--- a/projects/gloo/pkg/plugins/transformation/plugin.go
+++ b/projects/gloo/pkg/plugins/transformation/plugin.go
@@ -81,7 +81,7 @@ func (p *Plugin) Name() string {
 // Init attempts to set the plugin back to a clean slate state.
 func (p *Plugin) Init(params plugins.InitParams) error {
 	p.RequireEarlyTransformation = false
-	p.removeUnused = !params.Settings.GetGloo().GetRemoveUnusedFilters().GetValue()
+	p.removeUnused = params.Settings.GetGloo().GetRemoveUnusedFilters().GetValue()
 	p.filterRequiredForListener = make(map[*v1.HttpListener]struct{})
 	p.settings = params.Settings
 	p.TranslateTransformation = TranslateTransformation


### PR DESCRIPTION
# Description

- CORS filter respects the `removeUnusedFilters` setting
- GrpcWeb filter respects the `removeUnusedFilters` setting
- `removeUnusedFilters` setting applied per HttpListener, instead of globally per plugin

# Context

### CORS Filter
As part of [some previous work](https://github.com/solo-io/gloo/issues/5651), we enable the ability to not load empty http filters into the filter chain. This behavior is opt-in, using the `removeUnusedFilters` flag in the Settings CR. We extended this work to apply the behavior to the CORS filter as well.

### GrpcWeb Filter
The GrpcWeb filter has a per HttpListener configuration. If that config is true, the filter is generated. If that config is not present, we fallback to a Settings `disableGrpcWeb`. This setting, if it wasn't defined would fallback to false. I changed the fallback to instead respect the value of `removeUnusedFilters`. The relationship is now: if defined on listener respect it, if defined at granular disableGrpcWeb setting respect it, fallback to removeUnusedFilters. This is a backwards compatible change.

### Per Listener Resolution of RemoveUnusedFilters
We translate gloo resources into a listener using the following steps:
1. Initialize plugins [link](https://github.com/solo-io/gloo/blob/f615958487507cda229bea1fe0521766c27d9003/projects/gloo/pkg/translator/translator.go#L110)
2. Iterate over proxies, and for each proxy [link](https://github.com/solo-io/gloo/blob/f615958487507cda229bea1fe0521766c27d9003/projects/gloo/pkg/translator/translator.go#L231)
3. Generate a listener by building route configuration from Route and VirtualHostPlugins [link](https://github.com/solo-io/gloo/blob/f615958487507cda229bea1fe0521766c27d9003/projects/gloo/pkg/translator/translator.go#L244)

The implication is that a plugin lifecycle exists for a single translation run. This means that it may process multiple HttpListeners. In the previous solution of `removeUnusedFilters` we would keep the bool state of whether or not configuration existed for a filter globally on the plugin. This meant that if we processed one listener that had configuration, we would toggle the state to 'required', and then process another listener with no configuration and we would treat it the same way, as 'required'. *The solution is to track the state per httpListener and reset it whenever the plugin is reinitialized*

I added a test in the registry test. You'll notice that it passes on this branch and will fail on the main branch with:
```
=== RUN   TestPlugins
--- PASS: TestPlugins (0.00s)
=== RUN   TestPluginsHttpFilterUsefulness
=== RUN   TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed
=== RUN   TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed/Http_Filters_without_override_value
    registry_test.go:201: Found a set of filters that were added by default [envoy.filters.http.grpc_web envoy.filters.http.cors]
=== RUN   TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed/Http_Filters_with_override_value
=== RUN   TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed/Http_Filters_with_route_configuration_and_multiple_listeners
    registry_test.go:307: Found 5 filters that were configured, but expected 0
--- FAIL: TestPluginsHttpFilterUsefulness (0.00s)
    --- FAIL: TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed (0.00s)
        --- FAIL: TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed/Http_Filters_without_override_value (0.00s)
        --- PASS: TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed/Http_Filters_with_override_value (0.00s)
        --- FAIL: TestPluginsHttpFilterUsefulness/Http_Filters_are_only_added_if_needed/Http_Filters_with_route_configuration_and_multiple_listeners (0.00s)
FAIL

Ginkgo ran 1 suite in 5.206075804s
Test Suite Failed
```

This confirms that we would have generated 5 filters for a listener that expected to have 0.

### Federation CRDS
We introduced a new Federated CRD (https://github.com/solo-io/solo-projects/pull/3591) that needs to be cleaned up on uninstalls

### Metric Status Logging
We support updating metrics based on the status of a resource so that users can be alert on status changes. We have not added support for all resources (ratelimit, extauth). Currently, this warning floods the logs and confuses users. There is no action for the user to take so it feels like warn level logging is not appropriate.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
