### PR TITLE
Use 1 Gloo Replica in Gateway Kube Test

### DIFF
--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -133,7 +133,7 @@ gateway:
   persistProxySpec: true
 gloo:
   deployment:
-    replicas: 2
+    replicas: 1
 gatewayProxies:
   gatewayProxy:
     healthyPanicThreshold: 0


### PR DESCRIPTION
# Description

Use a single replica of the Gloo pod in the Gateway kube2e tests

# Context

We've noticed an increase in flakes with this test, after increasing the replica count. While we explore solutions to the flakes with multiple replicas, this should should allow CI to function more consistently in the meantime.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
