### PR TITLE
Helm customization for rollout/migration/cleanup jobs

### DIFF
--- a/changelog/v1.13.0-beta3/helm-job-customization.yaml
+++ b/changelog/v1.13.0-beta3/helm-job-customization.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6847
+    resolvesIssue: false
+    description: Add helm customization (pod spec fields, resource requirements, disabling istio injection) that was missing from the `gloo-resource-rollout`, `gloo-resource-migration`, and `gloo-resource-cleanup` jobs. Allow disabling the jobs (not recommended unless default Gateways/Upstreams are not needed).

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -288,6 +288,17 @@
 |gateway.certGenJob.cron.enabled|bool|false|enable the cronjob|
 |gateway.certGenJob.cron.schedule|string|* * * * *|Cron job scheduling|
 |gateway.certGenJob.cron.mtlsKubeResourceOverride.NAME|interface||override fields in the gloo-mtls-certgen cronjob.|
+|gateway.rolloutJob.restartPolicy|string||restart policy to use when the pod exits|
+|gateway.rolloutJob.nodeName|string||name of node to run on|
+|gateway.rolloutJob.nodeSelector.NAME|string||label selector for nodes|
+|gateway.rolloutJob.tolerations[].key|string|||
+|gateway.rolloutJob.tolerations[].operator|string|||
+|gateway.rolloutJob.tolerations[].value|string|||
+|gateway.rolloutJob.tolerations[].effect|string|||
+|gateway.rolloutJob.tolerations[].tolerationSeconds|int64|||
+|gateway.rolloutJob.affinity.NAME|interface|||
+|gateway.rolloutJob.hostAliases[]|interface|||
+|gateway.rolloutJob.enabled|bool|true|Enable the job that applies default Gloo Edge custom resources at install and upgrade time (default true).|
 |gateway.rolloutJob.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |gateway.rolloutJob.image.repository|string|kubectl|The image repository (name) for the container.|
 |gateway.rolloutJob.image.digest|string||The hash digest of the container's image, ie. sha256:12345....|
@@ -296,10 +307,25 @@
 |gateway.rolloutJob.image.pullSecret|string||The image pull secret to use for the container, in the same namespace as the container pod.|
 |gateway.rolloutJob.image.extended|bool||If true, deploys an extended version of the container with additional debug tools.|
 |gateway.rolloutJob.image.fips|bool||If true, deploys a version of the data-plane containers that is built with FIPS-compliant crypto libraries. (Enterprise-only feature.)|
+|gateway.rolloutJob.resources.limits.memory|string||amount of memory|
+|gateway.rolloutJob.resources.limits.cpu|string||amount of CPUs|
+|gateway.rolloutJob.resources.requests.memory|string||amount of memory|
+|gateway.rolloutJob.resources.requests.cpu|string||amount of CPUs|
 |gateway.rolloutJob.floatingUserId|bool||If true, allows the cluster to dynamically assign a user ID for the processes running in the container.|
 |gateway.rolloutJob.runAsUser|float64||Explicitly set the user ID for the processes in the container to run as. Default is 10101.|
 |gateway.rolloutJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.rolloutJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
+|gateway.cleanupJob.restartPolicy|string||restart policy to use when the pod exits|
+|gateway.cleanupJob.nodeName|string||name of node to run on|
+|gateway.cleanupJob.nodeSelector.NAME|string||label selector for nodes|
+|gateway.cleanupJob.tolerations[].key|string|||
+|gateway.cleanupJob.tolerations[].operator|string|||
+|gateway.cleanupJob.tolerations[].value|string|||
+|gateway.cleanupJob.tolerations[].effect|string|||
+|gateway.cleanupJob.tolerations[].tolerationSeconds|int64|||
+|gateway.cleanupJob.affinity.NAME|interface|||
+|gateway.cleanupJob.hostAliases[]|interface|||
+|gateway.cleanupJob.enabled|bool|true|Enable the job that removes Gloo Edge custom resources when Gloo Edge is uninstalled (default true).|
 |gateway.cleanupJob.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |gateway.cleanupJob.image.repository|string|kubectl|The image repository (name) for the container.|
 |gateway.cleanupJob.image.digest|string||The hash digest of the container's image, ie. sha256:12345....|
@@ -308,6 +334,10 @@
 |gateway.cleanupJob.image.pullSecret|string||The image pull secret to use for the container, in the same namespace as the container pod.|
 |gateway.cleanupJob.image.extended|bool||If true, deploys an extended version of the container with additional debug tools.|
 |gateway.cleanupJob.image.fips|bool||If true, deploys a version of the data-plane containers that is built with FIPS-compliant crypto libraries. (Enterprise-only feature.)|
