### PR TITLE
build(regression-tests): revoke comment-triggers for CI

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -14,23 +14,20 @@
 ## [Regression Tests](./regression-tests.yaml)
 Regression tests run the suite of [Kubernetes End-To-End Tests](https://github.com/solo-io/gloo/tree/master/test).
 
-### Issue Comment Directives
-There are several directives that can be used to interact with this Github Action via a comment on the github pull request. The comments must be made by a member of the organization that owns the repo.
-
-- A comment containing `/sig-ci` will clear the status and trigger a new build. This is useful for when the CI build has a flake.
-- A comment containing `/skip-ci` will mark the status as successful and bypass the CI build. This should be used sparingly in situations where CI is not needed (i.e. a readme update).
-
 ### Draft Pull Requests
-This Github Action will not run by default on a Draft Pull Request. However, you can use the above issue comment directives to signal CI.
+This Github Action will not run by default on a Draft Pull Request. If you would like to run this, you need to:
+1. Mark the PR as `Ready for Review`
+1. Push an empty commit to run the jobs: `git commit --allow-empty -m "Trigger CI"` 
 
 ## [Docs Generation](./docs-gen.yaml)
 Docs generation builds the docs that power https://docs.solo.io/gloo-edge/latest/, and on pushes to the main branch, deploys those changes to Firebase.
 
-### Issue Comment Directives
-There are several directives that can be used to interact with this Github Action via a comment on the github pull request. The comments must be made by a member of the organization that owns the repo.
-
-- A comment containing `/sig-docs` will clear the status and trigger a new build. This is useful for when the CI build has a flake.
-- A comment containing `/skip-docs` will mark the status as successful and bypass the CI build. This should be used sparingly in situations where CI is not needed (i.e. a readme update).
-
 ### Draft Pull Requests
-This Github Action will not run by default on a Draft Pull Request. However, you can use the above issue comment directives to signal a build.
+This Github Action will not run by default on a Draft Pull Request. If you would like to run this, you need to:
+1. Mark the PR as `Ready for Review`
+1. Push an empty commit to run the jobs: `git commit --allow-empty -m "Trigger CI"`
+
+## Future Work
+It would be great to add support for issue comment directives. This would mean that commenting `/sig-ci` would signal CI to run, or `/skip-ci` would auto-succeed CI.
+
+This was attempted, and the challenge is that Github workflows were kicked off, but not associated with the PR that contained the comment. Therefore, the PR status never changed, even if the job that was kicked off passed all the tests.

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -4,8 +4,6 @@ on:
     branches:
       - 'master'
   pull_request:
-  issue_comment:
-    types: [ created, edited ]
 jobs:
   prepare_env:
     name: Prepare Environment
@@ -14,6 +12,10 @@ jobs:
       should-run-regression-tests: ${{ steps.regression-tests.outputs.run_value }}
       should-pass-regression-tests: ${{ steps.regression-tests.outputs.pass_value }}
     steps:
+    - name: Cancel Previous Actions
+      uses: styfle/cancel-workflow-action@0.4.1
+      with:
+        access_token: ${{ github.token }}
     - id: is-draft-pr
       name: Process draft Pull Requests
       if: ${{ github.event.pull_request.draft }}
@@ -21,7 +23,8 @@ jobs:
     - id: signal-ci-comment
       name: Process comments on Pull Request to signal CI
       if:  ${{ github.event.issue.pull_request }}
-      run: echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/sig-ci') }})"
+      run: |
+        echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/sig-ci') }})"
     - id: skip-ci-comment
       name: Process comments on Pull Request to skip CI
       if: ${{ github.event.issue.pull_request }}

--- a/changelog/v1.12.0-beta25/ci-updates.yaml
+++ b/changelog/v1.12.0-beta25/ci-updates.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: revoke comment-triggers for CI


### PR DESCRIPTION
# Description
This commit removes the ability to trigger CI via comment.  While it was "working" before (started/matched a Github action trigger) it wasn't "working working".  A.K.A., a started job wasn't associated with the PR on which it was commented on.  ...effectively meaning we could trigger unit tests to run against `master` from any PR, just because.

Disabled the not-quite-working feature

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
