### PR TITLE
pre-upgrade helm hook for certgen rbac resources

### DIFF
--- a/changelog/v1.12.0-beta24/helm-certgen-hooks.yaml
+++ b/changelog/v1.12.0-beta24/helm-certgen-hooks.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6578
+    resolveIssue: false
+    description: Backwards compatibility for certgen rbac resources

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -71,7 +71,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job
   name: certgen
   namespace: {{ $.Release.Namespace }}
@@ -86,7 +86,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job
 subjects:
 - kind: ServiceAccount
@@ -107,7 +107,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job
 rules:
 - apiGroups: [""]

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3762,7 +3762,7 @@ metadata:
         app: gloo
         gloo: rbac
     annotations:
-      "helm.sh/hook": pre-install
+      "helm.sh/hook": "pre-install,pre-upgrade"
       "helm.sh/hook-weight": "5"
 rules:
 - apiGroups: [""]
@@ -3784,7 +3784,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "5"
 subjects:
 - kind: ServiceAccount
@@ -3807,7 +3807,7 @@ metadata:
     app: gloo
     gloo: rbac
   annotations:
-    "helm.sh/hook": "pre-install"
+    "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "5"
   name: certgen
   namespace: ` + namespace + `


### PR DESCRIPTION
# Description

After enabling cergen pre-upgrade,  the serviceaccount,clusterrole and clusterrolebinding might be missing if originally installed prior to v1.5.1 so it should be created when upgrading as well.

# Context

https://github.com/solo-io/gloo/issues/6578

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6578