### PR TITLE
[1.10] Upgrade GHA to use Ubuntu-22.04

### DIFF
--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -3,7 +3,7 @@ on: pull_request
 jobs:
   codegen:
     name: codegen check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Actions
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/do-not-submit.yaml
+++ b/.github/workflows/do-not-submit.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Test changed-files
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   build:
     name: Generate versioned docs site
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - name: Free disk space
       run: |

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -17,7 +17,7 @@ on:
 jobs:
   prepare-env:
     name: Prepare Environment Variables
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     outputs:
       # The tag for the release commit (ie v1.8.0)
       release-tag-name: ${{ steps.release-tag-name.outputs.value }}
@@ -49,7 +49,7 @@ jobs:
       RELEASE_BRANCH: ${{ needs.prepare-env.outputs.release-branch }}
       SOLO_APIS_PREFIX: ${{ needs.prepare-env.outputs.solo-apis-prefix }}
     name: Publish Gloo APIs
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Actions
         uses: styfle/cancel-workflow-action@0.4.1

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   regression_tests:
     name: k8s regression tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         # knative support has been deprecated: https://github.com/solo-io/gloo/issues/5707

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   scan-images:
     name: Trivy Scan
-    runs-on: "ubuntu-18.04"
+    runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Actions
         uses: styfle/cancel-workflow-action@0.4.1

--- a/test/kube2e/containers/testrunner/Dockerfile
+++ b/test/kube2e/containers/testrunner/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 RUN apt update && apt install -y curl
 COPY --from=lachlanevenson/k8s-kubectl:v1.10.3 /usr/local/bin/kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
# Description

Backport of: https://github.com/solo-io/gloo/pull/7001

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
