### PR TITLE
ratelimit_config: Update to no longer panic and only add a todo

### DIFF
--- a/changelog/v1.12.19/rate-limit-status-hotfix.yaml
+++ b/changelog/v1.12.19/rate-limit-status-hotfix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/4069
+    resolvesIssue: false
+    description: |
+     Post status update rate limit CRs would crash the control plane when they needed a status added.
+     This will cause a single cycle of the control plane whenever the crs needed updating.

--- a/projects/gloo/api/external/solo/ratelimit/rate_limit_config.go
+++ b/projects/gloo/api/external/solo/ratelimit/rate_limit_config.go
@@ -70,11 +70,14 @@ func (r *RateLimitConfig) SetStatus(status *core.Status) {
 }
 
 func (r *RateLimitConfig) GetNamespacedStatuses() *core.NamespacedStatuses {
-	panic("implement me")
+	// TODO: Add namespaced statuses to rate limiting.
+	// Since we only check if rate limit is in a rejected state
+	return &core.NamespacedStatuses{}
 }
 
 func (r *RateLimitConfig) SetNamespacedStatuses(status *core.NamespacedStatuses) {
-	panic("implement me")
+	// TODO: Add namespaced statuses to rate limiting.
+	// Since we only check if rate limit is in a rejected state
 }
 
 func (r *RateLimitConfig) convertSoloKitStatusToRateLimitConfigStatus(status *core.Status) *v1alpha1.RateLimitConfigStatus {


### PR DESCRIPTION
Remove panic for now to restore operations.
Glooctl check will always pass as has been the case since namespaced statuses existed for rate limit configs.