### PR TITLE
`glooctl check --context <string>`

### DIFF
--- a/changelog/v1.14.0-beta4/glooctl-check-context.yaml
+++ b/changelog/v1.14.0-beta4/glooctl-check-context.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo/issues/7565
+    description: Added `glooctl check-crds --contex <string>` to allow selection of the kubecontext we perform our check with
+

--- a/docs/content/reference/cli/glooctl_check.md
+++ b/docs/content/reference/cli/glooctl_check.md
@@ -17,6 +17,7 @@ glooctl check [flags]
 ### Options
 
 ```
+      --context string                    kube context to use when interacting with kubernetes
   -x, --exclude strings                   check to exclude: (deployments, pods, upstreams, upstreamgroup, auth-configs, rate-limit-configs, secrets, virtual-services, gateways, proxies, xds-metrics)
   -h, --help                              help for check
   -n, --namespace string                  namespace for reading or writing resources (default "gloo-system")

--- a/projects/gloo/cli/pkg/cmd/options/options.go
+++ b/projects/gloo/cli/pkg/cmd/options/options.go
@@ -50,6 +50,7 @@ type Top struct {
 	PodSelector        string   // label selector for pod scanning
 	ResourceNamespaces []string // namespaces in which to check custom resources
 	ReadOnly           bool     // Makes check read only by skipping any checks that create resources in the cluster
+	KubeContext        string   // K8s Context to run glooctl on
 }
 
 type HelmInstall struct {

--- a/projects/gloo/cli/pkg/flagutils/metadata.go
+++ b/projects/gloo/cli/pkg/flagutils/metadata.go
@@ -38,3 +38,8 @@ func AddExcludeCheckFlag(set *pflag.FlagSet, strarrptr *[]string) {
 func AddReadOnlyFlag(set *pflag.FlagSet, readOnly *bool) {
 	set.BoolVarP(readOnly, "read-only", "", false, "only do checks that dont require creating resources (i.e. port forwards)")
 }
+
+// AddReadOnlyFlag adds a flag to our flag set that indicates we shouldn't do anything that requires RBAC create permissions
+func AddKubeContextFlag(set *pflag.FlagSet, KubeContext *string) {
+	set.StringVarP(KubeContext, "context", "", "", "kube context to use when interacting with kubernetes")
+}

--- a/projects/gloo/cli/pkg/printers/virtualservice.go
+++ b/projects/gloo/cli/pkg/printers/virtualservice.go
@@ -160,7 +160,7 @@ func getSingleVirtualServiceStatus(status *core.Status, ctx context.Context, nam
 	// If the virtual service was accepted, don't include confusing errors on subresources but note if there's another resource potentially blocking config updates.
 	if resourceStatus == core.Status_Accepted {
 		// if route replacement is turned on, don't say that updates to this resource may be blocked
-		settingsClient, err := helpers.SettingsClient(ctx, []string{namespace})
+		settingsClient, err := helpers.SettingsClient(ctx, []string{namespace}, "")
 		// if we get any errors, ignore and default to more verbose error message
 		if err == nil {
 			settings, err := settingsClient.Read(namespace, defaults.SettingsName, clients.ReadOpts{})

--- a/projects/gloo/cli/pkg/surveyutils/survey.go
+++ b/projects/gloo/cli/pkg/surveyutils/survey.go
@@ -85,7 +85,7 @@ func EnsureResourceByName(message string, static bool, source string, target *re
 var PromptInteractiveNamespace = "Please choose a namespace"
 
 func InteractiveNamespace(ctx context.Context, namespace *string) error {
-	nsList, err := helpers.GetNamespaces(ctx)
+	nsList, err := helpers.GetNamespaces(ctx, "")
 	if err != nil {
 		// user may not have permission to list namespaces, let them type the name by hand
 		return cliutil.GetStringInput(PromptInteractiveNamespace, namespace)

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -510,6 +510,12 @@ var _ = Describe("Kube2e: glooctl", func() {
 		It("fails when scanning with invalid kubecontext", func() {
 			_, err := runGlooctlCommand("check", "check", "--context", "not-gloo-context")
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Could not get kubernetes client: Error retrieving Kubernetes configuration: context \"not-gloo-context\" does not exist"))
+		})
+
+		It("succeeds with correct kubecontext", func() {
+			_, err := runGlooctlCommand("check", "check", "--context", "kind-kind")
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 	Context("check-crds", func() {

--- a/test/kube2e/glooctl/glooctl_test.go
+++ b/test/kube2e/glooctl/glooctl_test.go
@@ -489,9 +489,9 @@ var _ = Describe("Kube2e: glooctl", func() {
 		})
 
 		It("connection fails on incorrect namespace check", func() {
-			_, err := runGlooctlCommand("check", "check", "-n", "not-gloo-sysyem")
+			_, err := runGlooctlCommand("check", "check", "-n", "not-gloo-system")
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Could not communicate with kubernetes cluster: namespaces \"not-gloo-sysyem\" not found"))
+			Expect(err.Error()).To(ContainSubstring("Could not communicate with kubernetes cluster: namespaces \"not-gloo-system\" not found"))
 
 			_, err = runGlooctlCommand("check", "-n", "default")
 			Expect(err).To(HaveOccurred())
@@ -505,6 +505,11 @@ var _ = Describe("Kube2e: glooctl", func() {
 			_, err = runGlooctlCommand("check", "-r", "not-gloo-system")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("No namespaces specified are currently being watched (defaulting to 'gloo-system' namespace)"))
+		})
+
+		It("fails when scanning with invalid kubecontext", func() {
+			_, err := runGlooctlCommand("check", "check", "--context", "not-gloo-context")
+			Expect(err).To(HaveOccurred())
 		})
 	})
 	Context("check-crds", func() {


### PR DESCRIPTION
# Description

Currently we dont have any mechanism for setting the kubecontext to use when performing `glooctl check` and we default to the kubecontext currently selected. We would like a mechanism to select the kubecontext used when scanning, preferably with a similar UX to `kubectl --context <string>`

# Context

A new `--context <string>` was added to select the context used for scanning. Changes were made to each of our clients which originally created a rest config with the kubecontext being hardcoded to an empty string (corresponding to the currently selected kubecontext), each of these clients were changed to now create rest config with the kubecontext being set by the `--context` flag value.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
