### PR TITLE
[1.11] gateway/translator: Update grouping for ssl configs to emit stable order

### DIFF
--- a/changelog/v1.11.38/stable-filter-chain.yaml
+++ b/changelog/v1.11.38/stable-filter-chain.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7155
+    resolvesIssue: false
+    description: Update Gateway logic for multiple filter chains due to multiple SSL configurations

--- a/projects/gateway/pkg/translator/aggregate_translator_test.go
+++ b/projects/gateway/pkg/translator/aggregate_translator_test.go
@@ -1,0 +1,151 @@
+package translator_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	. "github.com/solo-io/gloo/projects/gateway/pkg/translator"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	gloov1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
+	"github.com/solo-io/gloo/test/samples"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
+)
+
+var _ = Describe("Aggregate translator", func() {
+	var (
+		ctx = context.TODO()
+
+		snap    *gloov1snap.ApiSnapshot
+		proxy   *gloov1.Proxy
+		reports reporter.ResourceReports
+		ns      = "namespace"
+	)
+
+	genProxyWithTranslatorOpts := func(opts Opts) {
+		tx := NewDefaultTranslator(opts)
+		proxy, reports = tx.Translate(ctx, "proxy-name", snap, snap.Gateways)
+	}
+
+	genProxyWithIsolatedVirtualHosts := func() {
+		genProxyWithTranslatorOpts(Opts{
+			WriteNamespace:                 ns,
+			IsolateVirtualHostsBySslConfig: true,
+		})
+	}
+
+	BeforeEach(func() {
+		snap = samples.SimpleGlooSnapshot(ns)
+	})
+
+	It("Computes listener idempotently when provided different ssl configs", func() {
+		gw1 := snap.Gateways[1]
+		gw := gw1.GetHttpGateway()
+		gw.VirtualServiceExpressions = nil
+		gw.VirtualServiceSelector = nil
+		gw.VirtualServices = append(gw.VirtualServices, &core.ResourceRef{
+			Name:      "ssl-vs-0",
+			Namespace: ns,
+		}, &core.ResourceRef{
+			Name:      "ssl-vs-1",
+			Namespace: ns,
+		}, &core.ResourceRef{
+			Name:      "ssl-vs-2",
+			Namespace: ns,
+		}, &core.ResourceRef{
+			Name:      "ssl-vs-3",
+			Namespace: ns,
+		}, &core.ResourceRef{
+			Name:      "ssl-vs-4",
+			Namespace: ns,
+		})
+		snap.Gateways = v1.GatewayList{gw1}
+
+		snap.VirtualServices = append(snap.VirtualServices, &v1.VirtualService{
+			VirtualHost: &v1.VirtualHost{},
+			SslConfig: &gloov1.SslConfig{
+				SniDomains: []string{"sni-0"},
+				// We have to add some other config since we merge configs where the only
+				// difference is the SniDomains
+				TransportSocketConnectTimeout: &durationpb.Duration{Seconds: 0},
+			},
+			DisplayName: "ssl-vs-0",
+			Metadata: &core.Metadata{
+				Name:      "ssl-vs-0",
+				Namespace: ns,
+			},
+		}, &v1.VirtualService{
+			VirtualHost: &v1.VirtualHost{},
+			SslConfig: &gloov1.SslConfig{
+				SniDomains: []string{"sni-1"},
+				// We have to add some other config since we merge configs where the only
+				// difference is the SniDomains
+				TransportSocketConnectTimeout: &durationpb.Duration{Seconds: 1},
+			},
+			DisplayName: "ssl-vs-1",
+			Metadata: &core.Metadata{
+				Name:      "ssl-vs-1",
+				Namespace: ns,
+			},
+		}, &v1.VirtualService{
+			VirtualHost: &v1.VirtualHost{},
+			SslConfig: &gloov1.SslConfig{
+				SniDomains: []string{"sni-2"},
+				// We have to add some other config since we merge configs where the only
+				// difference is the SniDomains
+				TransportSocketConnectTimeout: &durationpb.Duration{Seconds: 2},
+			},
+			DisplayName: "ssl-vs-2",
+			Metadata: &core.Metadata{
+				Name:      "ssl-vs-2",
+				Namespace: ns,
+			},
+		}, &v1.VirtualService{
+			VirtualHost: &v1.VirtualHost{},
+			SslConfig: &gloov1.SslConfig{
+				SniDomains: []string{"sni-3"},
+				// We have to add some other config since we merge configs where the only
+				// difference is the SniDomains
+				TransportSocketConnectTimeout: &durationpb.Duration{Seconds: 3},
+			},
+			DisplayName: "ssl-vs-3",
+			Metadata: &core.Metadata{
+				Name:      "ssl-vs-3",
+				Namespace: ns,
+			},
+		}, &v1.VirtualService{
+			VirtualHost: &v1.VirtualHost{},
+			SslConfig: &gloov1.SslConfig{
+				SniDomains: []string{"sni-4"},
+				// We have to add some other config since we merge configs where the only
+				// difference is the SniDomains
+				TransportSocketConnectTimeout: &durationpb.Duration{Seconds: 4},
+			},
+			DisplayName: "ssl-vs-4",
+			Metadata: &core.Metadata{
+				Name:      "ssl-vs-4",
+				Namespace: ns,
+			},
+		})
+		genProxyWithIsolatedVirtualHosts()
+		proxyName := proxy.Metadata.Name
+		aggregateTranslator := &AggregateTranslator{VirtualServiceTranslator: &VirtualServiceTranslator{}}
+		// run 100 times to ensure idempotency
+		// not sure if 100 times is valid; in anecdotal testing it tended to fail in under 20
+		for i := 0; i < 100; i++ {
+			l := aggregateTranslator.ComputeListener(NewTranslatorParams(ctx, snap, reports), proxyName, snap.Gateways[0])
+			Expect(l).NotTo(BeNil())
+			Expect(l.GetAggregateListener())
+			// since we sort on hashes, this is the ordered output of this config
+			Expect(l.GetAggregateListener().HttpFilterChains[0].GetMatcher().GetSslConfig().GetSniDomains()[0]).To(Equal("sni-1"))
+			Expect(l.GetAggregateListener().HttpFilterChains[1].GetMatcher().GetSslConfig().GetSniDomains()[0]).To(Equal("sni-4"))
+			Expect(l.GetAggregateListener().HttpFilterChains[2].GetMatcher().GetSslConfig().GetSniDomains()[0]).To(Equal("sni-3"))
+			Expect(l.GetAggregateListener().HttpFilterChains[3].GetMatcher().GetSslConfig().GetSniDomains()[0]).To(Equal("sni-0"))
+			Expect(l.GetAggregateListener().HttpFilterChains[4].GetMatcher().GetSslConfig().GetSniDomains()[0]).To(Equal("sni-2"))
+		}
+	})
+})

