### PR TITLE
`glooctl check` virtual service reporting fixes/improvements

### DIFF
--- a/changelog/v1.14.0-beta4/glooctl-check-virtual-services
+++ b/changelog/v1.14.0-beta4/glooctl-check-virtual-services
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7153
+    description: >
+    	Glooctls `checkResourceX` functions now report all resources regardless if resource.GetNamespacedStatuses() != nil. Added error messages for resources with no statuses.
+

--- a/changelog/v1.14.0-beta4/glooctl-check-virtual-services
+++ b/changelog/v1.14.0-beta4/glooctl-check-virtual-services
@@ -1,5 +1,5 @@
 changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/7153
-    description: Glooctls `checkResourceX` functions now report all resources regardless if resource.GetNamespacedStatuses() != nil. Added error messages for resources with no statuses.
+    description: Glooctl check functions now report all resources regardless if they have statuses reported yet or not. Added error messages for resources with no statuses.
 

--- a/changelog/v1.14.0-beta4/glooctl-check-virtual-services
+++ b/changelog/v1.14.0-beta4/glooctl-check-virtual-services
@@ -1,6 +1,5 @@
 changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/7153
-    description: >
-    	Glooctls `checkResourceX` functions now report all resources regardless if resource.GetNamespacedStatuses() != nil. Added error messages for resources with no statuses.
+    description: Glooctls `checkResourceX` functions now report all resources regardless if resource.GetNamespacedStatuses() != nil. Added error messages for resources with no statuses.
 

--- a/projects/gloo/cli/pkg/cmd/check/check_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/check_test.go
@@ -32,8 +32,8 @@ var _ = Describe("Check", func() {
 		cancel()
 	})
 
