### PR TITLE
fix cleanup job

### DIFF
--- a/changelog/v1.12.0-beta11/fix-cleanup-job.yaml
+++ b/changelog/v1.12.0-beta11/fix-cleanup-job.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6213
+    resolvesIssue: false
+    description: |
+      Fix the rbac/syntax in the job that cleans up the validation webhook and custom resources on uninstall.

--- a/docs/content/guides/dev/example-proxy-controller.md
+++ b/docs/content/guides/dev/example-proxy-controller.md
@@ -866,8 +866,8 @@ However, we don't actually have an Envoy instance deployed that will receive thi
 we'll walk through the steps to deploy an Envoy pod wired to receive config from Gloo Edge, identifying itself as 
 `my-cool-proxy`.  
 {{% notice warning %}}
-Proxies that are managed by Gloo Edge have a label named `created-by` with values that begin with `gloo`. Do not modify these 
-labels or use the same labels for your own proxies. Gloo Edge might overwrite or delete proxies with the label `created-by: gloo-*`
+Proxies that are managed by Gloo Edge have a label named `created_by` with values that begin with `gloo`. Do not modify these
+labels or use the same labels for your own proxies. Gloo Edge might overwrite or delete proxies with the label `created_by: gloo-*`
 
 {{% /notice %}}
 ## Deploying Envoy to Kubernetes

--- a/install/helm/gloo/templates/5-gateway-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-gateway-cleanup-job.yaml
@@ -38,8 +38,8 @@ spec:
           - -c
           - |
             kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io gloo-gateway-validation-webhook-{{ .Release.Namespace }}
-            kubectl delete gateways.gateway.solo.io -n {{ .Release.Namespace }} -l created-by=gloo-install
-            kubectl delete upstreams.gloo.solo.io -n {{ .Release.Namespace }} -l created-by=gloo-install
+            kubectl delete gateways.gateway.solo.io -n {{ .Release.Namespace }} -l created_by=gloo-install
+            kubectl delete upstreams.gloo.solo.io -n {{ .Release.Namespace }} -l created_by=gloo-install
       restartPolicy: Never
   ttlSecondsAfterFinished: 0
 ---

--- a/install/helm/gloo/templates/5-gateway-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-gateway-cleanup-job.yaml
@@ -36,9 +36,10 @@ spec:
           command:
           - /bin/sh
           - -c
-          - "kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io gloo-gateway-validation-webhook-{{ .Release.Namespace }}"
-          - "kubectl delete gateways.gateway.solo.io -n {{ .Release.Namespace }} -l created-by=gloo-install"
-          - "kubectl delete upstreams.gloo.solo.io -n {{ .Release.Namespace }} -l created-by=gloo-install"
+          - |
+            kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io gloo-gateway-validation-webhook-{{ .Release.Namespace }}
+            kubectl delete gateways.gateway.solo.io -n {{ .Release.Namespace }} -l created-by=gloo-install
+            kubectl delete upstreams.gloo.solo.io -n {{ .Release.Namespace }} -l created-by=gloo-install
       restartPolicy: Never
   ttlSecondsAfterFinished: 0
 ---
@@ -69,8 +70,11 @@ metadata:
     "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
 rules:
 - apiGroups: ["gateway.solo.io"]
-  resources: ["gateways"]
-  verbs: ["delete"]
+  resources: ["*"]
+  verbs: ["list", "delete"]
+- apiGroups: ["gloo.solo.io"]
+  resources: ["*"]
+  verbs: ["list", "delete"]
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -133,7 +133,7 @@ The input to the function should be a dict with the following key/value mappings
     {{$k}}: {{$v}}
 {{- end }}
 {{- if $customResourceLifecycle }}
