### PR TITLE
CI Improvements

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,9 +14,23 @@
 ## [Regression Tests](./regression-tests.yaml)
 Regression tests run the suite of [Kubernetes End-To-End Tests](https://github.com/solo-io/gloo/tree/master/test).
 
-**This action will not execute on Draft PRs**
+### Issue Comment Directives
+There are several directives that can be used to interact with this Github Action via a comment on the github pull request. The comments must be made by a member of the organization that owns the repo.
+
+- A comment containing `/sig-ci` will clear the status and trigger a new build. This is useful for when the CI build has a flake.
+- A comment containing `/skip-ci` will mark the status as successful and bypass the CI build. This should be used sparingly in situations where CI is not needed (i.e. a readme update).
+
+### Draft Pull Requests
+This Github Action will not run by default on a Draft Pull Request. However, you can use the above issue comment directives to signal CI.
 
 ## [Docs Generation](./docs-gen.yaml)
-Build the docs that power https://docs.solo.io/gloo-edge/latest/, and on pushes to the main branch, deploy those changes to Firebase.
+Docs generation builds the docs that power https://docs.solo.io/gloo-edge/latest/, and on pushes to the main branch, deploys those changes to Firebase.
 
-**This action will not execute on Draft PRs**
+### Issue Comment Directives
+There are several directives that can be used to interact with this Github Action via a comment on the github pull request. The comments must be made by a member of the organization that owns the repo.
+
+- A comment containing `/sig-docs` will clear the status and trigger a new build. This is useful for when the CI build has a flake.
+- A comment containing `/skip-docs` will mark the status as successful and bypass the CI build. This should be used sparingly in situations where CI is not needed (i.e. a readme update).
+
+### Draft Pull Requests
+This Github Action will not run by default on a Draft Pull Request. However, you can use the above issue comment directives to signal a build.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,4 +14,9 @@
 ## [Regression Tests](./regression-tests.yaml)
 Regression tests run the suite of [Kubernetes End-To-End Tests](https://github.com/solo-io/gloo/tree/master/test).
 
-**These tests will not execute on Draft PRs**
+**This action will not execute on Draft PRs**
+
+## [Docs Generation](./docs-gen.yaml)
+Build the docs that power https://docs.solo.io/gloo-edge/latest/, and on pushes to the main branch, deploy those changes to Firebase.
+
+**This action will not execute on Draft PRs**

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,6 +1,6 @@
 # GH Workflows
 
-## Push API Changes to Solo-APIs
+## [Push API Changes to Solo-APIs](./push-solo-apis-branch.yaml)
  - This workflow is used to open a PR in Solo-APIs which corresponds to a set of changes in Gloo OSS
  - The workflow is run when a Gloo OSS release is published
  - The workflow can be run manually from the "Actions" tab in Github while viewing the Gloo OSS repo
@@ -10,3 +10,8 @@
    - `Use workflow from`: The branch in Gloo OSS which the generated Solo-APIs PR should mirror
    - `Release Tag Name`: The specific commit hash/tag in Gloo OSS from which the Solo-APIs PR should be generated
    - `Release Branch`: The Solo-APIs branch which the generated PR should target, most likely `master`
+
+## [Regression Tests](./regression-tests.yaml)
+Regression tests run the suite of [Kubernetes End-To-End Tests](https://github.com/solo-io/gloo/tree/master/test).
+
+**These tests will not execute on Draft PRs**

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -14,16 +14,58 @@ on:
     types:
       - completed
 jobs:
+  prepare_env:
+    name: Prepare Environment
+    runs-on: ubuntu-18.04
+    outputs:
+      should-build-docs: ${{ steps.build-docs.outputs.build_value }}
+      should-pass-docs: ${{ steps.build-docs.outputs.pass_value }}
+    steps:
+      - id: is-draft-pr
+        name: Process draft Pull Requests
+        if: ${{ github.event.pull_request.draft }}
+        run: echo "::set-output name=value::$(echo true)"
+      - id: signal-docs-comment
+        name: Process comments on Pull Request to signal Docs
+        if: ${{ github.event.issue.pull_request }}
+        run: echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/sig-docs') }})"
+      - id: skip-docs-comment
+        name: Process comments on Pull Request to skip Docs
+        if: ${{ github.event.issue.pull_request }}
+        run: echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/skip-docs') }})"
+      - id: build-docs
+        name: Determine whether or not to build docs
+        run: |
+          should_build=true
+          should_pass=false
+
+          is_draft_pr=${{ steps.is-draft-pr.outputs.value }}
+          if [[ ! -z $is_draft_pr && $is_draft_pr = true ]] ; then
+            should_build=false
+          fi
+
+          pr_comment_signal=${{ steps.signal-docs-comment.outputs.value }}
+          if [[ ! -z $pr_comment_signal && $pr_comment_signal = true ]] ; then
+            should_build=true
+          fi
+
+          pr_comment_skip=${{ steps.skip-docs-comment.outputs.value }}
+          if [[ ! -z $pr_comment_skip && $pr_comment_skip = true ]] ; then
+            should_pass=true
+          fi
+
+          echo "Should build docs? $should_build"
+          echo "Should auto-pass docs? $should_pass"
+          echo "::set-output name=build_value::$(echo $should_build)"
+          echo "::set-output name=pass_value::$(echo $should_pass)"
   build:
     name: Generate versioned docs site
+    needs: prepare_env
+    if: needs.prepare_env.outputs.should-build-docs == 'true'
     runs-on: ubuntu-18.04
     steps:
-    - name: Fail if Draft PR
-      if: github.event.pull_request.draft == true
-      run: |
-        echo "Docs generation does not run on Draft PRs"
-        exit 1
     - name: Free disk space
+      if: needs.prepare_env.outputs.should-pass-docs != 'true'
       run: |
         echo "Before clearing disk space:"
         df -h
@@ -41,15 +83,18 @@ jobs:
         echo "After clearing disk space:"
         df -h
     - name: Set up Go
+      if: needs.prepare_env.outputs.should-pass-docs != 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18.2
       id: go
     - name: Setup Hugo
+      if: needs.prepare_env.outputs.should-pass-docs != 'true'
       uses: peaceiris/actions-hugo@v2
       with:
         hugo-version: '0.69.2'
     - name: Check out code into the Go module directory
+      if: needs.prepare_env.outputs.should-pass-docs != 'true'
       uses: actions/checkout@v2
     - name: Detect Community PR
       id: community-pr-check
@@ -59,7 +104,7 @@ jobs:
         echo "Pull Request is from a fork. Setting IS_COMMUNITY_PR to true"
         echo "::set-output name=IS_COMMUNITY_PR::true"
     - name: Generate versioned docs site
-      if: ${{ !steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
+      if: ${{ !steps.community-pr-check.outputs.IS_COMMUNITY_PR && needs.prepare_env.outputs.should-pass-docs != 'true' }}
       run: make -C docs build-site
       env:
         GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
@@ -78,7 +123,7 @@ jobs:
         entryPoint: ./docs/ci
     - name: Deploy to Firebase (preview)
       # Generate live preview of docs for PRs to master
-      if: ${{ github.event_name == 'pull_request' && !steps.community-pr-check.outputs.IS_COMMUNITY_PR }}
+      if: ${{ github.event_name == 'pull_request' && !steps.community-pr-check.outputs.IS_COMMUNITY_PR && needs.prepare_env.outputs.should-pass-docs != 'true' }}
       uses: FirebaseExtended/action-hosting-deploy@v0
       with:
         repoToken: ${{ secrets.GITHUB_TOKEN }}
@@ -92,4 +137,4 @@ jobs:
         curl -X POST\
              -H 'Content-type: application/json'\
              --data '{"text":"Gloo Edge has <https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}|failed a docs build> on `master` branch"}'\
-             ${{ env.SLACK_DEBUG_TESTING && secrets.SLACK_INTEGRATION_TESTING_WEBHOOK || secrets.EDGE_TEAM_BOTS_WEBHOOK }}
+             ${{ env.SLACK_DEBUG_TESTING == true && secrets.SLACK_INTEGRATION_TESTING_WEBHOOK || secrets.EDGE_TEAM_BOTS_WEBHOOK }}

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -18,6 +18,11 @@ jobs:
     name: Generate versioned docs site
     runs-on: ubuntu-18.04
     steps:
+    - name: Fail if Draft PR
+      if: github.event.pull_request.draft == true
+      run: |
+        echo "Docs generation does not run on Draft PRs"
+        exit 1
     - name: Free disk space
       run: |
         echo "Before clearing disk space:"

--- a/.github/workflows/notify-on-regression-failure-list.json
+++ b/.github/workflows/notify-on-regression-failure-list.json
@@ -10,8 +10,6 @@
     "__jenshu": "U016LC0Q70A",
     "__jmunozro" : "U0214QV6L3Y",
     "kdorosh": "ULE7TSJ12",
-    "__MitchAman": "U01TH9ZJP3N",
-    "mkazin": "U02JFCX4YAE",
     "__nfuden": "U02JCDBKEDT",
     "__Rachael-Graham": "U02BQ7E7W3S",
     "__saiskee": "U01D06A9NVA",

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -22,6 +22,11 @@ jobs:
       uses: styfle/cancel-workflow-action@0.4.1
       with:
         access_token: ${{ github.token }}
+    - name: Fail if Draft PR
+      if: github.event.pull_request.draft == true
+      run: |
+        echo "Regresssion tests do not run on Draft PRs"
+        exit 1
     - name: Free disk space
       run: |
         echo "Before clearing disk space:"

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -4,9 +4,57 @@ on:
     branches:
       - 'master'
   pull_request:
+  issue_comment:
+    types: [ created, edited ]
 jobs:
+  prepare_env:
+    name: Prepare Environment
+    runs-on: ubuntu-18.04
+    outputs:
+      should-run-regression-tests: ${{ steps.regression-tests.outputs.run_value }}
+      should-pass-regression-tests: ${{ steps.regression-tests.outputs.pass_value }}
+    steps:
+    - id: is-draft-pr
+      name: Process draft Pull Requests
+      if: ${{ github.event.pull_request.draft }}
+      run: echo "::set-output name=value::$(echo true)"
+    - id: signal-ci-comment
+      name: Process comments on Pull Request to signal CI
+      if:  ${{ github.event.issue.pull_request }}
+      run: echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/sig-ci') }})"
+    - id: skip-ci-comment
+      name: Process comments on Pull Request to skip CI
+      if: ${{ github.event.issue.pull_request }}
+      run: echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/skip-ci') }})"
+    - id: regression-tests
+      name: Determine how to run regression tests
+      run: |
+        should_run=true
+        should_pass=false
+
+        is_draft_pr=${{ steps.is-draft-pr.outputs.value }}
+        if [[ ! -z $is_draft_pr && $is_draft_pr = true ]] ; then
+          should_run=false
+        fi
+
+        pr_comment_signal=${{ steps.signal-ci-comment.outputs.value }}
+        if [[ ! -z $pr_comment_signal && $pr_comment_signal = true ]] ; then
+          should_run=true
+        fi
+
+        pr_comment_skip=${{ steps.skip-ci-comment.outputs.value }}
+        if [[ ! -z $pr_comment_skip && $pr_comment_skip = true ]] ; then
+          should_pass=true
+        fi
+
+        echo "Should run regression tests? $should_run"
+        echo "Should auto-pass regression tests? $should_pass"
+        echo "::set-output name=run_value::$(echo $should_run)"
+        echo "::set-output name=pass_value::$(echo $should_pass)"
   regression_tests:
     name: k8s regression tests
+    needs: prepare_env
+    if: needs.prepare_env.outputs.should-run-regression-tests == 'true'
     runs-on: ubuntu-18.04
     strategy:
       matrix:
@@ -22,12 +70,8 @@ jobs:
       uses: styfle/cancel-workflow-action@0.4.1
       with:
         access_token: ${{ github.token }}
-    - name: Fail if Draft PR
-      if: github.event.pull_request.draft == true
-      run: |
-        echo "Regresssion tests do not run on Draft PRs"
-        exit 1
     - name: Free disk space
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       run: |
         echo "Before clearing disk space:"
         df -h
@@ -45,33 +89,40 @@ jobs:
         echo "After clearing disk space:"
         df -h
     - name: Set up Go
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       uses: actions/setup-go@v2
       with:
         go-version: 1.18.2
       id: go
     - name: Check out code into the Go module directory
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
     - uses: actions/cache@v1
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       with:
         path: ~/go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-go-
     - uses: engineerd/setup-kind@v0.5.0
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       with:
         # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
         skipClusterCreation: true
         version: v0.11.1
     - uses: azure/setup-kubectl@v1
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       id: kubectl
       with:
         version: 'v1.22.4'
     - uses: azure/setup-helm@v1
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       with:
         version: v3.6.3
     - name: Setup test env
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
         USE_XDS_RELAY: ${{ matrix.xds-relay }}
@@ -81,6 +132,7 @@ jobs:
       run: |
         ./ci/deploy-to-kind-cluster.sh
     - name: Testing - kube e2e regression tests
+      if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
         ACK_GINKGO_RC: true

--- a/projects/envoyinit/cmd/main.go
+++ b/projects/envoyinit/cmd/main.go
@@ -2,100 +2,13 @@ package main
 
 import (
 	_ "github.com/solo-io/gloo/projects/envoyinit/hack/filter_types"
-
-	"bytes"
-	"log"
-	"os"
-	"syscall"
-
-	"github.com/solo-io/gloo/projects/envoyinit/pkg/downward"
-)
-
-const (
-	// Environment variable for the file that is used to inject input configuration used to bootstrap envoy
-	inputConfigPathEnv     = "INPUT_CONF"
-	defaultInputConfigPath = "/etc/envoy/envoy.yaml"
-
-	// Environment variable for the file that is written to with transformed bootstrap configuration
-	outputConfigPathEnv     = "OUTPUT_CONF"
-	defaultOutputConfigPath = "/tmp/envoy.yaml"
-
-	// Environment variable for the path to the envoy executable
-	envoyExecutableEnv     = "ENVOY"
-	defaultEnvoyExecutable = "/usr/local/bin/envoy"
+	"github.com/solo-io/gloo/projects/envoyinit/pkg/runner"
 )
 
 func main() {
-	envoyExecutable := GetEnvoyExecutable()
-	inputPath := GetInputConfigPath()
-	outputPath := GetOutputConfigPath()
+	envoyExecutable := runner.GetEnvoyExecutable()
+	inputPath := runner.GetInputConfigPath()
+	outputPath := runner.GetOutputConfigPath()
 
-	RunEnvoy(envoyExecutable, inputPath, outputPath)
-}
-
-// RunEnvoy run Envoy with bootstrap configuration injected from a file
-func RunEnvoy(envoyExecutable, inputPath, outputPath string) {
-	// 1. Transform the configuration using the Kubernetes Downward API
-	bootstrapConfig, err := getAndTransformConfig(inputPath)
-	if err != nil {
-		log.Fatalf("initializer failed: %v", err)
-	}
-
-	// 2. Write to a file for debug purposes
-	// since this operation is meant only for debug purposes, we ignore the error
-	// this might fail if root fs is read only
-	_ = os.WriteFile(outputPath, []byte(bootstrapConfig), 0444)
-
-	// 3. Execute Envoy with the provided configuration
-	args := []string{envoyExecutable, "--config-yaml", bootstrapConfig}
-	if len(os.Args) > 1 {
-		args = append(args, os.Args[1:]...)
-	}
-	if err = syscall.Exec(args[0], args, os.Environ()); err != nil {
-		panic(err)
-	}
-}
-
-// GetInputConfigPath returns the path to a file containing the Envoy bootstrap configuration
-// This configuration may leverage the Kubernetes Downward API
-// https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
-func GetInputConfigPath() string {
-	return getEnvOrDefault(inputConfigPathEnv, defaultInputConfigPath)
-}
-
-// GetOutputConfigPath returns the path to a file where the raw Envoy bootstrap configuration will
-// be persisted for debugging purposes
-func GetOutputConfigPath() string {
-	return getEnvOrDefault(outputConfigPathEnv, defaultOutputConfigPath)
-}
-
-// GetEnvoyExecutable returns the Envoy executable
-func GetEnvoyExecutable() string {
-	return getEnvOrDefault(envoyExecutableEnv, defaultEnvoyExecutable)
-}
-
-// getEnvOrDefault returns the value of the environment variable, if one exists, or a default string
-func getEnvOrDefault(envName, defaultValue string) string {
-	maybeEnvValue := os.Getenv(envName)
-	if maybeEnvValue != "" {
-		return maybeEnvValue
-	}
-	return defaultValue
-}
-
-// getAndTransformConfig reads a file, transforms it using the Downward API
-// and returns the transformed configuration
-func getAndTransformConfig(inputFile string) (string, error) {
-	inReader, err := os.Open(inputFile)
-	if err != nil {
-		return "", err
-	}
-	defer inReader.Close()
-
-	var buffer bytes.Buffer
-	err = downward.Transform(inReader, &buffer)
-	if err != nil {
-		return "", err
-	}
-	return buffer.String(), nil
+	runner.RunEnvoy(envoyExecutable, inputPath, outputPath)
 }

--- a/projects/envoyinit/pkg/runner/run.go
+++ b/projects/envoyinit/pkg/runner/run.go
@@ -1,0 +1,91 @@
+package runner
+
+import (
+	"bytes"
+	"log"
+	"os"
+	"syscall"
+
+	"github.com/solo-io/gloo/projects/envoyinit/pkg/downward"
+)
+
+const (
+	// Environment variable for the file that is used to inject input configuration used to bootstrap envoy
+	inputConfigPathEnv     = "INPUT_CONF"
+	defaultInputConfigPath = "/etc/envoy/envoy.yaml"
+
+	// Environment variable for the file that is written to with transformed bootstrap configuration
+	outputConfigPathEnv     = "OUTPUT_CONF"
+	defaultOutputConfigPath = "/tmp/envoy.yaml"
+
+	// Environment variable for the path to the envoy executable
+	envoyExecutableEnv     = "ENVOY"
+	defaultEnvoyExecutable = "/usr/local/bin/envoy"
+)
+
+// RunEnvoy run Envoy with bootstrap configuration injected from a file
+func RunEnvoy(envoyExecutable, inputPath, outputPath string) {
+	// 1. Transform the configuration using the Kubernetes Downward API
+	bootstrapConfig, err := getAndTransformConfig(inputPath)
+	if err != nil {
+		log.Fatalf("initializer failed: %v", err)
+	}
+
+	// 2. Write to a file for debug purposes
+	// since this operation is meant only for debug purposes, we ignore the error
+	// this might fail if root fs is read only
+	_ = os.WriteFile(outputPath, []byte(bootstrapConfig), 0444)
+
+	// 3. Execute Envoy with the provided configuration
+	args := []string{envoyExecutable, "--config-yaml", bootstrapConfig}
+	if len(os.Args) > 1 {
+		args = append(args, os.Args[1:]...)
+	}
+	if err = syscall.Exec(args[0], args, os.Environ()); err != nil {
+		panic(err)
+	}
+}
+
+// GetInputConfigPath returns the path to a file containing the Envoy bootstrap configuration
+// This configuration may leverage the Kubernetes Downward API
+// https://kubernetes.io/docs/tasks/inject-data-application/downward-api-volume-expose-pod-information/#the-downward-api
+func GetInputConfigPath() string {
+	return getEnvOrDefault(inputConfigPathEnv, defaultInputConfigPath)
+}
+
+// GetOutputConfigPath returns the path to a file where the raw Envoy bootstrap configuration will
+// be persisted for debugging purposes
+func GetOutputConfigPath() string {
+	return getEnvOrDefault(outputConfigPathEnv, defaultOutputConfigPath)
+}
+
+// GetEnvoyExecutable returns the Envoy executable
+func GetEnvoyExecutable() string {
+	return getEnvOrDefault(envoyExecutableEnv, defaultEnvoyExecutable)
+}
+
+// getEnvOrDefault returns the value of the environment variable, if one exists, or a default string
+func getEnvOrDefault(envName, defaultValue string) string {
+	maybeEnvValue := os.Getenv(envName)
+	if maybeEnvValue != "" {
+		return maybeEnvValue
+	}
+	return defaultValue
+}
+
+// getAndTransformConfig reads a file, transforms it using the Downward API
+// and returns the transformed configuration
+func getAndTransformConfig(inputFile string) (string, error) {
+	inReader, err := os.Open(inputFile)
+	if err != nil {
+		return "", err
+	}
+	defer inReader.Close()
+
+	var buffer bytes.Buffer
+	err = downward.Transform(inReader, &buffer)
+	if err != nil {
+		return "", err
+	}
+	return buffer.String(), nil
+}


### PR DESCRIPTION
# Description

A set of minor optimizations to our CI pipeline, and other related bug fixes
# Context

## Envoy Runner
Gloo defines all of the code for running an instance of Envoy. Solo-Projects re-defines this logic verbatim. To enable this code to be imported, we move the logic into a Runner package, and out of the main package.

This is a non-functional change, but follows a good practice of keeping main as slim as possible.

## CI: Docs Gen
Do not run the docs generation GitHub action on Draft PRs. This is a fairly expensive operation (20 minutes) that only needs to run once a PR is ready for review.

**As part of this, I also added support to trigger and skip this action based on a comment. Since the `on comment` trigger only applies from the default branch, I can't validate this trigger. However, I can validate (by modifying the script) that we succeed the job if configured to auto-pass and skip the job if configured to not run.**

## CI: Regression Tests
Do not run the regresssion test GitHub action on Draft PRs. We should rely on local development to run tests, and once a PR is ready for review, these tests will run.

**As part of this, I also added support to trigger and skip these tests based on a comment. Since the `on comment` trigger only applies from the default branch, I can't validate this trigger. However, I can validate (by modifying the script) that we succeed the job if configured to auto-pass and skip the job if configured to not run.**

## CI: Notification on Docs Deploy Failure
When docs gen fails, we attempt to notify the team in a channel. Based on a conditional, we either push to a testing channel or a production channel. That conditional needed to be fixed, since docs build failures (on merges to master) were being published to the testing repo.

## CI: Readme
Updated the readme to call out explicitly that certain jobs will not run on Draft PRs.

## CI: Regression Failure User List
We maintain a list of slack handles for users who want to be notified directly on Github action failures. This list needed to be updated to reflect the current team.

# Warning
After a pull request is converted from a draft to 'ready for review', the CI will not run the docs gen or regression tests. Those must be signaled using `/sig-ci` and `/sig-docs`. That signal functionality has not beeen fully tested (and cannot be until the code is on the default branch). In the case that those signals do not work, developers will be required to push up an empty commit after the pull request is ready for review, to re-trigger all actions.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
