### PR TITLE
mod: move to release-1.13.0 and update skv2

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -69,7 +69,7 @@ jobs:
       with:
         # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
         skipClusterCreation: true
-        version: v0.11.1
+        version: v0.17.0
     - uses: azure/setup-kubectl@v1
       id: kubectl
       with:
@@ -81,7 +81,7 @@ jobs:
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
         CLUSTER_NAME: 'kind'
-        CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
+        CLUSTER_NODE_VERSION: 'v1.24.7@sha256:5c015142d9b60a0f6c45573f809957076514e38ec973565e2b2fe828b91597f5'
         VERSION: '0.0.0-kind1'
         JUST_KIND: 'true'
       run: |

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -111,7 +111,7 @@ jobs:
       with:
         # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
         skipClusterCreation: true
-        version: v0.11.1
+        version: v0.17.0
     - uses: azure/setup-kubectl@v1
       if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       id: kubectl
@@ -126,7 +126,7 @@ jobs:
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
         CLUSTER_NAME: 'kind'
-        CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
+        CLUSTER_NODE_VERSION: 'v1.24.7@sha256:5c015142d9b60a0f6c45573f809957076514e38ec973565e2b2fe828b91597f5'
         VERSION: '1.0.0-ci'
       run: |
         ./ci/deploy-to-kind-cluster.sh

--- a/changelog/v1.13.0/deps-and-release.yaml
+++ b/changelog/v1.13.0/deps-and-release.yaml
@@ -3,3 +3,7 @@ changelog:
     dependencyOwner: solo-io
     dependencyRepo: skv2
     dependencyTag: v0.26.0
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: k8s-utils
+    dependencyTag: v0.1.7

--- a/changelog/v1.13.0/deps-and-release.yaml
+++ b/changelog/v1.13.0/deps-and-release.yaml
@@ -7,3 +7,5 @@ changelog:
     dependencyOwner: solo-io
     dependencyRepo: k8s-utils
     dependencyTag: v0.1.7
+  - type: NON_USER_FACING
+    description: CI to use k8s1.24 like enterprise

--- a/changelog/v1.13.0/deps-and-release.yaml
+++ b/changelog/v1.13.0/deps-and-release.yaml
@@ -1,4 +1,8 @@
 changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: skv2
+    dependencyTag: v0.26.0
   - type: NEW_FEATURE
     issueLink: https://github.com/solo-io/gloo/issues/7406
     description: Expose Envoy's opencensus plugin via Gloo. This extension is provided to enable W3C-compliant tracing metadata to be sent to a collector. Note that the Envoy extension has severe limitations which are documented in this feature, so users should take great care before enabling it.

--- a/changelog/v1.13.0/deps-and-release.yaml
+++ b/changelog/v1.13.0/deps-and-release.yaml
@@ -3,6 +3,3 @@ changelog:
     dependencyOwner: solo-io
     dependencyRepo: skv2
     dependencyTag: v0.26.0
-  - type: NEW_FEATURE
-    issueLink: https://github.com/solo-io/gloo/issues/7406
-    description: Expose Envoy's opencensus plugin via Gloo. This extension is provided to enable W3C-compliant tracing metadata to be sent to a collector. Note that the Envoy extension has severe limitations which are documented in this feature, so users should take great care before enabling it.

--- a/changelog/v1.13.0/opencensus.yaml
+++ b/changelog/v1.13.0/opencensus.yaml
@@ -1,3 +1,4 @@
- - type: NEW_FEATURE
+changelog:
+  - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/7406
     description: Expose Envoy's opencensus plugin via Gloo. This extension is provided to enable W3C-compliant tracing metadata to be sent to a collector. Note that the Envoy extension has severe limitations which are documented in this feature, so users should take great care before enabling it.

--- a/changelog/v1.13.0/opencensus.yaml
+++ b/changelog/v1.13.0/opencensus.yaml
@@ -1,0 +1,3 @@
+ - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/7406
+    description: Expose Envoy's opencensus plugin via Gloo. This extension is provided to enable W3C-compliant tracing metadata to be sent to a collector. Note that the Envoy extension has severe limitations which are documented in this feature, so users should take great care before enabling it.

--- a/ci/deploy-to-kind-cluster.sh
+++ b/ci/deploy-to-kind-cluster.sh
@@ -91,27 +91,15 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 kubeadmConfigPatches:
 - |
