### PR TITLE
Remove default activeDeadlineSeconds from jobs

### DIFF
--- a/changelog/v1.13.0-beta6/remove-default-activedeadline.yaml
+++ b/changelog/v1.13.0-beta6/remove-default-activedeadline.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6821
+    description: Remove default activeDeadlineSeconds from jobs.

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -276,7 +276,7 @@
 |gateway.certGenJob.tolerations[].tolerationSeconds|int64|||
 |gateway.certGenJob.affinity.NAME|interface|||
 |gateway.certGenJob.hostAliases[]|interface|||
-|gateway.certGenJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
+|gateway.certGenJob.activeDeadlineSeconds|int||Deadline in seconds for Kubernetes jobs.|
 |gateway.certGenJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.certGenJob.kubeResourceOverride.NAME|interface||override fields in the gateway-certgen job.|
 |gateway.certGenJob.mtlsKubeResourceOverride.NAME|interface||override fields in the gloo-mtls-certgen job.|
@@ -303,7 +303,7 @@
 |gateway.rolloutJob.tolerations[].tolerationSeconds|int64|||
 |gateway.rolloutJob.affinity.NAME|interface|||
 |gateway.rolloutJob.hostAliases[]|interface|||
-|gateway.rolloutJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
+|gateway.rolloutJob.activeDeadlineSeconds|int||Deadline in seconds for Kubernetes jobs.|
 |gateway.rolloutJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.rolloutJob.enabled|bool|true|Enable the job that applies default Gloo Edge custom resources at install and upgrade time (default true).|
 |gateway.rolloutJob.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
@@ -331,7 +331,7 @@
 |gateway.cleanupJob.tolerations[].tolerationSeconds|int64|||
 |gateway.cleanupJob.affinity.NAME|interface|||
 |gateway.cleanupJob.hostAliases[]|interface|||
-|gateway.cleanupJob.activeDeadlineSeconds|int|100|Deadline in seconds for Kubernetes jobs.|
+|gateway.cleanupJob.activeDeadlineSeconds|int||Deadline in seconds for Kubernetes jobs.|
 |gateway.cleanupJob.ttlSecondsAfterFinished|int|60|Clean up the finished job after this many seconds. Defaults to 60|
 |gateway.cleanupJob.enabled|bool|true|Enable the job that removes Gloo Edge custom resources when Gloo Edge is uninstalled (default true).|
 |gateway.cleanupJob.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
@@ -16,7 +16,9 @@ spec:
   schedule: {{ .Values.gateway.certGenJob.cron.schedule | quote }}
   jobTemplate:
     spec:
