### PR TITLE
Fix for glooctl nightly tests

### DIFF
--- a/changelog/v1.14.0-beta5/glooctl-nightly.yaml
+++ b/changelog/v1.14.0-beta5/glooctl-nightly.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Ensure that we use a string without a leading 'v' when pulling helm charts for glooctl tests.
+    issueLink: https://github.com/solo-io/solo-projects/issues/4191
+    resolvesIssue: false

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -510,7 +510,7 @@ var _ = Describe("Kube2e: glooctl", func() {
 	Context("check-crds", func() {
 		It("validates correct CRDs", func() {
 			if testHelper.ReleasedVersion != "" {
-				_, err := runGlooctlCommand("check-crds", "--version", testHelper.ReleasedVersion)
+				_, err := runGlooctlCommand("check-crds", "--version", testHelper.ChartVersion())
 				Expect(err).ToNot(HaveOccurred())
 			} else {
 				chartUri := filepath.Join(testHelper.RootDir, testHelper.TestAssetDir, testHelper.HelmChartName+"-"+testHelper.ChartVersion()+".tgz")


### PR DESCRIPTION
# Description

The glooctl nightly tests have been failing to pull the helm chart to test checking crds because it tries to get a version that starts with 'v'. This change uses the value for the latest version that doesn't have a leading 'v'. 

# Context
Failed run: https://github.com/solo-io/gloo/actions/runs/3827002749/jobs/6511247290
I verified that this works by running the tests locally.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
