### PR TITLE
Update the secret used for Github automation

### DIFF
--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -13,11 +13,11 @@ jobs:
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/solo-io/projects/22
-          github-token: ${{ secrets.ORG_CROSS_REPO }}
+          github-token: ${{ secrets.ORG_CROSS_REPO_DEUX }}
           labeled: "Type: Enhancement,Type: Bug"
           label-operator: OR
       - uses: actions/add-to-project@main
         with:
           project-url: https://github.com/orgs/solo-io/projects/24
-          github-token: ${{ secrets.ORG_CROSS_REPO }}
+          github-token: ${{ secrets.ORG_CROSS_REPO_DEUX }}
           labeled: "Type: Docs"

--- a/changelog/v1.12.0-beta31/automation_secret.yaml
+++ b/changelog/v1.12.0-beta31/automation_secret.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Use the new secret to access issues and add them to team boards.


### PR DESCRIPTION
The secret we originally used to automate adding issues to boards stopped working. This change updates to a new secret Jacob created for the automation. 
This was already tested in GME (https://github.com/solo-io/gloo-mesh-enterprise/pull/4406/files)