-	Context("test", func() {
-		FIt("all checks pass with OK status", func() {
+	Context("glooctl check", func() {
+		FIt("should error if resource has no status", func() {
 
 			client := helpers.MustKubeClient()
 			client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{

--- a/projects/gloo/cli/pkg/cmd/check/check_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/check_test.go
@@ -3,6 +3,7 @@ package check_test
 import (
 	"context"
 	"fmt"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"

--- a/projects/gloo/cli/pkg/cmd/check/check_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/check_test.go
@@ -1,0 +1,74 @@
+package check_test
+
+import (
+	"context"
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/testutils"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Check", func() {
+
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
+
+	BeforeEach(func() {
+		helpers.UseMemoryClients()
+		ctx, cancel = context.WithCancel(context.Background())
+	})
+
+	AfterEach(func() {
+		cancel()
+	})
+
+	Context("test", func() {
+		FIt("all checks pass with OK status", func() {
+
+			client := helpers.MustKubeClient()
+			client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: defaults.GlooSystem,
+				},
+			}, metav1.CreateOptions{})
+
+			appName := "default"
+			client.AppsV1().Deployments("gloo-system").Create(ctx, &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      appName,
+					Namespace: "gloo-system",
+				},
+				Spec: appsv1.DeploymentSpec{},
+			}, metav1.CreateOptions{})
+
+			helpers.MustNamespacedSettingsClient(ctx, "gloo-system").Write(&v1.Settings{
+				Metadata: &core.Metadata{
+					Name:      "default",
+					Namespace: "gloo-system",
+				},
+			}, clients.WriteOpts{})
+
+			warningUpstream := &v1.Upstream{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-upstream",
+					Namespace: "gloo-system",
+				},
+			}
+			_, usErr := helpers.MustNamespacedUpstreamClient(ctx, "gloo-system").Write(warningUpstream, clients.WriteOpts{})
+			Expect(usErr).NotTo(HaveOccurred())
+
+			_, err := testutils.GlooctlOut("check -x xds-metrics,proxies")
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found upstream with no status: %s %s", warningUpstream.GetMetadata().GetNamespace(), warningUpstream.GetMetadata().GetName())))
+		})
+	})
+})

--- a/projects/gloo/cli/pkg/cmd/check/check_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/check_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"fmt"
 
+	gatewaysoloiov1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	extauthv1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
@@ -68,8 +71,78 @@ var _ = Describe("Check", func() {
 			_, usErr := helpers.MustNamespacedUpstreamClient(ctx, "gloo-system").Write(noStatusUpstream, clients.WriteOpts{})
 			Expect(usErr).NotTo(HaveOccurred())
 
-			_, err := testutils.GlooctlOut("check -x xds-metrics,proxies")
+			noStatusUpstreamGroup := &v1.UpstreamGroup{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-upstream-group",
+					Namespace: "gloo-system",
+				},
+			}
+			_, usgErr := helpers.MustNamespacedUpstreamGroupClient(ctx, "gloo-system").Write(noStatusUpstreamGroup, clients.WriteOpts{})
+			Expect(usgErr).NotTo(HaveOccurred())
+
+			noStatusAuthConfig := &extauthv1.AuthConfig{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-auth-config",
+					Namespace: "gloo-system",
+				},
+			}
+			_, acErr := helpers.MustNamespacedAuthConfigClient(ctx, "gloo-system").Write(noStatusAuthConfig, clients.WriteOpts{})
+			Expect(acErr).NotTo(HaveOccurred())
+
+			noStatusVHO := &gatewaysoloiov1.VirtualHostOption{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-virtual-host-option",
+					Namespace: "gloo-system",
+				},
+			}
+			_, vhoErr := helpers.MustNamespacedVirtualHostOptionClient(ctx, "gloo-system").Write(noStatusVHO, clients.WriteOpts{})
+			Expect(vhoErr).NotTo(HaveOccurred())
+
+			noStatusRouteOption := &gatewaysoloiov1.RouteOption{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-route-option",
+					Namespace: "gloo-system",
+				},
+			}
+			_, roErr := helpers.MustNamespacedRouteOptionClient(ctx, "gloo-system").Write(noStatusRouteOption, clients.WriteOpts{})
+			Expect(roErr).NotTo(HaveOccurred())
+
+			noStatusVS := &gatewaysoloiov1.VirtualService{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-virtual-service",
+					Namespace: "gloo-system",
+				},
+			}
+			_, vsErr := helpers.MustNamespacedVirtualServiceClient(ctx, "gloo-system").Write(noStatusVS, clients.WriteOpts{})
+			Expect(vsErr).NotTo(HaveOccurred())
+
+			noStatusGateway := &gatewaysoloiov1.Gateway{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-gateway",
+					Namespace: "gloo-system",
+				},
+			}
+			_, gwErr := helpers.MustNamespacedGatewayClient(ctx, "gloo-system").Write(noStatusGateway, clients.WriteOpts{})
+			Expect(gwErr).NotTo(HaveOccurred())
+
+			noStatusProxy := &v1.Proxy{
+				Metadata: &core.Metadata{
+					Name:      "some-warning-proxy",
+					Namespace: "gloo-system",
+				},
+			}
+			_, proxyErr := helpers.MustNamespacedProxyClient(ctx, "gloo-system").Write(noStatusProxy, clients.WriteOpts{})
+			Expect(proxyErr).NotTo(HaveOccurred())
+
+			_, err := testutils.GlooctlOut("check -x xds-metrics")
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found upstream with no status: %s %s", noStatusUpstream.GetMetadata().GetNamespace(), noStatusUpstream.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found upstream group with no status: %s %s", noStatusUpstreamGroup.GetMetadata().GetNamespace(), noStatusUpstreamGroup.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found auth config with no status: %s %s", noStatusAuthConfig.GetMetadata().GetNamespace(), noStatusAuthConfig.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found VirtualHostOption with no status: %s %s", noStatusVHO.GetMetadata().GetNamespace(), noStatusVHO.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found RouteOption with no status: %s %s", noStatusRouteOption.GetMetadata().GetNamespace(), noStatusRouteOption.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found gateway with no status: %s %s", noStatusGateway.GetMetadata().GetNamespace(), noStatusGateway.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found virtual service with no status: %s %s", noStatusVS.GetMetadata().GetNamespace(), noStatusVS.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found proxy with no status: %s %s", noStatusProxy.GetMetadata().GetNamespace(), noStatusProxy.GetMetadata().GetName())))
 		})
 	})
 })

