### PR TITLE
disable istio injection on jobs/cronjobs

### DIFF
--- a/changelog/v1.13.0-beta12/disable-istio-inject-jobs.yaml
+++ b/changelog/v1.13.0-beta12/disable-istio-inject-jobs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7081
+    resolvesIssue: false
+    description: Disable istio sidecar injection for Jobs and CronJobs (regardless of `global.istioIntegration.disableAutoinjection` value) as it causes jobs to hang.

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-cronjob.yaml
@@ -23,9 +23,7 @@ spec:
         metadata:
           labels:
             gloo: gloo-mtls-certs
-            {{- if .Values.global.istioIntegration.disableAutoinjection }}
             sidecar.istio.io/inject: "false"
-            {{- end }}
         spec:
           {{- include "gloo.pullSecret" $image | nindent 10 -}}
           serviceAccountName: certgen

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -28,9 +28,7 @@ spec:
     metadata:
       labels:
         gloo: gloo-mtls-certs
-        {{- if .Values.global.istioIntegration.disableAutoinjection }}
         sidecar.istio.io/inject: "false"
-        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: certgen

--- a/install/helm/gloo/templates/5-resource-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-resource-cleanup-job.yaml
@@ -23,9 +23,7 @@ spec:
     metadata:
       labels:
         gloo: resource-cleanup
-        {{- if .Values.global.istioIntegration.disableAutoinjection }}
         sidecar.istio.io/inject: "false"
-        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gloo-resource-cleanup

--- a/install/helm/gloo/templates/5-resource-migration-job.yaml
+++ b/install/helm/gloo/templates/5-resource-migration-job.yaml
@@ -23,9 +23,7 @@ spec:
     metadata:
       labels:
         gloo: resource-migration
-        {{- if .Values.global.istioIntegration.disableAutoinjection }}
         sidecar.istio.io/inject: "false"
-        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gloo-resource-migration

--- a/install/helm/gloo/templates/5-resource-rollout-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job.yaml
@@ -23,9 +23,7 @@ spec:
     metadata:
       labels:
         gloo: resource-rollout
-        {{- if .Values.global.istioIntegration.disableAutoinjection }}
         sidecar.istio.io/inject: "false"
-        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gloo-resource-rollout

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -25,9 +25,7 @@ spec:
     metadata:
       labels:
         gloo: gateway-certgen
-        {{- if .Values.global.istioIntegration.disableAutoinjection }}
         sidecar.istio.io/inject: "false"
-        {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: certgen

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -1045,10 +1045,10 @@ var _ = Describe("Helm Test", func() {
 						}
 					})
 				})
-				It("should be able to disable istio injection on all job pod templates", func() {
+				It("istio injection should always be disabled in job pod templates", func() {
 					prepareMakefile(namespace, helmValues{
 						valuesArgs: []string{
-							"global.istioIntegration.disableAutoinjection=true",
+							"global.istioIntegration.disableAutoinjection=false",
 							"global.glooMtls.enabled=true",
 						},
 					})
@@ -3974,6 +3974,7 @@ spec:
   template:
     metadata:
       labels:
+        sidecar.istio.io/inject: "false"
         gloo: gateway-certgen
     spec:
       serviceAccountName: certgen


### PR DESCRIPTION
# Description

Disable istio sidecar injection for Jobs and CronJobs (regardless of `global.istioIntegration.disableAutoinjection` value) as it causes jobs to hang.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
