### PR TITLE
Truncate long proxy statuses

### DIFF
--- a/projects/gateway/pkg/syncer/translator_syncer.go
+++ b/projects/gateway/pkg/syncer/translator_syncer.go
@@ -3,6 +3,7 @@ package syncer
 import (
 	"context"
 	"fmt"
+	"os"
 	"sort"
 	"sync"
 	"time"
@@ -37,6 +38,7 @@ type TranslatorSyncer struct {
 	translator         translator.Translator
 	statusSyncer       statusSyncer
 	managedProxyLabels map[string]string
+	proxyStatusMaxSize string
 }
 
 func NewTranslatorSyncer(ctx context.Context, writeNamespace string, proxyWatcher gloov1.ProxyClient, proxyReconciler reconciler.ProxyReconciler, reporter reporter.StatusReporter, translator translator.Translator, statusClient resources.StatusClient, statusMetrics metrics.ConfigStatusMetrics) *TranslatorSyncer {
@@ -49,6 +51,9 @@ func NewTranslatorSyncer(ctx context.Context, writeNamespace string, proxyWatche
 		managedProxyLabels: map[string]string{
 			"created_by": "gloo-gateway-translator",
 		},
+	}
+	if pxStatusSizeEnv := os.Getenv("PROXY_STATUS_MAX_SIZE"); pxStatusSizeEnv != "" {
+		t.proxyStatusMaxSize = pxStatusSizeEnv
 	}
 	go t.statusSyncer.syncStatusOnEmit(ctx)
 	return t
@@ -96,7 +101,9 @@ func (s *TranslatorSyncer) GeneratedDesiredProxies(ctx context.Context, snap *v1
 			if s.shouldCompresss(ctx) {
 				compress.SetShouldCompressed(proxy)
 			}
-
+			if s.proxyStatusMaxSize != "" {
+				compress.SetMaxStatusSize(proxy, s.proxyStatusMaxSize)
+			}
 			logger.Infof("desired proxy %v", proxy.GetMetadata().Ref())
 			proxy.GetMetadata().Labels = s.managedProxyLabels
 			desiredProxies[proxy] = reports
@@ -116,7 +123,6 @@ func (s *TranslatorSyncer) GeneratedDesiredProxies(ctx context.Context, snap *v1
 func (s *TranslatorSyncer) shouldCompresss(ctx context.Context) bool {
 	return settingsutil.MaybeFromContext(ctx).GetGateway().GetCompressedProxySpec()
 }
-
 func (s *TranslatorSyncer) reconcile(ctx context.Context, desiredProxies reconciler.GeneratedProxies, invalidProxies reconciler.InvalidProxies) error {
 	if err := s.proxyReconciler.ReconcileProxies(ctx, desiredProxies, s.writeNamespace, s.managedProxyLabels); err != nil {
 		return err

--- a/projects/gloo/pkg/api/compress/compress.go
+++ b/projects/gloo/pkg/api/compress/compress.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"io"
+	"strconv"
 
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd"
@@ -16,10 +17,12 @@ import (
 )
 
 const (
-	CompressedKey   = "gloo.solo.io/compress"
-	CompressedValue = "true"
-	compressedSpec  = "compressedSpec"
-	compressed_spec = "compressed_spec"
+	CompressedKey           = "gloo.solo.io/compress"
+	CompressedValue         = "true"
+	compressedSpec          = "compressedSpec"
+	compressed_spec         = "compressed_spec"
+	ShortenKey              = "gloo.solo.io/maxStatusSize"
+	MaxLengthWarningMessage = "\nStatus truncated, see logs for details."
 )
 
 func isCompressed(in v1.Spec) bool {
@@ -36,7 +39,6 @@ func shouldCompress(in resources.Resource) bool {
 
 	return annotations[CompressedKey] == CompressedValue
 }
-
 func SetShouldCompressed(in resources.Resource) {
 	metadata := &core.Metadata{}
 	if in.GetMetadata() != nil {
@@ -50,7 +52,30 @@ func SetShouldCompressed(in resources.Resource) {
 	metadata.Annotations = annotations
 	in.SetMetadata(metadata)
 }
-
+func GetMaxStatusSize(in resources.Resource) int64 {
+	annotations := in.GetMetadata().GetAnnotations()
+	if annotations == nil {
+		return -1
+	}
+	if maxSize, ok := annotations[ShortenKey]; ok {
+		size, _ := strconv.ParseInt(maxSize, 0, 64)
+		return size
+	}
+	return -1
+}
+func SetMaxStatusSize(in resources.Resource, maxStatusSize string) {
+	metadata := &core.Metadata{}
+	if in.GetMetadata() != nil {
+		metadata = in.GetMetadata()
+	}
+	annotations := metadata.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+	annotations[ShortenKey] = maxStatusSize
+	metadata.Annotations = annotations
+	in.SetMetadata(metadata)
+}
 func compressSpec(s v1.Spec) (v1.Spec, error) {
 	// serialize  spec to json:
 	ser, err := json.Marshal(s)
@@ -157,9 +182,25 @@ func MarshalStatus(in resources.InputResource) (v1.Status, error) {
 	if namespacedStatuses == nil {
 		return v1.Status{}, nil
 	}
+	maxStatusSize := GetMaxStatusSize(in)
+	if maxStatusSize > 0 {
+		namespacedStatuses = shortenStatus(namespacedStatuses, maxStatusSize)
+	}
 	namespacedStatusMap, err := protoutils.MarshalMapFromProtoWithEnumsAsInts(namespacedStatuses)
 	if err != nil {
 		return nil, crd.MarshalErr(err, "resource status to map")
 	}
 	return namespacedStatusMap, nil
+}
+
+func shortenStatus(namespacedStatuses *core.NamespacedStatuses, maxLength int64) *core.NamespacedStatuses {
+	statuses := namespacedStatuses.GetStatuses()
+	for ns, status := range namespacedStatuses.GetStatuses() {
+		if int64(len(status.GetReason())) > maxLength {
+			status.Reason = status.GetReason()[0:maxLength] + MaxLengthWarningMessage
+			statuses[ns] = status
+		}
+	}
+	namespacedStatuses.Statuses = statuses
+	return namespacedStatuses
 }

--- a/projects/gloo/pkg/syncer/translator_syncer.go
+++ b/projects/gloo/pkg/syncer/translator_syncer.go
@@ -140,7 +140,6 @@ func (s *translatorSyncer) Sync(ctx context.Context, snap *v1snap.ApiSnapshot) e
 	}
 	return multiErr.ErrorOrNil()
 }
-
 func (s *translatorSyncer) translateProxies(ctx context.Context, snap *v1snap.ApiSnapshot) error {
 	gwSnap := &gatewayv1.ApiSnapshot{
 		VirtualServices:    snap.VirtualServices,


### PR DESCRIPTION
# Description

In large deployments, when every warning is added to the proxy status, the field can grow too large to persist to etcd. This change introduces an environment variable `PROXY_STATUS_MAX_SIZE`. When the status is longer than the provided size (in bytes), the status will be truncated. This way, users can still see some of the warnings associated with their proxies but the size of the status field can be limited. 

For example install gloo with the following values override: 
```
cat <<EOF | glooctl install gateway -f  --values -
gateway:
  persistProxySpec: true
gloo:
  deployment:
    customEnv:
      - name: "PROXY_STATUS_MAX_SIZE"
        value: "100"
EOF
```

And create virtual services pointing to upstreams that do not exist. The proxy will have a status with 100 characters and a message that the status was truncated:
```
namespacedStatuses:
  statuses:
    gloo-system:
      reason: "warning: \n  Route Warning: InvalidDestinationWarning. Reason: *v1.Upstream
        { gloo-system.default-dis\nStatus truncated, see logs for details."
      reportedBy: gloo
      state: Warning
```
# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
