### PR TITLE
[1.12.x] Default Gloo Liveness Probe Shouldn't Wait for XDS

### DIFF
--- a/changelog/v1.12.21/fix-liveness-probe.yaml
+++ b/changelog/v1.12.21/fix-liveness-probe.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7197
+    resolvesIssue: true
+    description: >-
+      Updates the default gloo liveness probe (disabled by default) to use a new http server that always returns http 200 "ok".
+      The old probe would wait for xds before signalling health, which in large environments could lag while EDS is warming.
+      This could, in rare cases, cause the gloo pod to needless bounce while it was warming.

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -97,11 +97,12 @@ spec:
           failureThreshold: 3
 {{- if .Values.gloo.deployment.livenessProbeEnabled }}
         livenessProbe:
-          tcpSocket:
-            port: {{ .Values.gloo.deployment.xdsPort }}
+          httpGet:
+            path: /healthz
+            port: 8765
           initialDelaySeconds: 3
           periodSeconds: 10
-          failureThreshold: 10
+          failureThreshold: 3
 {{- end}}
         volumeMounts:
         - mountPath: /etc/envoy
@@ -242,8 +243,9 @@ spec:
           failureThreshold: 3
 {{- if .Values.gloo.deployment.livenessProbeEnabled }}
         livenessProbe:
-          tcpSocket:
-            port: {{ .Values.gloo.deployment.xdsPort }}
+          httpGet:
+            path: /healthz
+            port: 8765
           initialDelaySeconds: 3
           periodSeconds: 10
           failureThreshold: 3

--- a/pkg/utils/probes/healthz.go
+++ b/pkg/utils/probes/healthz.go
@@ -1,0 +1,48 @@
+package probes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/solo-io/go-utils/contextutils"
+)
+
+func StartLivenessProbeServer(ctx context.Context) {
+	var server *http.Server
+
+	// Run the server in a goroutine
+	go func() {
+		mux := new(http.ServeMux)
+		mux.HandleFunc("/healthz", okHandler)
+		server = &http.Server{
+			Addr:    fmt.Sprintf(":%d", 8765),
+			Handler: mux,
+		}
+		contextutils.LoggerFrom(ctx).Infof("healthz server starting at %s", server.Addr)
+		err := server.ListenAndServe()
+		if err == http.ErrServerClosed {
+			contextutils.LoggerFrom(ctx).Info("healthz server closed")
+		} else {
+			contextutils.LoggerFrom(ctx).Warnf("healthz server closed with unexpected error: %v", err)
+		}
+	}()
+
+	// Run a separate goroutine to handle the server shutdown when the context is cancelled
+	go func() {
+		<-ctx.Done()
+		if server != nil {
+			shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer shutdownCancel()
+			if err := server.Shutdown(shutdownCtx); err != nil {
+				contextutils.LoggerFrom(shutdownCtx).Warnf("healthz server shutdown returned error: %v", err)
+			}
+		}
+	}()
+}
+
+func okHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "OK\n")
+}

--- a/projects/gloo/cmd/main.go
+++ b/projects/gloo/cmd/main.go
@@ -3,15 +3,17 @@ package main
 import (
 	"context"
 
+	"github.com/solo-io/gloo/pkg/utils/probes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/setup"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/stats"
 )
 
 func main() {
+	ctx := context.Background()
+	probes.StartLivenessProbeServer(ctx)
 	stats.ConditionallyStartStatsServer()
-
-	if err := setup.Main(context.Background()); err != nil {
+	if err := setup.Main(ctx); err != nil {
 		log.Fatalf("err in main: %v", err.Error())
 	}
 }

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -101,6 +101,7 @@ gloo:
     customEnv:
       - name: LEADER_ELECTION_LEASE_DURATION
         value: 4s
+    livenessProbeEnabled: true
 gatewayProxies:
   gatewayProxy:
     healthyPanicThreshold: 0


### PR DESCRIPTION
backport of https://github.com/solo-io/gloo/pull/7199
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/7197