### PR TITLE
ci: added hack script to compress changelogs by minor version

### DIFF
--- a/changelog/v1.13.0-beta1/changelog-compressor.yaml
+++ b/changelog/v1.13.0-beta1/changelog-compressor.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: added hack script to compress changelogs by minor version

--- a/hack/squash-changelogs.sh
+++ b/hack/squash-changelogs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+CURRENT_MAJOR_VERSION=1         # major semvar version of supported product
+CURRENT_MINOR_VERSION=13        # minor semvar version of supported product
+SUPPORTED_VERSIONS=4            # how many versions of product are in active support
+LEGACY_CODE_FOLDER="_archive"   # intended destination of legacy changelogs
+
+cd ../changelog
+
+for folder in v*.*.*; do
+    folder="${folder#?}"
+    semver=( ${folder//./ } )
+    major="${semver[0]}"
+    minor="${semver[1]}"
+
+    # active version, supported version, legacy version
+    if   [ $CURRENT_MAJOR_VERSION = $major ] && [ $CURRENT_MINOR_VERSION = $minor ]; then
+        continue
+    elif [ $CURRENT_MAJOR_VERSION = $major ] && [ $(($minor+$SUPPORTED_VERSIONS+1)) -gt $CURRENT_MINOR_VERSION ]; then
+        dst="$major.$minor"
+    else
+        dst="$LEGACY_CODE_FOLDER/$major.$minor"
+    fi
+
+    mkdir -p $dst
+    mv "v$folder" $dst
+done


### PR DESCRIPTION
When run, the script produces a changelog directory resembling:

<img width="191" alt="Screen Shot 2022-08-04 at 8 15 28 AM" src="https://user-images.githubusercontent.com/92050522/182844495-ce5f12e6-51e1-4023-9bfb-9d148f12dd8b.png">

This commit was made _without_ running, as the number of changes it generates, otherwise, is overwhelming to review