-      activeDeadlineSeconds: {{ .Values.gateway.certGenJob.activeDeadlineSeconds }}
+      {{- with .Values.gateway.certGenJob.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ . }}
+      {{- end }}
       template:
         metadata:
           labels:

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -21,7 +21,9 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
-  activeDeadlineSeconds: {{ .Values.gateway.certGenJob.activeDeadlineSeconds }}
+  {{- with .Values.gateway.certGenJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/gloo/templates/5-resource-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-resource-cleanup-job.yaml
@@ -16,7 +16,9 @@ metadata:
     "helm.sh/hook-weight": "5" # run this job after the role/rolebinding is created
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
-  activeDeadlineSeconds: {{ .Values.gateway.cleanupJob.activeDeadlineSeconds }}
+  {{- with .Values.gateway.cleanupJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/gloo/templates/5-resource-migration-job.yaml
+++ b/install/helm/gloo/templates/5-resource-migration-job.yaml
@@ -16,7 +16,9 @@ metadata:
     "helm.sh/hook-weight": "3" # run this job after the role/rolebinding is created, and before the validation webhook is upgraded
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
-  activeDeadlineSeconds: {{ .Values.gateway.rolloutJob.activeDeadlineSeconds }}
+  {{- with .Values.gateway.rolloutJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/gloo/templates/5-resource-rollout-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job.yaml
@@ -16,7 +16,9 @@ metadata:
     "helm.sh/hook-weight": "5" # run this job after the role/rolebinding is created
     "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
 spec:
-  activeDeadlineSeconds: {{ .Values.gateway.rolloutJob.activeDeadlineSeconds }}
+  {{- with .Values.gateway.rolloutJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -18,7 +18,9 @@ metadata:
     "helm.sh/hook-weight": "10"
     "helm.sh/hook-delete-policy": hook-succeeded
 spec:
-  activeDeadlineSeconds: {{ .Values.gateway.certGenJob.activeDeadlineSeconds }}
+  {{- with .Values.gateway.certGenJob.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ . }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -85,7 +85,6 @@ gateway:
     setTtlAfterFinished: true
     ttlSecondsAfterFinished: 60
     runAsUser: 10101
-    activeDeadlineSeconds: 100
     cron:
       enabled: false
       schedule: "* * * * *"
@@ -96,7 +95,6 @@ gateway:
       repository: kubectl
     restartPolicy: OnFailure
     runAsUser: 10101
-    activeDeadlineSeconds: 100
     ttlSecondsAfterFinished: 60
   cleanupJob:
     enabled: true
@@ -104,7 +102,6 @@ gateway:
       repository: kubectl
     restartPolicy: OnFailure
     runAsUser: 10101
-    activeDeadlineSeconds: 100
     ttlSecondsAfterFinished: 60
   proxyServiceAccount: {}
 gatewayProxies:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3862,7 +3862,6 @@ metadata:
     "helm.sh/hook-weight": "10"
 spec:
   ttlSecondsAfterFinished: 60
-  activeDeadlineSeconds: 100
   template:
     metadata:
       labels:
@@ -5157,7 +5156,7 @@ metadata:
 					Entry("resource cleanup job", "Job", "gloo-resource-cleanup", "gateway.cleanupJob"),
 				)
 
-				DescribeTable("activeDeadlineSeconds and ttlSecondsAfterFinished on Jobs",
+				DescribeTable("can set activeDeadlineSeconds and ttlSecondsAfterFinished on Jobs",
 					func(kind string, resourceName string, jobValuesPrefix string, extraArgs ...string) {
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: append([]string{
@@ -5187,6 +5186,33 @@ metadata:
 					Entry("resource rollout job", "Job", "gloo-resource-rollout", "gateway.rolloutJob"),
 					Entry("resource migration job", "Job", "gloo-resource-migration", "gateway.rolloutJob"),
 					Entry("resource cleanup job", "Job", "gloo-resource-cleanup", "gateway.cleanupJob"),
+				)
+
+				DescribeTable("by default, activeDeadlineSeconds is unset on Jobs",
+					func(kind string, resourceName string, extraArgs ...string) {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: append([]string{}, extraArgs...),
+						})
+						resources := testManifest.SelectResources(func(u *unstructured.Unstructured) bool {
+							var prefixPath []string
+							if kind == "CronJob" {
+								prefixPath = []string{"spec", "jobTemplate"}
+							}
+							if u.GetKind() == kind && u.GetName() == resourceName {
+								a := getFieldFromUnstructured(u, append(prefixPath, "spec", "activeDeadlineSeconds")...)
+								Expect(a).To(BeNil())
+								return true
+							}
+							return false
+						})
+						Expect(resources.NumResources()).To(Equal(1))
+					},
+					Entry("gateway certgen job", "Job", "gateway-certgen"),
+					Entry("mtls certgen job", "Job", "gloo-mtls-certgen", "global.glooMtls.enabled=true"),
+					Entry("mtls certgen cronjob", "CronJob", "gloo-mtls-certgen-cronjob", "global.glooMtls.enabled=true", "gateway.certGenJob.cron.enabled=true"),
+					Entry("resource rollout job", "Job", "gloo-resource-rollout"),
+					Entry("resource migration job", "Job", "gloo-resource-migration"),
+					Entry("resource cleanup job", "Job", "gloo-resource-cleanup"),
 				)
 			})
 


### PR DESCRIPTION
Only set the value if it's explicitly passed in through helm values.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6821