+|gateway.cleanupJob.resources.limits.memory|string||amount of memory|
+|gateway.cleanupJob.resources.limits.cpu|string||amount of CPUs|
+|gateway.cleanupJob.resources.requests.memory|string||amount of memory|
+|gateway.cleanupJob.resources.requests.cpu|string||amount of CPUs|
 |gateway.cleanupJob.floatingUserId|bool||If true, allows the cluster to dynamically assign a user ID for the processes running in the container.|
 |gateway.cleanupJob.runAsUser|float64||Explicitly set the user ID for the processes in the container to run as. Default is 10101.|
 |gateway.cleanupJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -272,11 +272,12 @@
 |gateway.certGenJob.tolerations[].tolerationSeconds|int64|||
 |gateway.certGenJob.affinity.NAME|interface|||
 |gateway.certGenJob.hostAliases[]|interface|||
+|gateway.certGenJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
+|gateway.certGenJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.certGenJob.kubeResourceOverride.NAME|interface||override fields in the gateway-certgen job.|
 |gateway.certGenJob.mtlsKubeResourceOverride.NAME|interface||override fields in the gloo-mtls-certgen job.|
 |gateway.certGenJob.enabled|bool|true|enable the job that generates the certificates for the validating webhook at install time (default true)|
-|gateway.certGenJob.setTtlAfterFinished|bool|true|Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true|
-|gateway.certGenJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
+|gateway.certGenJob.setTtlAfterFinished|bool|true|Set ttlSecondsAfterFinished on the job. Defaults to true|
 |gateway.certGenJob.floatingUserId|bool||If true, allows the cluster to dynamically assign a user ID for the processes running in the container.|
 |gateway.certGenJob.runAsUser|float64||Explicitly set the user ID for the processes in the container to run as. Default is 10101.|
 |gateway.certGenJob.resources.limits.memory|string||amount of memory|
@@ -284,11 +285,10 @@
 |gateway.certGenJob.resources.requests.memory|string||amount of memory|
 |gateway.certGenJob.resources.requests.cpu|string||amount of CPUs|
 |gateway.certGenJob.runOnUpdate|bool|false|enable to run the job also on pre-upgrade|
-|gateway.certGenJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
 |gateway.certGenJob.cron.enabled|bool|false|enable the cronjob|
 |gateway.certGenJob.cron.schedule|string|* * * * *|Cron job scheduling|
 |gateway.certGenJob.cron.mtlsKubeResourceOverride.NAME|interface||override fields in the gloo-mtls-certgen cronjob.|
-|gateway.rolloutJob.restartPolicy|string||restart policy to use when the pod exits|
+|gateway.rolloutJob.restartPolicy|string|OnFailure|restart policy to use when the pod exits|
 |gateway.rolloutJob.nodeName|string||name of node to run on|
 |gateway.rolloutJob.nodeSelector.NAME|string||label selector for nodes|
 |gateway.rolloutJob.tolerations[].key|string|||
@@ -298,6 +298,8 @@
 |gateway.rolloutJob.tolerations[].tolerationSeconds|int64|||
 |gateway.rolloutJob.affinity.NAME|interface|||
 |gateway.rolloutJob.hostAliases[]|interface|||
+|gateway.rolloutJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
+|gateway.rolloutJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.rolloutJob.enabled|bool|true|Enable the job that applies default Gloo Edge custom resources at install and upgrade time (default true).|
 |gateway.rolloutJob.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |gateway.rolloutJob.image.repository|string|kubectl|The image repository (name) for the container.|
@@ -313,9 +315,7 @@
 |gateway.rolloutJob.resources.requests.cpu|string||amount of CPUs|
 |gateway.rolloutJob.floatingUserId|bool||If true, allows the cluster to dynamically assign a user ID for the processes running in the container.|
 |gateway.rolloutJob.runAsUser|float64||Explicitly set the user ID for the processes in the container to run as. Default is 10101.|
-|gateway.rolloutJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
-|gateway.rolloutJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
-|gateway.cleanupJob.restartPolicy|string||restart policy to use when the pod exits|
+|gateway.cleanupJob.restartPolicy|string|OnFailure|restart policy to use when the pod exits|
 |gateway.cleanupJob.nodeName|string||name of node to run on|
 |gateway.cleanupJob.nodeSelector.NAME|string||label selector for nodes|
 |gateway.cleanupJob.tolerations[].key|string|||
@@ -325,6 +325,8 @@
 |gateway.cleanupJob.tolerations[].tolerationSeconds|int64|||
 |gateway.cleanupJob.affinity.NAME|interface|||
 |gateway.cleanupJob.hostAliases[]|interface|||
