### PR TITLE
fix: expose isolateVirtualHostsBySslConfig as a values yaml parameter…

### DIFF
--- a/changelog/v1.13.0-beta12/expose-isolateVirtualHostsBySslConfig-chart-value.yaml
+++ b/changelog/v1.13.0-beta12/expose-isolateVirtualHostsBySslConfig-chart-value.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6677
+    resolvesIssue: false
+    description: Enable to set isolateVirtualHostsBySslConfig parameter in the setting.yaml template by exposing it in the chart.yaml file  

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -353,6 +353,7 @@
 |gateway.proxyServiceAccount.disableAutomount|bool||disable automounting the service account to the gateway proxy. not mounting the token hardens the proxy container, but may interfere with service mesh integrations|
 |gateway.proxyServiceAccount.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gateway.readGatewaysFromAllNamespaces|bool|false|if true, read Gateway custom resources from all watched namespaces rather than just the namespace of the Gateway controller|
+|gateway.isolateVirtualHostsBySslConfig|bool|false|if true, Added support for the envoy.filters.listener.tls_inspector listener_filter when using the gateway.isolateVirtualHostsBySslConfig=true global setting.|
 |gateway.compressedProxySpec|bool||if true, enables compression for the Proxy CRD spec|
 |gateway.logLevel|string||Level at which the pod should log. Options include "info", "debug", "warn", "error", "panic" and "fatal". Default level is info|
 |gateway.persistProxySpec|bool||Enable writing Proxy CRD to etcd. Disabled by default for performance.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -265,18 +265,19 @@ type UdsOptions struct {
 }
 
 type Gateway struct {
-	Enabled                       *bool             `json:"enabled,omitempty" desc:"enable Gloo Edge API Gateway features"`
-	Validation                    GatewayValidation `json:"validation,omitempty" desc:"enable Validation Webhook on the Gateway. This will cause requests to modify Gateway-related Custom Resources to be validated by the Gateway."`
-	CertGenJob                    *CertGenJob       `json:"certGenJob,omitempty" desc:"generate self-signed certs with this job to be used with the gateway validation webhook. this job will only run if validation is enabled for the gateway"`
-	RolloutJob                    *RolloutJob       `json:"rolloutJob,omitempty" desc:"This job waits for the 'gloo' deployment to successfully roll out (if the validation webhook is enabled), and then applies the Gloo Edge custom resources."`
-	CleanupJob                    *CleanupJob       `json:"cleanupJob,omitempty" desc:"This job cleans up resources that are not deleted by Helm when Gloo Edge is uninstalled."`
-	UpdateValues                  *bool             `json:"updateValues,omitempty" desc:"if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions"`
-	ProxyServiceAccount           ServiceAccount    `json:"proxyServiceAccount,omitempty" `
-	ReadGatewaysFromAllNamespaces *bool             `json:"readGatewaysFromAllNamespaces,omitempty" desc:"if true, read Gateway custom resources from all watched namespaces rather than just the namespace of the Gateway controller"`
-	CompressedProxySpec           *bool             `json:"compressedProxySpec,omitempty" desc:"if true, enables compression for the Proxy CRD spec"`
-	LogLevel                      *string           `json:"logLevel,omitempty" desc:"Level at which the pod should log. Options include \"info\", \"debug\", \"warn\", \"error\", \"panic\" and \"fatal\". Default level is info"`
-	PersistProxySpec              *bool             `json:"persistProxySpec,omitempty" desc:"Enable writing Proxy CRD to etcd. Disabled by default for performance."`
-	Service                       *KubeResourceOverride
+	Enabled                        *bool             `json:"enabled,omitempty" desc:"enable Gloo Edge API Gateway features"`
+	Validation                     GatewayValidation `json:"validation,omitempty" desc:"enable Validation Webhook on the Gateway. This will cause requests to modify Gateway-related Custom Resources to be validated by the Gateway."`
+	CertGenJob                     *CertGenJob       `json:"certGenJob,omitempty" desc:"generate self-signed certs with this job to be used with the gateway validation webhook. this job will only run if validation is enabled for the gateway"`
+	RolloutJob                     *RolloutJob       `json:"rolloutJob,omitempty" desc:"This job waits for the 'gloo' deployment to successfully roll out (if the validation webhook is enabled), and then applies the Gloo Edge custom resources."`
+	CleanupJob                     *CleanupJob       `json:"cleanupJob,omitempty" desc:"This job cleans up resources that are not deleted by Helm when Gloo Edge is uninstalled."`
+	UpdateValues                   *bool             `json:"updateValues,omitempty" desc:"if true, will use a provided helm helper 'gloo.updatevalues' to update values during template render - useful for plugins/extensions"`
+	ProxyServiceAccount            ServiceAccount    `json:"proxyServiceAccount,omitempty" `
+	ReadGatewaysFromAllNamespaces  *bool             `json:"readGatewaysFromAllNamespaces,omitempty" desc:"if true, read Gateway custom resources from all watched namespaces rather than just the namespace of the Gateway controller"`
+	IsolateVirtualHostsBySslConfig *bool             `json:"isolateVirtualHostsBySslConfig,omitempty" desc:"if true, Added support for the envoy.filters.listener.tls_inspector listener_filter when using the gateway.isolateVirtualHostsBySslConfig=true global setting."`
+	CompressedProxySpec            *bool             `json:"compressedProxySpec,omitempty" desc:"if true, enables compression for the Proxy CRD spec"`
+	LogLevel                       *string           `json:"logLevel,omitempty" desc:"Level at which the pod should log. Options include \"info\", \"debug\", \"warn\", \"error\", \"panic\" and \"fatal\". Default level is info"`
+	PersistProxySpec               *bool             `json:"persistProxySpec,omitempty" desc:"Enable writing Proxy CRD to etcd. Disabled by default for performance."`
+	Service                        *KubeResourceOverride
 }
 
 type ServiceAccount struct {

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -87,6 +87,7 @@ spec:
 {{- end }}
 
   gateway:
+    isolateVirtualHostsBySslConfig: {{ .Values.gateway.isolateVirtualHostsBySslConfig }}
     readGatewaysFromAllNamespaces: {{ .Values.gateway.readGatewaysFromAllNamespaces }}
 {{- if or .Values.gateway.persistProxySpec (not .Values.gateway.enabled) }}
     persistProxySpec: true

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -64,6 +64,7 @@ discovery:
 gateway:
   enabled: true
   readGatewaysFromAllNamespaces: false
+  isolateVirtualHostsBySslConfig: false
   validation:
     enabled: true
     failurePolicy: "Ignore"

--- a/install/test/fixtures/settings/compressed_proxy_spec.yaml
+++ b/install/test/fixtures/settings/compressed_proxy_spec.yaml
@@ -13,6 +13,7 @@ spec:
    readGatewaysFromAllNamespaces: false
    compressedProxySpec: true
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
  gloo:
    enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977

--- a/install/test/fixtures/settings/consul_config_upstream_discovery.yaml
+++ b/install/test/fixtures/settings/consul_config_upstream_discovery.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    enableGatewayController: true
    readGatewaysFromAllNamespaces: false
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/consul_config_values.yaml
+++ b/install/test/fixtures/settings/consul_config_values.yaml
@@ -11,6 +11,7 @@ spec:
    fdsMode: WHITELIST
  gateway:
    readGatewaysFromAllNamespaces: false
+   isolateVirtualHostsBySslConfig: false
    enableGatewayController: true
    validation:
      alwaysAccept: true

--- a/install/test/fixtures/settings/disable_kubernetes_destinations.yaml
+++ b/install/test/fixtures/settings/disable_kubernetes_destinations.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: false
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/disable_proxy_garbage_collection.yaml
+++ b/install/test/fixtures/settings/disable_proxy_garbage_collection.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: false
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/disabled_gateway.yaml
+++ b/install/test/fixtures/settings/disabled_gateway.yaml
@@ -13,6 +13,7 @@ spec:
     readGatewaysFromAllNamespaces: false
     enableGatewayController: false
     persistProxySpec: true
+    isolateVirtualHostsBySslConfig: false
     validation:
       alwaysAccept: true
       allowWarnings: true

--- a/install/test/fixtures/settings/enable_default_credentials.yaml
+++ b/install/test/fixtures/settings/enable_default_credentials.yaml
@@ -12,6 +12,7 @@ spec:
   gateway:
     readGatewaysFromAllNamespaces: false
     enableGatewayController: true
+    isolateVirtualHostsBySslConfig: false
     validation:
       alwaysAccept: true
       allowWarnings: true

--- a/install/test/fixtures/settings/enable_rest_eds.yaml
+++ b/install/test/fixtures/settings/enable_rest_eds.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: false
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/enable_rest_eds_and_gloo_mtls.yaml
+++ b/install/test/fixtures/settings/enable_rest_eds_and_gloo_mtls.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: false
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/gateway_settings.yaml
+++ b/install/test/fixtures/settings/gateway_settings.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: false
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/gateway_validation.yaml
+++ b/install/test/fixtures/settings/gateway_validation.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: false
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/isolate_virtual_hosts_by_ssl_config.yaml
+++ b/install/test/fixtures/settings/isolate_virtual_hosts_by_ssl_config.yaml
@@ -1,0 +1,38 @@
+apiVersion: gloo.solo.io/v1
+kind: Settings
+metadata:
+  labels:
+    app: gloo
+    gloo: settings
+  name: default
+  namespace: {{ . }}
+spec:
+  discovery:
+    fdsMode: WHITELIST
+  gateway:
+    readGatewaysFromAllNamespaces: false
+    enableGatewayController: true
+    isolateVirtualHostsBySslConfig: true
+    validation:
+      alwaysAccept: true
+      allowWarnings: true
+      disableTransformationValidation: false
+      warnRouteShortCircuiting: false
+      proxyValidationServerAddr: gloo:9988
+      validationServerGrpcMaxSizeBytes: 104857600
+  gloo:
+    enableRestEds: false
+    xdsBindAddr: 0.0.0.0:9977
+    restXdsBindAddr: 0.0.0.0:9976
+    proxyDebugBindAddr: 0.0.0.0:9966
+    disableKubernetesDestinations: false
+    disableProxyGarbageCollection: false
+    invalidConfigPolicy:
+      invalidRouteResponseBody: Gloo Gateway has invalid configuration. Administrators should run `glooctl check` to find and fix config errors.
+      invalidRouteResponseCode: 404
+      replaceInvalidRoutes: false
+  kubernetesArtifactSource: {}
+  kubernetesConfigSource: {}
+  kubernetesSecretSource: {}
+  refreshRate: 60s
+  discoveryNamespace: {{ . }}

--- a/install/test/fixtures/settings/ratelimit_descriptors.yaml
+++ b/install/test/fixtures/settings/ratelimit_descriptors.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: false
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
    validation:
      alwaysAccept: true
      allowWarnings: true

--- a/install/test/fixtures/settings/read_gateways_from_all_namespaces.yaml
+++ b/install/test/fixtures/settings/read_gateways_from_all_namespaces.yaml
@@ -12,6 +12,7 @@ spec:
  gateway:
    readGatewaysFromAllNamespaces: true
    enableGatewayController: true
+   isolateVirtualHostsBySslConfig: false
  gloo:
    enableRestEds: false
    xdsBindAddr: 0.0.0.0:9977

--- a/install/test/fixtures/settings/set_regex_max_program_size.yaml
+++ b/install/test/fixtures/settings/set_regex_max_program_size.yaml
@@ -12,6 +12,7 @@ spec:
   gateway:
     readGatewaysFromAllNamespaces: false
     enableGatewayController: true
+    isolateVirtualHostsBySslConfig: false
     validation:
       alwaysAccept: true
       allowWarnings: true

--- a/install/test/fixtures/settings/sts_discovery.yaml
+++ b/install/test/fixtures/settings/sts_discovery.yaml
@@ -12,6 +12,7 @@ spec:
   gateway:
     readGatewaysFromAllNamespaces: false
     enableGatewayController: true
+    isolateVirtualHostsBySslConfig: false
     validation:
       alwaysAccept: true
       allowWarnings: true

--- a/install/test/fixtures/settings/uds_disabled.yaml
+++ b/install/test/fixtures/settings/uds_disabled.yaml
@@ -14,6 +14,7 @@ spec:
   gateway:
     readGatewaysFromAllNamespaces: false
     enableGatewayController: true
+    isolateVirtualHostsBySslConfig: false
     validation:
       alwaysAccept: true
       allowWarnings: true

--- a/install/test/fixtures/settings/watched_discovery_labels.yaml
+++ b/install/test/fixtures/settings/watched_discovery_labels.yaml
@@ -15,6 +15,7 @@ spec:
   gateway:
     readGatewaysFromAllNamespaces: false
     enableGatewayController: true
+    isolateVirtualHostsBySslConfig: false
     validation:
       alwaysAccept: true
       allowWarnings: true

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3593,7 +3593,7 @@ spec:
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
-					FIt("can enable isolateVirtualHostsBySslConfig", func() {
+					It("can enable isolateVirtualHostsBySslConfig", func() {
 						settings := makeUnstructureFromTemplateFile("fixtures/settings/isolate_virtual_hosts_by_ssl_config.yaml", namespace)
 
 						prepareMakefile(namespace, helmValues{

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3635,6 +3635,7 @@ spec:
   gateway:
     readGatewaysFromAllNamespaces: false
     enableGatewayController: true
+    isolateVirtualHostsBySslConfig: false
     validation:
       proxyValidationServerAddr: gloo:9988
       alwaysAccept: true

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3593,12 +3593,12 @@ spec:
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
-					It("can enable isolateVirtualHostsBySslConfig", func() {
+					FIt("can enable isolateVirtualHostsBySslConfig", func() {
 						settings := makeUnstructureFromTemplateFile("fixtures/settings/isolate_virtual_hosts_by_ssl_config.yaml", namespace)
 
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{
-								"settings.gateway.isolateVirtualHostsBySslConfig=true",
+								"gateway.isolateVirtualHostsBySslConfig=true",
 							},
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3593,6 +3593,16 @@ spec:
 						})
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
+					FIt("can enable isolateVirtualHostsBySslConfig", func() {
+						settings := makeUnstructureFromTemplateFile("fixtures/settings/isolate_virtual_hosts_by_ssl_config.yaml", namespace)
+
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"settings.gateway.isolateVirtualHostsBySslConfig=true",
+							},
+						})
+						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
+					})
 
 					It("allows setting extauth", func() {
 						expectedYaml := makeUnstructured(`


### PR DESCRIPTION
Expose isolateVirtualHostsBySslConfig as a values yaml parameter to enable setting it in the settings.yaml

# Context

this PR allows consuming the fix from this issue https://github.com/solo-io/gloo/issues/6677

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
