### PR TITLE
gloo/cli/cmd/install: Update the error message on enterprise install

### DIFF
--- a/changelog/v1.12.0-beta13/ctl-install-error-str.yaml
+++ b/changelog/v1.12.0-beta13/ctl-install-error-str.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Make glooctl install gateway enterprise mimic error output of glooctl install gateway

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -10,6 +10,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/install/helm/gloo/generate"
 	"github.com/solo-io/gloo/pkg/cliutil"
@@ -31,9 +32,11 @@ import (
 )
 
 var (
+	// ChartAndReleaseFlagErr is thrown when both options are set.
 	ChartAndReleaseFlagErr = func(chartOverride, versionOverride string) error {
 		return eris.Errorf("you may not specify both a chart with -f and a release version with --version. Received: %s and %s", chartOverride, versionOverride)
 	}
+	// UnreleasedWithoutOverrideErr details that the user is running an unreleased or invalid verison of gloo.
 	UnreleasedWithoutOverrideErr = eris.Errorf("you must provide a Gloo Helm chart URI via the 'file' option " +
 		"when running an unreleased version of glooctl")
 )
@@ -59,12 +62,14 @@ const (
 	Federation
 )
 
+// NewInstaller consumes a helm client and sets up an installer for usage in glooctl.
 func NewInstaller(helmClient HelmClient) Installer {
 	client := helpers.MustKubeClient()
 	return NewInstallerWithWriter(helmClient, client.CoreV1().Namespaces(), os.Stdout)
 }
 
-// visible for testing
+// NewInstallerWithWriter creates a new Installer for a given helm client,
+// namespace and output writer. The extra variables are exposed to allow for ease of testing.
 func NewInstallerWithWriter(helmClient HelmClient, kubeNsClient v1.NamespaceInterface, outputWriter io.Writer) Installer {
 	return &installer{
 		helmClient:         helmClient,
@@ -73,6 +78,7 @@ func NewInstallerWithWriter(helmClient HelmClient, kubeNsClient v1.NamespaceInte
 	}
 }
 
+// Install gloo given the provided config.
 func (i *installer) Install(installerConfig *InstallerConfig) error {
 	return i.installFromConfig(installerConfig)
 }
@@ -287,7 +293,7 @@ func getChartUri(chartOverride, versionOverride string, mode Mode) (string, erro
 		case Enterprise:
 			enterpriseVersion, err := version.GetLatestEnterpriseVersion(true)
 			if err != nil {
-				return "", err
+				return "", errors.Wrap(err, UnreleasedWithoutOverrideErr.Error())
 			}
 			helmChartVersion = enterpriseVersion
 		case Gloo:

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -10,7 +10,6 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/install/helm/gloo/generate"
 	"github.com/solo-io/gloo/pkg/cliutil"
@@ -293,7 +292,7 @@ func getChartUri(chartOverride, versionOverride string, mode Mode) (string, erro
 		case Enterprise:
 			enterpriseVersion, err := version.GetLatestEnterpriseVersion(true)
 			if err != nil {
-				return "", errors.Wrap(err, UnreleasedWithoutOverrideErr.Error())
+				return "", eris.Wrap(UnreleasedWithoutOverrideErr, err.Error())
 			}
 			helmChartVersion = enterpriseVersion
 		case Gloo:


### PR DESCRIPTION
Update glooctl install to have more consistent error messages that indicate the --file option