### PR TITLE
Remove VALIDATION_MUST_START

### DIFF
--- a/changelog/v1.12.0-beta16/validation_envvar.yaml
+++ b/changelog/v1.12.0-beta16/validation_envvar.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/6421
+    resolvesIssue: true
+    description: >
+      Remove the reference to the VALIDATION_MUST_START environment variable from gloo setup.

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4019,7 +4019,31 @@ metadata:
 						})
 						testManifest.ExpectDeploymentAppsV1(glooDeployment)
 					})
-
+					It("can disable validation", func() {
+						glooDeployment.Spec.Template.Spec.Volumes = []v1.Volume{{
+							Name: "labels-volume",
+							VolumeSource: v1.VolumeSource{
+								DownwardAPI: &v1.DownwardAPIVolumeSource{
+									Items: []v1.DownwardAPIVolumeFile{{
+										Path: "labels",
+										FieldRef: &v1.ObjectFieldSelector{
+											FieldPath: "metadata.labels",
+										},
+									}},
+								},
+							},
+						},
+						}
+						glooDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = []v1.VolumeMount{
+							{Name: "labels-volume",
+								MountPath: "/etc/gloo",
+								ReadOnly:  true,
+							}}
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{"gateway.validation.enabled=false"},
+						})
+						testManifest.ExpectDeploymentAppsV1(glooDeployment)
+					})
 					It("can accept extra env vars", func() {
 						glooDeployment.Spec.Template.Spec.Containers[0].Env = append(
 							[]v1.EnvVar{GetTestExtraEnvVar()},

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -1105,11 +1105,6 @@ func constructOpts(ctx context.Context, clientset *kubernetes.Interface, kubeCac
 		if validation.ValidatingWebhookKeyPath == "" {
 			validation.ValidatingWebhookKeyPath = gwdefaults.ValidationWebhookTlsKeyPath
 		}
-	} else {
-		if validationMustStart := os.Getenv("VALIDATION_MUST_START"); validationMustStart != "" && validationMustStart != "false" {
-			return bootstrap.Opts{}, errors.Errorf("VALIDATION_MUST_START was set to true, but no validation configuration was provided in the settings. "+
-				"Ensure the v1.Settings %v contains the spec.gateway.validation config", settings.GetMetadata().Ref())
-		}
 	}
 	readGatewaysFromAllNamespaces := settings.GetGateway().GetReadGatewaysFromAllNamespaces()
 	return bootstrap.Opts{


### PR DESCRIPTION
# Description
We were copying the value of `gateway.validation.enabled` into an environment variable, and checking it in the event that no other validation configuration was provided in the settings custom resource. However, when we create the settings custom resource, we never leave the validation configuration empty if validation is enabled so this code was not reachable. 

I removed the reference to the environment variable and also added a helm test for the case where validation is not enabled in the gloo deployment (which is only partially relevant here but I noticed the lack of a test while I was trying to decide what to do with `VALIDATION_MUST_START`)


# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