+|gateway.cleanupJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
+|gateway.cleanupJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.cleanupJob.enabled|bool|true|Enable the job that removes Gloo Edge custom resources when Gloo Edge is uninstalled (default true).|
 |gateway.cleanupJob.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |gateway.cleanupJob.image.repository|string|kubectl|The image repository (name) for the container.|
@@ -340,8 +342,6 @@
 |gateway.cleanupJob.resources.requests.cpu|string||amount of CPUs|
 |gateway.cleanupJob.floatingUserId|bool||If true, allows the cluster to dynamically assign a user ID for the processes running in the container.|
 |gateway.cleanupJob.runAsUser|float64||Explicitly set the user ID for the processes in the container to run as. Default is 10101.|
-|gateway.cleanupJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
-|gateway.cleanupJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
 |gateway.updateValues|bool||if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions|
 |gateway.proxyServiceAccount.extraAnnotations.NAME|string||extra annotations to add to the service account|
 |gateway.proxyServiceAccount.disableAutomount|bool||disable automounting the service account to the gateway proxy. not mounting the token hardens the proxy container, but may interfere with service mesh integrations|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -322,19 +322,25 @@ type CertGenJob struct {
 }
 
 type RolloutJob struct {
-	Image                   *Image   `json:"image,omitempty"`
-	FloatingUserId          *bool    `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
-	RunAsUser               *float64 `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
-	TtlSecondsAfterFinished *int     `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
-	ActiveDeadlineSeconds   *int     `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
+	*JobSpec
+	Enabled                 *bool                 `json:"enabled,omitempty" desc:"Enable the job that applies default Gloo Edge custom resources at install and upgrade time (default true)."`
+	Image                   *Image                `json:"image,omitempty"`
+	Resources               *ResourceRequirements `json:"resources,omitempty"`
+	FloatingUserId          *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
+	RunAsUser               *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
+	TtlSecondsAfterFinished *int                  `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
+	ActiveDeadlineSeconds   *int                  `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
 }
 
 type CleanupJob struct {
-	Image                   *Image   `json:"image,omitempty"`
-	FloatingUserId          *bool    `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
-	RunAsUser               *float64 `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
-	TtlSecondsAfterFinished *int     `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
-	ActiveDeadlineSeconds   *int     `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
+	*JobSpec
+	Enabled                 *bool                 `json:"enabled,omitempty" desc:"Enable the job that removes Gloo Edge custom resources when Gloo Edge is uninstalled (default true)."`
+	Image                   *Image                `json:"image,omitempty"`
+	Resources               *ResourceRequirements `json:"resources,omitempty"`
+	FloatingUserId          *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
+	RunAsUser               *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
+	TtlSecondsAfterFinished *int                  `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
+	ActiveDeadlineSeconds   *int                  `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
 }
 
 /*

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -78,6 +78,8 @@ type PodSpec struct {
 
 type JobSpec struct {
 	*PodSpec
+	ActiveDeadlineSeconds   *int `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
+	TtlSecondsAfterFinished *int `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
 }
 
 type DeploymentSpecSansResources struct {
@@ -310,37 +312,31 @@ type Job struct {
 
 type CertGenJob struct {
 	Job
-	Enabled                 *bool                 `json:"enabled,omitempty" desc:"enable the job that generates the certificates for the validating webhook at install time (default true)"`
-	SetTtlAfterFinished     *bool                 `json:"setTtlAfterFinished,omitempty" desc:"Set ttlSecondsAfterFinished (a k8s feature in Alpha) on the job. Defaults to true"`
-	TtlSecondsAfterFinished *int                  `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
-	FloatingUserId          *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
-	RunAsUser               *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
-	Resources               *ResourceRequirements `json:"resources,omitempty"`
-	RunOnUpdate             *bool                 `json:"runOnUpdate,omitempty" desc:"enable to run the job also on pre-upgrade"`
-	ActiveDeadlineSeconds   *int                  `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
-	Cron                    *CertGenCron          `json:"cron,omitempty" desc:"CronJob parameters"`
+	Enabled             *bool                 `json:"enabled,omitempty" desc:"enable the job that generates the certificates for the validating webhook at install time (default true)"`
+	SetTtlAfterFinished *bool                 `json:"setTtlAfterFinished,omitempty" desc:"Set ttlSecondsAfterFinished on the job. Defaults to true"`
+	FloatingUserId      *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
+	RunAsUser           *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
+	Resources           *ResourceRequirements `json:"resources,omitempty"`
+	RunOnUpdate         *bool                 `json:"runOnUpdate,omitempty" desc:"enable to run the job also on pre-upgrade"`
+	Cron                *CertGenCron          `json:"cron,omitempty" desc:"CronJob parameters"`
 }
 
 type RolloutJob struct {
 	*JobSpec
-	Enabled                 *bool                 `json:"enabled,omitempty" desc:"Enable the job that applies default Gloo Edge custom resources at install and upgrade time (default true)."`
-	Image                   *Image                `json:"image,omitempty"`
-	Resources               *ResourceRequirements `json:"resources,omitempty"`
-	FloatingUserId          *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
-	RunAsUser               *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
-	TtlSecondsAfterFinished *int                  `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
-	ActiveDeadlineSeconds   *int                  `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
+	Enabled        *bool                 `json:"enabled,omitempty" desc:"Enable the job that applies default Gloo Edge custom resources at install and upgrade time (default true)."`
+	Image          *Image                `json:"image,omitempty"`
+	Resources      *ResourceRequirements `json:"resources,omitempty"`
+	FloatingUserId *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
+	RunAsUser      *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
 }
 
 type CleanupJob struct {
 	*JobSpec
-	Enabled                 *bool                 `json:"enabled,omitempty" desc:"Enable the job that removes Gloo Edge custom resources when Gloo Edge is uninstalled (default true)."`
-	Image                   *Image                `json:"image,omitempty"`
-	Resources               *ResourceRequirements `json:"resources,omitempty"`
-	FloatingUserId          *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
-	RunAsUser               *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
-	TtlSecondsAfterFinished *int                  `json:"ttlSecondsAfterFinished,omitempty" desc:"Clean up the finished job after this many seconds. Defaults to 60"`
-	ActiveDeadlineSeconds   *int                  `json:"activeDeadlineSeconds,omitempty" desc:"Deadline in seconds for Kubernetes jobs."`
+	Enabled        *bool                 `json:"enabled,omitempty" desc:"Enable the job that removes Gloo Edge custom resources when Gloo Edge is uninstalled (default true)."`
+	Image          *Image                `json:"image,omitempty"`
+	Resources      *ResourceRequirements `json:"resources,omitempty"`
+	FloatingUserId *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
+	RunAsUser      *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
 }
 
 /*

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
@@ -15,11 +15,15 @@ metadata:
 spec:
   schedule: {{ .Values.gateway.certGenJob.cron.schedule | quote }}
   jobTemplate:
+    activeDeadlineSeconds: {{ .Values.gateway.certGenJob.activeDeadlineSeconds }}
     spec:
       template:
         metadata:
           labels:
             gloo: gloo-mtls-certs
+            {{- if .Values.global.istioIntegration.disableAutoinjection }}
+            sidecar.istio.io/inject: "false"
+            {{- end }}
         spec:
           {{- include "gloo.pullSecret" $image | nindent 10 -}}
           serviceAccountName: certgen
@@ -33,6 +37,9 @@ spec:
                 {{- if not .Values.gateway.certGenJob.floatingUserId }}
                 runAsUser: {{ printf "%.0f" (float64 .Values.gateway.certGenJob.runAsUser) -}}
                 {{- end }}
+              {{- with .Values.gateway.certGenJob.resources }}
+              resources: {{ toYaml . | nindent 16 }}
+              {{- end }}
               env:
                 - name: POD_NAMESPACE
                   valueFrom:
@@ -42,13 +49,9 @@ spec:
                 - "--secret-name=gloo-mtls-certs"
                 - "--svc-name=gloo"
                 - "--force-rotation=true"
-          restartPolicy: Never
-      # this feature is still in Alpha, which means it must be manually enabled in the k8s api server
-      # with --feature-gates="TTLAfterFinished=true". This flag also works with minikube start ...
-      # if the feature flag is not enabled in the k8s api server, this setting will be silently ignored at creation time
-      {{- if semverCompare ">=1.12" .Capabilities.KubeVersion.GitVersion }}
-      ttlSecondsAfterFinished: 60
-  {{- end }}
+      {{- if .Values.gateway.certGenJob.setTtlAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.gateway.certGenJob.ttlSecondsAfterFinished }}
+      {{- end }}
 {{- end }} {{/* if and .Values.global.glooMtls.enabled .Values.gateway.certGenJob.cron.enabled */}}
 {{- end }} {{/* define gateway.certGenJob.JobSpec*/}}
 

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
@@ -15,8 +15,8 @@ metadata:
 spec:
   schedule: {{ .Values.gateway.certGenJob.cron.schedule | quote }}
   jobTemplate:
