### PR TITLE
Fix for robustness test flake

### DIFF
--- a/changelog/v1.12.0-beta12/robustness_test_fix.yaml
+++ b/changelog/v1.12.0-beta12/robustness_test_fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/6430
+    description: Add an `Eventually` to a common test flake.

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -229,8 +229,10 @@ var _ = Describe("Robustness tests", func() {
 				return false
 
 			}, "12s", "1s").Should(BeTrue())
-			_, writeErr := virtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx})
-			Expect(writeErr).NotTo(HaveOccurred())
+			Eventually(func() error {
+				_, writeErr := virtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx})
+				return writeErr
+			}, "12s", "1s").ShouldNot(HaveOccurred())
 
 			// Wait for the proxy to be accepted
 			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {


### PR DESCRIPTION
# Description
In the robustness test, wrap creating a new virtual service in `Eventually`. We already have a check to see that all the old virtual services have been deleted but we don't confirm that the Proxy has been updated. I think an `Eventually` here will help ensure that we've reached a consistent state before adding a new Virtual Service.

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6430