### PR TITLE
Truncate rl status

### DIFF
--- a/changelog/v1.13.0-beta19/truncate-status.yaml
+++ b/changelog/v1.13.0-beta19/truncate-status.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    resolvesIssue: false
+    description: >-
+      Truncate size of ratelimitconfig statuses written to k8s / etcd to protect against large keys stored in k8s backend.
+    issueLink: https://github.com/solo-io/solo-kit/issues/523

--- a/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
+++ b/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"context"
+	"os"
 
 	"github.com/rotisserie/eris"
 	skratelimit "github.com/solo-io/gloo/projects/gloo/api/external/solo/ratelimit"
@@ -15,8 +16,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+const (
+	// 1024 chars = 1kb
+	MaxStatusMessageBytes = 1024
+)
+
+func init() {
+	DisableMaxStatusSize = os.Getenv("DISABLE_MAX_STATUS_SIZE") == "true"
+}
+
 var (
-	RateLimitConfigCrd = crd.NewCrd(
+	// only public for unit tests!
+	DisableMaxStatusSize = false
+	RateLimitConfigCrd   = crd.NewCrd(
 		"ratelimitconfigs",
 		RateLimitConfigGVK.Group,
 		RateLimitConfigGVK.Version,
@@ -92,6 +104,12 @@ func (c *kubeReporterClient) ApplyStatus(statusClient resources.StatusClient, in
 	}
 
 	baseRlConfig := rlv1alpha1.RateLimitConfig(rlConfig.RateLimitConfig)
+
+	// see https://github.com/solo-io/solo-kit/issues/523
+	// we should move this logic into skv2 so other clients can benefit from it
+	if !DisableMaxStatusSize && len(baseRlConfig.Status.GetMessage()) > MaxStatusMessageBytes {
+		baseRlConfig.Status.Message = baseRlConfig.Status.Message[:MaxStatusMessageBytes]
+	}
 
 	err := c.skv2Client.UpdateRateLimitConfigStatus(opts.Ctx, &baseRlConfig)
 	if err != nil {

--- a/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
+++ b/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
@@ -22,12 +22,11 @@ const (
 )
 
 func init() {
-	DisableMaxStatusSize = os.Getenv("DISABLE_MAX_STATUS_SIZE") == "true"
+	disableMaxStatusSize = os.Getenv("DISABLE_MAX_STATUS_SIZE") == "true"
 }
 
 var (
-	// only public for unit tests!
-	DisableMaxStatusSize = false
+	disableMaxStatusSize = false
 	RateLimitConfigCrd   = crd.NewCrd(
 		"ratelimitconfigs",
 		RateLimitConfigGVK.Group,
@@ -107,7 +106,7 @@ func (c *kubeReporterClient) ApplyStatus(statusClient resources.StatusClient, in
 
 	// see https://github.com/solo-io/solo-kit/issues/523
 	// we should move this logic into skv2 so other clients can benefit from it
-	if !DisableMaxStatusSize && len(baseRlConfig.Status.GetMessage()) > MaxStatusMessageBytes {
+	if !disableMaxStatusSize && len(baseRlConfig.Status.GetMessage()) > MaxStatusMessageBytes {
 		baseRlConfig.Status.Message = baseRlConfig.Status.Message[:MaxStatusMessageBytes]
 	}
 

--- a/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
+++ b/projects/gloo/pkg/api/external/solo/ratelimit/extensions.go
@@ -107,7 +107,7 @@ func (c *kubeReporterClient) ApplyStatus(statusClient resources.StatusClient, in
 	// see https://github.com/solo-io/solo-kit/issues/523
 	// we should move this logic into skv2 so other clients can benefit from it
 	if !disableMaxStatusSize && len(baseRlConfig.Status.GetMessage()) > MaxStatusMessageBytes {
-		baseRlConfig.Status.Message = baseRlConfig.Status.Message[:MaxStatusMessageBytes]
+		baseRlConfig.Status.Message = baseRlConfig.Status.GetMessage()[:MaxStatusMessageBytes]
 	}
 
 	err := c.skv2Client.UpdateRateLimitConfigStatus(opts.Ctx, &baseRlConfig)


### PR DESCRIPTION
# Description

Handles skv2 client statuses, related to https://github.com/solo-io/gloo/pull/7259

tested manually with:
- `kind create cluster --image kindest/node:v1.20.15@sha256:6f2d011dffe182bad80b85f6c00e8ca9d86b5b8922cdf433d53575c4c5212248`
- `glooctl install gateway --version 1.12.24`
- manually updating the line right before truncation to a very long message
- `VERSION=0.0.0-kdorosh make gloo-docker -B`
- `kind load docker-image quay.io/solo-io/gloo:0.0.0-kdorosh`
- `kubectl set image deployment gloo -n gloo-system gloo=quay.io/solo-io/gloo:0.0.0-kdorosh`
- apply yaml to cluster from clipboard: `xclip | kubectl apply -f -`

```yaml
apiVersion: ratelimit.solo.io/v1alpha1
kind: RateLimitConfig
metadata:
  name: my-rate-limit-policy
  namespace: gloo-system
spec:
  raw:
    descriptors:
    - key: generic_key
      value: counter
      rateLimit:
        requestsPerUnit: 10
        unit: MINUTE
    rateLimits:
    - actions:
      - genericKey:
          descriptorValue: counter
```

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
