### PR TITLE
6983 http protocol options

### DIFF
--- a/changelog/v1.13.0-beta26/http-protocol-options.yaml
+++ b/changelog/v1.13.0-beta26/http-protocol-options.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/6983
+    description: >
+      Fix a bug in configuring Envoy upstreams where some http protocol options could not be specified when useHttp2 was enabled

--- a/projects/gloo/pkg/plugins/protocoloptions/plugin.go
+++ b/projects/gloo/pkg/plugins/protocoloptions/plugin.go
@@ -48,7 +48,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 
 	//At this point we know that we are passing the Http2 settings - check to make sure we aren't incorrectly passing http1 at the same time
 	if in.GetProtocolSelection() == v1.Upstream_USE_CONFIGURED_PROTOCOL {
-		if in.GetConnectionConfig() != nil {
+		if in.GetConnectionConfig() != nil && in.GetConnectionConfig().GetHttp1ProtocolOptions() != nil {
 			return errors.Errorf(
 				"Both HTTP1 and HTTP2 options may only be configured with non-default 'Upstream_USE_DOWNSTREAM_PROTOCOL' specified for Protocol Selection")
 		}

--- a/projects/gloo/pkg/plugins/protocoloptions/plugin.go
+++ b/projects/gloo/pkg/plugins/protocoloptions/plugin.go
@@ -48,7 +48,7 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 
 	//At this point we know that we are passing the Http2 settings - check to make sure we aren't incorrectly passing http1 at the same time
 	if in.GetProtocolSelection() == v1.Upstream_USE_CONFIGURED_PROTOCOL {
-		if in.GetConnectionConfig() != nil && in.GetConnectionConfig().GetHttp1ProtocolOptions() != nil {
+		if in.GetConnectionConfig().GetHttp1ProtocolOptions() != nil {
 			return errors.Errorf(
 				"Both HTTP1 and HTTP2 options may only be configured with non-default 'Upstream_USE_DOWNSTREAM_PROTOCOL' specified for Protocol Selection")
 		}

--- a/projects/gloo/pkg/plugins/protocoloptions/plugin_test.go
+++ b/projects/gloo/pkg/plugins/protocoloptions/plugin_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	protocol "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/protocol"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/protocoloptions"
 	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/protocol"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	"github.com/solo-io/solo-kit/pkg/utils/prototime"
 )
@@ -36,7 +36,7 @@ var _ = Describe("Plugin", func() {
 	Context("upstream", func() {
 		Context("USE_DOWNSTREAM_PROTOCOL is set", func() {
 			It("should account for `nil` Http1ProtocolOptions", func() {
-				upstream := createTestUpstreamWithProtocolOptions(true, v1.Upstream_USE_DOWNSTREAM_PROTOCOL)
+				upstream := createTestUpstreamWithProtocolOptions(true, true, v1.Upstream_USE_DOWNSTREAM_PROTOCOL)
 				upstream.ConnectionConfig = nil
 
 				err := p.ProcessUpstream(params, upstream, out)
@@ -44,7 +44,7 @@ var _ = Describe("Plugin", func() {
 			})
 
 			It("should unpack Http1ProtocolOptions to envoy object", func() {
-				upstream := createTestUpstreamWithProtocolOptions(true, v1.Upstream_USE_DOWNSTREAM_PROTOCOL)
+				upstream := createTestUpstreamWithProtocolOptions(true, true, v1.Upstream_USE_DOWNSTREAM_PROTOCOL)
 				upstream.ConnectionConfig.Http1ProtocolOptions = &protocol.Http1ProtocolOptions{
 					EnableTrailers: true,
 				}
@@ -61,7 +61,7 @@ var _ = Describe("Plugin", func() {
 			})
 
 			It("should unpack Http2ProtocolOptions to envoy object", func() {
-				upstream := createTestUpstreamWithProtocolOptions(true, v1.Upstream_USE_DOWNSTREAM_PROTOCOL)
+				upstream := createTestUpstreamWithProtocolOptions(true, true, v1.Upstream_USE_DOWNSTREAM_PROTOCOL)
 
 				err := p.ProcessUpstream(params, upstream, out)
 				Expect(err).ToNot(HaveOccurred())
@@ -149,39 +149,44 @@ var _ = Describe("Plugin", func() {
 				To(Equal(&wrappers.BoolValue{Value: true}))
 		})
 
-		It("Should be rejected if Http2 is true and protocol options is passed as USE_CONFIGURED_PROTOCOL and http1 settings are not nil", func() {
-			upstream := createTestUpstreamWithProtocolOptions(true, v1.Upstream_USE_CONFIGURED_PROTOCOL) //passed value won't be used
-			err := p.ProcessUpstream(params, upstream, out)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(BeEquivalentTo(expectedProtocolErrorString))
+		// the configuration should only be rejected if all of the conditions are met:
+		//    1. useHttp2 == true
+		//    2. Http1ProtocolOptions != nil
+		//    3. protocolSelection == CONFIGURED
+		// otherwise, all configurations should be accepted
+		It("Should only deny configuration if (1) useHttp2 is true AND (2) Http1ProtocolOptions != nil AND (3) ProtocolSelection == CONFIGURED", func() {
+			useHttp2Opts := []bool{false, true}
+			nilHttp1Opts := []bool{false, true}
+			protocolSelectionOpts := []v1.Upstream_ClusterProtocolSelection{
+				v1.Upstream_USE_CONFIGURED_PROTOCOL,
+				v1.Upstream_USE_DOWNSTREAM_PROTOCOL,
+			}
+			for _, useHttp2 := range useHttp2Opts {
+				for _, nilHttp1 := range nilHttp1Opts {
+					for _, protocolSelection := range protocolSelectionOpts {
+						upstream := createTestUpstreamWithProtocolOptions(useHttp2, nilHttp1, protocolSelection)
+						err := p.ProcessUpstream(params, upstream, out)
+						if useHttp2 && !nilHttp1 && protocolSelection == v1.Upstream_USE_CONFIGURED_PROTOCOL {
+							Expect(err).To(HaveOccurred())
+							Expect(err.Error()).To(BeEquivalentTo(expectedProtocolErrorString))
+						} else {
+							Expect(err).NotTo(HaveOccurred())
+						}
+					}
+				}
+			}
 		})
 
-		It("Should be rejected if Http2 is true and protocol options not passed and default of Upstream_USE_CONFIGURED_PROTOCOL and http1 settings are not nil", func() {
-			upstream := createTestUpstreamWithProtocolOptions(false, v1.Upstream_USE_CONFIGURED_PROTOCOL) //passed value won't be used
-			err := p.ProcessUpstream(params, upstream, out)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(BeEquivalentTo(expectedProtocolErrorString))
-		})
-
-		It("Should accept http2 setting if protocol options is passed as USE_DOWNSTREAM_PROTOCOL", func() {
-			upstream := createTestUpstreamWithProtocolOptions(true, v1.Upstream_USE_DOWNSTREAM_PROTOCOL)
-			err := p.ProcessUpstream(params, upstream, out)
-			Expect(err).NotTo(HaveOccurred())
-			//further validation not added as the code logic is covered in previous tests
-		})
 	})
 })
 
-func createTestUpstreamWithProtocolOptions(includeProtocolSelection bool, protocolSelection v1.Upstream_ClusterProtocolSelection) *v1.Upstream {
+func createTestUpstreamWithProtocolOptions(useHttp2 bool, nilHttp1Opts bool, protocolSelection v1.Upstream_ClusterProtocolSelection) *v1.Upstream {
 	upstream := &v1.Upstream{
 		MaxConcurrentStreams:        &wrappers.UInt32Value{Value: 1234},
 		InitialStreamWindowSize:     &wrappers.UInt32Value{Value: 268435457},
 		InitialConnectionWindowSize: &wrappers.UInt32Value{Value: 65535},
-		UseHttp2:                    &wrappers.BoolValue{Value: true},
-	}
-
-	if includeProtocolSelection {
-		upstream.ProtocolSelection = protocolSelection
+		UseHttp2:                    &wrappers.BoolValue{Value: useHttp2},
+		ProtocolSelection:           protocolSelection,
 	}
 
 	minute := prototime.DurationToProto(time.Minute)
@@ -192,6 +197,10 @@ func createTestUpstreamWithProtocolOptions(includeProtocolSelection bool, protoc
 			KeepaliveTime:     hour,
 			KeepaliveProbes:   3,
 		},
+	}
+
+	if !nilHttp1Opts {
+		upstream.ConnectionConfig.Http1ProtocolOptions = &protocol.Http1ProtocolOptions{}
 	}
 
 	return upstream

--- a/projects/gloo/pkg/plugins/protocoloptions/plugin_test.go
+++ b/projects/gloo/pkg/plugins/protocoloptions/plugin_test.go
@@ -155,28 +155,45 @@ var _ = Describe("Plugin", func() {
 		//    3. protocolSelection == CONFIGURED
 		// otherwise, all configurations should be accepted
 		It("Should only deny configuration if (1) useHttp2 is true AND (2) Http1ProtocolOptions != nil AND (3) ProtocolSelection == CONFIGURED", func() {
-			useHttp2Opts := []bool{false, true}
-			http1Opts := []*protocol.Http1ProtocolOptions{nil, {}}
-			protocolSelectionOpts := []v1.Upstream_ClusterProtocolSelection{
-				v1.Upstream_USE_CONFIGURED_PROTOCOL,
-				v1.Upstream_USE_DOWNSTREAM_PROTOCOL,
-			}
-			for _, useHttp2 := range useHttp2Opts {
-				for _, http1Opt := range http1Opts {
-					for _, protocolSelection := range protocolSelectionOpts {
-						upstream := createTestUpstreamWithProtocolOptions(useHttp2, http1Opt, protocolSelection)
-						err := p.ProcessUpstream(params, upstream, out)
-						if useHttp2 && http1Opt != nil && protocolSelection == v1.Upstream_USE_CONFIGURED_PROTOCOL {
-							Expect(err).To(HaveOccurred())
-							Expect(err.Error()).To(BeEquivalentTo(expectedProtocolErrorString))
-						} else {
-							Expect(err).NotTo(HaveOccurred())
-						}
-					}
-				}
-			}
+			var http1Opt *protocol.Http1ProtocolOptions
+			useHttp2 := true
+			http1Opt = &protocol.Http1ProtocolOptions{}
+			protocolSelection := v1.Upstream_USE_CONFIGURED_PROTOCOL
+			upstream := createTestUpstreamWithProtocolOptions(useHttp2, http1Opt, protocolSelection)
+			err := p.ProcessUpstream(params, upstream, out)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(BeEquivalentTo(expectedProtocolErrorString))
 		})
 
+		It("Should allow configuration if useHttp2 is false", func() {
+			var http1Opt *protocol.Http1ProtocolOptions
+			useHttp2 := false
+			http1Opt = &protocol.Http1ProtocolOptions{}
+			protocolSelection := v1.Upstream_USE_CONFIGURED_PROTOCOL
+			upstream := createTestUpstreamWithProtocolOptions(useHttp2, http1Opt, protocolSelection)
+			err := p.ProcessUpstream(params, upstream, out)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should allow configuration if Http1ProtocolOptions is nil", func() {
+			var http1Opt *protocol.Http1ProtocolOptions
+			useHttp2 := true
+			http1Opt = nil
+			protocolSelection := v1.Upstream_USE_CONFIGURED_PROTOCOL
+			upstream := createTestUpstreamWithProtocolOptions(useHttp2, http1Opt, protocolSelection)
+			err := p.ProcessUpstream(params, upstream, out)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("Should allow configuration if Upstream_ClusterProtocolSelection is USE_DOWNSTREAM_PROTOCOL", func() {
+			var http1Opt *protocol.Http1ProtocolOptions
+			useHttp2 := true
+			http1Opt = &protocol.Http1ProtocolOptions{}
+			protocolSelection := v1.Upstream_USE_DOWNSTREAM_PROTOCOL
+			upstream := createTestUpstreamWithProtocolOptions(useHttp2, http1Opt, protocolSelection)
+			err := p.ProcessUpstream(params, upstream, out)
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
 })
 


### PR DESCRIPTION
# Description

Fix a bug in configuring Envoy upstreams where some http protocol options could not be specified when useHttp2 was enabled

# Context

This is a bugfix

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/6983