### PR TITLE
Install gateway-proxy in separate namespace from Gloo Edge Control Plane

### DIFF
--- a/changelog/v1.12.0-beta17/custom-proxy-namespace.yaml
+++ b/changelog/v1.12.0-beta17/custom-proxy-namespace.yaml
@@ -1,6 +1,6 @@
 changelog:
   - type: NEW_FEATURE
-    issueLink: https://github.com/solo-io/solo-projects/issues/6295
+    issueLink: https://github.com/solo-io/gloo/issues/6295
     resolvesIssue: true
     description: >
       Allow specifying a non-control plane namespace in which to deploy gatewayProxies

--- a/changelog/v1.12.0-beta17/custom-proxy-namespace.yaml
+++ b/changelog/v1.12.0-beta17/custom-proxy-namespace.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/6295
+    resolvesIssue: true
+    description: >
+      Allow specifying a non-control plane namespace in which to deploy gatewayProxies

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -398,7 +398,7 @@
 |gatewayProxies.NAME.kind.deployment.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.NAME.kind.daemonSet.hostPort|bool||whether or not to enable host networking on the pod. Only relevant when running as a DaemonSet|
 |gatewayProxies.NAME.kind.daemonSet.hostNetwork|bool|||
-|gatewayProxies.NAME.namespace|string||namespace in which to deploy this gateway proxy|
+|gatewayProxies.NAME.namespace|string||Namespace in which to deploy this gateway proxy. Defaults to the value of Settings.WriteNamespace|
 |gatewayProxies.NAME.podTemplate.image.tag|string||The image tag for the container.|
 |gatewayProxies.NAME.podTemplate.image.repository|string||The image repository (name) for the container.|
 |gatewayProxies.NAME.podTemplate.image.registry|string||The image hostname prefix and registry, such as quay.io/solo-io.|
@@ -589,7 +589,7 @@
 |gatewayProxies.gatewayProxy.kind.deployment.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.gatewayProxy.kind.daemonSet.hostPort|bool||whether or not to enable host networking on the pod. Only relevant when running as a DaemonSet|
 |gatewayProxies.gatewayProxy.kind.daemonSet.hostNetwork|bool|||
-|gatewayProxies.gatewayProxy.namespace|string||namespace in which to deploy this gateway proxy|
+|gatewayProxies.gatewayProxy.namespace|string||Namespace in which to deploy this gateway proxy. Defaults to the value of Settings.WriteNamespace|
 |gatewayProxies.gatewayProxy.podTemplate.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |gatewayProxies.gatewayProxy.podTemplate.image.repository|string|gloo-envoy-wrapper|The image repository (name) for the container.|
 |gatewayProxies.gatewayProxy.podTemplate.image.registry|string||The image hostname prefix and registry, such as quay.io/solo-io.|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -398,6 +398,7 @@
 |gatewayProxies.NAME.kind.deployment.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.NAME.kind.daemonSet.hostPort|bool||whether or not to enable host networking on the pod. Only relevant when running as a DaemonSet|
 |gatewayProxies.NAME.kind.daemonSet.hostNetwork|bool|||
+|gatewayProxies.NAME.namespace|string||namespace in which to deploy this gateway proxy|
 |gatewayProxies.NAME.podTemplate.image.tag|string||The image tag for the container.|
 |gatewayProxies.NAME.podTemplate.image.repository|string||The image repository (name) for the container.|
 |gatewayProxies.NAME.podTemplate.image.registry|string||The image hostname prefix and registry, such as quay.io/solo-io.|
@@ -588,6 +589,7 @@
 |gatewayProxies.gatewayProxy.kind.deployment.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.gatewayProxy.kind.daemonSet.hostPort|bool||whether or not to enable host networking on the pod. Only relevant when running as a DaemonSet|
 |gatewayProxies.gatewayProxy.kind.daemonSet.hostNetwork|bool|||
