### PR TITLE
fix(tls_inspector): added AggregateListener support

### DIFF
--- a/changelog/v1.13.0-beta6/isolate-virtual-hosts-sharing.yaml
+++ b/changelog/v1.13.0-beta6/isolate-virtual-hosts-sharing.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issuelink: https://github.com/solo-io/gloo/issues/6677
+    resolvesIssue: false
+    description: Added support fo the `envoy.filters.listener.tls_inspector` listener_filter when using the gateway.isolateVirtualHostsBySslConfig=true global setting.
+      is provided

--- a/projects/gloo/pkg/plugins/tls_inspector/plugin.go
+++ b/projects/gloo/pkg/plugins/tls_inspector/plugin.go
@@ -55,7 +55,19 @@ func (p *plugin) ProcessListener(params plugins.Params, in *v1.Listener, out *en
 func shouldIncludeTlsInspectorListenerFilter(in *v1.Listener) bool {
 	return includeTlsInspectorForListener(in) ||
 		includeTlsInspectorForTcpListener(in.GetTcpListener()) ||
-		includeTlsInspectorForHybridListener(in.GetHybridListener())
+		includeTlsInspectorForHybridListener(in.GetHybridListener()) ||
+		includeTlsInspectorForAggregateListener(in.GetAggregateListener())
+}
+
+func includeTlsInspectorForAggregateListener(in *v1.AggregateListener) bool {
+	// check all httpFilterChains for a matcher-specified ssl config
+	for _, filterChain := range in.GetHttpFilterChains() {
+		if filterChain.GetMatcher().GetSslConfig() != nil {
+			return true
+		}
+	}
+
+	return false
 }
 
 func includeTlsInspectorForListener(in *v1.Listener) bool {


### PR DESCRIPTION
[envoy.filters.listener.tls_inspector](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/listener_filters/tls_inspector) is an essential [listener_filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/listeners/listener_filters/listener_filters) when attempting to use TLS.  For _most_ gateways, we would previously always consider logic on whether or not to add it based on the presence of a user-provided SslConfig field.  For the new [AggregateListener](https://github.com/solo-io/gloo/pull/6558/files#diff-2272a3c8b202d19594dd9a455396b8fd7504a83cdd5eeacc918cecca586f2375), we neglected to add support, originally.  This caused TLS to be unable to function when using the [isolateVirtualHostsBySslConfig](https://docs.solo.io/gloo-edge/latest/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/settings.proto.sk/) feature flag.

related https://github.com/solo-io/gloo/issues/6677