### PR TITLE
fixes #5961 disable strict response headers to allow websocket connections

### DIFF
--- a/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/12-ingress-proxy-configmap.yaml
@@ -18,6 +18,7 @@ data:
         static_layer:
           overload:
             global_downstream_max_connections: 250000
+          envoy.reloadable_features.require_strict_1xx_and_204_response_headers: false
       - name: admin_layer
         admin_layer: {}
     node:


### PR DESCRIPTION
# Description

This pr fixes #5961 by adding the config line to disable require_strict_1xx_and_204_response_headers by default. 
The disabling is necessary to connect websocket connections through the gateway .

# Context

Users ran into this bug doing websocket connections e.g. SignalR.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
