### PR TITLE
Unmarshal status never error 1.9

### DIFF
--- a/changelog/v1.9.19/support-new-statuses.yaml
+++ b/changelog/v1.9.19/support-new-statuses.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: solo-kit
+    dependencyTag: v0.20.8
+    issueLink: https://github.com/solo-io/solo-kit/issues/484
+    resolvesIssue: false
+    description: Support future status setup.

--- a/changelog/v1.9.19/support-new-statuses.yaml
+++ b/changelog/v1.9.19/support-new-statuses.yaml
@@ -1,8 +1,0 @@
-changelog:
-  - type: DEPENDENCY_BUMP
-    dependencyOwner: solo-io
-    dependencyRepo: solo-kit
-    dependencyTag: v0.20.8
-    issueLink: https://github.com/solo-io/solo-kit/issues/484
-    resolvesIssue: false
-    description: Support future status setup.

--- a/changelog/v1.9.19/unmarshal-status-never-errors-solo-kit-bump.yaml
+++ b/changelog/v1.9.19/unmarshal-status-never-errors-solo-kit-bump.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: solo-kit
+    dependencyTag: v0.24.6
+    issueLink: https://github.com/solo-io/solo-kit/issues/484
+    resolvesIssue: false
+    description: Never error when unmarshalling status.

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/solo-io/skv2 v0.17.17
 	// Pinned to the `gloo-namespaced-statuses` tag of solo-apis
 	github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c
-	github.com/solo-io/solo-kit v0.24.5
+	github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e
 	github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.1.3

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/solo-io/skv2 v0.17.17
 	// Pinned to the `gloo-namespaced-statuses` tag of solo-apis
 	github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c
-	github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e
+	github.com/solo-io/solo-kit v0.24.6
 	github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -1381,8 +1381,8 @@ github.com/solo-io/skv2 v0.17.17/go.mod h1:nYjANLlL1SLPV/7Gr2mKgfxO3Jta/yNAxKnAH
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c h1:4/yTroUmyUJonldE5EyC3AinNG4KVLgG0FVMrI2SQ04=
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c/go.mod h1:4HQsQO4Cy/4V7ZZxWncvnMvIq7pYnb66jAT5hvDJBgQ=
 github.com/solo-io/solo-kit v0.23.0/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
-github.com/solo-io/solo-kit v0.24.5 h1:GfDEhS0c2J+t3dRXT9Z7NdxjgQgfptKFOxqB/tfIzXU=
-github.com/solo-io/solo-kit v0.24.5/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
+github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e h1:ssxchq6QuOqA2tTwEaaFR/JcWIHsfKUeTiZUgS2+uj4=
+github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3 h1:Am1RMaWH7jOug0ys4gUeBCgwR/94NSfZqu90j9u8eTA=
 github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3/go.mod h1:3lckq1wF8I6I2a1Jx5IsEG+PQArE57Jp3wBE2rQnKmw=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=

--- a/go.sum
+++ b/go.sum
@@ -1383,6 +1383,8 @@ github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c/go.mod h1:4HQsQO
 github.com/solo-io/solo-kit v0.23.0/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
 github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e h1:ssxchq6QuOqA2tTwEaaFR/JcWIHsfKUeTiZUgS2+uj4=
 github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
+github.com/solo-io/solo-kit v0.24.6 h1:7it801gRA//jmyJKO5tqCrFLE1R86G9QYzQGiQ2f9PI=
+github.com/solo-io/solo-kit v0.24.6/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3 h1:Am1RMaWH7jOug0ys4gUeBCgwR/94NSfZqu90j9u8eTA=
 github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3/go.mod h1:3lckq1wF8I6I2a1Jx5IsEG+PQArE57Jp3wBE2rQnKmw=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=

--- a/go.sum
+++ b/go.sum
@@ -1381,8 +1381,6 @@ github.com/solo-io/skv2 v0.17.17/go.mod h1:nYjANLlL1SLPV/7Gr2mKgfxO3Jta/yNAxKnAH
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c h1:4/yTroUmyUJonldE5EyC3AinNG4KVLgG0FVMrI2SQ04=
 github.com/solo-io/solo-apis v0.0.0-20210922150112-505473b2e66c/go.mod h1:4HQsQO4Cy/4V7ZZxWncvnMvIq7pYnb66jAT5hvDJBgQ=
 github.com/solo-io/solo-kit v0.23.0/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
-github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e h1:ssxchq6QuOqA2tTwEaaFR/JcWIHsfKUeTiZUgS2+uj4=
-github.com/solo-io/solo-kit v0.24.6-0.20220630190915-e2772006570e/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/solo-io/solo-kit v0.24.6 h1:7it801gRA//jmyJKO5tqCrFLE1R86G9QYzQGiQ2f9PI=
 github.com/solo-io/solo-kit v0.24.6/go.mod h1:y/A2Lr12jMPf9vyP5cuLYNumTYVCDinm4ZbbDULfHBo=
 github.com/solo-io/wasm/tools/wasme/pkg v0.0.0-20201021213306-77f82bdc3cc3 h1:Am1RMaWH7jOug0ys4gUeBCgwR/94NSfZqu90j9u8eTA=


### PR DESCRIPTION
# Description

- Bump solo-kit dependency

# Context

This brings in a change in behavior that prevents an error from being returned due to malformed status
In turn this prevents Gloo from crashing or getting stuck if a CR has a malformed status for any reason
The malformed status will be ignored and rewritten during the next reconcile of the resource

It has been manually verified in a local kind cluster that this branch behaves as expected in this regard

See #6642

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
