### PR TITLE
build: allow VERSION var to be set in local dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ ORIGIN_URL ?= $(shell git remote get-url origin)
 UPSTREAM_ORIGIN_URL ?= git@github.com:solo-io/gloo.git
 UPSTREAM_ORIGIN_URL_HTTPS ?= https://www.github.com/solo-io/gloo.git
 ifeq ($(filter "$(ORIGIN_URL)", "$(UPSTREAM_ORIGIN_URL)" "$(UPSTREAM_ORIGIN_URL_HTTPS)"),)
-	VERSION := 0.0.1-fork
+	VERSION ?= 0.0.1-fork
 	CREATE_TEST_ASSETS := "false"
 endif
 

--- a/changelog/v1.12.41/version-var-repair.yaml
+++ b/changelog/v1.12.41/version-var-repair.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Allow VERSION to be explicitly set in local dev


### PR DESCRIPTION
# Description
Changed a _very heavily used_ Makefile variable, `VERSION`, from being always hardcoded to `0.0.1-fork` when doing local development

# Context
I was chasing a subtle bug when working on some EE actions, and found that I could not build arbitrary versions on the `1.12.x` OSS branch

(replaces PR https://github.com/solo-io/gloo/pull/7647 to test CI when running from a fork)