-    activeDeadlineSeconds: {{ .Values.gateway.certGenJob.activeDeadlineSeconds }}
     spec:
+      activeDeadlineSeconds: {{ .Values.gateway.certGenJob.activeDeadlineSeconds }}
       template:
         metadata:
           labels:

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -26,6 +26,9 @@ spec:
     metadata:
       labels:
         gloo: gloo-mtls-certs
+        {{- if .Values.global.istioIntegration.disableAutoinjection }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: certgen
@@ -39,6 +42,9 @@ spec:
             {{- if not .Values.gateway.certGenJob.floatingUserId }}
             runAsUser: {{ printf "%.0f" (float64 .Values.gateway.certGenJob.runAsUser) -}}
             {{- end }}
+          {{- with .Values.gateway.certGenJob.resources }}
+          resources: {{ toYaml . | nindent 12}}
+          {{- end }}
           env:
             - name: POD_NAMESPACE
               valueFrom:
@@ -47,12 +53,8 @@ spec:
           args:
             - "--secret-name=gloo-mtls-certs"
             - "--svc-name=gloo"
-      restartPolicy: Never
-  # this feature is still in Alpha, which means it must be manually enabled in the k8s api server
-  # with --feature-gates="TTLAfterFinished=true". This flag also works with minikube start ...
-  # if the feature flag is not enabled in the k8s api server, this setting will be silently ignored at creation time
-  {{- if semverCompare ">=1.12" .Capabilities.KubeVersion.GitVersion }}
-  ttlSecondsAfterFinished: 60
+  {{- if .Values.gateway.certGenJob.setTtlAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.gateway.certGenJob.ttlSecondsAfterFinished }}
   {{- end }}
 {{- end }} {{/* if .Values.global.glooMtls.enabled */}}
 {{- end }} {{/* define gateway.certGenJob.JobSpec*/}}

--- a/install/helm/gloo/templates/5-resource-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-resource-cleanup-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.cleanupJob.enabled }}
 {{- $image := .Values.gateway.cleanupJob.image }}
 {{- if .Values.global }}
 {{- $image = merge .Values.gateway.cleanupJob.image .Values.global.image }}
