### PR TITLE
fix(hcm): 2nd passthrough of subfields to make nullable

### DIFF
--- a/changelog/v1.13.0-beta12/hcm-0-value-overrides.yaml
+++ b/changelog/v1.13.0-beta12/hcm-0-value-overrides.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6476
+    resolvesIssue: false
+    description: Enable HCM options to support 0-value overrides for `Duration` and `ResourceRef` object types

--- a/projects/gateway/pkg/translator/hybrid_translator_test.go
+++ b/projects/gateway/pkg/translator/hybrid_translator_test.go
@@ -20,11 +20,13 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	. "github.com/solo-io/gloo/projects/gateway/pkg/translator"
+	envoytrace_gloo "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/config/trace/v3"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	gloov1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	hcm "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/hcm"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/tcp"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/tracing"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/solo-kit/pkg/utils/prototime"
 )
@@ -296,20 +298,8 @@ var _ = Describe("Hybrid Translator", func() {
 
 			Context("anscestry override logic", func() {
 				var (
-					parent  *v1.DelegatedHttpGateway
-					child   *v1.MatchableHttpGateway
-					sslTrue *gloov1.SslConfig = &gloov1.SslConfig{
-						OneWayTls: &wrapperspb.BoolValue{
-							Value: true,
-						},
-					}
-
-					// sslEmpty *gloov1.SslConfig                  = &gloov1.SslConfig{}
-					hcmTrue *hcm.HttpConnectionManagerSettings = &hcm.HttpConnectionManagerSettings{
-						SkipXffAppend: &wrapperspb.BoolValue{
-							Value: true,
-						},
-					}
+					parent *v1.DelegatedHttpGateway
+					child  *v1.MatchableHttpGateway
 
 					sslNil  *gloov1.SslConfig
 					sslZero = &gloov1.SslConfig{
@@ -326,15 +316,11 @@ var _ = Describe("Hybrid Translator", func() {
 				)
 
 				type DesiredResult int64
-
 				const (
 					False DesiredResult = iota
 					True
 					Nil
 					Error
-					EmptyString
-					StringA
-					StringB
 				)
 
 				BeforeEach(func() {
@@ -385,171 +371,182 @@ var _ = Describe("Hybrid Translator", func() {
 					child = snap.HttpGateways[0]
 				})
 
-				DescribeTable("SslConfig anscestry override tests", func(childSsl, parentSsl *gloov1.SslConfig, preventChildOverrides bool, desiredResult DesiredResult) {
-					parent.PreventChildOverrides = preventChildOverrides
-					// config setting
-					child.GetMatcher().SslConfig = childSsl
-					parent.SslConfig = parentSsl
+				Context("SslConfig", func() {
+					DescribeTable("SslConfig anscestry override tests", func(childSsl, parentSsl *gloov1.SslConfig, preventChildOverrides bool, desiredResult DesiredResult) {
+						parent.PreventChildOverrides = preventChildOverrides
+						// config setting
+						child.GetMatcher().SslConfig = childSsl
+						parent.SslConfig = parentSsl
 
-					// perform translation
-					params := NewTranslatorParams(ctx, snap, reports)
-					listener := hybridTranslator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])
+						// perform translation
+						params := NewTranslatorParams(ctx, snap, reports)
+						listener := hybridTranslator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])
 
-					if desiredResult == Error {
-						// evaluate results
-						Expect(reports.ValidateStrict()).To(HaveOccurred())
-						Expect(listener).To(BeNil())
-						return
-					} else {
-						// evaluate results
-						Expect(reports.ValidateStrict()).NotTo(HaveOccurred())
-						Expect(listener).NotTo(BeNil())
-					}
+						if desiredResult == Error {
+							// evaluate results
+							Expect(reports.ValidateStrict()).To(HaveOccurred())
+							Expect(listener).To(BeNil())
+							return
+						} else {
+							// evaluate results
+							Expect(reports.ValidateStrict()).NotTo(HaveOccurred())
+							Expect(listener).NotTo(BeNil())
+						}
 
-					matchedListeners := listener.GetHybridListener().GetMatchedListeners()
-					Expect(matchedListeners).To(HaveLen(1))
+						matchedListeners := listener.GetHybridListener().GetMatchedListeners()
+						Expect(matchedListeners).To(HaveLen(1))
 
-					singleMatchedListener := matchedListeners[0]
-					Expect(singleMatchedListener).NotTo(BeNil())
+						singleMatchedListener := matchedListeners[0]
+						Expect(singleMatchedListener).NotTo(BeNil())
 
-					sslAfter := singleMatchedListener.GetMatcher().GetSslConfig()
+						sslAfter := singleMatchedListener.GetMatcher().GetSslConfig()
 
-					// assertion ladder is a bit annoying, given that I needed a custom type that could be one of [true, false, nil]
-					if desiredResult == Nil {
-						Expect(sslAfter.GetOneWayTls()).To(BeNil())
-					} else if desiredResult == True {
-						Expect(sslAfter.GetOneWayTls().GetValue()).To(BeTrue())
-					} else if desiredResult == False {
-						Expect(sslAfter.GetOneWayTls().GetValue()).To(BeFalse())
-					}
-				},
-					/*┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓
-					I am sitting here, possibly having descended into madness.  In my madness, I have found it necessary/expedient to construct a 36-entry table.
-					So some explanations are in order.  In general, a field can be affected in any 1 of 4 ways:
-						* nil		| an object not existing/instantiated.							|	ssl = nil
-						* zero		| a zero-value being set on a subfield.  ex: (0, "", false)		|	ssl.OneWayTls.Value = false
-						* empty 	| object exists, but has nil subfield.							|	ssl.OneWayTls = nil
-						* set		| object exists and has populated subfield						|	ssl.OneWayTls.Value = true
-					Since our merge operations take in (childSsl, parentSsl, PreventChildOverrides), this leaves 4*4*2 = 36 possible combinations to test.
+						// assertion ladder is a bit annoying, given that I needed a custom type that could be one of [true, false, nil]
+						if desiredResult == Nil {
+							Expect(sslAfter.GetOneWayTls()).To(BeNil())
+						} else if desiredResult == True {
+							Expect(sslAfter.GetOneWayTls().GetValue()).To(BeTrue())
+						} else if desiredResult == False {
+							Expect(sslAfter.GetOneWayTls().GetValue()).To(BeFalse())
+						}
+					},
+						/*┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓
+						I am sitting here, possibly having descended into madness.  In my madness, I have found it necessary/expedient to construct a 36-entry table.
+						So some explanations are in order.  In general, a field can be affected in any 1 of 4 ways:
+							* nil		| an object not existing/instantiated.							|	ssl = nil
+							* zero		| a zero-value being set on a subfield.  ex: (0, "", false)		|	ssl.OneWayTls.Value = false
+							* empty 	| object exists, but has nil subfield.							|	ssl.OneWayTls = nil
+							* set		| object exists and has populated subfield						|	ssl.OneWayTls.Value = true
+						Since our merge operations take in (childSsl, parentSsl, PreventChildOverrides), this leaves 4*4*2 = 36 possible combinations to test.
 
-					When performing all of said combinations on a _nested_ field, such as ssl.OneWayTls.Value, there are 4 possible results:
-						* True		| ssl.OneWayTls.Value is true
-						* False		| ssl.OneWayTls.Value is false
-						* Nil		| ssl or OneWayTls is nil
-						* Error		| translation failed; see "anscestry override tests for mismatched ssl definitions" for exact details
-					(┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓)*/
-					Entry("nil,nil,1", sslNil, sslNil, true, Nil),
-					Entry("nil,nil,0", sslNil, sslNil, false, Nil),
-					Entry("nil,zero,1", sslNil, sslZero, true, Error),
-					Entry("nil,zero,0", sslNil, sslZero, false, Error),
-					Entry("nil,empty,1", sslNil, sslEmpty, true, Error),
-					Entry("nil,empty,0", sslNil, sslEmpty, false, Error),
-					Entry("nil,set,1", sslNil, sslSet, true, Error),
-					Entry("nil,set,0", sslNil, sslSet, false, Error),
+						When performing all of said combinations on a _nested_ field, such as ssl.OneWayTls.Value, there are 4 possible results:
+							* True		| ssl.OneWayTls.Value is true
+							* False		| ssl.OneWayTls.Value is false
+							* Nil		| ssl or OneWayTls is nil
+							* Error		| translation failed; when either parent XOR child has ssl defined, we should yield an error on the report
+						(┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓			┏(･o･)┛♪┗ (･o･) ┓)*/
+						Entry("nil,nil,1", sslNil, sslNil, true, Nil),
+						Entry("nil,nil,0", sslNil, sslNil, false, Nil),
+						Entry("nil,zero,1", sslNil, sslZero, true, Error),
+						Entry("nil,zero,0", sslNil, sslZero, false, Error),
+						Entry("nil,empty,1", sslNil, sslEmpty, true, Error),
+						Entry("nil,empty,0", sslNil, sslEmpty, false, Error),
+						Entry("nil,set,1", sslNil, sslSet, true, Error),
+						Entry("nil,set,0", sslNil, sslSet, false, Error),
 
-					Entry("zero,nil,1", sslZero, sslNil, true, Error),
-					Entry("zero,nil,0", sslZero, sslNil, false, Error),
-					Entry("zero,zero,1", sslZero, sslZero, true, False),
-					Entry("zero,zero,0", sslZero, sslZero, false, False),
-					Entry("zero,empty,1", sslZero, sslEmpty, true, False),
-					Entry("zero,empty,0", sslZero, sslEmpty, false, False),
-					Entry("zero,set,1", sslZero, sslSet, true, True),
-					Entry("zero,set,0", sslZero, sslSet, false, True),
+						Entry("zero,nil,1", sslZero, sslNil, true, Error),
+						Entry("zero,nil,0", sslZero, sslNil, false, Error),
+						Entry("zero,zero,1", sslZero, sslZero, true, False),
+						Entry("zero,zero,0", sslZero, sslZero, false, False),
+						Entry("zero,empty,1", sslZero, sslEmpty, true, False),
+						Entry("zero,empty,0", sslZero, sslEmpty, false, False),
+						Entry("zero,set,1", sslZero, sslSet, true, True),
+						Entry("zero,set,0", sslZero, sslSet, false, False), // prefer child value; 0-value override
 
-					Entry("empty,nil,1", sslEmpty, sslNil, true, Error),
-					Entry("empty,nil,0", sslEmpty, sslNil, false, Error),
-					Entry("empty,zero,1", sslEmpty, sslZero, true, False),
-					Entry("empty,zero,0", sslEmpty, sslZero, false, False),
-					Entry("empty,empty,1", sslEmpty, sslEmpty, true, Nil),
-					Entry("empty,empty,0", sslEmpty, sslEmpty, false, Nil),
-					Entry("empty,set,1", sslEmpty, sslSet, true, True),
-					Entry("empty,set,0", sslEmpty, sslSet, false, True),
+						Entry("empty,nil,1", sslEmpty, sslNil, true, Error),
+						Entry("empty,nil,0", sslEmpty, sslNil, false, Error),
+						Entry("empty,zero,1", sslEmpty, sslZero, true, False),
+						Entry("empty,zero,0", sslEmpty, sslZero, false, False),
+						Entry("empty,empty,1", sslEmpty, sslEmpty, true, Nil),
+						Entry("empty,empty,0", sslEmpty, sslEmpty, false, Nil),
+						Entry("empty,set,1", sslEmpty, sslSet, true, True),
+						Entry("empty,set,0", sslEmpty, sslSet, false, True),
 
-					Entry("set,nil,1", sslSet, sslNil, true, Error),
-					Entry("set,nil,0", sslSet, sslNil, false, Error),
-					Entry("set,zero,1", sslSet, sslZero, true, True),
-					Entry("set,zero,0", sslSet, sslZero, false, True),
-					Entry("set,empty,1", sslSet, sslEmpty, true, True),
-					Entry("set,empty,0", sslSet, sslEmpty, false, True),
-					Entry("set,set,1", sslSet, sslSet, true, True),
-					Entry("set,set,0", sslSet, sslSet, false, True),
-				)
+						Entry("set,nil,1", sslSet, sslNil, true, Error),
+						Entry("set,nil,0", sslSet, sslNil, false, Error),
+						Entry("set,zero,1", sslSet, sslZero, true, False), // prefer parent value; 0-value override
+						Entry("set,zero,0", sslSet, sslZero, false, True),
+						Entry("set,empty,1", sslSet, sslEmpty, true, True),
+						Entry("set,empty,0", sslSet, sslEmpty, false, True),
+						Entry("set,set,1", sslSet, sslSet, true, True),
+						Entry("set,set,0", sslSet, sslSet, false, True),
 
-				DescribeTable("anscestry override tests for mismatched ssl definitions", func(childSsl *gloov1.SslConfig, parentSsl *gloov1.SslConfig, childHcm *hcm.HttpConnectionManagerSettings, parentHcm *hcm.HttpConnectionManagerSettings, preventChildOverrides bool) {
-					// In this test we configure Gateway and MatchableHttpGateway with mismatched SslConfigs
-					// that is, one has ssl defined and the other does not
-					// that should not generate a Listener and instead yield an error on the report
-
-					parent.PreventChildOverrides = preventChildOverrides
-					// config setting
-					child.GetMatcher().SslConfig = childSsl
-					parent.SslConfig = parentSsl
-					child.GetHttpGateway().GetOptions().HttpConnectionManagerSettings = childHcm
-					parent.HttpConnectionManagerSettings = parentHcm
-
-					// perform translation
-					params := NewTranslatorParams(ctx, snap, reports)
-					listener := hybridTranslator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])
-
-					// evaluate results
-					Expect(reports.ValidateStrict()).To(HaveOccurred())
-					Expect(listener).To(BeNil())
-				},
-					Entry("PreventChildOverrides, child == nil", // should prefer parent fields
-						nil, sslTrue, nil, hcmTrue, true),
-					Entry("PreventChildOverrides, parent == nil", // should prefer child fields
-						sslTrue, nil, hcmTrue, nil, true),
-					Entry("!PreventChildOverrides, child == nil", // should prefer parent fields
-						nil, sslTrue, nil, hcmTrue, false),
-					Entry("!PreventChildOverrides, parent == nil", // should prefer child fields
-						sslTrue, nil, hcmTrue, nil, false),
-				)
-
-				It("Should set child HCM options when child has `nil` options field", func() {
-					// config setting
-					child.GetHttpGateway().Options = nil
-					parent.HttpConnectionManagerSettings = hcmTrue
-
-					// perform transformation
-					params := NewTranslatorParams(ctx, snap, reports)
-					listener := hybridTranslator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])
-
-					// evaluate results
-					Expect(listener).NotTo(BeNil())
-
-					matchedListeners := listener.GetHybridListener().GetMatchedListeners()
-					Expect(matchedListeners).To(HaveLen(1))
-
-					singleMatchedListener := matchedListeners[0]
-					Expect(singleMatchedListener).NotTo(BeNil())
-
-					hcmAfter := singleMatchedListener.GetHttpListener().GetOptions().GetHttpConnectionManagerSettings()
-					Expect(hcmAfter.GetSkipXffAppend().GetValue()).To(Equal(true))
+						// extra entries added for code reuse/testing convenience.  Prior examples didn't consider top-level nil fields
+						// a.k.a., extra "should error" examples
+						Entry("-,set,0", nil, sslSet, false, Error),
+						Entry("-,set,1", nil, sslSet, true, Error),
+						Entry("set,-,0", sslSet, nil, false, Error),
+						Entry("set,-,1", sslSet, nil, true, Error),
+					)
 				})
 
-				It("Should overwrite nested nil child fields", func() {
-					// config setting
-					child.GetMatcher().SslConfig = sslEmpty
-					parent.SslConfig = sslEmpty
-					parent.GetSslConfig().TransportSocketConnectTimeout = &duration.Duration{
-						Seconds: 10,
-					}
+				Context("HttpConnectionManagerSettings", func() {
+					// while the test for SslConfig seeks to represent a, frankly, hysterical amount of edge conditions, this test
+					// takes a more "throw it at the wall" approach. Notably, it tests more object types than just wrapperspb.BoolValue
+					It("Should merge complicated config of various object types with PreventChildOverrides=false", func() {
+						// config setting
+						parent.PreventChildOverrides = false
+						child.GetHttpGateway().GetOptions().HttpConnectionManagerSettings = &hcm.HttpConnectionManagerSettings{
+							SkipXffAppend:       &wrapperspb.BoolValue{Value: false},    // prefer 0-value for bool
+							Via:                 &wrapperspb.StringValue{Value: ""},     // prefer 0-value for string
+							XffNumTrustedHops:   &wrapperspb.UInt32Value{Value: 0},      // prefer 0-value for uint32
+							UseRemoteAddress:    nil,                                    // parent should overwrite `nil` fields
+							StreamIdleTimeout:   &duration.Duration{},                   // prefer 0-value for duration
+							MaxRequestHeadersKb: &wrapperspb.UInt32Value{Value: 32},     // demonstrate "regular" override capabilities
+							CodecType:           hcm.HttpConnectionManagerSettings_AUTO, // prefer an enum's 0-value
+							HeaderFormat: &hcm.HttpConnectionManagerSettings_ProperCaseHeaderKeyFormat{ // "one of" overrides should be respected
+								ProperCaseHeaderKeyFormat: &wrapperspb.BoolValue{Value: true},
+							},
+							Tracing: &tracing.ListenerTracingSettings{
+								ProviderConfig: &tracing.ListenerTracingSettings_ZipkinConfig{
+									ZipkinConfig: &envoytrace_gloo.ZipkinConfig{
+										CollectorCluster: &envoytrace_gloo.ZipkinConfig_CollectorUpstreamRef{
+											CollectorUpstreamRef: &core.ResourceRef{
+												Name:      "",
+												Namespace: "",
+											},
+										},
+									},
+								},
+							},
+						}
+						parent.HttpConnectionManagerSettings = &hcm.HttpConnectionManagerSettings{
+							SkipXffAppend:       &wrapperspb.BoolValue{Value: true},
+							Via:                 &wrapperspb.StringValue{Value: "should-not-overwrite"},
+							XffNumTrustedHops:   &wrapperspb.UInt32Value{Value: 32},
+							UseRemoteAddress:    &wrapperspb.BoolValue{Value: true},
+							StreamIdleTimeout:   &duration.Duration{Seconds: 10, Nanos: 32},
+							MaxRequestHeadersKb: &wrapperspb.UInt32Value{Value: 31},
+							CodecType:           hcm.HttpConnectionManagerSettings_HTTP1,
+							HeaderFormat: &hcm.HttpConnectionManagerSettings_PreserveCaseHeaderKeyFormat{
+								PreserveCaseHeaderKeyFormat: &wrapperspb.BoolValue{Value: true},
+							},
+							Tracing: &tracing.ListenerTracingSettings{
+								ProviderConfig: &tracing.ListenerTracingSettings_ZipkinConfig{
+									ZipkinConfig: &envoytrace_gloo.ZipkinConfig{
+										CollectorCluster: &envoytrace_gloo.ZipkinConfig_CollectorUpstreamRef{
+											CollectorUpstreamRef: &core.ResourceRef{
+												Name:      "dummy-name",
+												Namespace: "dummy-namespace",
+											},
+										},
+									},
+								},
+							},
+						}
 
-					// perform transformation
-					params := NewTranslatorParams(ctx, snap, reports)
-					listener := hybridTranslator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])
+						// perform translation
+						params := NewTranslatorParams(ctx, snap, reports)
+						hybridTranslator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])
 
-					// evaluate results
-					Expect(listener).NotTo(BeNil())
+						// evaluate results
+						hcm_after := child.GetHttpGateway().GetOptions().GetHttpConnectionManagerSettings()
 
-					matchedListeners := listener.GetHybridListener().GetMatchedListeners()
-					Expect(matchedListeners).To(HaveLen(1))
+						Expect(hcm_after.GetSkipXffAppend().GetValue()).To(Equal(false))
+						Expect(hcm_after.GetVia().GetValue()).To(Equal(""))
+						Expect(hcm_after.GetXffNumTrustedHops().GetValue()).To(Equal(uint32(0)))
+						Expect(hcm_after.GetUseRemoteAddress().GetValue()).To(Equal(true))
+						Expect(hcm_after.GetStreamIdleTimeout().GetNanos()).To(Equal(int32(0)))
+						Expect(hcm_after.GetStreamIdleTimeout().GetSeconds()).To(Equal(int64(0)))
+						Expect(hcm_after.MaxRequestHeadersKb.GetValue()).To(Equal(uint32(32)))
+						Expect(hcm_after.GetProperCaseHeaderKeyFormat().GetValue()).To(Equal(true))
+						Expect(hcm_after.GetPreserveCaseHeaderKeyFormat().GetValue()).To(Equal(false))
+						Expect((hcm_after.GetTracing().GetZipkinConfig().GetCollectorUpstreamRef().GetName())).To(Equal(""))
+						Expect((hcm_after.GetTracing().GetZipkinConfig().GetCollectorUpstreamRef().GetNamespace())).To(Equal(""))
 
-					singleMatchedListener := matchedListeners[0]
-					Expect(singleMatchedListener).NotTo(BeNil())
-
-					sslAfter := singleMatchedListener.GetMatcher().GetSslConfig()
-					Expect(sslAfter.GetTransportSocketConnectTimeout().GetSeconds()).To(Equal(int64(10)))
+						// This is a limitation of this feature.  At present, we can't override enums
+						// Expect(hcm_after.GetCodecType()).To(Equal(hcm.HttpConnectionManagerSettings_AUTO))
+					})
 				})
 			})
 


