### PR TITLE
Fix gloo-resource-cleanup failure when CRD doesn't exist

### DIFF
--- a/changelog/v1.13.0-beta13/cleanup-ignore-crd-errors.yaml
+++ b/changelog/v1.13.0-beta13/cleanup-ignore-crd-errors.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7109
+    resolvesIssue: false
+    description: Exit early from the `gloo-resource-cleanup` job (instead of erroring) if the Gloo Edge CRDs have already been deleted.

--- a/install/helm/gloo/templates/5-resource-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-resource-cleanup-job.yaml
@@ -45,6 +45,12 @@ spec:
           - -c
           - |
             kubectl delete --ignore-not-found validatingwebhookconfigurations.admissionregistration.k8s.io gloo-gateway-validation-webhook-{{ .Release.Namespace }} || exit $?
+
+            if ! kubectl get crd upstreams.gloo.solo.io; then
+              echo "Could not find Upstream CRD. Gloo Edge CRDs may have already been deleted. Skipping cleanup of Gloo Edge resources."
+              exit 0
+            fi
+
             kubectl delete --ignore-not-found upstreams.gloo.solo.io -n {{ .Release.Namespace }} -l app=gloo || exit $?
 
             # gateways can be in multiple namespaces


### PR DESCRIPTION
Exit early from the `gloo-resource-cleanup` job (instead of erroring) if the Gloo Edge CRDs have already been deleted.