### PR TITLE
fix: Expose isolateVirtualHostsBySslConfig as a values yaml parameter…

### DIFF
--- a/changelog/v1.13.0-beta12/expose-isolateVirtualHostsBySslConfig-chart-value.yaml
+++ b/changelog/v1.13.0-beta12/expose-isolateVirtualHostsBySslConfig-chart-value.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6476
+    resolvesIssue: false
+    description: Enable HCM options to support 0-value overrides for `Duration` and `ResourceRef` object types

--- a/changelog/v1.13.0-beta12/expose-isolateVirtualHostsBySslConfig-chart-value.yaml
+++ b/changelog/v1.13.0-beta12/expose-isolateVirtualHostsBySslConfig-chart-value.yaml
@@ -1,5 +1,5 @@
 changelog:
   - type: FIX
-    issueLink: https://github.com/solo-io/gloo/issues/6476
+    issueLink: https://github.com/solo-io/gloo/issues/6677
     resolvesIssue: false
-    description: Enable HCM options to support 0-value overrides for `Duration` and `ResourceRef` object types
+    description: Enable to set isolateVirtualHostsBySslConfig parameter in the setting.yaml template by exposing it in the chart.yaml file  

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -265,18 +265,19 @@ type UdsOptions struct {
 }
 
 type Gateway struct {
-	Enabled                       *bool             `json:"enabled,omitempty" desc:"enable Gloo Edge API Gateway features"`
-	Validation                    GatewayValidation `json:"validation,omitempty" desc:"enable Validation Webhook on the Gateway. This will cause requests to modify Gateway-related Custom Resources to be validated by the Gateway."`
-	CertGenJob                    *CertGenJob       `json:"certGenJob,omitempty" desc:"generate self-signed certs with this job to be used with the gateway validation webhook. this job will only run if validation is enabled for the gateway"`
-	RolloutJob                    *RolloutJob       `json:"rolloutJob,omitempty" desc:"This job waits for the 'gloo' deployment to successfully roll out (if the validation webhook is enabled), and then applies the Gloo Edge custom resources."`
-	CleanupJob                    *CleanupJob       `json:"cleanupJob,omitempty" desc:"This job cleans up resources that are not deleted by Helm when Gloo Edge is uninstalled."`
-	UpdateValues                  *bool             `json:"updateValues,omitempty" desc:"if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions"`
-	ProxyServiceAccount           ServiceAccount    `json:"proxyServiceAccount,omitempty" `
-	ReadGatewaysFromAllNamespaces *bool             `json:"readGatewaysFromAllNamespaces,omitempty" desc:"if true, read Gateway custom resources from all watched namespaces rather than just the namespace of the Gateway controller"`
-	CompressedProxySpec           *bool             `json:"compressedProxySpec,omitempty" desc:"if true, enables compression for the Proxy CRD spec"`
-	LogLevel                      *string           `json:"logLevel,omitempty" desc:"Level at which the pod should log. Options include \"info\", \"debug\", \"warn\", \"error\", \"panic\" and \"fatal\". Default level is info"`
-	PersistProxySpec              *bool             `json:"persistProxySpec,omitempty" desc:"Enable writing Proxy CRD to etcd. Disabled by default for performance."`
-	Service                       *KubeResourceOverride
+	Enabled                        *bool             `json:"enabled,omitempty" desc:"enable Gloo Edge API Gateway features"`
+	Validation                     GatewayValidation `json:"validation,omitempty" desc:"enable Validation Webhook on the Gateway. This will cause requests to modify Gateway-related Custom Resources to be validated by the Gateway."`
+	CertGenJob                     *CertGenJob       `json:"certGenJob,omitempty" desc:"generate self-signed certs with this job to be used with the gateway validation webhook. this job will only run if validation is enabled for the gateway"`
+	RolloutJob                     *RolloutJob       `json:"rolloutJob,omitempty" desc:"This job waits for the 'gloo' deployment to successfully roll out (if the validation webhook is enabled), and then applies the Gloo Edge custom resources."`
+	CleanupJob                     *CleanupJob       `json:"cleanupJob,omitempty" desc:"This job cleans up resources that are not deleted by Helm when Gloo Edge is uninstalled."`
+	UpdateValues                   *bool             `json:"updateValues,omitempty" desc:"if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions"`
+	ProxyServiceAccount            ServiceAccount    `json:"proxyServiceAccount,omitempty" `
+	ReadGatewaysFromAllNamespaces  *bool             `json:"readGatewaysFromAllNamespaces,omitempty" desc:"if true, read Gateway custom resources from all watched namespaces rather than just the namespace of the Gateway controller"`
+	IsolateVirtualHostsBySslConfig *bool             `json:"isolateVirtualHostsBySslConfig,omitempty" desc:"if true, Added support for the envoy.filters.listener.tls_inspector listener_filter when using the gateway.isolateVirtualHostsBySslConfig=true global setting."`
+	CompressedProxySpec            *bool             `json:"compressedProxySpec,omitempty" desc:"if true, enables compression for the Proxy CRD spec"`
+	LogLevel                       *string           `json:"logLevel,omitempty" desc:"Level at which the pod should log. Options include \"info\", \"debug\", \"warn\", \"error\", \"panic\" and \"fatal\". Default level is info"`
+	PersistProxySpec               *bool             `json:"persistProxySpec,omitempty" desc:"Enable writing Proxy CRD to etcd. Disabled by default for performance."`
+	Service                        *KubeResourceOverride
 }
 
 type ServiceAccount struct {

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -87,6 +87,7 @@ spec:
 {{- end }}
 
   gateway:
+    isolateVirtualHostsBySslConfig: {{ .Values.gateway.isolateVirtualHostsBySslConfig }}
     readGatewaysFromAllNamespaces: {{ .Values.gateway.readGatewaysFromAllNamespaces }}
 {{- if or .Values.gateway.persistProxySpec (not .Values.gateway.enabled) }}
     persistProxySpec: true

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -64,6 +64,7 @@ discovery:
 gateway:
   enabled: true
   readGatewaysFromAllNamespaces: false
+  isolateVirtualHostsBySslConfig: false
   validation:
     enabled: true
     failurePolicy: "Ignore"


### PR DESCRIPTION

# Description

Expose isolateVirtualHostsBySslConfig as a values yaml parameter to enable setting it in the settings.yaml

# Context

this PR allows consuming the fix from this issue https://github.com/solo-io/gloo/issues/6677

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
