### PR TITLE
[1.10] Reconcile Proxies using both new and old labels

### DIFF
--- a/changelog/v1.10.25/set-based-proxy-label-selection.yaml
+++ b/changelog/v1.10.25/set-based-proxy-label-selection.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6406
+    resolvesIssue: false
+    description: Ensure Proxies with deprecated `created_by` labels can be reconciled correctly.
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: solo-kit
+    dependencyTag: v0.24.3

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/solo-io/skv2 v0.21.6
 	// Pinned to the `gloo-namespaced-statuses` tag of solo-apis
 	github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c
-	github.com/solo-io/solo-kit v0.24.2
+	github.com/solo-io/solo-kit v0.24.3
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1399,8 +1399,8 @@ github.com/solo-io/skv2 v0.21.6/go.mod h1:8jNcMWuAkBxdGhlRFMSgsK94q/jZGPEas8VHTr
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c h1:4/yTroUmyUJonldE5EyC3AinNG4KVLgG0FVMrI2SQ04=
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c/go.mod h1:4HQsQO4Cy/4V7ZZxWncvnMvIq7pYnb66jAT5hvDJBgQ=
 github.com/solo-io/solo-kit v0.23.0/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
-github.com/solo-io/solo-kit v0.24.2 h1:oR7aq/flPCc6S8dUdgMVMFtcodUV8Hj1TDWCxONYrx0=
-github.com/solo-io/solo-kit v0.24.2/go.mod h1:ZsqKgFsoZKz0MMWGD0J2K62u6qwBsk6X8P91fHTQUPg=
+github.com/solo-io/solo-kit v0.24.3 h1:9Mv/tEROAAkrxp7vZ/PyTMlhn28lPCOfZHCqMZ61cX0=
+github.com/solo-io/solo-kit v0.24.3/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/projects/clusteringress/pkg/translator/translator_syncer.go
+++ b/projects/clusteringress/pkg/translator/translator_syncer.go
@@ -33,6 +33,28 @@ type translatorSyncer struct {
 	statusClient    resources.StatusClient
 }
 