+|gatewayProxies.gatewayProxy.namespace|string||namespace in which to deploy this gateway proxy|
 |gatewayProxies.gatewayProxy.podTemplate.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |gatewayProxies.gatewayProxy.podTemplate.image.repository|string|gloo-envoy-wrapper|The image repository (name) for the container.|
 |gatewayProxies.gatewayProxy.podTemplate.image.registry|string||The image hostname prefix and registry, such as quay.io/solo-io.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -362,6 +362,7 @@ type CertGenCron struct {
 
 type GatewayProxy struct {
 	Kind                           *GatewayProxyKind            `json:"kind,omitempty" desc:"value to determine how the gateway proxy is deployed"`
+	Namespace                      string                       `json:"namespace,omitempty" desc:"namespace in which to deploy this gateway proxy"`
 	PodTemplate                    *GatewayProxyPodTemplate     `json:"podTemplate,omitempty"`
 	ConfigMap                      *ConfigMap                   `json:"configMap,omitempty"`
 	CustomStaticLayer              interface{}                  `json:"customStaticLayer,omitempty" desc:"Configure the static layer for global overrides to Envoy behavior, as defined in the Envoy bootstrap YAML. You cannot use this setting to set overload or upstream layers. For more info, see the Envoy docs. https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#config-runtime"`

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -362,7 +362,7 @@ type CertGenCron struct {
 
 type GatewayProxy struct {
 	Kind                           *GatewayProxyKind            `json:"kind,omitempty" desc:"value to determine how the gateway proxy is deployed"`
-	Namespace                      string                       `json:"namespace,omitempty" desc:"namespace in which to deploy this gateway proxy"`
+	Namespace                      *string                      `json:"namespace,omitempty" desc:"Namespace in which to deploy this gateway proxy. Defaults to the value of Settings.WriteNamespace"`
 	PodTemplate                    *GatewayProxyPodTemplate     `json:"podTemplate,omitempty"`
 	ConfigMap                      *ConfigMap                   `json:"configMap,omitempty"`
 	CustomStaticLayer              interface{}                  `json:"customStaticLayer,omitempty" desc:"Configure the static layer for global overrides to Envoy behavior, as defined in the Envoy bootstrap YAML. You cannot use this setting to set overload or upstream layers. For more info, see the Envoy docs. https://www.envoyproxy.io/docs/envoy/latest/configuration/operations/runtime#config-runtime"`

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -35,7 +35,7 @@ metadata:
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
   name: {{ $name | kebabcase }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
 spec:
   {{- if $spec.kind.deployment}}
   {{- if $spec.kind.deployment.replicas}}

--- a/install/helm/gloo/templates/8-default-gateways.yaml
+++ b/install/helm/gloo/templates/8-default-gateways.yaml
@@ -9,7 +9,7 @@ apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:
   name: {{ $name | kebabcase }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
 {{- include "gloo.customResourceLabelsAndAnnotations" $data }}
 spec:
   {{- if $gatewaySettings.ipv4Only }}
@@ -120,7 +120,7 @@ apiVersion: gateway.solo.io/v1
 kind: Gateway
 metadata:
   name: {{ $name | kebabcase }}-failover
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
 {{- include "gloo.customResourceLabelsAndAnnotations" $data }}
 spec:
 {{- if $gatewaySettings.ipv4Only }}

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -14,7 +14,7 @@ metadata:
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
   name: {{ $name | kebabcase }}-hpa
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
 spec:
   minReplicas: {{ $spec.horizontalPodAutoscaler.minReplicas }}
   maxReplicas: {{ $spec.horizontalPodAutoscaler.maxReplicas }}

--- a/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
@@ -10,7 +10,7 @@ apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ $name | kebabcase }}-pdb
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
 spec:
   {{- if $spec.podDisruptionBudget.minAvailable }}
   minAvailable: {{ $spec.podDisruptionBudget.minAvailable }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service-account.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service-account.yaml
@@ -18,7 +18,15 @@ metadata:
 automountServiceAccountToken: false
 {{ end }}
 {{ end }}
-{{- end }}
+{{- end }} {{/* define "gateway.proxyServiceAccountSpec" */}}
+{{/*# To create a single ServiceAccount in each namespace which includes a proxy instance,*/}}
+{{/*# we'll build a list of unique namespaces*/}}
+{{- $proxyNamespaces := list -}}
+{{- range $key, $gatewaySpec := .Values.gatewayProxies -}}
+  {{- $ns := $gatewaySpec.namespace | default $.Release.Namespace -}}
+  {{- $proxyNamespaces = append $proxyNamespaces $ns -}}
+{{- end -}}
+{{- $proxyNamespaces = $proxyNamespaces | uniq -}}
 
 {{- $kubeResourceOverride := dict -}}
 {{- if .Values.gateway -}}
@@ -26,4 +34,19 @@ automountServiceAccountToken: false
 {{- $kubeResourceOverride = .Values.gateway.proxyServiceAccount.kubeResourceOverride  -}}
 {{- end -}}
 {{- end -}}
-{{- include "gloo.util.merge" (list . (.Values.gateway.proxyServiceAccount.kubeResourceOverride ) "gateway.proxyServiceAccountSpec") -}}
+{{- $ctx := (list . $kubeResourceOverride) }}
+{{- $period := .}}
+{{- range $namespace := $proxyNamespaces -}}
+
+{{/*{{- template "magda.var_dump" $ctx }}*/}}
+
+{{- include "gloo.util.merge" (list $period ($period.Values.gateway.proxyServiceAccount.kubeResourceOverride ) "gateway.proxyServiceAccountSpec") -}}
+
+{{/*Original include: {{- include "gloo.util.merge" (list . (.Values.gateway.proxyServiceAccount.kubeResourceOverride ) "gateway.proxyServiceAccountSpec") -}}*/}}
+
+{{- end -}}   {{/*range $namespace := $proxyNamespaces | uniq*/}}
+
+
+{{- define "magda.var_dump" -}}
+{{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
+{{- end -}}

--- a/install/helm/gloo/templates/8-gateway-proxy-service-account.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service-account.yaml
@@ -1,4 +1,6 @@
 {{- define "gateway.proxyServiceAccountSpec" }}
+{{- $gatewayNs := (index . 1) }}
+{{- with (first .) }}
 {{- if .Values.gateway.enabled }}
 apiVersion: v1
 kind: ServiceAccount
@@ -13,20 +15,13 @@ metadata:
     app: gloo
     gloo: gateway-proxy
   name: gateway-proxy
-  namespace: {{ $.Release.Namespace }}
+  namespace: {{ $gatewayNs }}
 {{- if .Values.gateway.proxyServiceAccount.disableAutomount }}
 automountServiceAccountToken: false
 {{ end }}
 {{ end }}
-{{- end }} {{/* define "gateway.proxyServiceAccountSpec" */}}
-{{/*# To create a single ServiceAccount in each namespace which includes a proxy instance,*/}}
-{{/*# we'll build a list of unique namespaces*/}}
-{{- $proxyNamespaces := list -}}
-{{- range $key, $gatewaySpec := .Values.gatewayProxies -}}
-  {{- $ns := $gatewaySpec.namespace | default $.Release.Namespace -}}
-  {{- $proxyNamespaces = append $proxyNamespaces $ns -}}
-{{- end -}}
-{{- $proxyNamespaces = $proxyNamespaces | uniq -}}
+{{- end }}
+{{- end }}
 
 {{- $kubeResourceOverride := dict -}}
 {{- if .Values.gateway -}}
@@ -34,19 +29,16 @@ automountServiceAccountToken: false
 {{- $kubeResourceOverride = .Values.gateway.proxyServiceAccount.kubeResourceOverride  -}}
 {{- end -}}
 {{- end -}}
-{{- $ctx := (list . $kubeResourceOverride) }}
-{{- $period := .}}
-{{- range $namespace := $proxyNamespaces -}}
 
-{{/*{{- template "magda.var_dump" $ctx }}*/}}
-
-{{- include "gloo.util.merge" (list $period ($period.Values.gateway.proxyServiceAccount.kubeResourceOverride ) "gateway.proxyServiceAccountSpec") -}}
-
-{{/*Original include: {{- include "gloo.util.merge" (list . (.Values.gateway.proxyServiceAccount.kubeResourceOverride ) "gateway.proxyServiceAccountSpec") -}}*/}}
-
-{{- end -}}   {{/*range $namespace := $proxyNamespaces | uniq*/}}
-
-
-{{- define "magda.var_dump" -}}
-{{- . | mustToPrettyJson | printf "\nThe JSON output of the dumped var is: \n%s" | fail }}
+{{- $proxyNamespaces := list -}}
+{{- range $key, $gatewaySpec := .Values.gatewayProxies -}}
+  {{- $ns := $gatewaySpec.namespace | default $.Release.Namespace -}}
+  {{- $proxyNamespaces = append $proxyNamespaces $ns -}}
 {{- end -}}
+{{- $proxyNamespaces = $proxyNamespaces | uniq -}}
+
+{{- range $ns := $proxyNamespaces}}
+{{- $ctx := (list $ $ns) }}
+---
+{{- include "gloo.util.merge" (list $ctx ($kubeResourceOverride ) "gateway.proxyServiceAccountSpec") -}}
+{{- end }}

--- a/install/helm/gloo/templates/8-gateway-proxy-service.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-service.yaml
@@ -12,7 +12,7 @@ metadata:
     gloo: gateway-proxy
     gateway-proxy-id: {{ $name | kebabcase }}
   name: {{ $svcName | kebabcase }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
 {{- if $spec.service.extraAnnotations }}
   annotations:
   {{- range $key, $value := $spec.service.extraAnnotations }}
@@ -100,12 +100,13 @@ spec:
   {{- end }} {{/* define gatewayProxy.serviceSpec */}}
 {{- define "gatewayProxy.configDumpServiceSpec" }}
 {{- $name := (index . 1) }}
+{{- $spec := (index . 2) }}
 {{- with (first .) }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $name | kebabcase }}-config-dump-service
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
   labels:
     app: gloo
     gloo: gateway-proxy
@@ -122,12 +123,13 @@ spec:
 {{- end }} {{/* define gatewayProxy.configDumpServiceSpec */}}
 {{- define "gatewayProxy.monitoringServiceSpec" }}
 {{- $name := (index . 1) -}}
+{{- $spec := (index . 2) -}}
 {{- with (first .) }}
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ $name | kebabcase }}-monitoring-service
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
   labels:
     app: gloo
     gloo: gateway-proxy

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -15,7 +15,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ $name | kebabcase }}-envoy-config
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $spec.namespace | default .Release.Namespace }}
   labels:
     app: gloo
     gloo: gateway-proxy
@@ -41,8 +41,9 @@ data:
       cluster: gateway
       id: "{{ `{{.PodName}}.{{.PodNamespace}}` }}"
       metadata:
-        # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
-        role: "{{ `{{.PodNamespace}}` }}~{{ $name | kebabcase }}"
+        # Specifies the proxy's in-memory xds cache key (see projects/gloo/pkg/xds/envoy.go)
+        # This value needs to match discoveryNamespace (or "writeNamespace") in the settings template
+        role: {{.Values.settings.writeNamespace | default .Release.Namespace }}~{{ $name | kebabcase }}
     static_resources:
 {{- if or $statsConfig.enabled (or $spec.readConfig $spec.extraListenersHelper) }}
       listeners:

--- a/install/test/fixtures.go
+++ b/install/test/fixtures.go
@@ -17,7 +17,7 @@ node:
   id: "{{.PodName}}.{{.PodNamespace}}"
   metadata:
     # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
-    role: "{{.PodNamespace}}~gateway-proxy"
+    role: "gloo-system~gateway-proxy"
 static_resources:
   listeners: # if or $statsConfig.enabled (or $spec.readConfig $spec.extraListenersHelper) # $spec.extraListenersHelper
   - name: prometheus_listener
@@ -193,7 +193,7 @@ node:
   cluster: gateway
   id: '{{.PodName}}.{{.PodNamespace}}'
   metadata:
-    role: '{{.PodNamespace}}~gateway-proxy'
+    role: 'gloo-system~gateway-proxy'
 static_resources:
   clusters:
   - alt_stat_name: xds_cluster
@@ -331,7 +331,7 @@ node:
   cluster: gateway
   id: '{{.PodName}}.{{.PodNamespace}}'
   metadata:
-    role: '{{.PodNamespace}}~gateway-proxy'
+    role: 'gloo-system~gateway-proxy'
 static_resources:
   clusters:
   - alt_stat_name: xds_cluster
@@ -483,7 +483,7 @@ node:
   cluster: gateway
   id: '{{.PodName}}.{{.PodNamespace}}'
   metadata:
-    role: '{{.PodNamespace}}~gateway-proxy'
+    role: 'gloo-system~gateway-proxy'
 static_resources:
   clusters:
   - alt_stat_name: xds_cluster
@@ -670,7 +670,7 @@ node:
   cluster: gateway
   id: '{{.PodName}}.{{.PodNamespace}}'
   metadata:
-    role: '{{.PodNamespace}}~gateway-proxy'
+    role: 'gloo-system~gateway-proxy'
 static_resources:
   clusters:
   - alt_stat_name: xds_cluster

--- a/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
+++ b/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
@@ -14,7 +14,7 @@ node:
   id: "{{.PodName}}.{{.PodNamespace}}"
   metadata:
     # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
-    role: "{{.PodNamespace}}~gateway-proxy"
+    role: "gloo-system~gateway-proxy"
 static_resources:
   listeners:
   - name: prometheus_listener

--- a/install/test/fixtures/envoy_config/custom_static_bootstrap.yaml
+++ b/install/test/fixtures/envoy_config/custom_static_bootstrap.yaml
@@ -16,7 +16,7 @@ node:
   id: "{{.PodName}}.{{.PodNamespace}}"
   metadata:
     # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
-    role: "{{.PodNamespace}}~gateway-proxy"
+    role: "gloo-system~gateway-proxy"
 static_resources:
   listeners:
     - name: prometheus_listener

--- a/install/test/fixtures/envoy_config/overload_manager.yaml
+++ b/install/test/fixtures/envoy_config/overload_manager.yaml
@@ -14,7 +14,7 @@ node:
   id: "{{.PodName}}.{{.PodNamespace}}"
   metadata:
     # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
-    role: "{{.PodNamespace}}~gateway-proxy"
+    role: "gloo-system~gateway-proxy"
 static_resources:
   listeners:
   - name: prometheus_listener

--- a/install/test/fixtures/envoy_config/static_clusters.yaml
+++ b/install/test/fixtures/envoy_config/static_clusters.yaml
@@ -14,7 +14,7 @@ node:
   id: "{{.PodName}}.{{.PodNamespace}}"
   metadata:
     # role's value is the key for the in-memory xds cache (projects/gloo/pkg/xds/envoy.go)
-    role: "{{.PodNamespace}}~gateway-proxy"
+    role: "gloo-system~gateway-proxy"
 static_resources:
   listeners:
   - name: prometheus_listener

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -171,9 +171,17 @@ var _ = Describe("Kube2e: helm", func() {
 
 			upgradeGloo(testHelper, chartUri, crdDir, fromRelease, strictValidation, settings)
 
+			// Ensures deployment is created for extra namespace (name is kebab-case of gatewayProxies NAME helm value)
 			Eventually(func() (string, error) {
-				return exec_utils.RunCommandOutput(testHelper.RootDir, false, "kubectl", "get", "serviceaccount", "-n", externalNamespace)
-			}, "10s", "1s").Should(ContainSubstring(externalNamespace))
+				return exec_utils.RunCommandOutput(testHelper.RootDir, false,
+					"kubectl", "get", "deployment", "-n", externalNamespace)
+			}, "10s", "1s").Should(ContainSubstring("proxy-external"))
+
+			// Ensures service account is created for extra namespace
+			Eventually(func() (string, error) {
+				return exec_utils.RunCommandOutput(testHelper.RootDir, false,
+					"kubectl", "get", "serviceaccount", "-n", externalNamespace)
+			}, "10s", "1s").Should(ContainSubstring("gateway-proxy"))
 		})
 	})
 

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -171,13 +171,16 @@ var _ = Describe("Kube2e: helm", func() {
 
 			upgradeGloo(testHelper, chartUri, crdDir, fromRelease, strictValidation, settings)
 
-			// Ensures deployment is created for extra namespace (name is kebab-case of gatewayProxies NAME helm value)
+			// Ensures deployment is created for both default namespace and external one
+			// Note- name of external deployments is kebab-case of gatewayProxies NAME helm value
 			Eventually(func() (string, error) {
 				return exec_utils.RunCommandOutput(testHelper.RootDir, false,
-					"kubectl", "get", "deployment", "-n", externalNamespace)
-			}, "10s", "1s").Should(ContainSubstring("proxy-external"))
+					"kubectl", "get", "deployment", "-A")
+			}, "10s", "1s").Should(
+				And(ContainSubstring("gateway-proxy"),
+					ContainSubstring("proxy-external")))
 