-    created-by: gloo-install
+    created_by: gloo-install
     app.kubernetes.io/managed-by: Helm
   annotations:
     "meta.helm.sh/release-name": {{ .release.Name }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3564,9 +3564,10 @@ spec:
           command:
           - /bin/sh
           - -c
-          - "kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io gloo-gateway-validation-webhook-` + namespace + `"
-          - "kubectl delete gateways.gateway.solo.io -n ` + namespace + ` -l created-by=gloo-install"
-          - "kubectl delete upstreams.gloo.solo.io -n ` + namespace + ` -l created-by=gloo-install"
+          - |
+            kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io gloo-gateway-validation-webhook-` + namespace + `
+            kubectl delete gateways.gateway.solo.io -n ` + namespace + ` -l created-by=gloo-install
+            kubectl delete upstreams.gloo.solo.io -n ` + namespace + ` -l created-by=gloo-install
       restartPolicy: Never
   ttlSecondsAfterFinished: 0
 `)

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3566,8 +3566,8 @@ spec:
           - -c
           - |
             kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io gloo-gateway-validation-webhook-` + namespace + `
-            kubectl delete gateways.gateway.solo.io -n ` + namespace + ` -l created-by=gloo-install
-            kubectl delete upstreams.gloo.solo.io -n ` + namespace + ` -l created-by=gloo-install
+            kubectl delete gateways.gateway.solo.io -n ` + namespace + ` -l created_by=gloo-install
+            kubectl delete upstreams.gloo.solo.io -n ` + namespace + ` -l created_by=gloo-install
       restartPolicy: Never
   ttlSecondsAfterFinished: 0
 `)
@@ -3591,7 +3591,7 @@ metadata:
   namespace: ` + namespace + `
   labels:
     app: gloo
-    created-by: gloo-install
+    created_by: gloo-install
     "app.kubernetes.io/managed-by": Helm
   annotations:
     "helm.sh/hook": post-install,post-upgrade
@@ -3617,7 +3617,7 @@ metadata:
   namespace: ` + namespace + `
   labels:
     app: gloo
-    created-by: gloo-install
+    created_by: gloo-install
     "app.kubernetes.io/managed-by": Helm
   annotations:
     "helm.sh/hook": post-install,post-upgrade

