### PR TITLE
github: Regression test matrix success with no cancel due to prevelan…

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -60,6 +60,7 @@ jobs:
     if: needs.prepare_env.outputs.should-run-regression-tests == 'true'
     runs-on: ubuntu-22.04
     strategy:
+      fail-fast: false
       matrix:
         # knative support has been deprecated: https://github.com/solo-io/gloo/issues/5707
         # We have removed it from our CI regression tests


### PR DESCRIPTION
Too many flakes in k8s regression means we shouldnt fail all of the matrix at least for now. 
Until we can make this faster given that cancel exists we should not fail all of them