### PR TITLE
V3 clusters

### DIFF
--- a/changelog/v1.11.16/add-v3-clusters.yaml
+++ b/changelog/v1.11.16/add-v3-clusters.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - dependencyOwner: solo-io
+    dependencyRepo: solo-kit
+    dependencyTag: v0.28.3
+    description: Update solo-kit to version v0.28.3
+    type: DEPENDENCY_BUMP

--- a/changelog/v1.11.16/add-v3-clusters.yaml
+++ b/changelog/v1.11.16/add-v3-clusters.yaml
@@ -4,3 +4,4 @@ changelog:
     dependencyTag: v0.28.3
     description: Update solo-kit to version v0.28.3
     type: DEPENDENCY_BUMP
+

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/solo-io/skv2 v0.21.6
 	// Pinned to the `gloo-namespaced-statuses` tag of solo-apis
 	github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c
-	github.com/solo-io/solo-kit v0.28.0
+	github.com/solo-io/solo-kit v0.28.3
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -1404,6 +1404,8 @@ github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c/go.mod h1:4HQsQO
 github.com/solo-io/solo-kit v0.23.0/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
 github.com/solo-io/solo-kit v0.28.0 h1:wweme0yIwAiWVpWzR38t+eFjNdBw5hfDBoTz7oCR/z4=
 github.com/solo-io/solo-kit v0.28.0/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
+github.com/solo-io/solo-kit v0.28.3 h1:wTh5NSjFXHDlTswd6Pahw4LTmLySvPAdh+LNAS+YJWY=
+github.com/solo-io/solo-kit v0.28.3/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/go.sum
+++ b/go.sum
@@ -1402,8 +1402,6 @@ github.com/solo-io/skv2 v0.21.6/go.mod h1:8jNcMWuAkBxdGhlRFMSgsK94q/jZGPEas8VHTr
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c h1:4/yTroUmyUJonldE5EyC3AinNG4KVLgG0FVMrI2SQ04=
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c/go.mod h1:4HQsQO4Cy/4V7ZZxWncvnMvIq7pYnb66jAT5hvDJBgQ=
 github.com/solo-io/solo-kit v0.23.0/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
-github.com/solo-io/solo-kit v0.28.0 h1:wweme0yIwAiWVpWzR38t+eFjNdBw5hfDBoTz7oCR/z4=
-github.com/solo-io/solo-kit v0.28.0/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/solo-io/solo-kit v0.28.3 h1:wTh5NSjFXHDlTswd6Pahw4LTmLySvPAdh+LNAS+YJWY=
 github.com/solo-io/solo-kit v0.28.3/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=


### PR DESCRIPTION
# Description

Adding V3 clusters
[passing tests](https://github.com/solo-io/gloo/pull/6595)

# Context

V3 clusters need to be ordered in Envoy requests.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