+var (
+	// labels used to uniquely identify Proxies that are managed by the Gloo controllers
+	proxyLabelsToWrite = map[string]string{
+		"created_by": "gloo-knative",
+	}
+
+	// Previously, proxies would be identified with:
+	//   created_by: knative
+	// Now, proxies are identified with:
+	//   created_by: gloo-knative
+	//
+	// We need to ensure that users can successfully upgrade from versions
+	// where the previous labels were used, to versions with the new labels.
+	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with new labels.
+	//
+	// This is only required for backwards compatibility.
+	// Once users have upgraded to a version with new labels, we can delete this code and read/write the same labels.
+	proxyLabelSelectorOptions = clients.ListOpts{
+		ExpressionSelector: "created_by in (gloo-knative, knative)",
+	}
+)
+
 func NewSyncer(proxyAddress, writeNamespace string, proxyClient gloov1.ProxyClient, ingressClient knativeclient.IngressesGetter, statusClient resources.StatusClient, writeErrs chan error) v1.TranslatorSyncer {
 	return &translatorSyncer{
 		proxyAddress:    proxyAddress,
@@ -69,22 +91,19 @@ func (s *translatorSyncer) Sync(ctx context.Context, snap *v1.TranslatorSnapshot
 		return err
 	}
 
-	labels := map[string]string{
-		"created_by": "gloo-knative",
-	}
-
 	var desiredResources gloov1.ProxyList
 	if proxy != nil {
 		logger.Infof("creating proxy %v", proxy.GetMetadata().Ref())
-		proxy.GetMetadata().Labels = labels
+		proxy.GetMetadata().Labels = proxyLabelsToWrite
 		desiredResources = gloov1.ProxyList{proxy}
 	}
 
 	proxyTransitionFunction := utils.TransitionFunction(s.statusClient)
 
 	if err := s.proxyReconciler.Reconcile(s.writeNamespace, desiredResources, proxyTransitionFunction, clients.ListOpts{
-		Ctx:      ctx,
-		Selector: labels,
+		Ctx:                ctx,
+		Selector:           proxyLabelSelectorOptions.Selector,
+		ExpressionSelector: proxyLabelSelectorOptions.ExpressionSelector,
 	}); err != nil {
 		return err
 	}

--- a/projects/gateway/pkg/reconciler/proxy_reconciler.go
+++ b/projects/gateway/pkg/reconciler/proxy_reconciler.go
@@ -23,7 +23,7 @@ type GeneratedProxies map[*gloov1.Proxy]reporter.ResourceReports
 type InvalidProxies map[*core.ResourceRef]reporter.ResourceReports
 
 type ProxyReconciler interface {
-	ReconcileProxies(ctx context.Context, proxiesToWrite GeneratedProxies, writeNamespace string, labels map[string]string) error
+	ReconcileProxies(ctx context.Context, proxiesToWrite GeneratedProxies, writeNamespace string, labelSelectorOptions clients.ListOpts) error
 }
 
 type proxyReconciler struct {
@@ -42,7 +42,7 @@ func NewProxyReconciler(proxyValidator validation.GlooValidationServiceClient, p
 
 const proxyValidationErrMsg = "internal err: communication with proxy validation (gloo) failed"
 
-func (s *proxyReconciler) ReconcileProxies(ctx context.Context, proxiesToWrite GeneratedProxies, writeNamespace string, labels map[string]string) error {
+func (s *proxyReconciler) ReconcileProxies(ctx context.Context, proxiesToWrite GeneratedProxies, writeNamespace string, labelSelectorOptions clients.ListOpts) error {
 	if err := s.addProxyValidationResults(ctx, proxiesToWrite); err != nil {
 		return errors.Wrapf(err, "failed to add proxy validation results to reports")
 	}
@@ -64,8 +64,9 @@ func (s *proxyReconciler) ReconcileProxies(ctx context.Context, proxiesToWrite G
 	proxyTransitionFunction := transitionFunc(proxiesToWrite, s.statusClient)
 
 	if err := s.baseReconciler.Reconcile(writeNamespace, allProxies, proxyTransitionFunction, clients.ListOpts{
-		Ctx:      ctx,
-		Selector: labels,
+		Ctx:                ctx,
+		Selector:           labelSelectorOptions.Selector,
+		ExpressionSelector: labelSelectorOptions.ExpressionSelector,
 	}); err != nil {
 		return err
 	}

--- a/projects/gateway/pkg/reconciler/proxy_reconciler_test.go
+++ b/projects/gateway/pkg/reconciler/proxy_reconciler_test.go
@@ -100,7 +100,7 @@ var _ = Describe("ReconcileGatewayProxies", func() {
 	}
 
 	reconcile := func() {
-		err := reconciler.ReconcileProxies(ctx, proxyToWrite, ns, map[string]string{})
+		err := reconciler.ReconcileProxies(ctx, proxyToWrite, ns, clients.ListOpts{Selector: map[string]string{}})
 		ExpectWithOffset(1, err).NotTo(HaveOccurred())
 	}
 

--- a/projects/gateway/pkg/syncer/translator_syncer.go
+++ b/projects/gateway/pkg/syncer/translator_syncer.go
@@ -39,9 +39,30 @@ type translatorSyncer struct {
 	proxyReconciler    reconciler.ProxyReconciler
 	translator         translator.Translator
 	statusSyncer       statusSyncer
-	managedProxyLabels map[string]string
 	proxyStatusMaxSize string
 }
+
+var (
+	// labels used to uniquely identify Proxies that are managed by the Gloo controllers
+	proxyLabelsToWrite = map[string]string{
+		"created_by": "gloo-gateway-translator",
+	}
+
+	// Previously, proxies would be identified with:
+	//   created_by: gateway
+	// Now, proxies are identified with:
+	//   created_by: gloo-gateway-translator
+	//
+	// We need to ensure that users can successfully upgrade from versions
+	// where the previous labels were used, to versions with the new labels.
+	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with new labels.
+	//
+	// This is only required for backwards compatibility.
+	// Once users have upgraded to a version with new labels, we can delete this code and read/write the same labels.
+	proxyLabelSelectorOptions = clients.ListOpts{
+		ExpressionSelector: "created_by in (gloo-gateway-translator, gateway)",
+	}
+)
 
 func NewTranslatorSyncer(ctx context.Context, writeNamespace string, proxyWatcher gloov1.ProxyWatcher, proxyReconciler reconciler.ProxyReconciler, reporter reporter.StatusReporter, translator translator.Translator, statusClient resources.StatusClient, statusMetrics metrics.ConfigStatusMetrics) v1.ApiSyncer {
 	t := &translatorSyncer{
@@ -51,9 +72,6 @@ func NewTranslatorSyncer(ctx context.Context, writeNamespace string, proxyWatche
 		proxyReconciler: proxyReconciler,
 		translator:      translator,
 		statusSyncer:    newStatusSyncer(writeNamespace, proxyWatcher, reporter, statusClient, statusMetrics),
-		managedProxyLabels: map[string]string{
-			"created_by": "gloo-gateway-translator",
-		},
 	}
 	go t.statusSyncer.watchProxies(ctx)
 	if pxStatusSizeEnv := os.Getenv("PROXY_STATUS_MAX_SIZE_BYTES"); pxStatusSizeEnv != "" {
@@ -106,7 +124,7 @@ func (s *translatorSyncer) generatedDesiredProxies(ctx context.Context, snap *v1
 				}
 			}
 			logger.Infof("desired proxy %v", proxy.GetMetadata().Ref())
-			proxy.GetMetadata().Labels = s.managedProxyLabels
+			proxy.GetMetadata().Labels = proxyLabelsToWrite
 			desiredProxies[proxy] = reports
 		} else {
 			// We were unable to create a proxy
@@ -126,7 +144,7 @@ func (s *translatorSyncer) shouldCompresss(ctx context.Context) bool {
 }
 
 func (s *translatorSyncer) reconcile(ctx context.Context, desiredProxies reconciler.GeneratedProxies, invalidProxies reconciler.InvalidProxies) error {
-	if err := s.proxyReconciler.ReconcileProxies(ctx, desiredProxies, s.writeNamespace, s.managedProxyLabels); err != nil {
+	if err := s.proxyReconciler.ReconcileProxies(ctx, desiredProxies, s.writeNamespace, proxyLabelSelectorOptions); err != nil {
 		return err
 	}
 

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -218,6 +218,118 @@ var _ = Describe("Kube2e: gateway", func() {
 		})
 	})
 
+	Context("Proxy reconciliation", func() {
+
+		var (
+			virtualService *gatewayv1.VirtualService
+		)
+
+		BeforeEach(func() {
+			// Create virtual service routing directly to the testrunner service
+			dest := &gloov1.Destination{
+				DestinationType: &gloov1.Destination_Kube{
+					Kube: &gloov1.KubernetesServiceDestination{
+						Ref: &core.ResourceRef{
+							Namespace: testHelper.InstallNamespace,
+							Name:      helper.TestrunnerName,
+						},
+						Port: uint32(helper.TestRunnerPort),
+					},
+				},
+			}
+			virtualService = getVirtualService(dest, nil)
+
+			_, err := virtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err := virtualServiceClient.Delete(
+				virtualService.GetMetadata().GetNamespace(),
+				virtualService.GetMetadata().GetName(),
+				clients.DeleteOpts{Ctx: ctx})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// This function parses a Proxy and determines how many routes are configured to point to the testrunner service
+		getRoutesToTestRunner := func(proxy *gloov1.Proxy) int {
+			routesToTestRunner := 0
+			for _, l := range proxy.Listeners {
+				for _, vh := range l.GetHttpListener().VirtualHosts {
+					for _, r := range vh.Routes {
+						if action := r.GetRouteAction(); action != nil {
+							if single := action.GetSingle(); single != nil {
+								if svcDest := single.GetKube(); svcDest != nil {
+									if svcDest.Ref.Name == helper.TestrunnerName &&
+										svcDest.Ref.Namespace == testHelper.InstallNamespace &&
+										svcDest.Port == uint32(helper.TestRunnerPort) {
+										routesToTestRunner += 1
+									}
+								}
+							}
+						}
+					}
+				}
+			}
+			return routesToTestRunner
+		}
+
+		It("should process proxy with deprecated label", func() {
+			// wait for the expected proxy configuration to be accepted
+			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+				proxy, err := proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+				if err != nil {
+					return nil, err
+				}
+
+				expectedRoutesToTestRunner := 1 // we created a virtual service, with a single route to the testrunner service
+				actualRoutesToTestRunner := getRoutesToTestRunner(proxy)
+
+				if expectedRoutesToTestRunner != actualRoutesToTestRunner {
+					return nil, eris.Errorf("Expected %d routes to test runner service, but found %d", expectedRoutesToTestRunner, actualRoutesToTestRunner)
+				}
+				return proxy, nil
+			})
+
+			// modify the proxy to use the deprecated label
+			// this will simulate proxies that were persisted before the label change
+			proxy, err := proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+			Expect(err).NotTo(HaveOccurred())
+			proxy.Metadata.Labels = map[string]string{
+				"created_by": "gateway",
+			}
+			_, err = proxyClient.Write(proxy, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+			Expect(err).NotTo(HaveOccurred())
+
+			// modify the virtual service to trigger gateway reconciliation
+			// any modification will work, for simplicity we duplicate a route on the virtual host
+			vs, err := virtualServiceClient.Read(
+				virtualService.GetMetadata().GetNamespace(),
+				virtualService.GetMetadata().GetName(),
+				clients.ReadOpts{Ctx: ctx})
+			Expect(err).NotTo(HaveOccurred())
+			vs.VirtualHost.Routes = append(vs.VirtualHost.Routes, vs.VirtualHost.Routes[0])
+			_, err = virtualServiceClient.Write(vs, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+			Expect(err).NotTo(HaveOccurred())
+
+			// ensure that the changes from the virtual service are propagated to the proxy
+			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+				proxy, err := proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+				if err != nil {
+					return nil, err
+				}
+
+				expectedRoutesToTestRunner := 2 // we duplicated the route to the testrunner service
+				actualRoutesToTestRunner := getRoutesToTestRunner(proxy)
+
+				if expectedRoutesToTestRunner != actualRoutesToTestRunner {
+					return nil, eris.Errorf("Expected %d routes to test runner service, but found %d", expectedRoutesToTestRunner, actualRoutesToTestRunner)
+				}
+				return proxy, nil
+			})
+		})
+	})
+
 	Context("tests with virtual service", func() {
 
 		AfterEach(func() {


### PR DESCRIPTION
Backport of: https://github.com/solo-io/gloo/pull/6461

# Description

Reconcile proxies using labels that follow the current naming convention, and the previous naming convention.

# Context

Gloo maintains an internal CR, known as a [Proxy](https://github.com/solo-io/gloo/blob/e5df9c889c00a4756fc468432160732706554257/projects/gloo/api/v1/proxy.proto#L30). We identify these Proxies with [unique labels](https://github.com/solo-io/gloo/blob/bc380b36d42fdad7c83ab8dc4f055258b326aeac/projects/gateway/pkg/syncer/translator_syncer.go#L49). We rely on these labels to both read Proxies (to know which to reconcile) and write Proxies (to know which to reconcile on the next iteration). Recently we changed these labels on Proxies, which means that after an upgrade from a version with the old label, to a version with the new label, the Proxy controller will attempt to reconcile the existing persisted Proxies. However, since the Proxy uses the old label, but the new controller looks for the new label, it will find no proxies, and expect to create one. Our toolkit for modifying resources will then error, since it is attempting to create a resource that is meant for update.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
