### PR TITLE
V1.10.x: Deflake Glooctl Istio kube2e Tests (#7250)

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -72,7 +72,7 @@ jobs:
         USE_XDS_RELAY: ${{ matrix.xds-relay }}
         CLUSTER_NAME: 'kind'
         CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
-        VERSION: '0.0.0-kind'
+        VERSION: '0.0.0-kind1'
       run: |
         ./ci/deploy-to-kind-cluster.sh
     - name: Testing - kube e2e regression tests

--- a/changelog/v1.13.0-beta18/deflake-glooctl-istio-tests.yaml
+++ b/changelog/v1.13.0-beta18/deflake-glooctl-istio-tests.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Deflake Glooctl Istio Inject/Uninject kube2e tests
+    issueLink: https://github.com/solo-io/gloo/issues/4428

--- a/ci/deploy-to-kind-cluster.sh
+++ b/ci/deploy-to-kind-cluster.sh
@@ -6,7 +6,7 @@ CLUSTER_NAME="${CLUSTER_NAME:-kind}"
 # The version of the Node Docker image to use for booting the cluster
 CLUSTER_NODE_VERSION="${CLUSTER_NODE_VERSION:-v1.22.4}"
 # The version used to tag images
-VERSION="${VERSION:-0.0.0-kind}"
+VERSION="${VERSION:-0.0.0-kind1}"
 # Automatically (lazily) determine OS type
 if [[ $OSTYPE == 'darwin'* ]]; then
   OS='darwin'

--- a/test/kube2e/README.md
+++ b/test/kube2e/README.md
@@ -19,7 +19,7 @@ It accepts a number of environment variables, to control the creation of a kind 
 | ---                   |   ---      |    ---      |
 | CLUSTER_NAME          | kind       | The name of the cluster that will be generated |
 | CLUSTER_NODE_VERSION  | v1.22.4    | The version of the [Node Docker image](https://hub.docker.com/r/kindest/node/) to use for booting the cluster |
-| VERSION               | 0.0.0-kind | The version used to tag Gloo images that are deployed to the cluster |
+| VERSION               | 0.0.0-kind1 | The version used to tag Gloo images that are deployed to the cluster |
 
 Example:
 ```bash
@@ -31,9 +31,9 @@ CLUSTER_NAME=solo-test-cluster CLUSTER_NODE_VERSION=v1.22.4 VERSION=v1.0.0-solo-
 The CI install script executes a series of make targets.
 
 Create a kind cluster: `kind create cluster --name kind`\
-Build the helm chart: `VERSION=0.0.0-kind make build-test-chart`\
+Build the helm chart: `VERSION=0.0.0-kind1 make build-test-chart`\
 Build glooctl: `make glooctl`\
-Load the images into the cluster: `CLUSTER_NAME=kind VERSION=0.0.0-kind make push-kind-images`
+Load the images into the cluster: `CLUSTER_NAME=kind VERSION=0.0.0-kind1 make push-kind-images`
 
 
 ## Verify Your Setup
@@ -50,7 +50,7 @@ You should see the list of images in the cluster, including the ones you just up
 `Error: validation: chart.metadata.version "solo" is invalid`\
 In newer versions of helm (>3.5), the version used to build the helm chart (ie the VERSION env variable), needs to respect semantic versioning. This error implies that the version provided does not.
 
-Prepend a valid semver to avoid the error. (ie `kind` can become `0.0.0-kind`)
+Prepend a valid semver to avoid the error. (ie `kind` can become `0.0.0-kind1`)
 
 ## Run Tests
 

--- a/test/kube2e/glooctl/glooctl_suite_test.go
+++ b/test/kube2e/glooctl/glooctl_suite_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/gloo/test/kube2e"
 	"github.com/solo-io/go-utils/log"
+	"github.com/solo-io/k8s-utils/kubeutils"
 	"github.com/solo-io/k8s-utils/testutils/helper"
 	"github.com/solo-io/solo-kit/pkg/utils/statusutils"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
@@ -37,7 +38,10 @@ func TestGlooctl(t *testing.T) {
 	RunSpecsWithDefaultAndCustomReporters(t, "glooctl Suite", []Reporter{junitReporter})
 }
 
-var testHelper *helper.SoloTestHelper
+var (
+	testHelper        *helper.SoloTestHelper
+	resourceClientset *kube2e.KubeResourceClientSet
+)
 
 var ctx, _ = context.WithCancel(context.Background())
 var namespace = defaults.GlooSystem
@@ -73,6 +77,13 @@ func StartTestHelper() {
 
 	// Check that everything is OK
 	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
+
+	// Create KubeResourceClientSet
+	cfg, err := kubeutils.GetConfig("", "")
+	Expect(err).NotTo(HaveOccurred())
+
+	resourceClientset, err = kube2e.NewKubeResourceClientSet(ctx, cfg)
+	Expect(err).NotTo(HaveOccurred())
 }
 
 func getHelmValuesOverrideFile() (filename string, cleanup func()) {

--- a/test/kube2e/glooctl/glooctl_suite_test.go
+++ b/test/kube2e/glooctl/glooctl_suite_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/gloo/test/kube2e"
 	"github.com/solo-io/go-utils/log"
-	"github.com/solo-io/k8s-utils/kubeutils"
 	"github.com/solo-io/k8s-utils/testutils/helper"
 	"github.com/solo-io/solo-kit/pkg/utils/statusutils"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
@@ -39,8 +38,7 @@ func TestGlooctl(t *testing.T) {
 }
 
 var (
-	testHelper        *helper.SoloTestHelper
-	resourceClientset *kube2e.KubeResourceClientSet
+	testHelper *helper.SoloTestHelper
 )
 
 var ctx, _ = context.WithCancel(context.Background())
@@ -77,13 +75,6 @@ func StartTestHelper() {
 
 	// Check that everything is OK
 	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
-
-	// Create KubeResourceClientSet
-	cfg, err := kubeutils.GetConfig("", "")
-	Expect(err).NotTo(HaveOccurred())
-
-	resourceClientset, err = kube2e.NewKubeResourceClientSet(ctx, cfg)
-	Expect(err).NotTo(HaveOccurred())
 }
 
 func getHelmValuesOverrideFile() (filename string, cleanup func()) {

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	"github.com/solo-io/go-utils/testutils/exec"
 	"github.com/solo-io/k8s-utils/testutils/helper"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -62,15 +63,22 @@ var _ = Describe("Kube2e: glooctl", func() {
 			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "label", "namespace", "default", "istio-injection-")
 			Expect(err).NotTo(HaveOccurred(), "should be able to remove the istio injection label")
 
-			// Remove the gloo route to petstore
-			err = runGlooctlCommand("remove", "route", "--name", "petstore", "--namespace", testHelper.InstallNamespace)
-			Expect(err).NotTo(HaveOccurred(), "should be able to remove gloo route to petstore")
+			// Remove Petstore vs
+			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "delete", "vs", "petstore", "-n", testHelper.InstallNamespace)
+			Expect(err).NotTo(HaveOccurred(), "should be able to delete the petstore VS")
+
+			Eventually(func(g Gomega) {
+				virtualservices, err := resourceClientset.VirtualServiceClient().List(testHelper.InstallNamespace, clients.ListOpts{})
+				g.Expect(err).NotTo(HaveOccurred(), "should be able to list virtual services")
+				g.Expect(virtualservices).To(HaveLen(0), "should have no virtual services")
+			}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		})
 
 		ExpectIstioInjected := func() {
 			// Check for sds sidecar
 			sdsContainer, err := exec.RunCommandOutput(testHelper.RootDir, false, "kubectl", "get", "-n", testHelper.InstallNamespace, "deployments", "gateway-proxy", "-o", `jsonpath='{.spec.template.spec.containers[?(@.name == "sds")].name}'`)
 			ExpectWithOffset(1, sdsContainer).To(Equal("'sds'"), "sds container should be present after injection")
+			// check that container is started properly
 			ExpectWithOffset(1, err).NotTo(HaveOccurred(), "should be able to kubectl get the gateway-proxy containers")
 
 			// Check for istio-proxy sidecar
@@ -134,7 +142,7 @@ var _ = Describe("Kube2e: glooctl", func() {
 		Context("istio uninject", func() {
 
 			BeforeEach(func() {
-				testHelper.CurlEventuallyShouldRespond(petstoreCurlOpts, goodResponse, 1, 60*time.Second, 1*time.Second)
+				testHelper.CurlEventuallyShouldRespond(petstoreCurlOpts, goodResponse, 1, 10*time.Second, 1*time.Second)
 
 				err = runGlooctlCommand("istio", "inject", "--namespace", testHelper.InstallNamespace)
 				Expect(err).NotTo(HaveOccurred(), "should be able to run 'glooctl istio inject' without errors")
@@ -148,7 +156,14 @@ var _ = Describe("Kube2e: glooctl", func() {
 				Expect(err).NotTo(HaveOccurred(), "should be able to enable mtls strict mode on the petstore app")
 
 				// mTLS strict mode enabled
-				testHelper.CurlEventuallyShouldRespond(petstoreCurlOpts, goodResponse, 1, 60*time.Second, 1*time.Second)
+				testHelper.CurlEventuallyShouldRespond(petstoreCurlOpts, goodResponse, 1, 10*time.Second, 1*time.Second)
+			})
+
+			AfterEach(func() {
+				// Tests may have already successfully run uninject, so we can ignore the error
+				_ = runGlooctlCommand("istio", "uninject", "--namespace", testHelper.InstallNamespace, "--include-upstreams", "true")
+
+				ExpectIstioUninjected()
 			})
 
 			It("succeeds when no upstreams contain sds configuration", func() {
@@ -187,14 +202,6 @@ var _ = Describe("Kube2e: glooctl", func() {
 				// Expect it to work
 				testHelper.CurlEventuallyShouldRespond(petstoreCurlOpts, goodResponse, 1, 60*time.Second, 1*time.Second)
 			})
-
-			AfterEach(func() {
-				// Tests may have already successfully run uninject, so we can ignore the error
-				_ = runGlooctlCommand("istio", "uninject", "--namespace", testHelper.InstallNamespace, "--include-upstreams", "true")
-
-				ExpectIstioUninjected()
-			})
-
 		})
 
 	})
@@ -204,7 +211,8 @@ var _ = Describe("Kube2e: glooctl", func() {
 func runGlooctlCommand(args ...string) error {
 	glooctlCommand := []string{filepath.Join(testHelper.BuildAssetDir, testHelper.GlooctlExecName)}
 	glooctlCommand = append(glooctlCommand, args...)
-	return exec.RunCommand(testHelper.RootDir, false, glooctlCommand...)
+	// execute the command with verbose output
+	return exec.RunCommand(testHelper.RootDir, true, glooctlCommand...)
 }
 
 func toggleStictModePetstore(strictModeEnabled bool) error {

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Kube2e: glooctl", func() {
 				Expect(err).To(HaveOccurred(), "should not be able to run 'glooctl istio uninject' without errors")
 			})
 
-			FIt("succeeds when upstreams contain sds configuration and --include-upstreams=true", func() {
+			It("succeeds when upstreams contain sds configuration and --include-upstreams=true", func() {
 				// Swap mTLS mode to permissive for the petstore app
 				err = toggleStictModePetstore(false)
 				Expect(err).NotTo(HaveOccurred(), "should be able to enable mtls permissive mode on the petstore app")

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	"github.com/solo-io/go-utils/testutils/exec"
 	"github.com/solo-io/k8s-utils/testutils/helper"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -68,9 +67,10 @@ var _ = Describe("Kube2e: glooctl", func() {
 			Expect(err).NotTo(HaveOccurred(), "should be able to delete the petstore VS")
 
 			Eventually(func(g Gomega) {
-				virtualservices, err := resourceClientset.VirtualServiceClient().List(testHelper.InstallNamespace, clients.ListOpts{})
-				g.Expect(err).NotTo(HaveOccurred(), "should be able to list virtual services")
-				g.Expect(virtualservices).To(HaveLen(0), "should have no virtual services")
+				// get virtual services via kubectl
+				out, err := exec.RunCommandOutput(testHelper.RootDir, false, "kubectl", "get", "vs", "-n", testHelper.InstallNamespace)
+				g.Expect(err).NotTo(HaveOccurred(), "should be able to get virtual services")
+				g.Expect(out).To(ContainSubstring("No resources found"))
 			}, 5*time.Second, 1*time.Second).ShouldNot(HaveOccurred())
 		})
 
@@ -189,7 +189,7 @@ var _ = Describe("Kube2e: glooctl", func() {
 				Expect(err).To(HaveOccurred(), "should not be able to run 'glooctl istio uninject' without errors")
 			})
 
-			It("succeeds when upstreams contain sds configuration and --include-upstreams=true", func() {
+			FIt("succeeds when upstreams contain sds configuration and --include-upstreams=true", func() {
 				// Swap mTLS mode to permissive for the petstore app
 				err = toggleStictModePetstore(false)
 				Expect(err).NotTo(HaveOccurred(), "should be able to enable mtls permissive mode on the petstore app")


### PR DESCRIPTION
# Description

Backport #7250 to v1.10.x

This removes a couple of flakes in the Glooctl Istio kube2e tests
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/4428