-  apiVersion: kubeadm.k8s.io/v1beta2
+  apiVersion: kubeadm.k8s.io/v1beta3
   kind: ClusterConfiguration
   metadata:
     name: config
-  apiServer:
-    extraArgs:
-      "feature-gates": "EphemeralContainers=true"
-  scheduler:
-    extraArgs:
-      "feature-gates": "EphemeralContainers=true"
-  controllerManager:
-    extraArgs:
-      "feature-gates": "EphemeralContainers=true"
 - |
-  apiVersion: kubeadm.k8s.io/v1beta2
+  apiVersion: kubeadm.k8s.io/v1beta3
   kind: InitConfiguration
   metadata:
     name: config
-  nodeRegistration:
-    kubeletExtraArgs:
-      "feature-gates": "EphemeralContainers=true"
 $ARM_EXTENSION
 EOF
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/solo-io/k8s-utils v0.1.1
 	github.com/solo-io/protoc-gen-ext v0.0.17
 	github.com/solo-io/protoc-gen-openapi v0.1.0
-	github.com/solo-io/skv2 v0.21.6
+	github.com/solo-io/skv2 v0.26.0
 
 	// Pinned to the `gloo-edge-safe-hasher` tag of solo-apis
 	github.com/solo-io/solo-apis v0.0.0-20220923183548-9746539fc625
@@ -170,7 +170,7 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/snappy v0.0.4 // indirect
 	github.com/google/btree v1.0.1 // indirect
