### PR TITLE
Fix for setting XDS_RELAY in regression matrix

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -129,7 +129,6 @@ jobs:
       if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
-        USE_XDS_RELAY: ${{ matrix.xds-relay }}
         CLUSTER_NAME: 'kind'
         CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
         VERSION: '0.0.0-kind1'
@@ -139,6 +138,7 @@ jobs:
       if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
+        USE_XDS_RELAY: ${{ matrix.xds-relay }}
         GITHUB_TOKEN: ${{ github.token }}
         ACK_GINKGO_RC: true
         ACK_GINKGO_DEPRECATIONS: 1.16.5

--- a/changelog/v1.13.0-beta27/xds-ci.yaml
+++ b/changelog/v1.13.0-beta27/xds-ci.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Set USE_XDS_RELAY env variable during the step that actually runs tests.


### PR DESCRIPTION
# Description
We want run regression tests with and without  XDS relay enabled. We configure this with an environment variable that is checked by the test setup code. However the github actions were only setting this when we create the cluster, not when we install gloo and run the tests. 