-			// Ensures service account is created for extra namespace
+			// Ensures service account is created for the external namespace
 			Eventually(func() (string, error) {
 				return exec_utils.RunCommandOutput(testHelper.RootDir, false,
 					"kubectl", "get", "serviceaccount", "-n", externalNamespace)


### PR DESCRIPTION
# Description

Allows setting the namespace of amy named proxy (gatewayProxies.NAME) using a new 

Draft notes:
* This change does not create any of the specified non-control-plane namespaces. These must  be created manually.

# Context

This change allows Gloo Edge to be deployed in a more customized configuration. This is required when integrating proxies into Gloo Mesh Workspaces which use namespaces for isolation.
 
# Testing
Testing was done manually, verifying that XDS configuration reached proxies in both gloo-system and a custom  namespace.

Configuration used in testing (based on the [multi-gw deployment guide](https://github.com/solo-io/gloo/blob/master/docs/content/installation/advanced_configuration/multi-gw-deployment.md))
```
  gatewayProxies:
    publicGw: # Proxy name for public access (Internet facing)
      disabled: false # overwrite the "default" value in the merge step
      kind:
        deployment:
          replicas: 2
      service:
        kubeResourceOverride: # workaround for https://github.com/solo-io/gloo/issues/5297
          spec:
            ports:
              - port: 443
                protocol: TCP
                name: https
                targetPort: 8443
            type: LoadBalancer
      gatewaySettings:
        customHttpsGateway: # using the default HTTPS Gateway
          virtualServiceSelector:
            gateway-type: public # label set on the VirtualService
        disableHttpGateway: true # disable the default HTTP Gateway
    corpGw: # Proxy name for private access (intranet facing)
      disabled: false # overwrite the "default" value in the merge step
      namespace: corp-ns
      service:
        httpPort: 80
        httpsFirst: false
        httpsPort: 443
        httpNodePort: 32080 # random port to be fixed in your private network
        type: NodePort
      # Creates corp-gw-config-dump-service
      readConfig: true
      readConfigMulticluster: true
      gatewaySettings:
        customHttpGateway: {} # using the default HTTP Gateway
        disableHttpsGateway: true # disable the default HTTPS Gateway
    gatewayProxy:
      disabled: false # disable the default gateway-proxy deployment and its 2 default Gateway CRs
```

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6295