### PR TITLE
12 | helm: standardized *Image as the default data type

### DIFF
--- a/changelog/v1.12.28/helm-tweak.yaml
+++ b/changelog/v1.12.28/helm-tweak.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: force DiscoveryDeployment.Image field to be a standardized data type
+    issueLink: https://github.com/solo-io/gloo/issues/6581
+    resolvesIssue: false

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -245,7 +245,7 @@ type Discovery struct {
 }
 
 type DiscoveryDeployment struct {
-	Image                     Image             `json:"image,omitempty"`
+	Image                     *Image            `json:"image,omitempty"`
 	Stats                     Stats             `json:"stats,omitempty" desc:"overrides for prometheus stats published by the discovery pod"`
 	FloatingUserId            *bool             `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
 	RunAsUser                 *float64          `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`


### PR DESCRIPTION
backport of https://github.com/solo-io/gloo/pull/7268