@@ -20,9 +21,13 @@ spec:
     metadata:
       labels:
         gloo: resource-cleanup
+        {{- if .Values.global.istioIntegration.disableAutoinjection }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gloo-resource-cleanup
+      {{- include "gloo.podSpecStandardFields" .Values.gateway.cleanupJob | nindent 6 -}}
       containers:
         - name: kubectl
           image: {{template "gloo.image" $image}}
@@ -32,6 +37,9 @@ spec:
             {{- if not .Values.gateway.cleanupJob.floatingUserId }}
             runAsUser: {{ printf "%.0f" (float64 .Values.gateway.cleanupJob.runAsUser) -}}
             {{- end }}
+          {{- with .Values.gateway.cleanupJob.resources }}
+          resources: {{ toYaml . | nindent 12}}
+          {{- end }}
           command:
           - /bin/sh
           - -c
@@ -43,7 +51,9 @@ spec:
             {{- range include "gloo.gatewayNamespaces" . | fromJsonArray }}
             kubectl delete --ignore-not-found gateways.gateway.solo.io -n {{ . }} -l app=gloo || exit $?
             {{- end }}
+      {{- if not .Values.gateway.cleanupJob.restartPolicy }}
       restartPolicy: OnFailure
+      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.gateway.cleanupJob.ttlSecondsAfterFinished }}
 {{- if .Values.global.glooRbac.create }}
 ---
@@ -137,3 +147,4 @@ subjects:
   name: gloo-resource-cleanup
   namespace: {{ .Release.Namespace }}
 {{- end }}{{/* if .Values.global.glooRbac.create */}}
+{{- end }}{{/* if .Values.gateway.cleanupJob.enabled  */}}

--- a/install/helm/gloo/templates/5-resource-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-resource-cleanup-job.yaml
@@ -51,9 +51,6 @@ spec:
             {{- range include "gloo.gatewayNamespaces" . | fromJsonArray }}
             kubectl delete --ignore-not-found gateways.gateway.solo.io -n {{ . }} -l app=gloo || exit $?
             {{- end }}
-      {{- if not .Values.gateway.cleanupJob.restartPolicy }}
-      restartPolicy: OnFailure
-      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.gateway.cleanupJob.ttlSecondsAfterFinished }}
 {{- if .Values.global.glooRbac.create }}
 ---

--- a/install/helm/gloo/templates/5-resource-migration-job.yaml
+++ b/install/helm/gloo/templates/5-resource-migration-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.rolloutJob.enabled }}
 {{- $image := .Values.gateway.rolloutJob.image }}
 {{- if .Values.global }}
 {{- $image = merge .Values.gateway.rolloutJob.image .Values.global.image }}
