### PR TITLE
doc(helm): use --create-namespace parameter instead of separated `kubectl` command

### DIFF
--- a/docs/content/getting_started/_index.md
+++ b/docs/content/getting_started/_index.md
@@ -33,13 +33,9 @@ After you have a cluster, you can install Gloo Edge through the command line wit
    helm repo add gloo https://storage.googleapis.com/solo-public-helm
    helm repo update
    ```
-2. Create the namespace for the Gloo Edge components.
+2. Install the Helm chart. This command creates the `gloo-system` namespace and installs the Gloo Edge components into it.
    ```shell
-   kubectl create namespace gloo-system
-   ```
-3. Install the Helm chart.
-   ```shell
-   helm install gloo gloo/gloo --namespace gloo-system
+   helm install gloo gloo/gloo --namespace gloo-system --create-namespace
    ```
 {{% /tab %}}
 {{< /tabs >}}

--- a/docs/content/guides/integrations/service_mesh/istio.md
+++ b/docs/content/guides/integrations/service_mesh/istio.md
@@ -53,14 +53,9 @@ Install the Gloo Edge gateway and inject it with an Istio sidecar.
    {{< tabs >}} 
    {{< tab name="Install Gloo Edge">}}
 
-   1. Create the namespace where you want to install Gloo Edge. The following command creates the `gloo` namespace.
+   1. Install Gloo Edge with the settings in the `value-overrides.yaml` file. This command creates the `gloo-system` namespace and installs the Gloo Edge components into it.
       ```shell
-      kubectl create namespace gloo-system
-      ```
-   
-   2. Install Gloo Edge with the settings in the `value-overrides.yaml` file.  
-      ```shell
-      helm install gloo gloo/gloo --namespace gloo-system -f value-overrides.yaml
+      helm install gloo gloo/gloo --namespace gloo-system --create-namespace -f value-overrides.yaml
       ```
    {{< /tab >}}
    {{< tab name="Upgrade Gloo Edge">}}

--- a/docs/content/guides/observability/tracing.md
+++ b/docs/content/guides/observability/tracing.md
@@ -144,8 +144,7 @@ Use the Gloo Edge installation Helm chart template to configure the Zipkin traci
    
 2. Install Gloo Edge with your Zipkin configuration.   
    ```shell
-   kubectl create namespace gloo-system
-   helm install gloo gloo/gloo --namespace gloo-system -f values.yaml
+   helm install gloo gloo/gloo --namespace gloo-system --create-namespace -f values.yaml
    ```
 
 **Option 2: Update the Envoy configmap directly**

--- a/docs/content/installation/gloo_federation.md
+++ b/docs/content/installation/gloo_federation.md
@@ -48,11 +48,8 @@ helm repo add gloo-fed https://storage.googleapis.com/gloo-fed-helm
 # Update your repos 
 helm repo update
 
-# Create the gloo-system namespace
-kubectl create namespace gloo-system
-
 # Install using helm
-helm install -n gloo-system gloo-fed gloo-fed/gloo-fed --set license_key=<LICENSE_KEY>
+helm install -n gloo-system --create-namespace gloo-fed gloo-fed/gloo-fed --set license_key=<LICENSE_KEY>
 ```
 
 Make sure to change the placeholder `<LICENSE_KEY>` to the license key you have procured for Gloo Edge Federation.

--- a/docs/content/installation/ingress/_index.md
+++ b/docs/content/installation/ingress/_index.md
@@ -51,8 +51,7 @@ ingress:
 Then install Gloo Edge using the following command:
 
 ```shell
-kubectl create namespace gloo-system
-helm install gloo gloo/gloo --namespace gloo-system -f values.yaml
+helm install gloo gloo/gloo --namespace gloo-system --create-namespace -f values.yaml
 ```
 
 Gloo Edge can be installed to a namespace of your choosing with the `--namespace` flag.
@@ -64,8 +63,7 @@ Instead of creating a `values.yaml` file, you can simply define the settings in-
 Run the following commands to install the Gloo Edge ingress controller.
 
 ```shell
-kubectl create namespace gloo-system
-helm install gloo gloo/gloo --namespace gloo-system \
+helm install gloo gloo/gloo --namespace gloo-system --create-namespace \
   --set gateway.enabled=false,ingress.enabled=true
 ```
 

--- a/docs/content/installation/knative/_index.md
+++ b/docs/content/installation/knative/_index.md
@@ -104,8 +104,7 @@ For our example, we would Replace the `{{ . }}` with `v0.10.0`.
 Save the file and then run the following commands to install the Gloo Edge components.
 
 ```shell
-kubectl create namespace gloo-system
-helm install gloo gloo/gloo --namespace gloo-system -f values.yaml
+helm install gloo gloo/gloo --namespace gloo-system --create-namespace -f values.yaml
 ```
 
 Gloo Edge can be installed to a namespace of your choosing with the `--namespace` flag.
@@ -117,8 +116,7 @@ Instead of creating a `values.yaml` file, you can simply define the settings in-
 Run the following commands to install the Gloo Edge components with version `v0.10.0` of Knative.
 
 ```shell
-kubectl create namespace gloo-system
-helm install gloo gloo/gloo --namespace gloo-system \
+helm install gloo gloo/gloo --namespace gloo-system --create-namespace \
   --set gateway.enabled=false,settings.integrations.knative.enabled=true,settings.integrations.knative.version=v0.10.0
 ```
 


### PR DESCRIPTION
# Description

Small doc modification to remove one extra command when using `helm`. 

# Checklist:

- [~] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [~] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [~] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [~] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [~] I have performed a self-review of my own code
- [~] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [~] I have added tests that prove my fix is effective or that my feature works


Because this is a very minor documentation change, let me know if I have to do something else in the PR workflow 😇