### PR TITLE
 `--vault-token` flag description

### DIFF
--- a/changelog/v1.14.0-beta1/vault-token-description-fix.yaml
+++ b/changelog/v1.14.0-beta1/vault-token-description-fix.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: FIX
+    description: --vault-token flag incorrectly had the description associated with --vault-address
+    issueLink: https://github.com/solo-io/gloo/issues/7469

--- a/docs/content/reference/cli/glooctl_create_secret.md
+++ b/docs/content/reference/cli/glooctl_create_secret.md
@@ -28,7 +28,7 @@ glooctl create secret [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/reference/cli/glooctl_create_secret.md
+++ b/docs/content/reference/cli/glooctl_create_secret.md
@@ -19,7 +19,7 @@ glooctl create secret [flags]
 ```
   -h, --help                           help for secret
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -28,7 +28,7 @@ glooctl create secret [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### Options inherited from parent commands

--- a/docs/content/reference/cli/glooctl_create_secret_apikey.md
+++ b/docs/content/reference/cli/glooctl_create_secret_apikey.md
@@ -50,7 +50,7 @@ glooctl create secret apikey [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_apikey.md
+++ b/docs/content/reference/cli/glooctl_create_secret_apikey.md
@@ -41,7 +41,7 @@ glooctl create secret apikey [flags]
   -o, --output OutputType              output format: (yaml, json, table, kube-yaml, wide) (default table)
       --use-consul                     use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -50,7 +50,7 @@ glooctl create secret apikey [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_authcredentials.md
+++ b/docs/content/reference/cli/glooctl_create_secret_authcredentials.md
@@ -40,7 +40,7 @@ glooctl create secret authcredentials [flags]
   -o, --output OutputType              output format: (yaml, json, table, kube-yaml, wide) (default table)
       --use-consul                     use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -49,7 +49,7 @@ glooctl create secret authcredentials [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_authcredentials.md
+++ b/docs/content/reference/cli/glooctl_create_secret_authcredentials.md
@@ -49,7 +49,7 @@ glooctl create secret authcredentials [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_aws.md
+++ b/docs/content/reference/cli/glooctl_create_secret_aws.md
@@ -41,7 +41,7 @@ glooctl create secret aws [flags]
   -o, --output OutputType              output format: (yaml, json, table, kube-yaml, wide) (default table)
       --use-consul                     use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -50,7 +50,7 @@ glooctl create secret aws [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_aws.md
+++ b/docs/content/reference/cli/glooctl_create_secret_aws.md
@@ -50,7 +50,7 @@ glooctl create secret aws [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_azure.md
+++ b/docs/content/reference/cli/glooctl_create_secret_azure.md
@@ -39,7 +39,7 @@ glooctl create secret azure [flags]
   -o, --output OutputType              output format: (yaml, json, table, kube-yaml, wide) (default table)
       --use-consul                     use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -48,7 +48,7 @@ glooctl create secret azure [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_azure.md
+++ b/docs/content/reference/cli/glooctl_create_secret_azure.md
@@ -48,7 +48,7 @@ glooctl create secret azure [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_header.md
+++ b/docs/content/reference/cli/glooctl_create_secret_header.md
@@ -48,7 +48,7 @@ glooctl create secret header [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_header.md
+++ b/docs/content/reference/cli/glooctl_create_secret_header.md
@@ -39,7 +39,7 @@ glooctl create secret header [flags]
   -o, --output OutputType              output format: (yaml, json, table, kube-yaml, wide) (default table)
       --use-consul                     use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -48,7 +48,7 @@ glooctl create secret header [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_oauth.md
+++ b/docs/content/reference/cli/glooctl_create_secret_oauth.md
@@ -39,7 +39,7 @@ glooctl create secret oauth [flags]
   -o, --output OutputType              output format: (yaml, json, table, kube-yaml, wide) (default table)
       --use-consul                     use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -48,7 +48,7 @@ glooctl create secret oauth [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_oauth.md
+++ b/docs/content/reference/cli/glooctl_create_secret_oauth.md
@@ -48,7 +48,7 @@ glooctl create secret oauth [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_tls.md
+++ b/docs/content/reference/cli/glooctl_create_secret_tls.md
@@ -41,7 +41,7 @@ glooctl create secret tls [flags]
   -o, --output OutputType              output format: (yaml, json, table, kube-yaml, wide) (default table)
       --use-consul                     use Consul Key-Value storage as the backend for reading and writing config (VirtualServices, Upstreams, and Proxies)
       --use-vault                      use Vault Key-Value storage as the backend for reading and writing secrets
-      --vault-address string           address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
+      --vault-address string           address of the Vault server. This should be a complete URL such as "http://vault.example.com". Use with --use-vault (default "https://127.0.0.1:8200")
       --vault-ca-cert string           CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate.Use with --use-vault
       --vault-ca-path string           CAPath is the path to a directory of PEM-encoded CA cert files to verify the Vault server SSL certificate.Use with --use-vault
       --vault-client-cert string       ClientCert is the path to the certificate for Vault communication.Use with --use-vault
@@ -50,7 +50,7 @@ glooctl create secret tls [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             address of the Vault server. This should be a complete  URL such as "http://vault.example.com". Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/docs/content/reference/cli/glooctl_create_secret_tls.md
+++ b/docs/content/reference/cli/glooctl_create_secret_tls.md
@@ -50,7 +50,7 @@ glooctl create secret tls [flags]
       --vault-root-key string          key prefix for Vault key-value storage inside a storage engine. (default "gloo")
       --vault-tls-insecure             Insecure enables or disables SSL verification.Use with --use-vault
       --vault-tls-server-name string   TLSServerName, if set, is used to set the SNI host when connecting via TLS.Use with --use-vault
-      --vault-token string             The root token to authenticate with a Vault server.Use with --use-vault
+      --vault-token string             The root token to authenticate with a Vault server. Use with --use-vault
 ```
 
 ### SEE ALSO

--- a/projects/gloo/cli/pkg/flagutils/common.go
+++ b/projects/gloo/cli/pkg/flagutils/common.go
@@ -76,7 +76,7 @@ func AddVaultSecretFlags(set *pflag.FlagSet, vault *options.Vault) {
 
 	set.StringVar(&config.Address, "vault-address", config.Address, "address of the Vault server. This should be a complete URL such as \"http://vault.example.com\". "+
 		"Use with --use-vault")
-	set.StringVar(&token, "vault-token", "", "The root token to authenticate with a Vault server."+
+	set.StringVar(&token, "vault-token", "", "The root token to authenticate with a Vault server. "+
 		"Use with --use-vault")
 
 	set.StringVar(&tlsCfg.CACert, "vault-ca-cert", "", "CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate."+

--- a/projects/gloo/cli/pkg/flagutils/common.go
+++ b/projects/gloo/cli/pkg/flagutils/common.go
@@ -74,9 +74,9 @@ func AddVaultSecretFlags(set *pflag.FlagSet, vault *options.Vault) {
 	set.StringVar(&vault.PathPrefix, "vault-path-prefix", bootstrap.DefaultPathPrefix, "The Secrets Engine to which Vault should route traffic.")
 	set.StringVar(&vault.RootKey, "vault-root-key", bootstrap.DefaultRootKey, "key prefix for Vault key-value storage inside a storage engine.")
 
-	set.StringVar(&config.Address, "vault-address", config.Address, "address of the Vault server. This should be a complete  URL such as \"http://vault.example.com\". "+
+	set.StringVar(&config.Address, "vault-address", config.Address, "address of the Vault server. This should be a complete URL such as \"http://vault.example.com\". "+
 		"Use with --use-vault")
-	set.StringVar(&token, "vault-token", "", "address of the Vault server. This should be a complete  URL such as \"http://vault.example.com\". "+
+	set.StringVar(&token, "vault-token", "", "The root token to authenticate with a Vault server."+
 		"Use with --use-vault")
 
 	set.StringVar(&tlsCfg.CACert, "vault-ca-cert", "", "CACert is the path to a PEM-encoded CA cert file to use to verify the Vault server SSL certificate."+


### PR DESCRIPTION
# Description

The `--vault-token` flag incorrectly had the description associated with `--vault-address` but had correct behavior as we do use the value in vault-address (`&config.Address`)  for `vaultClient, err := vaultapi.NewClient(config)` and the value in vault-token (`&token`) for `vaultClient.SetToken(token)`.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/7469