@@ -20,9 +21,13 @@ spec:
     metadata:
       labels:
         gloo: resource-migration
+        {{- if .Values.global.istioIntegration.disableAutoinjection }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gloo-resource-migration
+      {{- include "gloo.podSpecStandardFields" .Values.gateway.rolloutJob | nindent 6 -}}
       containers:
         - name: kubectl
           image: {{template "gloo.image" $image}}
@@ -32,6 +37,9 @@ spec:
             {{- if not .Values.gateway.rolloutJob.floatingUserId }}
             runAsUser: {{ printf "%.0f" (float64 .Values.gateway.rolloutJob.runAsUser) -}}
             {{- end }}
+          {{- with .Values.gateway.rolloutJob.resources }}
+          resources: {{ toYaml . | nindent 12}}
+          {{- end }}
           command:
           - /bin/sh
           - -c
@@ -52,7 +60,9 @@ spec:
             kubectl annotate --overwrite gateways.gateway.solo.io -n {{ . }} -l app=gloo helm.sh/hook- helm.sh/hook-weight- meta.helm.sh/release-name- meta.helm.sh/release-namespace- helm.sh/resource-policy=keep || exit $?
             kubectl label gateways.gateway.solo.io -n {{ . }} -l app=gloo,app.kubernetes.io/managed-by=Helm app.kubernetes.io/managed-by- || exit $?
             {{- end }}
+      {{- if not .Values.gateway.rolloutJob.restartPolicy }}
       restartPolicy: OnFailure
+      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.gateway.rolloutJob.ttlSecondsAfterFinished }}
 {{- if .Values.global.glooRbac.create }}
 ---
@@ -146,3 +156,4 @@ subjects:
   name: gloo-resource-migration
   namespace: {{ .Release.Namespace }}
 {{- end }}{{/* if .Values.global.glooRbac.create */}}
+{{- end }}{{/* if .Values.gateway.rolloutJob.enabled  */}}

--- a/install/helm/gloo/templates/5-resource-migration-job.yaml
+++ b/install/helm/gloo/templates/5-resource-migration-job.yaml
@@ -60,9 +60,6 @@ spec:
             kubectl annotate --overwrite gateways.gateway.solo.io -n {{ . }} -l app=gloo helm.sh/hook- helm.sh/hook-weight- meta.helm.sh/release-name- meta.helm.sh/release-namespace- helm.sh/resource-policy=keep || exit $?
             kubectl label gateways.gateway.solo.io -n {{ . }} -l app=gloo,app.kubernetes.io/managed-by=Helm app.kubernetes.io/managed-by- || exit $?
             {{- end }}
-      {{- if not .Values.gateway.rolloutJob.restartPolicy }}
-      restartPolicy: OnFailure
-      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.gateway.rolloutJob.ttlSecondsAfterFinished }}
 {{- if .Values.global.glooRbac.create }}
 ---

--- a/install/helm/gloo/templates/5-resource-rollout-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.gateway.rolloutJob.enabled }}
 {{- $image := .Values.gateway.rolloutJob.image }}
 {{- if .Values.global }}
 {{- $image = merge .Values.gateway.rolloutJob.image .Values.global.image }}
@@ -20,9 +21,13 @@ spec:
     metadata:
       labels:
         gloo: resource-rollout
+        {{- if .Values.global.istioIntegration.disableAutoinjection }}
+        sidecar.istio.io/inject: "false"
+        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gloo-resource-rollout
+      {{- include "gloo.podSpecStandardFields" .Values.gateway.rolloutJob | nindent 6 -}}
       containers:
         - name: kubectl
           image: {{template "gloo.image" $image}}
@@ -32,6 +37,9 @@ spec:
             {{- if not .Values.gateway.rolloutJob.floatingUserId }}
             runAsUser: {{ printf "%.0f" (float64 .Values.gateway.rolloutJob.runAsUser) -}}
             {{- end }}
+          {{- with .Values.gateway.rolloutJob.resources }}
+          resources: {{ toYaml . | nindent 12}}
+          {{- end }}
           command:
           - /bin/sh
           - -c
@@ -56,7 +64,9 @@ spec:
             {{- range include "gloo.gatewayNamespaces" $ | fromJsonArray }}
             kubectl annotate gateways.gateway.solo.io -n {{ . }} -l app=gloo helm.sh/resource-policy- || exit $?
             {{- end }}
+      {{- if not .Values.gateway.rolloutJob.restartPolicy }}
       restartPolicy: OnFailure
