### PR TITLE
update ci to use k8s 1.24

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-ISSUE.yml
@@ -8,11 +8,11 @@ body:
       label: Gloo Edge Version
       description: What version of Gloo Edge are you using?
       options:
-        - 1.13.x (beta)
-        - 1.12.x (latest stable)
+        - 1.14.x (beta)
+        - 1.13.x (latest stable)
+        - 1.12.x
         - 1.11.x
         - 1.10.x
-        - 1.9.x
     validations:
       required: true
   - type: dropdown
@@ -21,6 +21,8 @@ body:
       label: Kubernetes Version
       description: What version of Kubernetes are you using with Gloo Edge?
       options:
+        - 1.26.x
+        - 1.25.x
         - 1.24.x
         - 1.23.x
         - 1.22.x 

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -64,11 +64,11 @@ jobs:
       with:
         # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
         skipClusterCreation: true
-        version: v0.11.1
+        version: v0.17.0
     - uses: azure/setup-kubectl@v1
       id: kubectl
       with:
-        version: 'v1.22.4'
+        version: 'v1.24.7'
     - uses: azure/setup-helm@v1
       with:
         version: v3.6.3
@@ -76,7 +76,7 @@ jobs:
       env:
         KUBE2E_TESTS: ${{ matrix.kube-e2e-test-type }}
         CLUSTER_NAME: 'kind'
-        CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
+        CLUSTER_NODE_VERSION: 'v1.24.7@sha256:5c015142d9b60a0f6c45573f809957076514e38ec973565e2b2fe828b91597f5'
         SKIP_DOCKER: 'true'
       run: |
         ./ci/deploy-to-kind-cluster.sh

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -8,8 +8,8 @@ on:
 env:
   VERSION: '1.0.0-ci'
   HELM_VERSION: 'v3.6.0'
-  KUBECTL_VERSION: 'v1.22.4'
-  CLUSTER_NODE_VERSION: 'v1.22.4@sha256:ca3587e6e545a96c07bf82e2c46503d9ef86fc704f44c17577fca7bcabf5f978'
+  KUBECTL_VERSION: 'v1.24.7'
+  CLUSTER_NODE_VERSION: 'v1.24.7@sha256:5c015142d9b60a0f6c45573f809957076514e38ec973565e2b2fe828b91597f5'
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
 jobs:
@@ -119,7 +119,7 @@ jobs:
       with:
         # We rely on the `deploy-to-kind-cluster` script to create a kind cluster
         skipClusterCreation: true
-        version: v0.11.1
+        version: v0.17.0
     - uses: azure/setup-kubectl@v1
       if: needs.prepare_env.outputs.should-pass-regression-tests != 'true'
       id: kubectl

--- a/changelog/v1.14.0-beta3/ci-1.24.yaml
+++ b/changelog/v1.14.0-beta3/ci-1.24.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: update CI to use k8s 1.24

--- a/changelog/v1.14.0-beta3/ci-1.24.yaml
+++ b/changelog/v1.14.0-beta3/ci-1.24.yaml
@@ -1,3 +1,3 @@
 changelog:
   - type: NON_USER_FACING
-    description: update CI to use k8s 1.24
+    description: update CI to use k8s 1.24, update issue template versions

--- a/ci/deploy-to-kind-cluster.sh
+++ b/ci/deploy-to-kind-cluster.sh
@@ -4,7 +4,7 @@
 # The name of the kind cluster to deploy to
 CLUSTER_NAME="${CLUSTER_NAME:-kind}"
 # The version of the Node Docker image to use for booting the cluster
-CLUSTER_NODE_VERSION="${CLUSTER_NODE_VERSION:-v1.22.4}"
+CLUSTER_NODE_VERSION="${CLUSTER_NODE_VERSION:-v1.24.7}"
 # The version used to tag images
 VERSION="${VERSION:-1.0.0-ci}"
 # Skip building docker images if we are testing a released version

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -10,7 +10,7 @@ function cleanup {
 }
 
 function start {
-    kind create cluster --name=$CLUSTER_NAME --wait=2m --image=kindest/node:v1.22.4
+    kind create cluster --name=$CLUSTER_NAME --wait=2m --image=kindest/node:v1.24.7
 }
 
 function kind-env {

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.22.12 as kubectl
+FROM bitnami/kubectl:1.24.7 as kubectl
 
 FROM alpine:3.15.6
 

--- a/projects/gloo/cli/pkg/cmd/demo/federation.go
+++ b/projects/gloo/cli/pkg/cmd/demo/federation.go
@@ -58,10 +58,10 @@ if [ "$4" == "" ]; then
   exit 1
 fi
 
-kind create cluster --name "$1" --image kindest/node:v1.22.4
+kind create cluster --name "$1" --image kindest/node:v1.24.7
 
 # Add locality labels to remote kind cluster for discovery
-(cat <<EOF | kind create cluster --name "$2" --image kindest/node:v1.22.4 --config=-
+(cat <<EOF | kind create cluster --name "$2" --image kindest/node:v1.24.7 --config=-
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:

--- a/test/kube2e/README.md
+++ b/test/kube2e/README.md
@@ -32,14 +32,14 @@ It accepts a number of environment variables, to control the creation of a kind 
 | Name                 | Default  | Description                                                                                                         |
 |----------------------|----------|---------------------------------------------------------------------------------------------------------------------|
 | CLUSTER_NAME         | kind     | The name of the cluster that will be generated                                                                      |
-| CLUSTER_NODE_VERSION | v1.22.4  | The version of the [Node Docker image](https://hub.docker.com/r/kindest/node/) to use for booting the cluster       |
+| CLUSTER_NODE_VERSION | v1.24.7  | The version of the [Node Docker image](https://hub.docker.com/r/kindest/node/) to use for booting the cluster       |
 | VERSION              | 1.0.0-ci | The version used to tag Gloo images that are deployed to the cluster                                                |
 | KUBE2E_TESTS         | gateway  | Name of the test suite to be run. Options: `'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade'` |
 | SKIP_DOCKER          | false    | Skip building docker images (used when testing a release version)                                                   |
 
 Example:
 ```bash
-CLUSTER_NAME=solo-test-cluster CLUSTER_NODE_VERSION=v1.22.4 VERSION=v1.0.0-solo-test ci/deploy-to-kind-cluster.sh
+CLUSTER_NAME=solo-test-cluster CLUSTER_NODE_VERSION=v1.24.7 VERSION=v1.0.0-solo-test ci/deploy-to-kind-cluster.sh
 ```
 
 ### Verify Your Setup

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// now that we run CI on a kube 1.22 cluster, we must ensure that we install versions of gloo with v1 CRDs
+// now that we run CI on a kube 1.22+ cluster, we must ensure that we install versions of gloo with v1 CRDs
 // Per https://github.com/solo-io/gloo/issues/4543: CRDs were migrated from v1beta1 -> v1 in Gloo 1.9.0
 const earliestVersionWithV1CRDs = "1.9.0"
 


### PR DESCRIPTION
- forward-port of the ci changes that were merged into 1.13 in https://github.com/solo-io/gloo/pull/7571, plus some that were missed
- update issue template