--- a/projects/gloo/cli/pkg/cmd/check/check_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/check_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Check", func() {
 	})
 
 	Context("glooctl check", func() {
-		FIt("should error if resource has no status", func() {
+		It("should error if resource has no status", func() {
 
 			client := helpers.MustKubeClient()
 			client.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{

--- a/projects/gloo/cli/pkg/cmd/check/check_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/check_test.go
@@ -58,17 +58,17 @@ var _ = Describe("Check", func() {
 				},
 			}, clients.WriteOpts{})
 
-			warningUpstream := &v1.Upstream{
+			noStatusUpstream := &v1.Upstream{
 				Metadata: &core.Metadata{
 					Name:      "some-warning-upstream",
 					Namespace: "gloo-system",
 				},
 			}
-			_, usErr := helpers.MustNamespacedUpstreamClient(ctx, "gloo-system").Write(warningUpstream, clients.WriteOpts{})
+			_, usErr := helpers.MustNamespacedUpstreamClient(ctx, "gloo-system").Write(noStatusUpstream, clients.WriteOpts{})
 			Expect(usErr).NotTo(HaveOccurred())
 
 			_, err := testutils.GlooctlOut("check -x xds-metrics,proxies")
-			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found upstream with no status: %s %s", warningUpstream.GetMetadata().GetNamespace(), warningUpstream.GetMetadata().GetName())))
+			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("Found upstream with no status: %s %s", noStatusUpstream.GetMetadata().GetNamespace(), noStatusUpstream.GetMetadata().GetName())))
 		})
 	})
 })

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -430,7 +430,7 @@ func checkUpstreams(ctx context.Context, opts *options.Options, namespaces []str
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found upstream with no status: %s\n", renderMetadata(upstream.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 			knownUpstreams = append(knownUpstreams, renderMetadata(upstream.GetMetadata()))
 		}
@@ -477,7 +477,7 @@ func checkUpstreamGroups(ctx context.Context, opts *options.Options, namespaces 
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found upstream group with no status: %s\n", renderMetadata(upstreamGroup.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 		}
 	}
@@ -521,7 +521,7 @@ func checkAuthConfigs(ctx context.Context, opts *options.Options, namespaces []s
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found auth config with no status: %s\n", renderMetadata(authConfig.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 			knownAuthConfigs = append(knownAuthConfigs, renderMetadata(authConfig.GetMetadata()))
 		}
@@ -558,7 +558,7 @@ func checkRateLimitConfigs(ctx context.Context, opts *options.Options, namespace
 			if config.Status.GetState() == v1alpha1.RateLimitConfigStatus_REJECTED {
 				errMessage := fmt.Sprintf("Found rejected rate limit config: %s ", renderMetadata(config.GetMetadata()))
 				errMessage += fmt.Sprintf("(Reason: %s)", config.Status.GetMessage())
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 
 			knownConfigs = append(knownConfigs, renderMetadata(config.GetMetadata()))
@@ -609,7 +609,7 @@ func checkVirtualHostOptions(ctx context.Context, opts *options.Options, namespa
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found VirtualHostOption with no status: %s\n", renderMetadata(vhOpt.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 			knownVhOpts = append(knownVhOpts, renderMetadata(vhOpt.GetMetadata()))
 		}
@@ -657,7 +657,7 @@ func checkRouteOptions(ctx context.Context, opts *options.Options, namespaces []
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found RouteOption with no status: %s\n", renderMetadata(routeOpt.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 			knownRouteOpts = append(knownRouteOpts, renderMetadata(routeOpt.GetMetadata()))
 		}
@@ -702,7 +702,7 @@ func checkVirtualServices(ctx context.Context, opts *options.Options, namespaces
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found virtual service with no status: %s\n", renderMetadata(virtualService.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 
 			for _, route := range virtualService.GetVirtualHost().GetRoutes() {
@@ -842,7 +842,7 @@ func checkGateways(ctx context.Context, opts *options.Options, namespaces []stri
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found gateway with no status: %s\n", renderMetadata(gateway.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 		}
 	}
@@ -895,7 +895,7 @@ func checkProxies(ctx context.Context, opts *options.Options, namespaces []strin
 				}
 			} else {
 				errMessage := fmt.Sprintf("Found proxy with no status: %s\n", renderMetadata(proxy.GetMetadata()))
-				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
+				multiErr = multierror.Append(multiErr, errors.New(errMessage))
 			}
 		}
 	}

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -428,8 +428,11 @@ func checkUpstreams(ctx context.Context, opts *options.Options, namespaces []str
 						multiErr = multierror.Append(multiErr, errors.New(errMessage))
 					}
 				}
