### PR TITLE
Fix make tests for ci

### DIFF
--- a/test/make/make_test.go
+++ b/test/make/make_test.go
@@ -100,7 +100,8 @@ var _ = Describe("Make", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			remoteUrl := string(out)
-			if !strings.Contains(remoteUrl, "git@github.com:solo-io/gloo.git") {
+			if !strings.Contains(remoteUrl, "git@github.com:solo-io/gloo.git") &&
+				!strings.Contains(remoteUrl, "https://www.github.com/solo-io/gloo.git") {
 				// we are on a fork
 				Skip("skip")
 			}
@@ -119,7 +120,8 @@ var _ = Describe("Make", func() {
 
 			expectedVersion := "0.0.0-fork"
 			remoteUrl := string(out)
-			if strings.Contains(remoteUrl, "git@github.com:solo-io/gloo.git") {
+			if strings.Contains(remoteUrl, "git@github.com:solo-io/gloo.git") ||
+				strings.Contains(remoteUrl, "https://www.github.com/solo-io/gloo.git") {
 				out, err := exec.Command("git", "describe", "--tags", "--abbrev=0").CombinedOutput()
 				Expect(err).NotTo(HaveOccurred())
 				gitDesc := strings.TrimSpace(string(out))
@@ -140,7 +142,8 @@ var _ = Describe("Make", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			remoteUrl := string(out)
-			if !strings.Contains(remoteUrl, "git@github.com:solo-io/gloo.git") {
+			if !strings.Contains(remoteUrl, "git@github.com:solo-io/gloo.git") &&
+				!strings.Contains(remoteUrl, "https://www.github.com/solo-io/gloo.git") {
 				// we are on a fork
 				Skip("skip")
 			}


### PR DESCRIPTION
# Description

ci make tests return different origin url string, related https://github.com/solo-io/gloo/pull/7018

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
