### PR TITLE
[DNM]run CI with k8s 1.23.14

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -120,7 +120,7 @@ jobs:
       if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       id: kubectl
       with:
-        version: 'v1.22.4'
+        version: 'v1.23.14'
     - uses: azure/setup-helm@v1
       if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       with:

--- a/ci/deploy-to-kind-cluster.sh
+++ b/ci/deploy-to-kind-cluster.sh
@@ -4,7 +4,7 @@
 # The name of the kind cluster to deploy to
 CLUSTER_NAME="${CLUSTER_NAME:-kind}"
 # The version of the Node Docker image to use for booting the cluster
-CLUSTER_NODE_VERSION="${CLUSTER_NODE_VERSION:-v1.22.4}"
+CLUSTER_NODE_VERSION="${CLUSTER_NODE_VERSION:-v1.23.14}"
 # The version used to tag images
 VERSION="${VERSION:-0.0.0-kind1}"
 # Automatically (lazily) determine OS type


### PR DESCRIPTION
For release testing, show that our k8s based regressions work on 1.23