### PR TITLE
Fix ci 1.12.22

### DIFF
--- a/changelog/v1.12.24/fix-ci.yaml
+++ b/changelog/v1.12.24/fix-ci.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: fix ci

--- a/ci/extended-docker/extended-docker.sh
+++ b/ci/extended-docker/extended-docker.sh
@@ -18,7 +18,7 @@ if [ "$err" != 0 ]; then
   exit $err
 fi
 # grab the image names out of the `make docker` output
-sed -nE 's|Successfully tagged (.*$)|\1|p' ${TEMP_FILE} | grep -v "build-container" | grep -v "-race" | while read f;
+sed -nE 's|Successfully tagged (.*$)|\1|p' ${TEMP_FILE} | grep -v "build-container" | grep -v '[-]race' | while read f;
 do
   docker build ci/extended-docker --build-arg BASE_IMAGE=$f -t $f-extended;
   docker push $f-extended;


### PR DESCRIPTION
# Description

fix ci broken grep in extended docker due to https://github.com/solo-io/gloo/pull/7229

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
