### PR TITLE
bump alpine to 3.15.6 [1.9]

### DIFF
--- a/changelog/v1.9.24/bump-alpine.yaml
+++ b/changelog/v1.9.24/bump-alpine.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: linux
+  dependencyRepo: alpine
+  dependencyTag: 3.15.6
+  description: Bump alpine to fix CVE-2022-37434
+  issueLink: https://github.com/solo-io/gloo/issues/6901
+  resolvesIssue: false

--- a/docs/content/guides/security/tls/Dockerfile
+++ b/docs/content/guides/security/tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 COPY cert.pem /cert.pem
 COPY key.pem /key.pem

--- a/docs/examples/session-affinity/Dockerfile
+++ b/docs/examples/session-affinity/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/docs/examples/xslt-guide/Dockerfile
+++ b/docs/examples/xslt-guide/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates curl \

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/jobs/certgen/cmd/Dockerfile
+++ b/jobs/certgen/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ARG GOARCH=amd64
 

--- a/projects/accesslogger/cmd/Dockerfile
+++ b/projects/accesslogger/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ARG GOARCH=amd64
 RUN apk -U upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*

--- a/projects/discovery/cmd/Dockerfile
+++ b/projects/discovery/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ARG GOARCH=amd64
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/projects/gateway/cmd/Dockerfile
+++ b/projects/gateway/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ARG GOARCH=amd64
 

--- a/projects/ingress/cmd/Dockerfile
+++ b/projects/ingress/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ARG GOARCH=amd64
 

--- a/projects/sds/cmd/Dockerfile
+++ b/projects/sds/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.4
+FROM alpine:3.15.6
 
 ARG GOARCH=amd64
 


### PR DESCRIPTION
Bump to fix CVE: https://security.alpinelinux.org/vuln/CVE-2022-37434