### PR TITLE
Fix helm upgrade failure when resourceVersion exists in last applied config

### DIFF
--- a/changelog/v1.12.0-beta31/helm-fix-kubectl-apply.yaml
+++ b/changelog/v1.12.0-beta31/helm-fix-kubectl-apply.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6732
+    resolvesIssue: false
+    description: |
+      Fix helm upgrade failure when resourceVersion exists in `kubectl.kubernetes.io/last-applied-configuration` annotation.

--- a/install/helm/gloo/templates/5-resource-rollout-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job.yaml
@@ -43,7 +43,7 @@ spec:
             {{- $cr := include "gloo.customResources" . | indent 12 -}}
             {{- if contains "kind:" $cr -}}{{/* only render if not empty */}}
             # apply Gloo Edge custom resources
-            kubectl apply -f - <<EOF || exit $?
+            kubectl apply --server-side -f - <<EOF || exit $?
             {{- $cr -}}
             EOF
             {{- else }}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -5450,7 +5450,7 @@ spec:
 				}
 				// skip all the content within kubectl apply commands (used in the rollout job)
 				// since there is extra whitespace that can't be removed
-				if strings.Contains(line, "kubectl apply -f - <<EOF") {
+				if strings.Contains(line, "kubectl apply --server-side -f - <<EOF") {
 					skip = true
 					continue
 				}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -5450,7 +5450,7 @@ spec:
 				}
 				// skip all the content within kubectl apply commands (used in the rollout job)
 				// since there is extra whitespace that can't be removed
-				if strings.Contains(line, "kubectl apply --server-side -f - <<EOF") {
+				if strings.Contains(line, "kubectl apply") && strings.Contains(line, "<<EOF") {
 					skip = true
 					continue
 				}


### PR DESCRIPTION
# Description

Use [server-side](https://kubernetes.io/docs/reference/using-api/server-side-apply/) kubectl apply to get around the issue where a resource's `kubectl.kubernetes.io/last-applied-configuration` annotation may already contain a resourceVersion.

> Server Side Apply helps users and controllers manage their resources through declarative configurations. Clients can create and modify their objects declaratively by sending their fully specified intent.
> A fully specified intent is a partial object that only includes the fields and values for which the user has an opinion. That intent either creates a new object or is combined, by the server, with the existing object.

# Context

See the linked issue (https://github.com/solo-io/gloo/issues/6732) for more details.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
