### PR TITLE
Fix ratelimit status reporting

### DIFF
--- a/changelog/v1.13.0-beta16/ratelimit-status-impl.yaml
+++ b/changelog/v1.13.0-beta16/ratelimit-status-impl.yaml
@@ -5,3 +5,8 @@ changelog:
     description: >-
       Update the ratelimit config status implementation with the correct permissions to write statuses.
       This will only affect enterprise code, so this change is marked as non user facing.
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/4076
+    resolvesIssue: true
+    description: >-
+      Update tests to ensure we can write ratelimit config statuses even though they use skv2 and /status

--- a/changelog/v1.13.0-beta16/ratelimit-status-impl.yaml
+++ b/changelog/v1.13.0-beta16/ratelimit-status-impl.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/4069
+    resolvesIssue: false
+    description: >-
+      Update the ratelimit config status implementation with the correct permissions to write statuses.
+      This will only affect enterprise code, so this change is marked as non user facing.

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -105,7 +105,6 @@ rules:
   - list
   - watch
   - patch # needed for status updates for skv1
-  - update # needed for status updates for skv2
 - apiGroups:
   - ratelimit.solo.io
   resources:
@@ -116,6 +115,7 @@ rules:
   - list
   - watch
   - patch # needed for status updates for skv1
+  - update # needed for status updates for skv2
 - apiGroups:
   - graphql.gloo.solo.io
   resources:

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -95,7 +95,7 @@ rules:
   - get
   - list
   - watch
-  - patch # needed for status updates
+  - patch # needed for status updates for skv1
 - apiGroups:
   - enterprise.gloo.solo.io
   resources:
@@ -104,7 +104,8 @@ rules:
   - get
   - list
   - watch
-  - patch # needed for status updates
+  - patch # needed for status updates for skv1
+  - update # needed for status updates for skv2
 - apiGroups:
   - ratelimit.solo.io
   resources:
@@ -114,7 +115,7 @@ rules:
   - get
   - list
   - watch
-  - patch # needed for status updates
+  - patch # needed for status updates for skv1
 - apiGroups:
   - graphql.gloo.solo.io
   resources:
@@ -124,7 +125,8 @@ rules:
   - get
   - list
   - watch
