### PR TITLE
11 | fix(glooctl): apply CRDs to cluster prior to register (#6565)

### DIFF
--- a/changelog/v1.11.16/gloo-fed-panic.yaml
+++ b/changelog/v1.11.16/gloo-fed-panic.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/5832
+    resolvesIssue: false
+    description: Enable registering of empty clusters without crashing gloo-fed.

--- a/install/test/helm_suite_test.go
+++ b/install/test/helm_suite_test.go
@@ -255,7 +255,7 @@ func readValuesFile(filePath string) (map[string]interface{}, error) {
 }
 
 func buildRenderer(namespace string) (*action.Install, error) {
-	settings := install.NewCLISettings(namespace)
+	settings := install.NewCLISettings(namespace, "")
 	actionConfig := new(action.Configuration)
 	noOpDebugLog := func(format string, v ...interface{}) {}
 

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -933,7 +933,7 @@ func isCrdNotFoundErr(crd crd.Crd, err error) bool {
 }
 
 func CheckVersionsMatch(opts *options.Options) {
-	vrs, err := version.GetClientServerVersions(opts.Top.Ctx, version.NewKube(opts.Metadata.GetNamespace()))
+	vrs, err := version.GetClientServerVersions(opts.Top.Ctx, version.NewKube(opts.Metadata.GetNamespace(), ""))
 
 	if err != nil {
 		return

--- a/projects/gloo/cli/pkg/cmd/federation/register/register.go
+++ b/projects/gloo/cli/pkg/cmd/federation/register/register.go
@@ -2,13 +2,42 @@ package register
 
 import (
 	"context"
+	"fmt"
+	"os"
 
+	"github.com/solo-io/gloo/pkg/cliutil"
+	linkedversion "github.com/solo-io/gloo/pkg/version"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/version"
 	"github.com/solo-io/skv2/pkg/multicluster/kubeconfig"
 	"github.com/solo-io/skv2/pkg/multicluster/register"
 	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+func installCrdsToRemote(context string) error {
+	helmClient := install.DefaultHelmClient()
+
+	chartObj, err := helmClient.DownloadChart("https://storage.googleapis.com/solo-public-helm/charts/gloo-" + linkedversion.Version + ".tgz")
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "\ngloo failed to download gloo-%s\n", linkedversion.Version)
+		return err
+	}
+	chartObj.Templates = nil // explicitly remove teamplates, since we only care about installing CRDs
+
+	helmInstall, _, err := helmClient.NewInstall("default", "gloo-automatic-crd-application", false, context)
+	if err != nil {
+		return err
+	}
+
+	_, err = helmInstall.Run(chartObj, nil)
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "\ngloo failed to install CRDs! Detailed logs available at %s.\n", cliutil.GetLogsPath())
+		return err
+	}
+	return nil
+}
 
 func Register(opts *options.Options) error {
 	ctx := context.Background()
@@ -20,6 +49,17 @@ func Register(opts *options.Options) error {
 	remoteKubeCfg, err := kubeconfig.GetClientConfigWithContext(registerOpts.RemoteKubeConfig, registerOpts.RemoteContext, "")
 	if err != nil {
 		return err
+	}
+
+	// check to see if Gloo is installed onto RemoteContext.  If not, install CRDs to prevent a gloo-fed crash, per
+	// https://github.com/solo-io/gloo/issues/5832
+	serverVersion, err := version.NewKube(opts.Metadata.GetNamespace(), registerOpts.RemoteContext).Get(ctx)
+	if err != nil {
+		return err
+	}
+	if serverVersion == nil {
+		fmt.Printf("No `gloo` install detected on %s.  Installing OSS CRDs.\n", registerOpts.RemoteContext)
+		installCrdsToRemote(registerOpts.RemoteContext)
 	}
 
 	clusterRegisterOpts := register.RegistrationOptions{

--- a/projects/gloo/cli/pkg/cmd/install/installer.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer.go
@@ -95,7 +95,7 @@ func (i *installer) installFromConfig(installerConfig *InstallerConfig) error {
 
 	preInstallMessage(installerConfig.InstallCliArgs, installerConfig.Mode)
 
-	helmInstall, helmEnv, err := i.helmClient.NewInstall(namespace, releaseName, installerConfig.InstallCliArgs.DryRun)
+	helmInstall, helmEnv, err := i.helmClient.NewInstall(namespace, releaseName, installerConfig.InstallCliArgs.DryRun, "")
 	if err != nil {
 		return err
 	}

--- a/projects/gloo/cli/pkg/cmd/install/installer_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/installer_test.go
@@ -126,7 +126,7 @@ rules:
 			Return(helmRelease, nil)
 
 		mockHelmClient.EXPECT().
-			NewInstall(helmInstallConfig.Namespace, helmInstallConfig.HelmReleaseName, installConfig.DryRun).
+			NewInstall(helmInstallConfig.Namespace, helmInstallConfig.HelmReleaseName, installConfig.DryRun, "").
 			Return(mockHelmInstallation, helmEnv, nil)
 
 		mockHelmClient.EXPECT().
@@ -241,7 +241,7 @@ rules:
 			Return(helmRelease, nil)
 
 		mockHelmClient.EXPECT().
-			NewInstall(defaults.GlooSystem, installConfig.Gloo.HelmReleaseName, installConfig.DryRun).
+			NewInstall(defaults.GlooSystem, installConfig.Gloo.HelmReleaseName, installConfig.DryRun, "").
 			Return(mockHelmInstallation, helmEnv, nil)
 
 		mockHelmClient.EXPECT().

--- a/projects/gloo/cli/pkg/cmd/install/mocks/mock_helm_client.go
+++ b/projects/gloo/cli/pkg/cmd/install/mocks/mock_helm_client.go
@@ -52,9 +52,9 @@ func (mr *MockHelmClientMockRecorder) DownloadChart(arg0 interface{}) *gomock.Ca
 }
 
 // NewInstall mocks base method.
-func (m *MockHelmClient) NewInstall(arg0, arg1 string, arg2 bool) (install.HelmInstallation, *cli.EnvSettings, error) {
+func (m *MockHelmClient) NewInstall(arg0, arg1 string, arg2 bool, arg3 string) (install.HelmInstallation, *cli.EnvSettings, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewInstall", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "NewInstall", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(install.HelmInstallation)
 	ret1, _ := ret[1].(*cli.EnvSettings)
 	ret2, _ := ret[2].(error)
@@ -62,9 +62,9 @@ func (m *MockHelmClient) NewInstall(arg0, arg1 string, arg2 bool) (install.HelmI
 }
 
 // NewInstall indicates an expected call of NewInstall.
-func (mr *MockHelmClientMockRecorder) NewInstall(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockHelmClientMockRecorder) NewInstall(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewInstall", reflect.TypeOf((*MockHelmClient)(nil).NewInstall), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewInstall", reflect.TypeOf((*MockHelmClient)(nil).NewInstall), arg0, arg1, arg2, arg3)
 }
 
 // NewUninstall mocks base method.

--- a/projects/gloo/cli/pkg/cmd/version/clients.go
+++ b/projects/gloo/cli/pkg/cmd/version/clients.go
@@ -20,7 +20,8 @@ type ServerVersion interface {
 }
 
 type kube struct {
-	namespace string
+	namespace   string
+	kubeContext string
 }
 
 var (
@@ -29,14 +30,19 @@ var (
 	GlooEUniqueContainers   = []string{"gloo-ee"}
 )
 
-func NewKube(namespace string) *kube {
+func NewKube(namespace, kubeContext string) *kube {
 	return &kube{
-		namespace: namespace,
+		namespace:   namespace,
+		kubeContext: kubeContext,
 	}
 }
 
 func (k *kube) Get(ctx context.Context) ([]*version.ServerVersion, error) {
 	cfg, err := kubeutils.GetConfig("", "")
+	if k.kubeContext != "" {
+		cfg, err = kubeutils.GetConfigWithContext("", "", k.kubeContext)
+	}
+
 	if err != nil {
 		// kubecfg is missing, therefore no cluster is present, only print client version
 		return nil, nil

--- a/projects/gloo/cli/pkg/cmd/version/cmd.go
+++ b/projects/gloo/cli/pkg/cmd/version/cmd.go
@@ -48,7 +48,7 @@ func RootCmd(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return printVersion(NewKube(opts.Metadata.GetNamespace()), os.Stdout, opts)
+			return printVersion(NewKube(opts.Metadata.GetNamespace(), ""), os.Stdout, opts)
 		},
 	}
 

--- a/projects/gloo/cli/pkg/prerun/version_warning.go
+++ b/projects/gloo/cli/pkg/prerun/version_warning.go
@@ -36,7 +36,7 @@ func VersionMismatchWarning(opts *options.Options, cmd *cobra.Command) error {
 		nsToCheck = opts.Install.Gloo.Namespace
 	}
 
-	return WarnOnMismatch(opts.Top.Ctx, os.Args[0], versioncmd.NewKube(nsToCheck), &defaultLogger{})
+	return WarnOnMismatch(opts.Top.Ctx, os.Args[0], versioncmd.NewKube(nsToCheck, ""), &defaultLogger{})
 }
 
 // use this logger interface, so that in the unit test we can accumulate lines that were output

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -341,7 +341,7 @@ var _ = Describe("Kube2e: helm", func() {
 })
 
 func getGlooServerVersion(ctx context.Context, namespace string) (v string) {
-	glooVersion, err := version.GetClientServerVersions(ctx, version.NewKube(namespace))
+	glooVersion, err := version.GetClientServerVersions(ctx, version.NewKube(namespace, ""))
 	Expect(err).To(BeNil())
 	Expect(len(glooVersion.GetServer())).To(Equal(1))
 	for _, container := range glooVersion.GetServer()[0].GetKubernetes().GetContainers() {


### PR DESCRIPTION
* fix(glooctl): apply CRDs to cluster prior to register

* install CRDs IFF not found on remote

* attempt to _exactly_ preserve earlier NewKube.Get functionality

* repaired badly copy/pasted error message

* lowercased error messages

# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
