### PR TITLE
Liveness probe in XDS test set up

### DIFF
--- a/changelog/v1.13.0-beta27/ci-fixes.yaml
+++ b/changelog/v1.13.0-beta27/ci-fixes.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Get CI working after re-enabling XDS relay tests.

--- a/changelog/v1.13.0-beta27/ci-fixes.yaml
+++ b/changelog/v1.13.0-beta27/ci-fixes.yaml
@@ -1,3 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: Get CI working after re-enabling XDS relay tests.

--- a/changelog/v1.13.0-beta28/ci-fixes.yaml
+++ b/changelog/v1.13.0-beta28/ci-fixes.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Get CI working after re-enabling XDS relay tests.

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -164,6 +164,7 @@ gloo:
     customEnv:
       - name: LEADER_ELECTION_LEASE_DURATION
         value: 4s
+    livenessProbeEnabled: true
 gatewayProxies:
   gatewayProxy:
     healthyPanicThreshold: 0


### PR DESCRIPTION
# Description

We were accidentally not running the tests that rely on the XDS relay. 
The XDS relay tests started flaking when we started actually running them. This PR is to handle getting them working/more stable, starting with enabling the liveness probe on install. 

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