-  - patch # needed for status updates
+  - patch # needed for status updates for skv1
+  - update # needed for status updates for skv2
 ---
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -276,12 +276,12 @@ var _ = Describe("RBAC Test", func() {
 							{
 								APIGroups: []string{"ratelimit.solo.io"},
 								Resources: []string{"ratelimitconfigs", "ratelimitconfigs/status"},
-								Verbs:     []string{"get", "list", "watch", "patch"},
+								Verbs:     []string{"get", "list", "watch", "patch", "update"},
 							},
 							{
 								APIGroups: []string{"graphql.gloo.solo.io"},
 								Resources: []string{"graphqlapis", "graphqlapis/status"},
-								Verbs:     []string{"get", "list", "watch", "patch"},
+								Verbs:     []string{"get", "list", "watch", "patch", "update"},
 							},
 						},
 						RoleRef: rbacv1.RoleRef{

--- a/install/test/util.go
+++ b/install/test/util.go
@@ -61,13 +61,13 @@ func GetServiceAccountPermissions(namespace string) *manifesttestutils.ServiceAc
 		namespace,
 		[]string{"ratelimit.solo.io"},
 		[]string{"ratelimitconfigs", "ratelimitconfigs/status"},
-		[]string{"get", "list", "watch", "patch"})
+		[]string{"get", "list", "watch", "patch", "update"})
 	permissions.AddExpectedPermission(
 		"gloo-system.gloo",
 		namespace,
 		[]string{"graphql.gloo.solo.io"},
 		[]string{"graphqlapis", "graphqlapis/status"},
-		[]string{"get", "list", "watch", "patch"})
+		[]string{"get", "list", "watch", "patch", "update"})
 
 	// Discovery
 	permissions.AddExpectedPermission(

--- a/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
+++ b/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
@@ -74,17 +74,9 @@ func (c *kubeReporterClient) Read(namespace, name string, opts clients.ReadOpts)
 }
 
 func (c *kubeReporterClient) ApplyStatus(statusClient resources.StatusClient, inputResource resources.InputResource, opts clients.ApplyStatusOpts) (resources.Resource, error) {
-	return c.skClient.ApplyStatus(statusClient, inputResource, opts)
-}
-
-func (c *kubeReporterClient) Write(resource resources.Resource, opts clients.WriteOpts) (resources.Resource, error) {
-	rlConfig, ok := resource.(*RateLimitConfig)
+	rlConfig, ok := inputResource.(*RateLimitConfig)
 	if !ok {
-		return nil, eris.Errorf("unexpected type: expected %T, got %T", &RateLimitConfig{}, resource)
-	}
-	if !opts.OverwriteExisting {
-		// Reporters should never create resources
-		return nil, eris.New("unexpected create operation")
+		return nil, eris.Errorf("unexpected type: expected %T, got %T", &RateLimitConfig{}, inputResource)
 	}
 
 	baseRlConfig := rlv1alpha1.RateLimitConfig(rlConfig.RateLimitConfig)
@@ -97,4 +89,8 @@ func (c *kubeReporterClient) Write(resource resources.Resource, opts clients.Wri
 	return &RateLimitConfig{
 		RateLimitConfig: skratelimit.RateLimitConfig(baseRlConfig),
 	}, nil
+}
+
+func (c *kubeReporterClient) Write(resource resources.Resource, opts clients.WriteOpts) (resources.Resource, error) {
+	return c.skClient.Write(resource, opts)
 }

--- a/projects/gloo/pkg/syncer/extauth/extauth_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/extauth/extauth_translator_syncer.go
@@ -62,6 +62,10 @@ func (s *translatorSyncerExtension) Sync(
 
 	reports.Accept(snap.Proxies.AsInputResources()...)
 
+	for _, ac := range snap.AuthConfigs {
+		reports.AddError(ac, getEnterpriseOnlyErr())
+	}
+
 	for _, proxy := range snap.Proxies {
 		for _, listener := range proxy.GetListeners() {
 			virtualHosts := utils.GetVirtualHostsForListener(listener)

--- a/projects/gloo/pkg/syncer/ratelimit/ratelimit_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/ratelimit/ratelimit_translator_syncer.go
@@ -57,6 +57,10 @@ func (s *translatorSyncerExtension) Sync(
 
 	reports.Accept(snap.Proxies.AsInputResources()...)
 
+	for _, rlc := range snap.Ratelimitconfigs {
+		reports.AddError(rlc, enterpriseOnlyError("RateLimitConfig"))
+	}
+
 	for _, proxy := range snap.Proxies {
 		for _, listener := range proxy.GetListeners() {
 			virtualHosts := utils.GetVirtualHostsForListener(listener)
@@ -65,13 +69,6 @@ func (s *translatorSyncerExtension) Sync(
 
 				// RateLimitConfigs is an enterprise feature https://docs.solo.io/gloo-edge/latest/guides/security/rate_limiting/crds/
 				if virtualHost.GetOptions().GetRateLimitConfigs() != nil {
-					for _, rateLimitConfig := range virtualHost.GetOptions().GetRateLimitConfigs().GetRefs() {
-						rlc, err := snap.Ratelimitconfigs.Find(rateLimitConfig.GetNamespace(), rateLimitConfig.GetName())
-						if err != nil {
-							continue
-						}
-						reports.AddError(rlc, enterpriseOnlyError("RateLimitConfig"))
-					}
 					reports.AddError(proxy, enterpriseOnlyError("RateLimitConfig"))
 				}
 

--- a/projects/gloo/pkg/syncer/ratelimit/ratelimit_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/ratelimit/ratelimit_translator_syncer.go
@@ -65,6 +65,13 @@ func (s *translatorSyncerExtension) Sync(
 
 				// RateLimitConfigs is an enterprise feature https://docs.solo.io/gloo-edge/latest/guides/security/rate_limiting/crds/
 				if virtualHost.GetOptions().GetRateLimitConfigs() != nil {
+					for _, rateLimitConfig := range virtualHost.GetOptions().GetRateLimitConfigs().GetRefs() {
+						rlc, err := snap.Ratelimitconfigs.Find(rateLimitConfig.GetNamespace(), rateLimitConfig.GetName())
+						if err != nil {
+							continue
+						}
+						reports.AddError(rlc, enterpriseOnlyError("RateLimitConfig"))
+					}
 					reports.AddError(proxy, enterpriseOnlyError("RateLimitConfig"))
 				}
 

--- a/test/helpers/resource_clientset.go
+++ b/test/helpers/resource_clientset.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	externalrl "github.com/solo-io/gloo/projects/gloo/pkg/api/external/solo/ratelimit"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 )
 
@@ -16,6 +17,7 @@ type ResourceClientSet interface {
 	UpstreamGroupClient() gloov1.UpstreamGroupClient
 	UpstreamClient() gloov1.UpstreamClient
 	ProxyClient() gloov1.ProxyClient
+	RateLimitConfigClient() externalrl.RateLimitConfigClient
 	SecretClient() gloov1.SecretClient
 	ArtifactClient() gloov1.ArtifactClient
 }

--- a/test/helpers/snapshot_writer.go
+++ b/test/helpers/snapshot_writer.go
@@ -85,6 +85,11 @@ func (s snapshotWriterImpl) doWriteSnapshot(snapshot *gloosnapshot.ApiSnapshot, 
 			return writeErr
 		}
 	}
+	for _, rlc := range snapshot.Ratelimitconfigs {
+		if _, writeErr := s.RateLimitConfigClient().Write(rlc, writeOptions); !s.isContinuableWriteError(writeErr) {
+			return writeErr
+		}
+	}
 	for _, rt := range snapshot.RouteTables {
 		if _, writeErr := s.RouteTableClient().Write(rt, writeOptions); !s.isContinuableWriteError(writeErr) {
 			return writeErr
@@ -150,6 +155,12 @@ func (s snapshotWriterImpl) DeleteSnapshot(snapshot *gloosnapshot.ApiSnapshot, d
 	for _, rt := range snapshot.RouteTables {
 		rtNamespace, rtName := rt.GetMetadata().Ref().Strings()
 		if deleteErr := s.RouteTableClient().Delete(rtNamespace, rtName, deleteOptions); deleteErr != nil {
+			return deleteErr
+		}
+	}
+	for _, rlc := range snapshot.Ratelimitconfigs {
+		rlcNamespace, rlcName := rlc.GetMetadata().Ref().Strings()
+		if deleteErr := s.RateLimitConfigClient().Delete(rlcNamespace, rlcName, deleteOptions); deleteErr != nil {
 			return deleteErr
 		}
 	}

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 	"time"
 
+	ratelimit2 "github.com/solo-io/gloo/projects/gloo/api/external/solo/ratelimit"
+	v1alpha1skv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/solo/ratelimit"
+	"github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
+	rlv1alpha1 "github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
 	matchers2 "github.com/solo-io/solo-kit/test/matchers"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
@@ -23,6 +27,7 @@ import (
 	gloostatusutils "github.com/solo-io/gloo/pkg/utils/statusutils"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"github.com/solo-io/solo-kit/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/golang/protobuf/ptypes/empty"
@@ -1244,6 +1249,60 @@ var _ = Describe("Kube2e: gateway", func() {
 				// properly and should fail
 				helpers.EventuallyResourceAccepted(getProxy)
 			})
+		})
+	})
+
+	Context("tests with RateLimitConfigs", func() {
+		It("correctly sets a status to a RateLimitConfig", func() {
+
+			rateLimitConfig := &v1alpha1skv1.RateLimitConfig{
+				RateLimitConfig: ratelimit2.RateLimitConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "testrlc",
+						Namespace: testHelper.InstallNamespace,
+					},
+					Spec: rlv1alpha1.RateLimitConfigSpec{
+						ConfigType: &rlv1alpha1.RateLimitConfigSpec_Raw_{
+							Raw: &rlv1alpha1.RateLimitConfigSpec_Raw{
+								Descriptors: []*rlv1alpha1.Descriptor{{
+									Key:   "generic_key",
+									Value: "foo",
+									RateLimit: &rlv1alpha1.RateLimit{
+										Unit:            rlv1alpha1.RateLimit_MINUTE,
+										RequestsPerUnit: 1,
+									},
+								}},
+								RateLimits: []*rlv1alpha1.RateLimitActions{{
+									Actions: []*rlv1alpha1.Action{{
+										ActionSpecifier: &rlv1alpha1.Action_GenericKey_{
+											GenericKey: &rlv1alpha1.Action_GenericKey{
+												DescriptorValue: "foo",
+											},
+										},
+									}},
+								}},
+							},
+						},
+					},
+				},
+			}
+			_, err := resourceClientset.RateLimitConfigClient().Write(rateLimitConfig, clients.WriteOpts{OverwriteExisting: false})
+			Expect(err).NotTo(HaveOccurred())
+
+			// demand that a created ratelimit config _has_ a rejected status.
+			Eventually(func() error {
+				rlc, err := resourceClientset.RateLimitConfigClient().Read(rateLimitConfig.GetMetadata().GetNamespace(), rateLimitConfig.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})
+				if err != nil {
+					return err
+				}
+				if rlc.Status.State != v1alpha1.RateLimitConfigStatus_REJECTED {
+					return errors.Errorf("expected rejected status, got %v", rlc.Status.State)
+				}
+				if !strings.Contains(rlc.Status.Message, "enterprise-only") {
+					return errors.Errorf("expected enterprise-only message in status, got %v", rlc.Status.Message)
+				}
+				return nil
+			}, "15s", "0.5s").ShouldNot(HaveOccurred())
 		})
 	})
 

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -1253,9 +1253,11 @@ var _ = Describe("Kube2e: gateway", func() {
 	})
 
 	Context("tests with RateLimitConfigs", func() {
-		It("correctly sets a status to a RateLimitConfig", func() {
 
-			rateLimitConfig := &v1alpha1skv1.RateLimitConfig{
+		var rateLimitConfig *v1alpha1skv1.RateLimitConfig
+
+		BeforeEach(func() {
+			rateLimitConfig = &v1alpha1skv1.RateLimitConfig{
 				RateLimitConfig: ratelimit2.RateLimitConfig{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "testrlc",
@@ -1286,9 +1288,10 @@ var _ = Describe("Kube2e: gateway", func() {
 					},
 				},
 			}
-			_, err := resourceClientset.RateLimitConfigClient().Write(rateLimitConfig, clients.WriteOpts{OverwriteExisting: false})
-			Expect(err).NotTo(HaveOccurred())
+			glooResources.Ratelimitconfigs = v1alpha1skv1.RateLimitConfigList{rateLimitConfig}
+		})
 
+		It("correctly sets a status to a RateLimitConfig", func() {
 			// demand that a created ratelimit config _has_ a rejected status.
 			Eventually(func() error {
 				rlc, err := resourceClientset.RateLimitConfigClient().Read(rateLimitConfig.GetMetadata().GetNamespace(), rateLimitConfig.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})

--- a/test/kube2e/resource_clientset.go
+++ b/test/kube2e/resource_clientset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	externalrl "github.com/solo-io/gloo/projects/gloo/pkg/api/external/solo/ratelimit"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/solo-kit/pkg/api/external/kubernetes/service"
@@ -28,6 +29,7 @@ type KubeResourceClientSet struct {
 	upstreamGroupClient     gloov1.UpstreamGroupClient
 	upstreamClient          gloov1.UpstreamClient
 	proxyClient             gloov1.ProxyClient
+	rateLimitConfigClient   externalrl.RateLimitConfigClient
 	serviceClient           skkube.ServiceClient
 	settingsClient          gloov1.SettingsClient
 
@@ -154,6 +156,21 @@ func NewKubeResourceClientSet(ctx context.Context, cfg *rest.Config) (*KubeResou
 	}
 	resourceClientSet.proxyClient = proxyClient
 
+	// RateLimitConfig
+	rateLimitConfigClientFactory := &factory.KubeResourceClientFactory{
+		Crd:         externalrl.RateLimitConfigCrd,
+		Cfg:         cfg,
+		SharedCache: cache,
+	}
+	rateLimitConfigClient, err := externalrl.NewRateLimitConfigClient(ctx, rateLimitConfigClientFactory)
+	if err != nil {
+		return nil, err
+	}
+	if err = rateLimitConfigClient.Register(); err != nil {
+		return nil, err
+	}
+	resourceClientSet.rateLimitConfigClient = rateLimitConfigClient
+
 	// VirtualHostOption
 	virtualHostOptionClientFactory := &factory.KubeResourceClientFactory{
 		Crd:         gatewayv1.VirtualHostOptionCrd,
@@ -239,6 +256,10 @@ func (k KubeResourceClientSet) UpstreamClient() gloov1.UpstreamClient {
 
 func (k KubeResourceClientSet) ProxyClient() gloov1.ProxyClient {
 	return k.proxyClient
+}
+
+func (k KubeResourceClientSet) RateLimitConfigClient() externalrl.RateLimitConfigClient {
+	return k.rateLimitConfigClient
 }
 
 func (k KubeResourceClientSet) SettingsClient() gloov1.SettingsClient {


### PR DESCRIPTION
# Description

Update permissions and apply status logic for `RateLimitConfig` CRs (enterprise-only) so they are implemented and have the proper permissions as of the changes made in https://github.com/solo-io/gloo/pull/7133

### Automated Testing

Added k8s regression test per https://github.com/solo-io/solo-projects/issues/4076

### Manual Testing

- `kind create cluster --image kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248`
- `VERSION=0.0.0-kdorosh make clean build-test-chart push-kind-images -B`
- `glooctl install gateway -f _test/gloo-0.0.0-kdorosh.tgz `
- apply some ratelimit configs / auth configs

see the following (note that statuses were successfully reported):

```yaml
apiVersion: enterprise.gloo.solo.io/v1
kind: AuthConfig
metadata:
  name: ac-9
  namespace: gloo-system
spec:
  configs:
  - oauth2:
      oidcAuthorizationCode:
        appUrl: https://ab9ade4e124974f55a47a906e8ff9070-2009971879.us-west-1.elb.amazonaws.com
        callbackPath: /callback
        clientId: solo
        clientSecretRef:
          name: keycloak-client-secret
          namespace: gloo-system
        issuerUrl: http://a9ef341cdcc0f4a5ab2c5c8a14b18940-177396470.us-west-1.elb.amazonaws.com:8080/auth/realms/solo/
        scopes:
        - openid
        session:
          cookieOptions: {}
status:
  statuses:
    gloo-system:
      reason: "1 error occurred:\n\t* The Gloo Advanced Extauth API is an enterprise-only
        feature, please upgrade or use the Envoy Extauth API instead\n\n"
      reportedBy: gloo
      state: Rejected
---
apiVersion: ratelimit.solo.io/v1alpha1
kind: RateLimitConfig
metadata:
  name: rlc-9
  namespace: gloo-system
spec:
  raw:
    descriptors:
    - key: remote_address
      rateLimit:
        requestsPerUnit: 3
        unit: MINUTE
    rateLimits:
    - actions:
      - remoteAddress: {}
status:
  message: "1 error occurred:\n\t* The Gloo Advanced Rate limit API feature 'RateLimitConfig'
    is enterprise-only, please upgrade or use the Envoy rate-limit API instead\n\n"
  observedGeneration: 1
  state: REJECTED
```

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/4076