### PR TITLE
Fix indentation in nightly build workflow

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -1,7 +1,7 @@
 name: Nightly
 on:
   schedule:
-    # run Monday-Friday mornings (midnight utc)
+    # run Monday-Friday mornings (midnight UTC)
     - cron: "0 0 * * 1-5"
 jobs:
   prepare_env:

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -28,96 +28,95 @@ jobs:
         #include:
         #  - kube-e2e-test-type: 'gateway'
         #    xds-relay: 'true'
-steps:
-  - name: Cancel Previous Actions
-    uses: styfle/cancel-workflow-action@0.4.1
-    with:
-      access_token: ${{ github.token }}
-  - name: Free disk space
-    run: |
-      echo "Before clearing disk space:"
-      df -h
-      
-      # https://github.com/actions/virtual-environments/issues/709
-      sudo apt-get clean
-      
-      # Clean up pre-installed tools
-      # https://github.com/actions/virtual-environments/issues/1918
-      sudo rm -rf /usr/share/dotnet
-      sudo rm -rf /opt/ghc
-      sudo rm -rf /usr/local/share/boost
-      sudo rm -rf $AGENT_TOOLSDIRECTORY
-      
-      echo "After clearing disk space:"
-      df -h
-  - name: Set up Go
-    uses: actions/setup-go@v2
-    with:
-      go-version: 1.18.2
-    id: go
-  - name: Check out code into the Go module directory
-    uses: actions/checkout@v2
-    with:
-      fetch-depth: 0
-  - uses: actions/cache@v1
-    with:
-      path: ~/go/pkg/mod
-      key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-      restore-keys: |
-        ${{ runner.os }}-go-
-  - uses: engineerd/setup-kind@v0.5.0
-    with:
-      # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
-      skipClusterCreation: true
-      version: v0.11.1
-  - uses: azure/setup-kubectl@v1
-    id: kubectl
-    with:
-      version: 'v1.22.4'
-  - uses: azure/setup-helm@v1
-    with:
-      version: v3.6.3
-  - name: Setup test env
-    env:
-      KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
-      CLUSTER_NAME: 'kind'
-      CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
-      VERSION: '0.0.0-kind1'
-      JUST_KIND: 'true'
-    run: |
-      ./ci/deploy-to-kind-cluster.sh
-      # TODO need to download the released version of glooctl
-      make glooctl-linux-amd64
-  - name: Testing - kube e2e regression tests
-    env:
-      KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
-      USE_XDS_RELAY: ${{ matrix.xds-relay }}
-      GITHUB_TOKEN: ${{ github.token }}
-      ACK_GINKGO_RC: true
-      ACK_GINKGO_DEPRECATIONS: 1.16.5
-      RELEASED_VERSION: "LATEST"
-    run: |
-      make run-ci-regression-tests
-  - uses: testspace-com/setup-testspace@v1
-    with:
-      domain: solo-io.testspace.com
-    if: ${{ always() && github.ref == 'refs/heads/master' }}
-  - name: Push result to Testspace server
-    run: |
-      testspace push --verbose "**/junit.xml"
-    if: ${{ always() && github.ref == 'refs/heads/master' }}
-  - name: Debug Info
-    if: failure()
-    run: |
-      # see what's in the cluster if we failed
-      kubectl get all -A
-      kubectl get configmaps -A
-  - name: Set direct_message_id
-  - name: Send Message
-    id: message-on-result
-    shell: bash
-    run: |
-      curl -X POST https://slack.com/api/chat.postMessage\
-            -H "Content-Type: application/json; charset=utf-8"\
-            -H "Authorization: Bearer ${{ secrets.SLACKBOT_BEARER }}"\
-            -d '{"channel":"edge-nightly-results","text":"The <https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}|regression tests> nightly run has completed. Result: ${{ job.status }}"}'
+    steps:
+    - name: Cancel Previous Actions
+      uses: styfle/cancel-workflow-action@0.4.1
+      with:
+        access_token: ${{ github.token }}
+    - name: Free disk space
+      run: |
+        echo "Before clearing disk space:"
+        df -h
+        
+        # https://github.com/actions/virtual-environments/issues/709
+        sudo apt-get clean
+        
+        # Clean up pre-installed tools
+        # https://github.com/actions/virtual-environments/issues/1918
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf $AGENT_TOOLSDIRECTORY
+        
+        echo "After clearing disk space:"
+        df -h
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18.2
+      id: go
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - uses: engineerd/setup-kind@v0.5.0
+      with:
+        # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
+        skipClusterCreation: true
+        version: v0.11.1
+    - uses: azure/setup-kubectl@v1
+      id: kubectl
+      with:
+        version: 'v1.22.4'
+    - uses: azure/setup-helm@v1
+      with:
+        version: v3.6.3
+    - name: Setup test env
+      env:
+        KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
+        CLUSTER_NAME: 'kind'
+        CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
+        VERSION: '0.0.0-kind1'
+        JUST_KIND: 'true'
+      run: |
+        ./ci/deploy-to-kind-cluster.sh
+        # TODO need to download the released version of glooctl
+        make glooctl-linux-amd64
+    - name: Testing - kube e2e regression tests
+      env:
+        KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
+        USE_XDS_RELAY: ${{ matrix.xds-relay }}
+        GITHUB_TOKEN: ${{ github.token }}
+        ACK_GINKGO_RC: true
+        ACK_GINKGO_DEPRECATIONS: 1.16.5
+        RELEASED_VERSION: "LATEST"
+      run: |
+        make run-ci-regression-tests
+    - uses: testspace-com/setup-testspace@v1
+      with:
+        domain: solo-io.testspace.com
+      if: ${{ always() && github.ref == 'refs/heads/master' }}
+    - name: Push result to Testspace server
+      run: |
+        testspace push --verbose "**/junit.xml"
+      if: ${{ always() && github.ref == 'refs/heads/master' }}
+    - name: Debug Info
+      if: failure()
+      run: |
+        # see what's in the cluster if we failed
+        kubectl get all -A
+        kubectl get configmaps -A
+    - name: Send Message
+      id: message-on-result
+      shell: bash
+      run: |
+        curl -X POST https://slack.com/api/chat.postMessage\
+              -H "Content-Type: application/json; charset=utf-8"\
+              -H "Authorization: Bearer ${{ secrets.SLACKBOT_BEARER }}"\
+              -d '{"channel":"edge-nightly-results","text":"The <https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}|regression tests> nightly run has completed. Result: ${{ job.status }}"}'

--- a/changelog/v1.13.0-beta28/worflow-fixes.yaml
+++ b/changelog/v1.13.0-beta28/worflow-fixes.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Formatting fix for nightly workflow.


### PR DESCRIPTION
The formatting was off in the first iteration of the workflow for nightly runs. This change fixes that and removes and extra empty step that also was invalid. I realized while making this PR that github will spit out formatting errors for bad workflows on pushes and it stopped doing that once I made these fixes (see: https://github.com/solo-io/gloo/actions/workflows/nightly-tests.yaml)