--- a/projects/gateway/pkg/translator/aggregate_translator_test.go
+++ b/projects/gateway/pkg/translator/aggregate_translator_test.go
@@ -10,7 +10,6 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	. "github.com/solo-io/gloo/projects/gateway/pkg/translator"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
-	gloov1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/solo-io/gloo/test/samples"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
@@ -20,7 +19,7 @@ var _ = Describe("Aggregate translator", func() {
 	var (
 		ctx = context.TODO()
 
-		snap    *gloov1snap.ApiSnapshot
+		snap    *v1.ApiSnapshot
 		proxy   *gloov1.Proxy
 		reports reporter.ResourceReports
 		ns      = "namespace"
@@ -39,7 +38,7 @@ var _ = Describe("Aggregate translator", func() {
 	}
 
 	BeforeEach(func() {
-		snap = samples.SimpleGlooSnapshot(ns)
+		snap = samples.SimpleGatewaySnapshot(&core.ResourceRef{Name: "fake-upstream", Namespace: ns}, ns)
 	})
 
 	It("Computes listener idempotently when provided different ssl configs", func() {

--- a/projects/gateway/pkg/translator/ssl_configuration.go
+++ b/projects/gateway/pkg/translator/ssl_configuration.go
@@ -2,14 +2,16 @@ package translator
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/golang/protobuf/proto"
 	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 )
 
-func groupVirtualServicesBySslConfig(virtualServices []*v1.VirtualService) map[*gloov1.SslConfig][]*v1.VirtualService {
-	result := map[*gloov1.SslConfig][]*v1.VirtualService{}
+// groupVirtualServicesBySslConfig returning a stable order of sslConfigs
+// and a map of sslconfigs to their associated Virtual service lists to use on.
+func groupVirtualServicesBySslConfig(virtualServices []*v1.VirtualService) ([]*gloov1.SslConfig, map[*gloov1.SslConfig][]*v1.VirtualService) {
 	mergedSslConfig := map[string]*gloov1.SslConfig{}
 	groupedVirtualServices := map[string][]*v1.VirtualService{}
 
@@ -35,10 +37,23 @@ func groupVirtualServicesBySslConfig(virtualServices []*v1.VirtualService) map[*
 		}
 	}
 
-	for sslHash, sslConfig := range mergedSslConfig {
+	// get an order of the strings as they are easier to compute once
+	// rather than adding as the sort criterion for sslconfigs after the fact
+	orderedHashes := make([]string, 0, len(mergedSslConfig))
+	for sslHash := range mergedSslConfig {
+		orderedHashes = append(orderedHashes, sslHash)
+	}
+	sort.Strings(orderedHashes)
+
+	result := map[*gloov1.SslConfig][]*v1.VirtualService{}
+	orderedResultKeys := make([]*gloov1.SslConfig, 0, len(mergedSslConfig))
+
+	for _, sslHash := range orderedHashes {
+		sslConfig := mergedSslConfig[sslHash]
+		orderedResultKeys = append(orderedResultKeys, sslConfig)
 		result[sslConfig] = groupedVirtualServices[sslHash]
 	}
-	return result
+	return orderedResultKeys, result
 }
 
 func hashSslConfig(sslConfig *gloov1.SslConfig) string {


### PR DESCRIPTION
Backport https://github.com/solo-io/gloo/pull/7180