--- a/projects/gloo/pkg/syncer/setup/proxy_cleanup.go
+++ b/projects/gloo/pkg/syncer/setup/proxy_cleanup.go
@@ -13,7 +13,7 @@ var (
 	// These could theoretically be passed in as arguments to make the cleanup resources by label functionality more generic
 	// Currently there isn't a clear use case for that and defining the values here feels most readable
 	gatewayLabelValue = "gloo-gateway-translator"
-	createdByLabelKey = "created-by"
+	createdByLabelKey = "created_by"
 )
 
 func deleteUnusedProxies(ctx context.Context, namespace string, proxyClient v1.ProxyClient) error {

--- a/projects/gloo/pkg/syncer/setup/proxy_cleanup_test.go
+++ b/projects/gloo/pkg/syncer/setup/proxy_cleanup_test.go
@@ -39,10 +39,10 @@ var _ = Describe("Clean up proxies", func() {
 			},
 		}
 		managedProxyLabels = map[string]string{
-			"created-by": "gloo-gateway-translator",
+			"created_by": "gloo-gateway-translator",
 		}
 		unmanagedProxyLabels = map[string]string{
-			"created-by": "other-controller",
+			"created_by": "other-controller",
 		}
 		gatewayProxy = &v1.Proxy{
 			Metadata: &core.Metadata{

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -410,7 +409,7 @@ func upgradeCrds(testHelper *helper.SoloTestHelper, fromRelease string, crdDir s
 	}
 
 	// delete all solo crds from the previous release
-	dir, err := ioutil.TempDir("", "old-gloo-chart")
+	dir, err := os.MkdirTemp("", "old-gloo-chart")
 	Expect(err).NotTo(HaveOccurred())
 	defer os.RemoveAll(dir)
 

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -102,7 +103,7 @@ var _ = Describe("Kube2e: helm", func() {
 			Expect(getGlooServerVersion(ctx, testHelper.InstallNamespace)).To(Equal(earliestVersionWithV1CRDs))
 
 			// upgrade to the gloo version being tested
-			upgradeGloo(testHelper, chartUri, crdDir, strictValidation, nil)
+			upgradeGloo(testHelper, chartUri, crdDir, fromRelease, strictValidation, nil)
 
 			By("should have upgraded to the gloo version being tested")
 			Expect(getGlooServerVersion(ctx, testHelper.InstallNamespace)).To(Equal(testHelper.ChartVersion()))
@@ -116,7 +117,7 @@ var _ = Describe("Kube2e: helm", func() {
 			Expect(err).To(BeNil())
 			Expect(settings.GetGloo().GetInvalidConfigPolicy().GetInvalidRouteResponseCode()).To(Equal(uint32(404)))
 
-			upgradeGloo(testHelper, chartUri, crdDir, strictValidation, []string{
+			upgradeGloo(testHelper, chartUri, crdDir, fromRelease, strictValidation, []string{
 				"--set", "settings.replaceInvalidRoutes=true",
 				"--set", "settings.invalidConfigPolicy.invalidRouteResponseCode=400",
 			})
@@ -136,7 +137,7 @@ var _ = Describe("Kube2e: helm", func() {
 			Expect(err).To(BeNil())
 			Expect(settings.GetGateway().GetValidation().GetValidationServerGrpcMaxSizeBytes().GetValue()).To(Equal(int32(4000000)))
 
-			upgradeGloo(testHelper, chartUri, crdDir, strictValidation, []string{
+			upgradeGloo(testHelper, chartUri, crdDir, fromRelease, strictValidation, []string{
 				"--set", "gateway.validation.validationServerGrpcMaxSizeBytes=5000000",
 			})
 
@@ -173,7 +174,7 @@ var _ = Describe("Kube2e: helm", func() {
 			Expect(webhookConfig.Webhooks[0].ClientConfig.CABundle).To(Equal(secret.Data[corev1.ServiceAccountRootCAKey]))
 
 			// do an upgrade
-			upgradeGloo(testHelper, chartUri, crdDir, strictValidation, nil)
+			upgradeGloo(testHelper, chartUri, crdDir, fromRelease, strictValidation, nil)
 
 			By("the webhook caBundle and secret's root ca value should still match after upgrade")
 			webhookConfig, err = webhookConfigClient.Get(ctx, "gloo-gateway-validation-webhook-"+testHelper.InstallNamespace, metav1.GetOptions{})
@@ -204,7 +205,7 @@ var _ = Describe("Kube2e: helm", func() {
 				if newFailurePolicy == admission_v1.Fail {
 					newStrictValue = true
 				}
-				upgradeGloo(testHelper, chartUri, crdDir, newStrictValue, []string{
+				upgradeGloo(testHelper, chartUri, crdDir, fromRelease, newStrictValue, []string{
 					// set some arbitrary value on the gateway, just to ensure the validation webhook is called
 					"--set", "gatewayProxies.gatewayProxy.gatewaySettings.ipv4Only=true",
 				})
@@ -378,6 +379,8 @@ func installGloo(testHelper *helper.SoloTestHelper, chartUri string, fromRelease
 	// construct helm args
 	var args = []string{"install", testHelper.HelmChartName}
 	if fromRelease != "" {
+		runAndCleanCommand("helm", "repo", "add", testHelper.HelmChartName,
+			"https://storage.googleapis.com/solo-public-helm", "--force-update")
 		args = append(args, "gloo/gloo",
 			"--version", fmt.Sprintf("v%s", fromRelease))
 	} else {
@@ -390,56 +393,43 @@ func installGloo(testHelper *helper.SoloTestHelper, chartUri string, fromRelease
 		args = append(args, strictValidationArgs...)
 	}
 
-	if fromRelease != "" {
-		runAndCleanCommand("helm", "repo", "add", testHelper.HelmChartName, "https://storage.googleapis.com/solo-public-helm",
-			"--force-update")
-		runAndCleanCommand("helm", "repo", "update")
-	}
 	fmt.Printf("running helm with args: %v\n", args)
 	runAndCleanCommand("helm", args...)
 
 	// Check that everything is OK
-	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
+	checkGlooHealthy(testHelper)
 }
 
-func applyCrds(crdDir string) {
-	// CRDs are applied to a cluster when performing a `helm install` operation
-	// However, `helm upgrade` intentionally does not apply CRDs (https://helm.sh/docs/topics/charts/#limitations-on-crds)
-	// Before performing the upgrade, we must manually apply any CRDs that were introduced since v1.9.0
-	type crd struct{ name, file string }
-	crdsToManuallyApply := []crd{
-		{
-			name: "graphqlapis.graphql.gloo.solo.io",
-			file: filepath.Join(crdDir, "graphql.gloo.solo.io_v1beta1_GraphQLApi.yaml"),
-		},
-		{
-			name: "httpgateways.gateway.solo.io",
-			file: filepath.Join(crdDir, "gateway.solo.io_v1_MatchableHttpGateway.yaml"),
-		},
-		{
-			name: "settings.gloo.solo.io",
-			file: filepath.Join(crdDir, "gloo.solo.io_v1_Settings.yaml"),
-		},
+// CRDs are applied to a cluster when performing a `helm install` operation
+// However, `helm upgrade` intentionally does not apply CRDs (https://helm.sh/docs/topics/charts/#limitations-on-crds)
+// Before performing the upgrade, we must manually apply any CRDs that were introduced since v1.9.0
+func upgradeCrds(testHelper *helper.SoloTestHelper, fromRelease string, crdDir string) {
+	// if we're just upgrading within the same release, no need to reapply crds
+	if fromRelease == "" {
+		return
 	}
 
-	for _, crd := range crdsToManuallyApply {
-		By(fmt.Sprintf("apply new %s CRD", crd.file))
-		// Apply the CRD and ensure it is eventually accepted
-		runAndCleanCommand("kubectl", "apply", "-f", crd.file)
-		runAndCleanCommand("kubectl", "wait", "--for", "condition=established", "crd/"+crd.name)
-	}
+	// delete all solo crds from the previous release
+	dir, err := ioutil.TempDir("", "old-gloo-chart")
+	Expect(err).NotTo(HaveOccurred())
+	defer os.RemoveAll(dir)
+
+	runAndCleanCommand("helm", "repo", "add", testHelper.HelmChartName, "https://storage.googleapis.com/solo-public-helm", "--force-update")
+	runAndCleanCommand("helm", "pull", testHelper.HelmChartName+"/gloo", "--version", fromRelease, "--untar", "--untardir", dir)
+	runAndCleanCommand("kubectl", "delete", "-f", dir+"/gloo/crds")
+
+	// apply crds from the release we're upgrading to
+	runAndCleanCommand("kubectl", "apply", "-f", crdDir)
 }
 
-func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, crdDir string, strictValidation bool, additionalArgs []string) {
-	applyCrds(crdDir)
+func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, crdDir string, fromRelease string, strictValidation bool, additionalArgs []string) {
+	upgradeCrds(testHelper, fromRelease, crdDir)
 
 	valueOverrideFile, cleanupFunc := kube2e.GetHelmValuesOverrideFile()
 	defer cleanupFunc()
 
 	var args = []string{"upgrade", testHelper.HelmChartName, chartUri,
 		"-n", testHelper.InstallNamespace,
-		// Using the flag --disable-openapi-validation although helm upgrade works without it everywhere except for CI
-		"--disable-openapi-validation",
 		"--values", valueOverrideFile}
 	if strictValidation {
 		args = append(args, strictValidationArgs...)
@@ -450,12 +440,12 @@ func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, crdDir stri
 	runAndCleanCommand("helm", args...)
 
 	// Check that everything is OK
-	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
+	checkGlooHealthy(testHelper)
 }
 
 func uninstallGloo(testHelper *helper.SoloTestHelper, ctx context.Context, cancel context.CancelFunc) {
 	Expect(testHelper).ToNot(BeNil())
-	err := testHelper.UninstallGloo()
+	err := testHelper.UninstallGlooAll()
 	Expect(err).NotTo(HaveOccurred())
 	_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(ctx, testHelper.InstallNamespace, metav1.GetOptions{})
 	Expect(apierrors.IsNotFound(err)).To(BeTrue())
@@ -481,4 +471,12 @@ func runAndCleanCommand(name string, arg ...string) []byte {
 	cmd.Process.Kill()
 	cmd.Process.Release()
 	return b
+}
+
+func checkGlooHealthy(testHelper *helper.SoloTestHelper) {
+	deploymentNames := []string{"gloo", "discovery", "gateway-proxy"}
+	for _, deploymentName := range deploymentNames {
+		runAndCleanCommand("kubectl", "rollout", "status", "deployment", "-n", testHelper.InstallNamespace, deploymentName)
+	}
+	kube2e.GlooctlCheckEventuallyHealthy(2, testHelper, "90s")
 }


### PR DESCRIPTION
# Description

- Fix missing permissions and syntax error in the Job that cleans up custom resources during helm uninstall.
- Rename `created-by` to `created_by` for consistency, as we already use `created_by` elsewhere in code.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
