### PR TITLE
`glooctl install gateway enterprise` license key check

### DIFF
--- a/changelog/v1.13.0-beta23/glooctl-install-enterprise-license-key.yaml
+++ b/changelog/v1.13.0-beta23/glooctl-install-enterprise-license-key.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/4124
+    description: Glooctl install enterprise now requires a license key or it will fail

--- a/projects/gloo/cli/pkg/cmd/install/enterprise.go
+++ b/projects/gloo/cli/pkg/cmd/install/enterprise.go
@@ -24,7 +24,9 @@ func enterpriseCmd(opts *options.Options) *cobra.Command {
 				"license_key":      opts.Install.LicenseKey,
 				"gloo-fed.enabled": opts.Install.WithGlooFed,
 			}
-
+			if opts.Install.LicenseKey == "" {
+				return eris.New("No licence key provided, please re-run the install with the following flag `--license_key=<YOUR-LICENSE-KEY>")
+			}
 			mode := Enterprise
 			if err := NewInstaller(DefaultHelmClient()).Install(&InstallerConfig{
 				InstallCliArgs: &opts.Install,

--- a/projects/gloo/cli/pkg/cmd/install/install_test.go
+++ b/projects/gloo/cli/pkg/cmd/install/install_test.go
@@ -64,6 +64,11 @@ var _ = Describe("Install", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
+	It("should get errors for installing enterprise without license key", func() {
+		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway enterprise --file %s --dry-run", file))
+		Expect(err).To(ContainSubstring("No licence key provided, please re-run the install with the following flag `--license_key=<YOUR-LICENSE-KEY>"))
+	})
+
 	It("shouldn't get errors for enterprise dry run without file", func() {
 		_, err := testutils.GlooctlOut(fmt.Sprintf("install gateway enterprise --dry-run %s", licenseKey))
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
# Description

Small behavior change with the `glooctl` CLI, installing enterprise will now check for a license key and fail if one wasn't provided via command line args it will return a non zero, prior to this the install would complete with some pods not spinning up.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
