### PR TITLE
[1.8] Proxy Reconciliation is Forward and Backward Compatible

### DIFF
--- a/changelog/v1.8.36/set-based-proxy-selection.yaml
+++ b/changelog/v1.8.36/set-based-proxy-selection.yaml
@@ -2,4 +2,6 @@ changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/6406
     resolvesIssue: false
-    description: Ensure Proxies with `created_by` labels in both the current   can be reconciled correctly.
+    description: >
+      Ensure Proxies with `created_by` labels in both
+      the original and updated format can be reconciled correctly.

--- a/changelog/v1.8.36/set-based-proxy-selection.yaml
+++ b/changelog/v1.8.36/set-based-proxy-selection.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6406
+    resolvesIssue: false
+    description: Ensure Proxies with `created_by` labels in both the current   can be reconciled correctly.

--- a/projects/clusteringress/pkg/translator/translator_syncer.go
+++ b/projects/clusteringress/pkg/translator/translator_syncer.go
@@ -34,20 +34,17 @@ type translatorSyncer struct {
 var (
 	// labels used to uniquely identify Proxies that are managed by the Gloo controllers
 	proxyLabelsToWrite = map[string]string{
-		"created_by": "gloo-knative",
+		"created_by": "knative",
 	}
 
-	// Previously, proxies would be identified with:
+	// Currently, proxies are identified with:
 	//   created_by: knative
-	// Now, proxies are identified with:
+	// In later version of Gloo, proxies are identified with:
 	//   created_by: gloo-knative
 	//
-	// We need to ensure that users can successfully upgrade from versions
-	// where the previous labels were used, to versions with the new labels.
-	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with new labels.
-	//
-	// This is only required for backwards compatibility.
-	// Once users have upgraded to a version with new labels, we can delete this code and read/write the same labels.
+	// We need to ensure that users can successfully downgrade from versions
+	// where the newer labels were used, to versions with the current labels.
+	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with old labels.
 	proxyLabelSelectorOptions = clients.ListOpts{
 		ExpressionSelector: "created_by in (gloo-knative, knative)",
 	}

--- a/projects/gateway/pkg/syncer/translator_syncer.go
+++ b/projects/gateway/pkg/syncer/translator_syncer.go
@@ -44,20 +44,17 @@ type translatorSyncer struct {
 var (
 	// labels used to uniquely identify Proxies that are managed by the Gloo controllers
 	proxyLabelsToWrite = map[string]string{
-		"created_by": "gloo-gateway-translator",
+		"created_by": "gateway",
 	}
 
-	// Previously, proxies would be identified with:
+	// Currently, proxies are identified with:
 	//   created_by: gateway
-	// Now, proxies are identified with:
+	// In later version of Gloo, proxies are identified with:
 	//   created_by: gloo-gateway-translator
 	//
-	// We need to ensure that users can successfully upgrade from versions
-	// where the previous labels were used, to versions with the new labels.
-	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with new labels.
-	//
-	// This is only required for backwards compatibility.
-	// Once users have upgraded to a version with new labels, we can delete this code and read/write the same labels.
+	// We need to ensure that users can successfully downgrade from versions
+	// where the newer labels were used, to versions with the current labels.
+	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with old labels.
 	proxyLabelSelectorOptions = clients.ListOpts{
 		ExpressionSelector: "created_by in (gloo-gateway-translator, gateway)",
 	}

--- a/projects/ingress/pkg/translator/translator_syncer.go
+++ b/projects/ingress/pkg/translator/translator_syncer.go
@@ -31,20 +31,17 @@ type translatorSyncer struct {
 var (
 	// labels used to uniquely identify Proxies that are managed by the Gloo controllers
 	proxyLabelsToWrite = map[string]string{
-		"created_by": "gloo-ingress",
+		"created_by": "ingress",
 	}
 
-	// Previously, proxies would be identified with:
+	// Currently, proxies are identified with:
 	//   created_by: ingress
-	// Now, proxies are identified with:
+	// In later version of Gloo, proxies are identified with:
 	//   created_by: gloo-ingress
 	//
-	// We need to ensure that users can successfully upgrade from versions
-	// where the previous labels were used, to versions with the new labels.
-	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with new labels.
-	//
-	// This is only required for backwards compatibility.
-	// Once users have upgraded to a version with new labels, we can delete this code and read/write the same labels.
+	// We need to ensure that users can successfully downgrade from versions
+	// where the newer labels were used, to versions with the current labels.
+	// Therefore, we watch Proxies with a superset of the old and new labels, and persist Proxies with old labels.
 	proxyLabelSelectorOptions = clients.ListOpts{
 		ExpressionSelector: "created_by in (gloo-ingress, ingress)",
 	}

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Kube2e: gateway", func() {
 			// Forward compatibility with later versions of Gloo
 			proxy, err = proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(proxy.Metadata.Labels["created_by"]).To(Equal("gloo"))
+			Expect(proxy.Metadata.Labels["created_by"]).To(Equal("gateway"))
 		})
 	})
 

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -266,7 +266,7 @@ var _ = Describe("Kube2e: gateway", func() {
 			proxy, err := proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
 			Expect(err).NotTo(HaveOccurred())
 			proxy.Metadata.Labels = map[string]string{
-				"created_by": "gateway",
+				"created_by": "gloo-gateway-translator",
 			}
 			_, err = proxyClient.Write(proxy, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
 			Expect(err).NotTo(HaveOccurred())
@@ -297,6 +297,13 @@ var _ = Describe("Kube2e: gateway", func() {
 				}
 				return proxy, nil
 			})
+
+			// Ensure that the updated Proxy has the old label
+			// This allows backwards compatibility with older versions of Gloo and
+			// Forward compatibility with later versions of Gloo
+			proxy, err = proxyClient.Read(testHelper.InstallNamespace, defaults.GatewayProxyName, clients.ReadOpts{Ctx: ctx})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(proxy.Metadata.Labels["created_by"]).To(Equal("gloo"))
 		})
 	})
 


### PR DESCRIPTION
# Description

Write Proxies with proper label format 

# Context

Follow-Up to https://github.com/solo-io/gloo/pull/6728

In Gloo, we reconcile Proxy CRs. To determine which proxies to reconcile we only select resources with a particular label. In a later version of Gloo Edge the label used to identify Gloo-managed proxies changed, resulting in this bug: https://github.com/solo-io/gloo/issues/6406.

To resolve this, we changed our selection process to list both Proxies with the old and new label, but write the new label. This would allow customer upgrading, to do so seamlessly. 

However, since 1.8 is an older version, we should be writing the label using the old format. In https://github.com/solo-io/gloo/pull/6728/files we correctly read the old and new format, but we write the new format.

The effect of the bug is that if you perform:
1. Install 1.8.34 (read proxy with old label, write with old label)
2. Upgrade to 1.8.35 (read proxy with old or new label, write proxy with new label)
3. Downgrade to 1.8.34 (read proxy with old label, and find none)


The effect of the solution is that we continue to write Proxies with the old format of the label (allow for downgrades from this version), but we also read Proxies with the new format of the label (allowing for upgrades to later versions of Gloo and then downgrades from them)

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
