### PR TITLE
CI Stability: Retry Patch Updates to Avoid ResourceVersionErr

### DIFF
--- a/changelog/v1.13.0-beta13/ci-resource-version-error.yaml
+++ b/changelog/v1.13.0-beta13/ci-resource-version-error.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/7044
+    resolvesIssue: false
+    description: Retry patch updates on resource version errors to protect against test flakes

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -295,7 +295,7 @@ func PatchResource(ctx context.Context, resourceRef *core.ResourceRef, mutator f
 	EventuallyWithOffset(1, func(g Gomega) {
 		resource, err := client.Read(resourceRef.GetNamespace(), resourceRef.GetName(), clients.ReadOpts{Ctx: ctx})
 		g.Expect(err).NotTo(HaveOccurred())
-		resourceVersion := resource.GetMetadata().ResourceVersion
+		resourceVersion := resource.GetMetadata().GetResourceVersion()
 
 		mutator(resource)
 		resource.GetMetadata().ResourceVersion = resourceVersion

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -13,6 +13,9 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	skerrors "github.com/solo-io/solo-kit/pkg/errors"
+
 	"github.com/solo-io/go-utils/testutils/goimpl"
 	"go.uber.org/zap/zapcore"
 
@@ -279,6 +282,29 @@ func ToFile(content string) string {
 	ExpectWithOffset(1, n).To(Equal(len(content)))
 	_ = f.Close()
 	return f.Name()
+}
+
+// PatchResource mutates an existing resource, retrying if a resourceVersionError is encountered
+func PatchResource(ctx context.Context, resourceRef *core.ResourceRef, mutator func(resource resources.Resource), client clients.ResourceClient) error {
+	// There is a potential bug in our resource writing implementation that leads to test flakes
+	// https://github.com/solo-io/gloo/issues/7044
+	// This is a temporary solution to ensure that tests do not flake
+
+	var patchErr error
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		resource, err := client.Read(resourceRef.GetNamespace(), resourceRef.GetName(), clients.ReadOpts{Ctx: ctx})
+		g.Expect(err).NotTo(HaveOccurred())
+		resourceVersion := resource.GetMetadata().ResourceVersion
+
+		mutator(resource)
+		resource.GetMetadata().ResourceVersion = resourceVersion
+
+		_, patchErr = client.Write(resource, clients.WriteOpts{Ctx: ctx, OverwriteExisting: true})
+		g.Expect(skerrors.IsResourceVersion(patchErr)).To(BeFalse())
+	}).ShouldNot(HaveOccurred())
+
+	return patchErr
 }
 
 // https://github.com/solo-io/gloo/issues/4043#issuecomment-772706604


### PR DESCRIPTION
# Description

Ensure that patch updates to resources in gateway tests are successful

# Context

When updating a resource, we read the existing resource, update it, and then overwrite the resource with a modified state. This should be successful. 

However, we have noticed the occasional flake in this behavior, and we have an issue tracking the behavior: https://github.com/solo-io/gloo/issues/7044.

I recently noticed, some infrequent test flakes:
- https://github.com/solo-io/gloo/runs/8272029770?check_suite_focus=true

where we see:
```
Fail handler msg Expected
    <*errors.resourceVersionErr | 0xc00222c5c0>: {
        namespace: "gloo-system",
        name: "testrunner",
        given: "",
        expected: "4354",
    }
to match error
    <*matchers.ContainSubstringMatcher | 0xc002075d70>: {
        Substr: "Failed to parse response template: Failed to parse header template ':status': [inja.exception.parser_error] expected statement close, got '%'",
        Args: nil,
    }
```

To avoid these flakes, I created a utility method PatchResource, which handles retries correctly. We have a couple of scenarios where we retried, and a couple where we didn't. Now, all Patch updates in our tests use this utility.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