+      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.gateway.rolloutJob.ttlSecondsAfterFinished }}
 {{- if .Values.global.glooRbac.create }}
 ---
@@ -150,3 +160,4 @@ subjects:
   name: gloo-resource-rollout
   namespace: {{ .Release.Namespace }}
 {{- end -}}{{/* if .Values.global.glooRbac.create */}}
+{{- end }}{{/* if .Values.gateway.rolloutJob.enabled  */}}

--- a/install/helm/gloo/templates/5-resource-rollout-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job.yaml
@@ -64,9 +64,6 @@ spec:
             {{- range include "gloo.gatewayNamespaces" $ | fromJsonArray }}
             kubectl annotate gateways.gateway.solo.io -n {{ . }} -l app=gloo helm.sh/resource-policy- || exit $?
             {{- end }}
-      {{- if not .Values.gateway.rolloutJob.restartPolicy }}
-      restartPolicy: OnFailure
-      {{- end }}
   ttlSecondsAfterFinished: {{ .Values.gateway.rolloutJob.ttlSecondsAfterFinished }}
 {{- if .Values.global.glooRbac.create }}
 ---

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -23,10 +23,9 @@ spec:
     metadata:
       labels:
         gloo: gateway-certgen
-      {{- if .Values.global.istioIntegration.disableAutoinjection }}
-      annotations:
+        {{- if .Values.global.istioIntegration.disableAutoinjection }}
         sidecar.istio.io/inject: "false"
-      {{- end }}
+        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: certgen

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -45,17 +45,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
           args:
-
             - "--secret-name={{ .Values.gateway.validation.secretName }}"
             - "--svc-name=gloo"
             - "--validating-webhook-configuration-name=gloo-gateway-validation-webhook-{{ .Release.Namespace }}"
         {{- with .Values.gateway.certGenJob.resources }}
           resources: {{ toYaml . | nindent 12}}
         {{- end }}
-  # this feature is still in Alpha, which means it must be manually enabled in the k8s api server
-  # with --feature-gates="TTLAfterFinished=true". This flag also works with minikube start ...
-  # if the feature flag is not enabled in the k8s api server, this setting will be silently ignored at creation time
-  {{- if and .Values.gateway.certGenJob.setTtlAfterFinished (semverCompare ">=1.12" .Capabilities.KubeVersion.GitVersion) }}
+  {{- if .Values.gateway.certGenJob.setTtlAfterFinished }}
   ttlSecondsAfterFinished: {{ .Values.gateway.certGenJob.ttlSecondsAfterFinished }}
   {{- end }}
 {{- end }} {{/* if and gateway.enabled gateway.validation.enabled gateway.certGenJob.enabled */}}

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -91,12 +91,14 @@ gateway:
       schedule: "* * * * *"
     runOnUpdate: false
   rolloutJob:
+    enabled: true
     image:
       repository: kubectl
     runAsUser: 10101
     activeDeadlineSeconds: 100
     ttlSecondsAfterFinished: 60
   cleanupJob:
+    enabled: true
     image:
       repository: kubectl
     runAsUser: 10101

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -94,6 +94,7 @@ gateway:
     enabled: true
     image:
       repository: kubectl
+    restartPolicy: OnFailure
     runAsUser: 10101
     activeDeadlineSeconds: 100
     ttlSecondsAfterFinished: 60
@@ -101,6 +102,7 @@ gateway:
     enabled: true
     image:
       repository: kubectl
