### PR TITLE
Weighted destination test updates

### DIFF
--- a/changelog/v1.12.0-beta29/weighted-destingation-test-updates.yaml
+++ b/changelog/v1.12.0-beta29/weighted-destingation-test-updates.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6098
+    description: Add new tests to cover destinations with 0 and higher weights
+    resolvesIssue: false

--- a/changelog/v1.12.0-beta29/weighted-destingation-test-updates.yaml
+++ b/changelog/v1.12.0-beta29/weighted-destingation-test-updates.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/gloo/issues/6098
-    description: Add new tests to cover destinations with 0 and higher weights
-    resolvesIssue: false

--- a/changelog/v1.12.0-beta30/weighted-destingation-test-updates.yaml
+++ b/changelog/v1.12.0-beta30/weighted-destingation-test-updates.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6098
+    description: Add new tests to cover destinations with 0 and higher weights
+    resolvesIssue: false

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -2244,10 +2244,11 @@ var _ = Describe("Translator", func() {
 
 		var (
 			multiActionRouteWithNoWeightPassedDest *v1.Route
-			multiActionRouteWithZeroWeightDest     *v1.Route
 			multiActionRouteWithOneValidDest       *v1.Route
+			multiActionRouteZeroAndFiveAsWeights   *v1.Route
 			expectedErrorString                    string
-			weightedDestValidWeight                *v1.WeightedDestination
+			weightedDestFiveWeight                 *v1.WeightedDestination
+			weightedDestZeroWeight                 *v1.WeightedDestination
 		)
 
 		BeforeEach(func() {
@@ -2255,12 +2256,12 @@ var _ = Describe("Translator", func() {
 			testUpstream2 := createStaticUpstream("test2", "gloo-system")
 
 			weightedDestNoWeightPassed := createWeightedDestination(false, 0, testUpstream1)
-			weightedDestWeightOfZero := createWeightedDestination(true, 0, testUpstream1)
-			weightedDestValidWeight = createWeightedDestination(true, 5, testUpstream2)
+			weightedDestZeroWeight = createWeightedDestination(true, 0, testUpstream1)
+			weightedDestFiveWeight = createWeightedDestination(true, 5, testUpstream2)
 
+			multiActionRouteWithOneValidDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight})
+			multiActionRouteZeroAndFiveAsWeights = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight, weightedDestZeroWeight})
 			multiActionRouteWithNoWeightPassedDest = createMultiActionRoute("NoWeightPassedDest", matcher, []*v1.WeightedDestination{weightedDestNoWeightPassed, weightedDestNoWeightPassed})
-			multiActionRouteWithZeroWeightDest = createMultiActionRoute("NegativeWeightDest", matcher, []*v1.WeightedDestination{weightedDestWeightOfZero, weightedDestWeightOfZero})
-			multiActionRouteWithOneValidDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestValidWeight})
 
 			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than or equal to 1")
 		})
