### PR TITLE
Istio compat - use kub service ip for upstreams

### DIFF
--- a/changelog/v1.12.0-beta13/istio-ip-routing.yaml
+++ b/changelog/v1.12.0-beta13/istio-ip-routing.yaml
@@ -2,4 +2,4 @@ changelog:
 - type: NEW_FEATURE
   issueLink: https://github.com/solo-io/gloo/issues/6195
   resolvesIssue: true
-  description: Add support for enabling ip routing when injecting istio sidecar.
+  description: Add support for istio integration in endpoint discovery, routing to service IP rather than pod IP.

--- a/changelog/v1.12.0-beta13/istio-ip-routing.yaml
+++ b/changelog/v1.12.0-beta13/istio-ip-routing.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/6195
+  resolvesIssue: true
+  description: Add support for enabling ip routing when injecting istio sidecar.

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -222,7 +222,7 @@ spec:
             value: {{ .Values.gloo.logLevel }}
         {{- end}}
         {{- if .Values.global.istioIntegration.enableIstioSidecarOnGateway }}
-          - name: ENABLE_ISTIO_SIDECAR
+          - name: ENABLE_ISTIO_INTEGRATION
             value: "true"
         {{- end}}
 {{- if not .Values.global.glooMtls.enabled }}

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -221,6 +221,10 @@ spec:
           - name: LOG_LEVEL
             value: {{ .Values.gloo.logLevel }}
         {{- end}}
+        {{- if .Values.global.istioIntegration.enableIstioSidecarOnGateway }}
+          - name: ENABLE_ISTIO_SIDECAR
+            value: "true"
+        {{- end}}
 {{- if not .Values.global.glooMtls.enabled }}
         readinessProbe:
           tcpSocket:

--- a/projects/gloo/pkg/plugins/kubernetes/eds.go
+++ b/projects/gloo/pkg/plugins/kubernetes/eds.go
@@ -123,12 +123,9 @@ func (c *edsWatcher) List(writeNamespace string, opts clients.ListOpts) (v1.Endp
 		endpointList = append(endpointList, endpoints...)
 	}
 
-	// TODO: Switch to filterServiceEndpoints when Gloo configured to user Kube services as endpoints (i.e. for Istio compatibility)
-	var eps v1.EndpointList
-	var warns, errsToLog []string //, []string
-	// TODO: I need to add the new Helm value and use it here
-	istioIntegration := os.Getenv("GLOO_INTEGRATION_ISTIO") == "true"
-	eps, warns, errsToLog = filterEndpoints(ctx, writeNamespace, endpointList, serviceList, podList, c.upstreams, istioIntegration)
+	lookupResult, found := os.LookupEnv("ENABLE_ISTIO_SIDECAR")
+	istioIntegration := found && strings.ToLower(lookupResult) == "true"
+	eps, warns, errsToLog := filterEndpoints(ctx, writeNamespace, endpointList, serviceList, podList, c.upstreams, istioIntegration)
 
 	warnsToLog = append(warnsToLog, warns...)
 

--- a/projects/gloo/pkg/plugins/kubernetes/eds.go
+++ b/projects/gloo/pkg/plugins/kubernetes/eds.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 
 	errors "github.com/rotisserie/eris"
 
@@ -29,14 +28,14 @@ func (p *plugin) WatchEndpoints(writeNamespace string, upstreamsToTrack v1.Upstr
 	kubeFactory := func(namespaces []string) KubePluginSharedFactory {
 		return getInformerFactory(opts.Ctx, p.kube, namespaces)
 	}
-	watcher, err := newEndpointWatcherForUpstreams(kubeFactory, p.kubeCoreCache, upstreamsToTrack, opts)
+	watcher, err := newEndpointWatcherForUpstreams(kubeFactory, p.kubeCoreCache, writeNamespace, upstreamsToTrack, opts)
 	if err != nil {
 		return nil, nil, err
 	}
 	return watcher.watch(writeNamespace, opts)
 }
 
-func newEndpointWatcherForUpstreams(kubeFactoryFactory func(ns []string) KubePluginSharedFactory, kubeCoreCache corecache.KubeCoreCache, upstreamsToTrack v1.UpstreamList, opts clients.WatchOpts) (*edsWatcher, error) {
+func newEndpointWatcherForUpstreams(kubeFactoryFactory func(ns []string) KubePluginSharedFactory, kubeCoreCache corecache.KubeCoreCache, writeNamespace string, upstreamsToTrack v1.UpstreamList, opts clients.WatchOpts) (*edsWatcher, error) {
 	var namespaces []string
 
 	settings := settingsutil.FromContext(opts.Ctx)

--- a/projects/gloo/pkg/plugins/kubernetes/eds_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/eds_test.go
@@ -2,17 +2,17 @@ package kubernetes
 
 import (
 	"context"
+	"os"
 
 	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/pkg/utils/settingsutil"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	kubev1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/kubernetes"
 	mock_kubernetes "github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes/mocks"
 	mock_cache "github.com/solo-io/gloo/test/mocks/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("Eds", func() {
@@ -52,6 +52,24 @@ var _ = Describe("Eds", func() {
 		watcher.List("foo", clients.ListOpts{Ctx: ctx})
 		Expect(func() {}).NotTo(Panic())
 
+	})
+
+	Context("Istio integration", func() {
+
+		It("isIstioIntegrationEnabled should respond correctly to ENABLE_ISTIO_INTEGRATION env var", func() {
+
+			os.Setenv("ENABLE_ISTIO_INTEGRATION", "true")
+			Expect(isIstioIntegrationEnabled()).To(BeTrue())
+
+			os.Setenv("ENABLE_ISTIO_INTEGRATION", "TRUE")
+			Expect(isIstioIntegrationEnabled()).To(BeTrue())
+
+			os.Unsetenv("ENABLE_ISTIO_INTEGRATION")
+			Expect(isIstioIntegrationEnabled()).To(BeFalse())
+
+			os.Setenv("ENABLE_ISTIO_INTEGRATION", "false")
+			Expect(isIstioIntegrationEnabled()).To(BeFalse())
+		})
 	})
 
 })


### PR DESCRIPTION
# Description

This change includes support for setting endpoints based on service ip addresses rather than dns names, which is required for integration with Istio.

This required breaking up a large and complicated function which was making code changes difficult. 

# Context
This is phase two of the work required to prepare Edge for full Istio integration (see s-p 3461)
It follows the work done in #6196 , utilizing the helm value established there to enable this code change.

# Testing
This was tested manually by repeating the method described in the earlier work to enable injection ([see here](https://github.com/solo-io/gloo/pull/6312#issuecomment-1098467998)), along with steps [described here](https://github.com/murphye/demo-gloo-edge-istio) to generate an error from the petstore sevice when strict mTLS is enabled .

A config dump shows the desired endpoint configuration:
```

 "endpoint_config": {
  "@type": "type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment",
  "cluster_name": "kube-svc:petstore-petstore-8080_petstore-16672974176135880674",
  "endpoints": [
   {
    "locality": {},
    "lb_endpoints": [
     {
      "endpoint": {
       "address": {
        "socket_address": {
         "address": "10.40.0.174",
         "port_value": 8080
        }
       },
       "health_check_config": {}
      },
      "health_status": "HEALTHY",
      "metadata": {
       "filter_metadata": {
        "envoy.lb": {
         "service": "petstore"
        }
       }
      },
      "load_balancing_weight": 1
     }
    ]
   }
```

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [X] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6195