### PR TITLE
docs : specify weight of 0 is allowed on weighted destination given other non zero destinations

### DIFF
--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk.md
@@ -534,7 +534,7 @@ route across multiple destinations according to their specified weights.
 
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
-| `destinations` | [[]gloo.solo.io.WeightedDestination](../proxy.proto.sk/#weighteddestination) | This list must contain at least one destination or the listener housing this route will be invalid, causing Gloo to error the parent proxy resource. |
+| `destinations` | [[]gloo.solo.io.WeightedDestination](../proxy.proto.sk/#weighteddestination) | This list must contain at least one destination with a weight greater than 0. Otherwise, the listener for this route becomes invalid, which causes an error for the parent proxy resource. |
 
 
 
@@ -555,7 +555,7 @@ WeightedDestination attaches a weight to a single destination.
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
 | `destination` | [.gloo.solo.io.Destination](../proxy.proto.sk/#destination) |  |
-| `weight` | `int` | Weight must be greater than zero Routing to each destination will be balanced by the ratio of the destination's weight to the total weight on a route. |
+| `weight` | `int` | Weight must be zero or greater - Routing to each destination is balanced according to the ratio of the destination’s weight to the total weight on a route. For example, if the weight for one destination is 2, and the total weight of all destinations on the route is 6, the destination receives 2/6 of the traffic. Note that a weight of 0 routes no traffic to the destination. |
 | `options` | [.gloo.solo.io.WeightedDestinationOptions](../options.proto.sk/#weighteddestinationoptions) | Apply configuration to traffic that is sent to this weighted destination. |
 
 

--- a/projects/gloo/api/v1/proxy.proto
+++ b/projects/gloo/api/v1/proxy.proto
@@ -439,8 +439,8 @@ message UpstreamGroup {
 // MultiDestination is a container for a set of weighted destinations. Gloo will load balance traffic for a single
 // route across multiple destinations according to their specified weights.
 message MultiDestination {
-    // This list must contain at least one destination or the listener housing this route will be invalid,
-    // causing Gloo to error the parent proxy resource.
+    // This list must contain at least one destination with a weight greater than 0.
+    // Otherwise, the listener for this route becomes invalid, which causes an error for the parent proxy resource.
     repeated WeightedDestination destinations = 1;
 }
 
@@ -448,8 +448,11 @@ message MultiDestination {
 message WeightedDestination {
     Destination destination = 1;
 
-    // Weight must be greater than zero
-    // Routing to each destination will be balanced by the ratio of the destination's weight to the total weight on a route
+    // Weight must be zero or greater -
+    // Routing to each destination is balanced according to the ratio of the destination’s weight to the total
+    // weight on a route. For example, if the weight for one destination is 2, and the total weight of all
+    // destinations on the route is 6, the destination receives 2/6 of the traffic. Note that a weight of 0
+    // routes no traffic to the destination.
     uint32 weight = 2;
 
     // Apply configuration to traffic that is sent to this weighted destination

--- a/projects/gloo/pkg/api/v1/proxy.pb.go
+++ b/projects/gloo/pkg/api/v1/proxy.pb.go
@@ -1685,8 +1685,8 @@ type MultiDestination struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// This list must contain at least one destination or the listener housing this route will be invalid,
-	// causing Gloo to error the parent proxy resource.
+	// This list must contain at least one destination with a weight greater than 0.
+	// Otherwise, the listener for this route becomes invalid, which causes an error for the parent proxy resource.
 	Destinations []*WeightedDestination `protobuf:"bytes,1,rep,name=destinations,proto3" json:"destinations,omitempty"`
 }
 
@@ -1736,8 +1736,11 @@ type WeightedDestination struct {
 	unknownFields protoimpl.UnknownFields
 
 	Destination *Destination `protobuf:"bytes,1,opt,name=destination,proto3" json:"destination,omitempty"`
-	// Weight must be greater than zero
-	// Routing to each destination will be balanced by the ratio of the destination's weight to the total weight on a route
+	// Weight must be zero or greater -
+	// Routing to each destination is balanced according to the ratio of the destination’s weight to the total
+	// weight on a route. For example, if the weight for one destination is 2, and the total weight of all
+	// destinations on the route is 6, the destination receives 2/6 of the traffic. Note that a weight of 0
+	// routes no traffic to the destination.
 	Weight uint32 `protobuf:"varint,2,opt,name=weight,proto3" json:"weight,omitempty"`
 	// Apply configuration to traffic that is sent to this weighted destination
 	Options *WeightedDestinationOptions `protobuf:"bytes,3,opt,name=options,proto3" json:"options,omitempty"`


### PR DESCRIPTION
# Context
Related issue: https://github.com/solo-io/gloo/issues/6098
Users are allowed to pass weights of 0 but we error if all weighted destinations have 0 or no weight. 

# Description
Documents updated to clarify the behavior of weighted destinations 

# Checklist:
- [x] I have made corresponding changes to the documentation
