### PR TITLE
Pass issue labels as a single string

### DIFF
--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -14,7 +14,7 @@ jobs:
         with:
           project-url: https://github.com/orgs/solo-io/projects/22
           github-token: ${{ secrets.ORG_CROSS_REPO }}
-          labeled: "Type: Enhancement", "Type: Bug"
+          labeled: "Type: Enhancement,Type: Bug"
           label-operator: OR
       - uses: actions/add-to-project@main
         with:


### PR DESCRIPTION
The action that we're using is expecting one string with a comma separated list embedded in it rather than a list of strings.
