### PR TITLE
Gateway disable validation webhook server when serverEnabled is false

### DIFF
--- a/projects/gateway/pkg/translator/opts.go
+++ b/projects/gateway/pkg/translator/opts.go
@@ -28,6 +28,7 @@ type Opts struct {
 }
 
 type ValidationOpts struct {
+	ServerEnabled                bool
 	ProxyValidationServerAddress string
 	ValidatingWebhookPort        int
 	ValidatingWebhookCertPath    string

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -831,7 +831,7 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 		}
 	}()
 
-	// Start the validation webhook
+	// Start the validation webhook if the user has not opted out of the validation server
 	validationServerErr := make(chan error, 1)
 	if gwOpts.Validation != nil && gwOpts.Validation.ServerEnabled == true {
 		// make sure non-empty WatchNamespaces contains the gloo instance's own namespace if

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -833,7 +833,7 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 
 	// Start the validation webhook
 	validationServerErr := make(chan error, 1)
-	if gwOpts.Validation != nil {
+	if gwOpts.Validation != nil && gwOpts.Validation.ServerEnabled == true {
 		// make sure non-empty WatchNamespaces contains the gloo instance's own namespace if
 		// ReadGatewaysFromAllNamespaces is false
 		if !gwOpts.ReadGatewaysFromAllNamespaces && !utils.AllNamespaces(opts.WatchNamespaces) {
@@ -1080,6 +1080,7 @@ func constructOpts(ctx context.Context, clientset *kubernetes.Interface, kubeCac
 		// allow user to explicitly disable validation server
 		validationServerEnabled = validationCfg.GetServerEnabled().GetValue()
 	}
+	validation.ServerEnabled = validationServerEnabled
 
 	var gatewayMode bool
 	if settings.GetGateway().GetEnableGatewayController() != nil {


### PR DESCRIPTION
# Description

- Added a check when creating & serving the VWH server so it only occurs when `ServerEnabled` is true.
- Q: Do we want to also disable the `ValidatingWebhookConfiguration` CR from being created as well? Or does that not matter to the server.

# Context

The `serverEnabled` toggle shoul feature-gate the vwh & certgen for it from being deployed

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
