### PR TITLE
v1.13.x-trivy-ignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -7,3 +7,15 @@ CVE-2022-1996
 # This CVE is not exploitable in Gloo Edge, and a fix is not yet available in the library
 # https://github.com/solo-io/solo-projects/issues/4016
 CVE-2022-37315
+
+# These CVEs only impacts install of Gloo-Edge from Glooctl CLI.
+# Also Helm module is used in testing, which has no impact on exploitation.
+# Gloo-Edge data and control planes are not impacted at all by the helm module.
+# Glooctl is not a long running program, and does not affect future uses of Glooctl.
+# https://github.com/solo-io/gloo/issues/7598
+# https://github.com/helm/helm/security/advisories/GHSA-6rx9-889q-vv2r
+CVE-2022-23524
+# https://github.com/helm/helm/security/advisories/GHSA-53c4-hhmh-vw5q
+CVE-2022-23525
+# https://github.com/helm/helm/security/advisories/GHSA-67fx-wx78-jx33
+CVE-2022-23526

--- a/changelog/v1.13.2/trivy-ignore-helm.yaml
+++ b/changelog/v1.13.2/trivy-ignore-helm.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/7598
+    resolvesIssue: false
+    description: >
+      Choosing to ignore helm upgrade, as it does not impact the data and control planes of Gloo Edge.
+      This only impacts GlooCtl and since it is not a long running service, panics will not affect future uses of Glooclt client.
+      It is therefore deemed to have little to no impact.


### PR DESCRIPTION
# Description
Updating Trivy ignore list because the impact of Helm upgrade is minimal, and does not impact the control and data planes of Gloo. Only glooctl can be impacted on helm values inserted during install.

# Context
Helm requires a much larger upgrade to the k8s/api which is not ready at this moment. Since the impact is minimal because Gloo data and control planes are not impacted, the helm module upgrade can be ignored.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