+    restartPolicy: OnFailure
     runAsUser: 10101
     activeDeadlineSeconds: 100
     ttlSecondsAfterFinished: 60

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -5117,18 +5117,22 @@ metadata:
 							}, extraArgs...),
 						})
 						resources := testManifest.SelectResources(func(u *unstructured.Unstructured) bool {
+							var prefixPath []string
+							if kind == "CronJob" {
+								prefixPath = []string{"spec", "jobTemplate"}
+							}
 							if u.GetKind() == kind && u.GetName() == resourceName {
-								a := getFieldFromUnstructured(u, "spec", "template", "spec", "nodeSelector")
+								a := getFieldFromUnstructured(u, append(prefixPath, "spec", "template", "spec", "nodeSelector")...)
 								Expect(a).To(Equal(map[string]interface{}{"label": "someLabel"}))
-								a = getFieldFromUnstructured(u, "spec", "template", "spec", "nodeName")
+								a = getFieldFromUnstructured(u, append(prefixPath, "spec", "template", "spec", "nodeName")...)
 								Expect(a).To(Equal("someNodeName"))
-								a = getFieldFromUnstructured(u, "spec", "template", "spec", "tolerations")
+								a = getFieldFromUnstructured(u, append(prefixPath, "spec", "template", "spec", "tolerations")...)
 								Expect(a).To(Equal([]interface{}{map[string]interface{}{"operator": "someToleration"}}))
-								a = getFieldFromUnstructured(u, "spec", "template", "spec", "hostAliases")
+								a = getFieldFromUnstructured(u, append(prefixPath, "spec", "template", "spec", "hostAliases")...)
 								Expect(a).To(Equal([]interface{}{"someHostAlias"}))
-								a = getFieldFromUnstructured(u, "spec", "template", "spec", "affinity")
+								a = getFieldFromUnstructured(u, append(prefixPath, "spec", "template", "spec", "affinity")...)
 								Expect(a).To(Equal(map[string]interface{}{"nodeAffinity": "someNodeAffinity"}))
-								a = getFieldFromUnstructured(u, "spec", "template", "spec", "restartPolicy")
+								a = getFieldFromUnstructured(u, append(prefixPath, "spec", "template", "spec", "restartPolicy")...)
 								Expect(a).To(Equal("someRestartPolicy"))
 								return true
 							}
@@ -5143,6 +5147,40 @@ metadata:
 					Entry("knative external proxy deployment", "Deployment", "knative-external-proxy", "settings.integrations.knative.proxy", "settings.integrations.knative.version=0.9.0", "settings.integrations.knative.enabled=true"),
 					Entry("knative internal proxy deployment", "Deployment", "knative-internal-proxy", "settings.integrations.knative.proxy", "settings.integrations.knative.version=0.9.0", "settings.integrations.knative.enabled=true"),
 					Entry("gateway certgen job", "Job", "gateway-certgen", "gateway.certGenJob"),
+					Entry("mtls certgen job", "Job", "gloo-mtls-certgen", "gateway.certGenJob", "global.glooMtls.enabled=true"),
+					Entry("mtls certgen cronjob", "CronJob", "gloo-mtls-certgen-cronjob", "gateway.certGenJob", "global.glooMtls.enabled=true", "gateway.certGenJob.cron.enabled=true"),
+					Entry("resource rollout job", "Job", "gloo-resource-rollout", "gateway.rolloutJob"),
+					Entry("resource migration job", "Job", "gloo-resource-migration", "gateway.rolloutJob"),
+					Entry("resource cleanup job", "Job", "gloo-resource-cleanup", "gateway.cleanupJob"),
+				)
+
+				DescribeTable("activeDeadlineSeconds and ttlSecondsAfterFinished on Jobs",
+					func(kind string, resourceName string, jobValuesPrefix string, extraArgs ...string) {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: append([]string{
+								jobValuesPrefix + ".activeDeadlineSeconds=123",
+								jobValuesPrefix + ".ttlSecondsAfterFinished=42",
+							}, extraArgs...),
+						})
+						resources := testManifest.SelectResources(func(u *unstructured.Unstructured) bool {
+							var prefixPath []string
+							if kind == "CronJob" {
+								prefixPath = []string{"spec", "jobTemplate"}
+							}
+							if u.GetKind() == kind && u.GetName() == resourceName {
+								a := getFieldFromUnstructured(u, append(prefixPath, "spec", "activeDeadlineSeconds")...)
+								Expect(a).To(Equal(int64(123)))
+								a = getFieldFromUnstructured(u, append(prefixPath, "spec", "ttlSecondsAfterFinished")...)
+								Expect(a).To(Equal(int64(42)))
+								return true
+							}
+							return false
+						})
+						Expect(resources.NumResources()).To(Equal(1))
+					},
+					Entry("gateway certgen job", "Job", "gateway-certgen", "gateway.certGenJob"),
+					Entry("mtls certgen job", "Job", "gloo-mtls-certgen", "gateway.certGenJob", "global.glooMtls.enabled=true"),
+					Entry("mtls certgen cronjob", "CronJob", "gloo-mtls-certgen-cronjob", "gateway.certGenJob", "global.glooMtls.enabled=true", "gateway.certGenJob.cron.enabled=true"),
 					Entry("resource rollout job", "Job", "gloo-resource-rollout", "gateway.rolloutJob"),
 					Entry("resource migration job", "Job", "gloo-resource-migration", "gateway.rolloutJob"),
 					Entry("resource cleanup job", "Job", "gloo-resource-cleanup", "gateway.cleanupJob"),


### PR DESCRIPTION
# Description
   
Add helm customization (pod spec fields, resource requirements, disabling istio injection) that was missing from the `gloo-resource-rollout`, `gloo-resource-migration`, and `gloo-resource-cleanup` jobs. 

Allow disabling the jobs (not recommended unless default Gateways/Upstreams are not needed). 

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
