### PR TITLE
fix(static/plugin.go): prevent auto-overwrite for host-level HC's

### DIFF
--- a/changelog/v1.13.0-beta3/static-upstream-host-healthchecks.yaml
+++ b/changelog/v1.13.0-beta3/static-upstream-host-healthchecks.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6770
+    description: Hosts now respect top-level healthChecks when provided

--- a/projects/gloo/pkg/plugins/static/plugin.go
+++ b/projects/gloo/pkg/plugins/static/plugin.go
@@ -101,6 +101,23 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 			}
 		}
 
+		healthCheckConfig := &envoy_config_endpoint_v3.Endpoint_HealthCheckConfig{
+			Hostname: host.GetAddr(),
+		}
+
+		if (in.GetHealthChecks() != nil) &&
+			(len(in.GetHealthChecks()) > 0) &&
+			(in.GetHealthChecks()[0].GetHttpHealthCheck().GetHost() != "") {
+
+			// The discerning reader may ask the question "Why are we hardcoding this to use the 0th healthcheck?"
+			// This was done with two assumptions:
+			// 		1) no one _currently_ uses this feature.  It was previously _always_ hardcoded to be a loopback call to host.GetAddr()
+			//		2) looking through our field engineering scripts/customer use-cases, _right now_, it appears that customers are using only a single top-level healthcheck
+			healthCheckConfig = &envoy_config_endpoint_v3.Endpoint_HealthCheckConfig{
+				Hostname: in.GetHealthChecks()[0].GetHttpHealthCheck().GetHost(),
+			}
+		}
+
 		out.GetLoadAssignment().GetEndpoints()[0].LbEndpoints = append(out.GetLoadAssignment().GetEndpoints()[0].GetLbEndpoints(),
 			&envoy_config_endpoint_v3.LbEndpoint{
 				Metadata: getMetadata(spec, host),
@@ -118,9 +135,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 								},
 							},
 						},
-						HealthCheckConfig: &envoy_config_endpoint_v3.Endpoint_HealthCheckConfig{
-							Hostname: host.GetAddr(),
-						},
+						HealthCheckConfig: healthCheckConfig,
 					},
 				},
 				LoadBalancingWeight: host.GetLoadBalancingWeight(),

--- a/projects/gloo/pkg/plugins/static/plugin_test.go
+++ b/projects/gloo/pkg/plugins/static/plugin_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	core1 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/api/v2/core"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	v1static "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
@@ -152,8 +153,20 @@ var _ = Describe("Plugin", func() {
 			}
 			p.ProcessUpstream(params, upstream, out)
 			Expect(out.LoadAssignment.Endpoints[0].LbEndpoints[0].Metadata.FilterMetadata[AdvancedHttpCheckerName].Fields[PathFieldName].GetStringValue()).To(Equal("/foo"))
+			Expect(out.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint().GetHealthCheckConfig().GetHostname()).To(Equal(upstreamSpec.Hosts[0].GetAddr()))
 		})
 
+		It("Should prefer top-level health-check hostnames, when available", func() {
+			upstream.HealthChecks = []*core1.HealthCheck{{
+				HealthChecker: &core1.HealthCheck_HttpHealthCheck_{
+					HttpHealthCheck: &core1.HealthCheck_HttpHealthCheck{
+						Host: "test.host.path",
+					},
+				},
+			}}
+			p.ProcessUpstream(params, upstream, out)
+			Expect(out.LoadAssignment.Endpoints[0].LbEndpoints[0].GetEndpoint().GetHealthCheckConfig().GetHostname()).To(Equal("test.host.path"))
+		})
 	})
 
 	Context("load balancing weight config", func() {


### PR DESCRIPTION
# Description
Removed an auto-created healthcheck which was preventing user-provided healthchecks from being reached

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6770