### PR TITLE
Fix broken stitching link in GraphQL API reference doc

### DIFF
--- a/docs/content/guides/graphql/stitching.md
+++ b/docs/content/guides/graphql/stitching.md
@@ -221,4 +221,4 @@ query {
 
 ## Next steps
 
-For more information, check out the API reference documentation for [`stitchedSchema`]({{% versioned_link_path fromRoot="/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/graphql/v1alpha1/graphql.proto.sk/#stitchedschema" %}}).
+For more information, check out the API reference documentation for [`stitchedSchema`]({{% versioned_link_path fromRoot="/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/graphql/v1beta1/graphql.proto.sk/#stitchedschema" %}}).


### PR DESCRIPTION
# Description

There's a broken doc link [here](https://docs.solo.io/gloo-edge/latest/guides/graphql/stitching/#next-steps) due to updating the GraphQLApi custom resource from gloo apiVersion v1alpha1 to v1beta1 at v1.11.0. This PR fixes that. I couldn't find any other links that were similarly broken.