-	github.com/google/go-cmp v0.5.7 // indirect
+	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
@@ -258,7 +258,7 @@ require (
 	github.com/shurcooL/sanitized_anchor_name v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/solo-io/anyvendor v0.0.4 // indirect
-	github.com/solo-io/cue v0.4.1 // indirect
+	github.com/solo-io/cue v0.4.6 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/src-d/gcfg v1.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/sergi/go-diff v1.1.0
 	github.com/solo-io/go-list-licenses v0.1.0
 	github.com/solo-io/go-utils v0.22.4
-	github.com/solo-io/k8s-utils v0.1.1
+	github.com/solo-io/k8s-utils v0.1.7
 	github.com/solo-io/protoc-gen-ext v0.0.17
 	github.com/solo-io/protoc-gen-openapi v0.1.0
 	github.com/solo-io/skv2 v0.26.0

--- a/go.sum
+++ b/go.sum
@@ -1393,6 +1393,8 @@ github.com/solo-io/k8s-utils v0.0.8/go.mod h1:Cg2ymG0xhLdyS3NJ0D98yxiSWjAKYPNopz
 github.com/solo-io/k8s-utils v0.1.0/go.mod h1:Cg2ymG0xhLdyS3NJ0D98yxiSWjAKYPNopzPTwVDl7e4=
 github.com/solo-io/k8s-utils v0.1.1 h1:PDvsqk+ySRrZsnb2T1sI+7fKipURjlxGs++85oxexII=
 github.com/solo-io/k8s-utils v0.1.1/go.mod h1:DFUAy3AeYZvAVfMhyRLdsZbQ5aCDWIUya7DEYFplpd4=
+github.com/solo-io/k8s-utils v0.1.7 h1:fZISv4SpeWHru0HF+fYYXrPzT4aHz6gBkYTV6QLZc1Y=
+github.com/solo-io/k8s-utils v0.1.7/go.mod h1:DFUAy3AeYZvAVfMhyRLdsZbQ5aCDWIUya7DEYFplpd4=
 github.com/solo-io/protoc-gen-ext v0.0.13/go.mod h1:/U/jMDtVI7R6N323sfaUXK9Mmo54D7SY3pP7JtI/kMo=
 github.com/solo-io/protoc-gen-ext v0.0.16/go.mod h1:j5wvKW5B7oes0hf46IxPDEkDK0pNNQ1Nbfrr1P+xBQo=
 github.com/solo-io/protoc-gen-ext v0.0.17 h1:T/rihlhzsbASnYJ/JkvwhF62LHsHki54Howe5SmPP2Y=

--- a/go.sum
+++ b/go.sum
@@ -694,8 +694,9 @@ github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
+github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
 github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=
 github.com/google/go-github/v27 v27.0.6/go.mod h1:/0Gr8pJ55COkmv+S/yPKCczSkUPIM/LnFyubufRNIS0=
@@ -1376,8 +1377,8 @@ github.com/solo-io/anyvendor v0.0.1/go.mod h1:SLucIeU8qBOYI82BveNVn2LzZFcMWJSCf8
 github.com/solo-io/anyvendor v0.0.3/go.mod h1:xHZ0KMrsG620iI4VnRDJGJ1gk8bR79HG/tlTWfY15UA=
 github.com/solo-io/anyvendor v0.0.4 h1:9nI7o7Srml2uaOpT5HJSru06IHUZpzSCU/dEkseiGa4=
 github.com/solo-io/anyvendor v0.0.4/go.mod h1:+TTkDGd11u8ugXccqtukBEWvkZkODaBbeWgdH/F/IWY=
-github.com/solo-io/cue v0.4.1 h1:P+A+/4o1NIJ0BDLmIF7vMDEsKQFlIn6M01Q9CHV77AY=
-github.com/solo-io/cue v0.4.1/go.mod h1:NaNBm1PrzINbNcE/ZU9wEAJ6JXvi//F/HU5cIpngeZE=
+github.com/solo-io/cue v0.4.6 h1:xfZN+SKo+WNOlGup6G2vMYl5MxgEuJ9r+NFFpo2SXm0=
+github.com/solo-io/cue v0.4.6/go.mod h1:P1tN9y6nBPAMoEK5aJxI8kn0VUcjVcRc+8esieRzQ7M=
 github.com/solo-io/go-list-licenses v0.0.4/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
 github.com/solo-io/go-list-licenses v0.1.0 h1:8FkdOtyiX8ga305U60tQbihXVpsZCWkWQH2uz4rqIMM=
 github.com/solo-io/go-list-licenses v0.1.0/go.mod h1:x6LSp/NrYgVXwNum7ZOiaAYTpg6B3F6TrWYfcdHVroA=
@@ -1399,8 +1400,8 @@ github.com/solo-io/protoc-gen-ext v0.0.17/go.mod h1:iGyCvmKmhJNXs5MgBcYFBF0om7LD
 github.com/solo-io/protoc-gen-openapi v0.1.0 h1:XBx0yAdjxoWxGQ+CiGcb29r+KAgyIkhdaB63uBvKzKY=
 github.com/solo-io/protoc-gen-openapi v0.1.0/go.mod h1:6d6gsEx74pW3UCA3G0al0GdMlYzGe/iCy2mPgGG9wI8=
 github.com/solo-io/skv2 v0.17.17/go.mod h1:nYjANLlL1SLPV/7Gr2mKgfxO3Jta/yNAxKnAHKhSamM=
-github.com/solo-io/skv2 v0.21.6 h1:LyJMbttLkzEIkyxg7ZQs81adNpwYCflniWOJRZ1MRns=
-github.com/solo-io/skv2 v0.21.6/go.mod h1:8jNcMWuAkBxdGhlRFMSgsK94q/jZGPEas8VHTr/al/Y=
+github.com/solo-io/skv2 v0.26.0 h1:g4SoYb2dCa+zeI35p7VUSLFmnMk+YBLUhTq38rcYLyc=
+github.com/solo-io/skv2 v0.26.0/go.mod h1:ZgInY/qtk1o5zS1brsSx9My3iDNf9jVlmRRPoFKAWgY=
 github.com/solo-io/solo-apis v0.0.0-20220923183548-9746539fc625 h1:Tah0/lj7EoXWCdkKUOMgl+uXhH7zAy4mlCnoJRMUFzg=
 github.com/solo-io/solo-apis v0.0.0-20220923183548-9746539fc625/go.mod h1:HeaqtVvRW8TJMzGDZMP9I9HOixQuZGHfw2J5sxE1qlQ=
 github.com/solo-io/solo-kit v0.23.0/go.mod h1:uCOi8RQ3MetHXsRFvVKPzafYySUvFuPxB+gvo7ScRR8=
@@ -1659,6 +1660,7 @@ golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EH
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20200513190911-00229845015e/go.mod h1:4M0jN8W1tt0AVLNr8HDosyJCDCDuyL9N9+3m7wDWgKw=
 golang.org/x/exp v0.0.0-20210126221216-84987778548c/go.mod h1:I6l2HNBLBZEcrOoCpyKLdY2lHoRZ8lI4x60KMCQDft4=
+golang.org/x/exp v0.0.0-20220921164117-439092de6870 h1:j8b6j9gzSigH28O5SjSpQSSh9lFd6f5D/q0aHjNTulc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=


### PR DESCRIPTION
Update skv2 and bump changelog for release.
Enables gloo fed via glooctl registration.

Updates ci to use 1.24 throughout