### PR TITLE
Remove xds relay from regression test matrix

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -65,10 +65,6 @@ jobs:
         # knative support has been deprecated: https://github.com/solo-io/gloo/issues/5707
         # We have removed it from our CI regression tests
         kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
-        xds-relay: [ 'false' ]
-        include:
-          - kube-e2e-test-type: 'gateway'
-            xds-relay: 'true'
     steps:
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.4.1
@@ -138,7 +134,6 @@ jobs:
       if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
-        USE_XDS_RELAY: ${{ matrix.xds-relay }}
         GITHUB_TOKEN: ${{ github.token }}
         ACK_GINKGO_RC: true
         ACK_GINKGO_DEPRECATIONS: 1.16.5


### PR DESCRIPTION
# Description
Stop running broken xds relay tests on every commit. We already updated branch protection to allow us to merge without these tests and since we aren't planning to fix them this spring, we can stop running them until we do get around to fixing them.

