### PR TITLE
Makefile m1update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -745,7 +745,6 @@ docker-push: docker-push-local docker-push-non-arm
 
 .PHONY: docker-push-local
 docker-push-local: $(DOCKER_IMAGES)
-ifeq ($(CREATE_ASSETS), "true")
 	docker push $(IMAGE_REPO)/ingress:$(VERSION) && \
 	docker push $(IMAGE_REPO)/discovery:$(VERSION) && \
 	docker push $(IMAGE_REPO)/gloo:$(VERSION) && \
@@ -754,7 +753,6 @@ ifeq ($(CREATE_ASSETS), "true")
 	docker push $(IMAGE_REPO)/kubectl:$(VERSION) && \
 	docker push $(IMAGE_REPO)/sds:$(VERSION) && \
 	docker push $(IMAGE_REPO)/access-logger:$(VERSION)
-endif
 
 .PHONY: docker-push-non-arm
 docker-push-non-arm:

--- a/changelog/v1.13.0-beta26/always-push-images-makefile-m1-update.yaml
+++ b/changelog/v1.13.0-beta26/always-push-images-makefile-m1-update.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description:  >
+     update makefile to always push docker images. For m1 machines the ci script does not push images leading to failures when trying to install and upgrade gloo


### PR DESCRIPTION
# Description

Remove conditional for architecture on push images. This would prevent m1 machines from pushing docker images when they are needed for use in kind cluster deployments 