-				knownUpstreams = append(knownUpstreams, renderMetadata(upstream.GetMetadata()))
+			} else {
+				errMessage := fmt.Sprintf("Found upstream with no status: %s\n", renderMetadata(upstream.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
+			knownUpstreams = append(knownUpstreams, renderMetadata(upstream.GetMetadata()))
 		}
 	}
 	if multiErr != nil {
@@ -472,6 +475,9 @@ func checkUpstreamGroups(ctx context.Context, opts *options.Options, namespaces 
 						multiErr = multierror.Append(multiErr, errors.New(errMessage))
 					}
 				}
+			} else {
+				errMessage := fmt.Sprintf("Found upstream group with no status: %s\n", renderMetadata(upstreamGroup.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
 		}
 	}
@@ -513,8 +519,11 @@ func checkAuthConfigs(ctx context.Context, opts *options.Options, namespaces []s
 						multiErr = multierror.Append(multiErr, errors.New(errMessage))
 					}
 				}
-				knownAuthConfigs = append(knownAuthConfigs, renderMetadata(authConfig.GetMetadata()))
+			} else {
+				errMessage := fmt.Sprintf("Found auth config with no status: %s\n", renderMetadata(authConfig.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
+			knownAuthConfigs = append(knownAuthConfigs, renderMetadata(authConfig.GetMetadata()))
 		}
 	}
 	if multiErr != nil {
@@ -598,8 +607,11 @@ func checkVirtualHostOptions(ctx context.Context, opts *options.Options, namespa
 						multiErr = multierror.Append(multiErr, errors.New(errMessage))
 					}
 				}
-				knownVhOpts = append(knownVhOpts, renderMetadata(vhOpt.GetMetadata()))
+			} else {
+				errMessage := fmt.Sprintf("Found VirtualHostOption with no status: %s\n", renderMetadata(vhOpt.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
+			knownVhOpts = append(knownVhOpts, renderMetadata(vhOpt.GetMetadata()))
 		}
 	}
 	if multiErr != nil {
@@ -643,8 +655,11 @@ func checkRouteOptions(ctx context.Context, opts *options.Options, namespaces []
 						multiErr = multierror.Append(multiErr, errors.New(errMessage))
 					}
 				}
-				knownRouteOpts = append(knownRouteOpts, renderMetadata(routeOpt.GetMetadata()))
+			} else {
+				errMessage := fmt.Sprintf("Found RouteOption with no status: %s\n", renderMetadata(routeOpt.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
+			knownRouteOpts = append(knownRouteOpts, renderMetadata(routeOpt.GetMetadata()))
 		}
 	}
 	if multiErr != nil {
@@ -685,6 +700,9 @@ func checkVirtualServices(ctx context.Context, opts *options.Options, namespaces
 						multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 					}
 				}
+			} else {
+				errMessage := fmt.Sprintf("Found virtual service with no status: %s\n", renderMetadata(virtualService.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
 
 			for _, route := range virtualService.GetVirtualHost().GetRoutes() {
@@ -822,6 +840,9 @@ func checkGateways(ctx context.Context, opts *options.Options, namespaces []stri
 						multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 					}
 				}
+			} else {
+				errMessage := fmt.Sprintf("Found gateway with no status: %s\n", renderMetadata(gateway.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
 		}
 	}
@@ -872,6 +893,9 @@ func checkProxies(ctx context.Context, opts *options.Options, namespaces []strin
 						multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 					}
 				}
+			} else {
+				errMessage := fmt.Sprintf("Found proxy with no status: %s\n", renderMetadata(proxy.GetMetadata()))
+				multiErr = multierror.Append(multiErr, fmt.Errorf(errMessage))
 			}
 		}
 	}


### PR DESCRIPTION
# Description

For some of our sub checks (checkResourceX functions), if we see that the status hasn’t been set on a given resource, we don’t add it to the list of known resources. This is an issue whenever resources exist in our cluster but Gloo hasn’t reported their status yet as these resources will not be listed as known for other checks that rely on them.
# Context

We want to append the resource to the list of known resources in any case, not just if resource.GetNamespacedStatuses() != nil. Also adding a new corresponding error message for the (resource.GetNamespacedStatuses() == nil) case.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/7153