### PR TITLE
Fix gateway ssl test flakes

### DIFF
--- a/test/e2e/gateway_test.go
+++ b/test/e2e/gateway_test.go
@@ -145,9 +145,15 @@ var _ = Describe("Gateway", func() {
 							},
 						}
 					}
-
-					_, err := gatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						current, err := gatewayClient.Read(g.Metadata.Namespace, g.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+						if err != nil {
+							return err
+						}
+						g.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+						_, err = gatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+						return err
+					}, "5s", "0.3s").ShouldNot(HaveOccurred())
 				}
 
 				// write a virtual service so we have a proxy
@@ -727,9 +733,16 @@ var _ = Describe("Gateway", func() {
 						if tcpGateway != nil {
 							tcpGateway.TcpHosts = []*gloov1.TcpHost{host}
 						}
+						Eventually(func() error {
+							current, err := gatewayClient.Read(g.Metadata.Namespace, g.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+							if err != nil {
+								return err
+							}
+							g.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+							_, err = gatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+							return err
+						}, "5s", "0.3s").ShouldNot(HaveOccurred())
 
-						_, err := gatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-						Expect(err).NotTo(HaveOccurred())
 					}
 
 					// Check tls inspector is correctly configured
@@ -835,8 +848,15 @@ var _ = Describe("Gateway", func() {
 						},
 					},
 				}
-				_, err = testClients.GatewayClient.Write(modifiedHybridGateway, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					current, err := testClients.GatewayClient.Read(modifiedHybridGateway.Metadata.Namespace, modifiedHybridGateway.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+					if err != nil {
+						return err
+					}
+					modifiedHybridGateway.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+					_, err = testClients.GatewayClient.Write(modifiedHybridGateway, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+					return err
+				}, "5s", "0.3s").ShouldNot(HaveOccurred())
 
 				// wait for hybrid listener to propagate to the proxy
 				gloohelpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
@@ -883,8 +903,15 @@ var _ = Describe("Gateway", func() {
 						Port: uint32(svc.Spec.Ports[0].Port),
 					},
 				}
-				_, err = testClients.VirtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() error {
+					current, err := testClients.VirtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+					if err != nil {
+						return err
+					}
+					virtualService.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+					_, err = testClients.VirtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+					return err
+				}, "5s", "0.3s").ShouldNot(HaveOccurred())
 
 				// Wait for proxy to be accepted
 				var proxy *gloov1.Proxy
@@ -1018,8 +1045,15 @@ var _ = Describe("Gateway", func() {
 							},
 						}}}
 
-					_, err := testClients.VirtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						current, err := testClients.VirtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+						if err != nil {
+							return err
+						}
+						virtualService.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+						_, err = testClients.VirtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+						return err
+					}, "5s", "0.3s").ShouldNot(HaveOccurred())
 
 					// Create a regular request
 					request, err := http.NewRequest("GET", fmt.Sprintf("http://localhost:%d/", defaults.HybridPort), nil)
@@ -1093,14 +1127,27 @@ var _ = Describe("Gateway", func() {
 									SslConfig: sslConfig,
 								}
 							}
-
-							_, err := testClients.GatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-							Expect(err).NotTo(HaveOccurred())
+							Eventually(func() error {
+								current, err := testClients.GatewayClient.Read(g.Metadata.Namespace, g.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+								if err != nil {
+									return err
+								}
+								g.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+								_, err = testClients.GatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+								return err
+							}, "5s", "0.3s").ShouldNot(HaveOccurred())
 						}
 
 						virtualService.SslConfig = sslConfig
-						_, err = testClients.VirtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-						Expect(err).NotTo(HaveOccurred())
+						Eventually(func() error {
+							current, err := testClients.VirtualServiceClient.Read(virtualService.Metadata.Namespace, virtualService.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+							if err != nil {
+								return err
+							}
+							virtualService.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+							_, err = testClients.VirtualServiceClient.Write(virtualService, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+							return err
+						}, "5s", "0.3s").ShouldNot(HaveOccurred())
 
 						TestUpstreamSslReachable()
 
@@ -1204,9 +1251,15 @@ var _ = Describe("Gateway", func() {
 								},
 							}
 						}
-
-						_, err := testClients.GatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
-						Expect(err).NotTo(HaveOccurred())
+						Eventually(func() error {
+							current, err := testClients.GatewayClient.Read(g.Metadata.Namespace, g.Metadata.Name, clients.ReadOpts{Ctx: ctx})
+							if err != nil {
+								return err
+							}
+							g.Metadata.ResourceVersion = current.Metadata.ResourceVersion
+							_, err = testClients.GatewayClient.Write(g, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+							return err
+						}, "5s", "0.3s").ShouldNot(HaveOccurred())
 					}
 
 					// Check tls inspector is correctly configured


### PR DESCRIPTION
# Description

Related https://github.com/solo-io/gloo/issues/7044

Test flakes happened because of resource version conflicts on update (e.g. status update race)

fixes errors of this kind:
```
• [SLOW TEST:13.031 seconds]
Gateway in memory http gateway traffic works when rapid virtual service creation and deletion causes no race conditions 
/workspace/gloo/test/e2e/gateway_test.go:402
------------------------------
••••Fail handler msg Unexpected error:
    <*errors.resourceVersionErr | 0xc00486b700>: {
        namespace: "gloo-system",
        name: "gateway-tcp-ssl",
        given: "2",
        expected: "3",
    }
    invalid resource version gloo-system.gateway-tcp-ssl given 2, expected 3
occurred

------------------------------
• Failure [1.027 seconds]
Gateway in memory tcp gateway ssl [It] should work with ssl 
/workspace/gloo/test/e2e/gateway_test.go:694

  Unexpected error:
      <*errors.resourceVersionErr | 0xc00486b700>: {
          namespace: "gloo-system",
          name: "gateway-tcp-ssl",
          given: "2",
          expected: "3",
      }
      invalid resource version gloo-system.gateway-tcp-ssl given 2, expected 3
  occurred

  /workspace/gloo/test/e2e/gateway_test.go:732
```

as seen in https://console.cloud.google.com/cloud-build/builds;region=global/a4e696f9-d6d5-48dd-aad5-1a12861e0d65;step=10?project=solo-public

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
