### PR TITLE
V1.11.x: Add Empty changelog to facilitate new v1.11.x release

### DIFF
--- a/changelog/v1.11.45/empty-change.yaml
+++ b/changelog/v1.11.45/empty-change.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Empty change. We intend to release this to facilitate the creation of a new solo-apis tag.


### PR DESCRIPTION
# Description
 - As an unexpected part of the work to backport the status reporting performance improvements to v1.11.x, it has become clear that we need to backport the below fix to solo-apis branch `gloo-v1.11.x`
   - https://github.com/solo-io/solo-apis/pull/665
 - This PR is intended to be merged and release after that fix is merged, so that another solo-apis tag can be created which contains those changes