@@ -2287,8 +2288,8 @@ var _ = Describe("Translator", func() {
 			Expect(ok).To(BeTrue())
 
 			//DataFromWeightedCluster
-			totalWeight := weightedDestValidWeight.Weight
-			expectedClusterName := weightedDestValidWeight.Destination.GetUpstream().Name + "_" + weightedDestValidWeight.Destination.GetUpstream().Namespace
+			totalWeight := weightedDestFiveWeight.Weight
+			expectedClusterName := weightedDestFiveWeight.Destination.GetUpstream().Name + "_" + weightedDestFiveWeight.Destination.GetUpstream().Namespace
 
 			//There is only one route with a weight of 5 so total weight for the cluster should be 5
 			Expect(clusterAction.WeightedClusters.TotalWeight.GetValue()).To(Equal(totalWeight))
@@ -2298,17 +2299,48 @@ var _ = Describe("Translator", func() {
 			Expect(clusters[0].Name).To(Equal(expectedClusterName))
 		})
 
-		//Negative Tests
-		It("Should report an error when a weighted destination is passed with no weight", func() {
-			proxy.Listeners[0].GetHttpListener().GetVirtualHosts()[0].Routes = []*v1.Route{multiActionRouteWithNoWeightPassedDest}
-			_, errs, _, err := translator.Translate(params, proxy)
-			Expect(err).To(BeNil())
-			Expect(errs.Validate()).To(HaveOccurred())
-			Expect(errs.Validate().Error()).To(ContainSubstring(expectedErrorString))
+		It("Should translate 0 weight destinations if there are other destinations with weights over 0", func() {
+			proxy.Listeners[0].GetHttpListener().GetVirtualHosts()[0].Routes = []*v1.Route{multiActionRouteZeroAndFiveAsWeights}
+			snap, resourceReport, _, _ := translator.Translate(params, proxy)
+			Expect(resourceReport.ValidateStrict()).To(HaveOccurred())
+
+			// A weighted route to the service has been configured
+			routes := snap.GetResources(types.RouteTypeV3)
+			Expect(routes.Items).To(HaveKey("http-listener-routes"))
+			routeResource := routes.Items["http-listener-routes"]
+			routeConfiguration = routeResource.ResourceProto().(*envoy_config_route_v3.RouteConfiguration)
+			Expect(routeConfiguration).NotTo(BeNil())
+			Expect(routeConfiguration.VirtualHosts).To(HaveLen(1))
+			Expect(routeConfiguration.VirtualHosts[0].Domains).To(HaveLen(1))
+			Expect(routeConfiguration.VirtualHosts[0].Domains[0]).To(Equal("*"))
+			Expect(routeConfiguration.VirtualHosts[0].Routes).To(HaveLen(1))
+			routeAction, ok := routeConfiguration.VirtualHosts[0].Routes[0].Action.(*envoy_config_route_v3.Route_Route)
+			Expect(ok).To(BeTrue())
+			clusterAction, ok := routeAction.Route.ClusterSpecifier.(*envoy_config_route_v3.RouteAction_WeightedClusters)
+			Expect(ok).To(BeTrue())
+
+			totalWeight := weightedDestFiveWeight.Weight + weightedDestZeroWeight.Weight
+			clusterNameFiveWeight := weightedDestFiveWeight.Destination.GetUpstream().Name + "_" + weightedDestFiveWeight.Destination.GetUpstream().Namespace
+			clusterNameZeroWeight := weightedDestZeroWeight.Destination.GetUpstream().Name + "_" + weightedDestZeroWeight.Destination.GetUpstream().Namespace
+
+			//There is only one route with a weight of 5 so total weight for the cluster should be 5
+			Expect(clusterAction.WeightedClusters.TotalWeight.GetValue()).To(Equal(totalWeight))
+			clusters := clusterAction.WeightedClusters.Clusters
+			Expect(clusters).To(HaveLen(2))
+
+			for _, c := range clusters {
+				switch c.Name {
+				case clusterNameFiveWeight:
+					Expect(c.Weight.GetValue()).To(Equal(uint32(5)))
+				case clusterNameZeroWeight:
+					Expect(c.Weight.GetValue()).To(Equal(uint32(0)))
+				}
+			}
 		})
 
-		It("Should report an error when a weighted destination is passed with weight less than 1", func() {
-			proxy.Listeners[0].GetHttpListener().GetVirtualHosts()[0].Routes = []*v1.Route{multiActionRouteWithZeroWeightDest}
+		//Negative Tests
+		It("Should report an error when total weight is 0 - nil and 0 weights passed", func() {
+			proxy.Listeners[0].GetHttpListener().GetVirtualHosts()[0].Routes = []*v1.Route{multiActionRouteWithNoWeightPassedDest}
 			_, errs, _, err := translator.Translate(params, proxy)
 			Expect(err).To(BeNil())
 			Expect(errs.Validate()).To(HaveOccurred())

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -2244,7 +2244,7 @@ var _ = Describe("Translator", func() {
 
 		var (
 			multiActionRouteWithNoWeightPassedDest *v1.Route
-			multiActionRouteWithOneValidDest       *v1.Route
+			multiActionRouteOneDest                *v1.Route
 			multiActionRouteZeroAndFiveAsWeights   *v1.Route
 			expectedErrorString                    string
 			weightedDestFiveWeight                 *v1.WeightedDestination
@@ -2259,7 +2259,7 @@ var _ = Describe("Translator", func() {
 			weightedDestZeroWeight = createWeightedDestination(true, 0, testUpstream1)
 			weightedDestFiveWeight = createWeightedDestination(true, 5, testUpstream2)
 
-			multiActionRouteWithOneValidDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight})
+			multiActionRouteOneDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight})
 			multiActionRouteZeroAndFiveAsWeights = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight, weightedDestZeroWeight})
 			multiActionRouteWithNoWeightPassedDest = createMultiActionRoute("NoWeightPassedDest", matcher, []*v1.WeightedDestination{weightedDestNoWeightPassed, weightedDestNoWeightPassed})
 
@@ -2268,7 +2268,7 @@ var _ = Describe("Translator", func() {
 
 		//Positive Tests
 		It("Should translate single routes when multiRoute is passed and only one destination is specified", func() {
-			proxy.Listeners[0].GetHttpListener().GetVirtualHosts()[0].Routes = []*v1.Route{multiActionRouteWithOneValidDest}
+			proxy.Listeners[0].GetHttpListener().GetVirtualHosts()[0].Routes = []*v1.Route{multiActionRouteOneDest}
 			snap, resourceReport, _, _ := translator.Translate(params, proxy)
 			Expect(resourceReport.ValidateStrict()).To(HaveOccurred())
 

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -2259,8 +2259,8 @@ var _ = Describe("Translator", func() {
 			weightedDestZeroWeight = createWeightedDestination(true, 0, testUpstream1)
 			weightedDestFiveWeight = createWeightedDestination(true, 5, testUpstream2)
 
-			multiActionRouteOneDest = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight})
-			multiActionRouteZeroAndFiveAsWeights = createMultiActionRoute("OneValidDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight, weightedDestZeroWeight})
+			multiActionRouteOneDest = createMultiActionRoute("OneDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight})
+			multiActionRouteZeroAndFiveAsWeights = createMultiActionRoute("TwoDest", matcher, []*v1.WeightedDestination{weightedDestFiveWeight, weightedDestZeroWeight})
 			multiActionRouteWithNoWeightPassedDest = createMultiActionRoute("NoWeightPassedDest", matcher, []*v1.WeightedDestination{weightedDestNoWeightPassed, weightedDestNoWeightPassed})
 
 			expectedErrorString = fmt.Sprintf("Incorrect configuration for Weighted Destination for route - Weighted Destinations require a total weight that is greater than or equal to 1")


### PR DESCRIPTION
# Description

Adding a new test to cover situations where users pass weighted destinations with 0 weight with weighted destinations with weights higher than 0

This also includes a name change to a previous test to reflect that we now check total weight and will only fail if all passed destinations have 0 weight 
