### PR TITLE
Reject WeightedDestination when Total Weight < 1 

### DIFF
--- a/changelog/v1.8.33/weighted-cluster-validation.yaml
+++ b/changelog/v1.8.33/weighted-cluster-validation.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6098
+    description: |
+      Validate that the total weight for a WeightedDestination is at least 1, even
+      if individual Destinations have a weight of less than 1.
+      This changes a previous behavior, which incorrectly would validate that each
+      Destination within a WeightedDestination was at least 1.
+    resolvesIssue: false

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -412,17 +412,6 @@ func (t *translatorInstance) setWeightedClusters(params plugins.RouteParams, mul
 			return err
 		}
 
-		//Catch when Customers pass weights less than 1 or forget to pass weights - this leads to envoy errors
-		if weightedDest.GetWeight() < 1 {
-			weightedDestUpstream := weightedDest.GetDestination().GetUpstream()
-
-			validation.AppendRouteError(routeReport,
-				validationapi.RouteReport_Error_ProcessingError,
-				fmt.Sprintf("Incorrect configuration for Weighted Destination for upstream: %s - Weighted Destinations require a weight that is greater than 0", weightedDestUpstream.GetName()),
-				routeName,
-			)
-		}
-
 		totalWeight += weightedDest.GetWeight()
 
 		weightedCluster := &envoy_config_route_v3.WeightedCluster_ClusterWeight{
@@ -453,10 +442,18 @@ func (t *translatorInstance) setWeightedClusters(params plugins.RouteParams, mul
 		}
 	}
 
-	//Envoy has a default total weight of 100 and requires all weights to equal the current value of total weight
-	//This overrides the default of 100 to the sum of all passed weights both satisfying the requirements
+	// Envoy has a default total weight of 100 and requires all weights to equal the current value of total weight
+	// This overrides the default of 100 to the sum of all passed weights both satisfying the requirements
 	// - that all weights equal total weight
 	// - the passed weights are weighted proportional to each other
+	if totalWeight < 1 {
+		// Envoy errors with:`WeightedClusterValidationError.TotalWeight: value must be greater than or equal to 1`
+		validation.AppendRouteError(routeReport,
+			validationapi.RouteReport_Error_ProcessingError,
+			fmt.Sprintf("Incorrect configuration for Weighted Destination for route: %s - Weighted Destinations require a total weight that is greater than 0", routeName),
+			routeName,
+		)
+	}
 	clusterSpecifier.WeightedClusters.TotalWeight = &wrappers.UInt32Value{Value: totalWeight}
 
 	out.ClusterSpecifier = clusterSpecifier

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -450,7 +450,7 @@ func (t *translatorInstance) setWeightedClusters(params plugins.RouteParams, mul
 		// Envoy errors with:`WeightedClusterValidationError.TotalWeight: value must be greater than or equal to 1`
 		validation.AppendRouteError(routeReport,
 			validationapi.RouteReport_Error_ProcessingError,
-			fmt.Sprintf("Incorrect configuration for Weighted Destination for route: %s - Weighted Destinations require a total weight that is greater than 0", routeName),
+			fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than 0"),
 			routeName,
 		)
 	}

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -450,7 +450,7 @@ func (t *translatorInstance) setWeightedClusters(params plugins.RouteParams, mul
 		// Envoy errors with:`WeightedClusterValidationError.TotalWeight: value must be greater than or equal to 1`
 		validation.AppendRouteError(routeReport,
 			validationapi.RouteReport_Error_ProcessingError,
-			fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than 0"),
+			fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than or equal to 1"),
 			routeName,
 		)
 	}

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -1926,7 +1926,7 @@ var _ = Describe("Translator", func() {
 			multiActionRouteWithZeroWeightDest = createMultiActionRoute("NegativeWeightDest", matcher, []*v1.WeightedDestination{weightedDestWeightOfZero, weightedDestWeightOfZero})
 			multiActionRouteWithOneValidDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestValidWeight})
 
-			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than 0")
+			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than 0 or equal to 1")
 		})
 
 		//Positive Tests

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -1922,11 +1922,11 @@ var _ = Describe("Translator", func() {
 			weightedDestWeightOfZero := createWeightedDestination(true, 0, testUpstream1)
 			weightedDestValidWeight = createWeightedDestination(true, 5, testUpstream2)
 
-			multiActionRouteWithNoWeightPassedDest = createMultiActionRoute("NoWeightPassedDest", matcher, []*v1.WeightedDestination{weightedDestNoWeightPassed, weightedDestValidWeight})
-			multiActionRouteWithZeroWeightDest = createMultiActionRoute("NegativeWeightDest", matcher, []*v1.WeightedDestination{weightedDestWeightOfZero, weightedDestValidWeight})
+			multiActionRouteWithNoWeightPassedDest = createMultiActionRoute("NoWeightPassedDest", matcher, []*v1.WeightedDestination{weightedDestNoWeightPassed, weightedDestNoWeightPassed})
+			multiActionRouteWithZeroWeightDest = createMultiActionRoute("NegativeWeightDest", matcher, []*v1.WeightedDestination{weightedDestWeightOfZero, weightedDestWeightOfZero})
 			multiActionRouteWithOneValidDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestValidWeight})
 
-			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for upstream: %s - Weighted Destinations require a weight that is greater than 0", "test1")
+			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than 0")
 		})
 
 		//Positive Tests

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -1926,7 +1926,7 @@ var _ = Describe("Translator", func() {
 			multiActionRouteWithZeroWeightDest = createMultiActionRoute("NegativeWeightDest", matcher, []*v1.WeightedDestination{weightedDestWeightOfZero, weightedDestWeightOfZero})
 			multiActionRouteWithOneValidDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestValidWeight})
 
-			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than 0 or equal to 1")
+			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than or equal to 1")
 		})
 
 		//Positive Tests


### PR DESCRIPTION
# Description

Reject WeightedDestination when Total Weight < 1 

# Context

Follow-Up to: https://github.com/solo-io/gloo/pull/6567/
Original issue: https://github.com/solo-io/gloo/issues/6098

The issue calls out that before validation, Envoy would produce the following error:
```
[2022-03-16 00:29:39.279][8][warning][config] [external/envoy/source/common/config/grpc_subscription_impl.cc:127] gRPC config for type.googleapis.com/envoy.config.route.v3.RouteConfiguration rejected: Proto constraint validation failed (RouteConfigurationValidationError.VirtualHosts[776]: embedded message failed validation | caused by VirtualHostValidationError.Routes[2]: embedded message failed validation | caused by RouteValidationError.Route: embedded message failed validation | caused by RouteActionValidationError.WeightedClusters: embedded message failed validation | caused by WeightedClusterValidationError.TotalWeight: value must be greater than or equal to 1): name: "listener-0.0.0.0-8443-routes"
```

Most importantly: `caused by WeightedClusterValidationError.TotalWeight: value must be greater than or equal to 1`

Instead of rejecting individual destinations with a weight of 0 (which is valid), we should instead reject when the total weight is < 1.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