### PR DESCRIPTION
special care taken with `Duration` and `ResourceRef` object types.
* updated tests

# Feature validation

When combining this `MatchableHttpGateway`
```yaml
apiVersion: gateway.solo.io/v1
kind: MatchableHttpGateway
metadata:
  name: client-ip-reject-gateway
  namespace: gloo-system
spec:
  httpGateway:
    options:
      httpConnectionManagerSettings:
        tracing:
          verbose: false
    virtualServices:
      - name: client-ip-reject
        namespace: gloo-system
  matcher: {}
```

With this `Gateway`
```yaml
apiVersion: gateway.solo.io/v1
kind: Gateway
metadata:
  labels:
    app: gloo
  name: gateway-proxy
  namespace: gloo-system
spec:
  bindAddress: '::'
  bindPort: 8080
  hybridGateway:
    delegatedHttpGateways:
      httpConnectionManagerSettings:
        tracing:
          verbose: true
      ref:
        name: client-ip-reject-gateway
        namespace: gloo-system
  options: {}
  proxyNames:
    - gateway-proxy
  useProxyProto: false
```

you generate this `Proxy`
```yaml
apiVersion: gloo.solo.io/v1
kind: Proxy
metadata:
  creationTimestamp: '2022-09-01T21:18:00Z'
  generation: 12
  labels:
    created_by: gloo-gateway-translator
  name: gateway-proxy
  namespace: gloo-system
  resourceVersion: '3358'
  uid: bcd004ca-9438-46cb-924e-8947a22032e7
spec:
  listeners:
    - bindAddress: '::'
      bindPort: 8080
      hybridListener:
        matchedListeners:
          - httpListener:
              options:
                httpConnectionManagerSettings:
                  tracing:
                    verbose: false
              virtualHosts:
                - domains:
                    - '*'
                  metadataStatic:
                    sources:
                      - observedGeneration: '3'
                        resourceKind: '*v1.VirtualService'
                        resourceRef:
                          name: client-ip-reject
                          namespace: gloo-system
                  name: gloo-system.client-ip-reject
                  routes:
                    - directResponseAction:
                        body: |
                          client ip forbidden
                        status: 403
                      matchers:
                        - prefix: /
                      metadataStatic:
                        sources:
                          - observedGeneration: '3'
                            resourceKind: '*v1.VirtualService'
                            resourceRef:
                              name: client-ip-reject
                              namespace: gloo-system
            matcher: {}
      metadataStatic:
        sources:
          - observedGeneration: '8'
            resourceKind: '*v1.Gateway'
            resourceRef:
              name: gateway-proxy
              namespace: gloo-system
      name: 'listener-::-8080'
      options: {}
      useProxyProto: false
    - bindAddress: '::'
      bindPort: 8443
      httpListener: {}
      metadataStatic:
        sources:
          - observedGeneration: '3'
            resourceKind: '*v1.Gateway'
            resourceRef:
              name: gateway-proxy-ssl
              namespace: gloo-system
      name: 'listener-::-8443'
      useProxyProto: false
status:
  statuses:
    gloo-system:
      reportedBy: gloo
      state: 1
```

Which!  If you dig through all of the fluff:
* `MatchableHttpGateway`: httpConnectionManagerSettings.tracing.verbose=false
* `Gateway`: httpConnectionManagerSettings.tracing.verbose=true
* `Proxy`: httpConnectionManagerSettings.tracing.verbose=false

meaning!  That this correctly solves the 0-value override problem for bools
