### PR TITLE
[1.11] setup/settings: Update to allow for validationServerGrpcMaxSizeBytes to take effect without manual kick

### DIFF
--- a/changelog/v1.11.17/grpcmaxvalidationbyte-refresh.yaml
+++ b/changelog/v1.11.17/grpcmaxvalidationbyte-refresh.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6564
+    description: Allow for validation bytes to be updated by settings without a manual roll
+    resolvesIssue: false

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -111,6 +111,8 @@ func NewSetupFuncWithRunAndExtensions(runFunc RunFunc, extensions *Extensions) s
 	return s.Setup
 }
 
+// grpcServer contains grpc server configuration fields we will need to persist after starting a server
+// to later check if they changed and we need to trigger a server restart
 type grpcServer struct {
 	addr            string
 	maxGrpcRecvSize int

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -112,8 +112,9 @@ func NewSetupFuncWithRunAndExtensions(runFunc RunFunc, extensions *Extensions) s
 }
 
 type grpcServer struct {
-	addr   string
-	cancel context.CancelFunc
+	addr            string
+	maxGrpcRecvSize int
+	cancel          context.CancelFunc
 }
 
 type setupSyncer struct {
@@ -214,9 +215,21 @@ func (s *setupSyncer) Setup(ctx context.Context, kubeCache kube.SharedCache, mem
 	}
 	watchNamespaces := utils.ProcessWatchNamespaces(settings.GetWatchNamespaces(), writeNamespace)
 
+	// process grpcserver options to understand if any servers will need a restart
+
+	var maxGrpcRecvSize int
+	// Use the same maxGrpcMsgSize as validation as this is determined by the size of proxies.
+	if maxGrpcMsgSize := settings.GetGateway().GetValidation().GetValidationServerGrpcMaxSizeBytes(); maxGrpcMsgSize != nil {
+		if maxGrpcMsgSize.GetValue() < 0 {
+			return errors.Errorf("validationServerGrpcMaxSizeBytes in settings CRD must be non-negative, current value: %v", maxGrpcMsgSize.GetValue())
+		}
+		maxGrpcRecvSize = int(maxGrpcMsgSize.GetValue())
+	}
+
 	emptyControlPlane := bootstrap.ControlPlane{}
 	emptyValidationServer := bootstrap.ValidationServer{}
 
+	// check if we need to restart the control plane
 	if xdsAddr != s.previousXdsServer.addr {
 		if s.previousXdsServer.cancel != nil {
 			s.previousXdsServer.cancel()
@@ -225,7 +238,8 @@ func (s *setupSyncer) Setup(ctx context.Context, kubeCache kube.SharedCache, mem
 		s.controlPlane = emptyControlPlane
 	}
 
-	if validationAddr != s.previousValidationServer.addr {
+	// check if we need to restart the validation server
+	if validationAddr != s.previousValidationServer.addr || maxGrpcRecvSize != s.previousValidationServer.maxGrpcRecvSize {
 		if s.previousValidationServer.cancel != nil {
 			s.previousValidationServer.cancel()
 			s.previousValidationServer.cancel = nil
@@ -250,17 +264,11 @@ func (s *setupSyncer) Setup(ctx context.Context, kubeCache kube.SharedCache, mem
 	if s.validationServer == emptyValidationServer {
 		// create new context as the grpc server might survive multiple iterations of this loop.
 		ctx, cancel := context.WithCancel(context.Background())
-		var validationGrpcServerOpts []grpc.ServerOption
-		if maxGrpcMsgSize := settings.GetGateway().GetValidation().GetValidationServerGrpcMaxSizeBytes(); maxGrpcMsgSize != nil {
-			if maxGrpcMsgSize.GetValue() < 0 {
-				cancel()
-				return errors.Errorf("validationServerGrpcMaxSizeBytes in settings CRD must be non-negative, current value: %v", maxGrpcMsgSize.GetValue())
-			}
-			validationGrpcServerOpts = append(validationGrpcServerOpts, grpc.MaxRecvMsgSize(int(maxGrpcMsgSize.GetValue())))
-		}
+		validationGrpcServerOpts := []grpc.ServerOption{grpc.MaxRecvMsgSize(maxGrpcRecvSize)}
 		s.validationServer = NewValidationServer(ctx, s.makeGrpcServer(ctx, validationGrpcServerOpts...), validationTcpAddress, true)
 		s.previousValidationServer.cancel = cancel
 		s.previousValidationServer.addr = validationAddr
+		s.previousValidationServer.maxGrpcRecvSize = maxGrpcRecvSize
 	}
 
 	consulClient, err := bootstrap.ConsulClientForSettings(ctx, settings)

--- a/test/kube2e/gloo/setup_syncer_test.go
+++ b/test/kube2e/gloo/setup_syncer_test.go
@@ -2,12 +2,13 @@ package gloo_test
 
 import (
 	"context"
-	"github.com/golang/protobuf/ptypes/wrappers"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	"net"
 	"os"
 	"sync"
 	"time"
+
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 
 	"github.com/solo-io/gloo/pkg/utils/setuputils"
 

--- a/test/kube2e/gloo/setup_syncer_test.go
+++ b/test/kube2e/gloo/setup_syncer_test.go
@@ -183,8 +183,9 @@ var _ = Describe("SetupSyncer", func() {
 				err = setup(ctx, nil, memcache, settings)
 				Expect(err).NotTo(HaveOccurred())
 
-				// make sure that validation server was restarted with new value
-				// it should now reject the request
+				// make sure that validation server rejects request with appropriate error
+				// in order to verify that new ValidationServerGrpcMaxSizeBytes value was accepted and
+				// grpc server was restarted configured with new value
 				Eventually(func() string {
 					if err := testFunc(); err != nil {
 						return err.Error()

--- a/test/kube2e/gloo/setup_syncer_test.go
+++ b/test/kube2e/gloo/setup_syncer_test.go
@@ -2,6 +2,8 @@ package gloo_test
 
 import (
 	"context"
+	"github.com/golang/protobuf/ptypes/wrappers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	"net"
 	"os"
 	"sync"
@@ -84,6 +86,11 @@ var _ = Describe("SetupSyncer", func() {
 				XdsBindAddr:        getRandomAddr(),
 				ValidationBindAddr: getRandomAddr(),
 			},
+			Gateway: &v1.GatewayOptions{
+				Validation: &v1.GatewayOptions_ValidationOptions{
+					ValidationServerGrpcMaxSizeBytes: &wrappers.Int32Value{Value: 4000000},
+				},
+			},
 			DiscoveryNamespace: "non-existent-namespace",
 			WatchNamespaces:    []string{"non-existent-namespace"},
 		}
@@ -96,32 +103,31 @@ var _ = Describe("SetupSyncer", func() {
 	})
 
 	Context("Setup", func() {
-		setupTestGrpcClient := func() func() error {
-			cc, err := grpc.DialContext(ctx, settings.Gloo.XdsBindAddr, grpc.WithInsecure(), grpc.FailOnNonTempDialError(true))
-			Expect(err).NotTo(HaveOccurred())
-			// setup a gRPC client to make sure connection is persistent across invocations
-			client := reflectpb.NewServerReflectionClient(cc)
-			req := &reflectpb.ServerReflectionRequest{
-				MessageRequest: &reflectpb.ServerReflectionRequest_ListServices{
-					ListServices: "*",
-				},
-			}
-			clientstream, err := client.ServerReflectionInfo(context.Background())
-			Expect(err).NotTo(HaveOccurred())
-			err = clientstream.Send(req)
-			go func() {
-				for {
-					_, err := clientstream.Recv()
-					if err != nil {
-						return
-					}
+		Context("xds", func() {
+			setupTestGrpcClient := func() func() error {
+				cc, err := grpc.DialContext(ctx, settings.Gloo.XdsBindAddr, grpc.WithInsecure(), grpc.FailOnNonTempDialError(true))
+				Expect(err).NotTo(HaveOccurred())
+				// setup a gRPC client to make sure connection is persistent across invocations
+				client := reflectpb.NewServerReflectionClient(cc)
+				req := &reflectpb.ServerReflectionRequest{
+					MessageRequest: &reflectpb.ServerReflectionRequest_ListServices{
+						ListServices: "*",
+					},
 				}
-			}()
-			Expect(err).NotTo(HaveOccurred())
-			return func() error { return clientstream.Send(req) }
-		}
-
-		Context("XDS tests", func() {
+				clientstream, err := client.ServerReflectionInfo(context.Background())
+				Expect(err).NotTo(HaveOccurred())
+				err = clientstream.Send(req)
+				go func() {
+					for {
+						_, err := clientstream.Recv()
+						if err != nil {
+							return
+						}
+					}
+				}()
+				Expect(err).NotTo(HaveOccurred())
+				return func() error { return clientstream.Send(req) }
+			}
 
 			It("setup can be called twice", func() {
 				setup := newSynchronizedSetupFunc()
@@ -141,6 +147,50 @@ var _ = Describe("SetupSyncer", func() {
 				// make sure that xds snapshot was not restarted
 				err = testFunc()
 				Expect(err).NotTo(HaveOccurred())
+			})
+
+		})
+		Context("validation", func() {
+			setupTestGrpcClient := func() func() error {
+				cc, err := grpc.DialContext(ctx, settings.Gloo.ValidationBindAddr, grpc.WithInsecure(), grpc.FailOnNonTempDialError(true))
+				Expect(err).NotTo(HaveOccurred())
+				// setup a gRPC client to make sure connection is persistent across invocations
+				client := validation.NewGlooValidationServiceClient(cc)
+				req := &validation.GlooValidationServiceRequest{Proxy: &v1.Proxy{Listeners: []*v1.Listener{{Name: "test-listener"}}}}
+				return func() error {
+					_, err := client.Validate(ctx, req)
+					if err != nil {
+						return err
+					}
+					return nil
+				}
+			}
+
+			It("restarts validation grpc server when validationServerGrpcMaxSizeBytes setting is changed", func() {
+				setup := newSynchronizedSetupFunc()
+
+				err := setup(ctx, nil, memcache, settings)
+				Expect(err).NotTo(HaveOccurred())
+
+				// make sure happy path works
+				testFunc := setupTestGrpcClient()
+				err = testFunc()
+				Expect(err).NotTo(HaveOccurred())
+
+				newContext()
+				settings.Gateway.Validation.ValidationServerGrpcMaxSizeBytes = &wrappers.Int32Value{Value: 1}
+				err = setup(ctx, nil, memcache, settings)
+				Expect(err).NotTo(HaveOccurred())
+
+				// make sure that validation server was restarted with new value
+				// it should now reject the request
+				Eventually(func() string {
+					if err := testFunc(); err != nil {
+						return err.Error()
+					}
+					return ""
+				}, "10s", "0.5s").Should(ContainSubstring("received message larger than max"))
+
 			})
 		})
 


### PR DESCRIPTION
# Description

On settings update we check if grpc servers need a kick
Right now we only do it if the addr changes but we also need to set anything else that is passed in as a grpc opt. In this case the validation bytes.

# Context

Users were confused when the settings change was not reflected in the validation server's behavior
