### PR TITLE
Fix istio-proxy pod being placed inside `tolerations` in helm template

### DIFF
--- a/changelog/v1.10.43/fix-gateway-proxy-config-and-tolerations.yaml
+++ b/changelog/v1.10.43/fix-gateway-proxy-config-and-tolerations.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    description: >
+      Fix issue with `istio-proxy` being set in `tolerations` by moving pod-level options (including `tolerations`) out of container configuration.
+    issueLink: https://github.com/solo-io/gloo/issues/5665
+    resolvesIssue: false
+  - type: HELM
+    description: >
+      Move pod-level options outside of istio/sds container configuration.

--- a/changelog/v1.10.43/fix-gateway-proxy-config-and-tolerations.yaml
+++ b/changelog/v1.10.43/fix-gateway-proxy-config-and-tolerations.yaml
@@ -7,3 +7,5 @@ changelog:
   - type: HELM
     description: >
       Move pod-level options outside of istio/sds container configuration.
+    issueLink: https://github.com/solo-io/gloo/issues/5665
+    resolvesIssue: false

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -136,12 +136,12 @@ spec:
       {{- if $spec.podTemplate.nodeSelector }}
       nodeSelector:
       {{- range $key, $value := $spec.podTemplate.nodeSelector }}
-      {{ $key }}: {{ $value | quote }}
+        {{ $key }}: {{ $value | quote }}
       {{- end }}
       {{- end }}
       {{- if $spec.podTemplate.tolerations }}
       tolerations:
-      {{ toYaml $spec.podTemplate.tolerations | indent 6}}
+{{ toYaml $spec.podTemplate.tolerations | indent 6}}
       {{- end }}
       {{- if $spec.podTemplate.terminationGracePeriodSeconds }}
       terminationGracePeriodSeconds: {{ $spec.podTemplate.terminationGracePeriodSeconds }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -124,6 +124,28 @@ spec:
 {{- end}}
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       serviceAccountName: gateway-proxy
+      {{- if $spec.kind.daemonSet }}
+      {{- if $spec.kind.daemonSet.hostPort }}
+      hostNetwork: {{ ne "false" ($spec.kind.daemonSet.hostNetwork | toString) }} {{/* defaults to true if undefined */}}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end}}
+      {{- end}}
+      {{- if $spec.podTemplate.nodeName }}
+      nodeName: {{$spec.podTemplate.nodeName}}
+      {{- end }}
+      {{- if $spec.podTemplate.nodeSelector }}
+      nodeSelector:
+      {{- range $key, $value := $spec.podTemplate.nodeSelector }}
+      {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
+      {{- if $spec.podTemplate.tolerations }}
+      tolerations:
+      {{ toYaml $spec.podTemplate.tolerations | indent 6}}
+      {{- end }}
+      {{- if $spec.podTemplate.terminationGracePeriodSeconds }}
+      terminationGracePeriodSeconds: {{ $spec.podTemplate.terminationGracePeriodSeconds }}
+      {{- end }}
       {{- if $spec.extraInitContainersHelper }}
       initContainers:
       {{- include $spec.extraInitContainersHelper . | nindent 6 }}
@@ -303,28 +325,6 @@ spec:
           name: sds
           protocol: TCP
 {{- end }} {{- /* $global.glooMtls.enabled or $.Values.istioSDS.enabled */}}
-      {{- if $spec.kind.daemonSet }}
-      {{- if $spec.kind.daemonSet.hostPort }}
-      hostNetwork: {{ ne "false" ($spec.kind.daemonSet.hostNetwork | toString) }} {{/* defaults to true if undefined */}}
-      dnsPolicy: ClusterFirstWithHostNet
-      {{- end}}
-      {{- end}}
-      {{- if $spec.podTemplate.nodeName }}
-      nodeName: {{$spec.podTemplate.nodeName}}
-      {{- end }}
-      {{- if $spec.podTemplate.nodeSelector }}
-      nodeSelector:
-      {{- range $key, $value := $spec.podTemplate.nodeSelector }}
-        {{ $key }}: {{ $value | quote }}
-      {{- end }}
-      {{- end }}
-      {{- if $spec.podTemplate.tolerations }}
-      tolerations:
-{{ toYaml $spec.podTemplate.tolerations | indent 6}}
-      {{- end }}
-      {{- if $spec.podTemplate.terminationGracePeriodSeconds }}
-      terminationGracePeriodSeconds: {{ $spec.podTemplate.terminationGracePeriodSeconds }}
-      {{- end }}
 {{- if $global.istioSDS.enabled }}
 {{- if $global.istioSDS.customSidecars }}
 {{ toYaml $global.istioSDS.customSidecars | indent 6}}

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4778,7 +4778,7 @@ metadata:
 
 			})
 
-			FDescribe("Standard k8s values", func() {
+			Describe("Standard k8s values", func() {
 				DescribeTable("PodSpec affinity, tolerations, nodeName, hostAliases, nodeSelector, restartPolicy on Deployments and Jobs",
 					func(kind string, resourceName string, value string, extraArgs ...string) {
 						prepareMakefile(namespace, helmValues{

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2182,6 +2182,43 @@ spec:
 						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
 					})
 
+					It("doesn't break containers when enabling multiple containers", func() {
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"global.glooMtls.enabled=true",
+								"global.istioSDS.enabled=true",
+							},
+						})
+
+						// Containers we expect to have
+						expectedContainers := map[string]struct{}{
+							"gateway-proxy": {},
+							"istio-proxy":   {},
+							"sds":           {},
+						}
+
+						testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+							return resource.GetKind() == "Deployment" && resource.GetName() == "gateway-proxy"
+						}).ExpectAll(func(deployment *unstructured.Unstructured) {
+							deploymentObject, err := kuberesource.ConvertUnstructured(deployment)
+							Expect(err).NotTo(HaveOccurred(), fmt.Sprintf("Deployment %+v should be able to convert from unstructured", deployment))
+							structuredDeployment, ok := deploymentObject.(*appsv1.Deployment)
+							Expect(ok).To(BeTrue(), fmt.Sprintf("Deployment %+v should be able to cast to a structured deployment", deployment))
+
+							for _, container := range structuredDeployment.Spec.Template.Spec.Containers {
+								if _, ok := expectedContainers[container.Name]; ok {
+									// delete found containers from our expectedContainers list
+									delete(expectedContainers, container.Name)
+								} else {
+									Fail(fmt.Sprintf("Unexpected container found: %+v", container.Name))
+								}
+							}
+						})
+
+						// An expected container was not correctly set
+						Expect(len(expectedContainers)).To(BeZero(), "all enabled containers must have been found")
+					})
+
 					It("supports extra args to envoy", func() {
 						prepareMakefile(namespace, helmValues{
 							valuesArgs: []string{


### PR DESCRIPTION
# Description

Please include a summary of the changes.
- Moved pod-level options outside of container configuration.
- Essentially a backport of #5987, which also fixes the issue of istio being placed in the `tolerations` field.
  - Backported test. It passes without this fix, although was added for extra guard-railing against(?) future changes.
- New test to verify istio-proxy gets set as a `container`, not a `toleration`.

# Context

When adding `tolerations` and enabling `istioSDS`, the `istio-proxy` container was being set in the `tolerations` field instead of `containers`. This fixes that issue.

# Reproduction

1. `VERSION=<whatever> make build-test-chart`
2. `helm template gloo-fixed ~/go/src/github.com/solo-io/gloo/_test/gloo-<VERSION>.tgz 
--values ./values1.yaml --values ./values2.yaml > file`
    - values file linked in issue
3. find `istio-proxy` in `file`.
    - without this fix: it is placed inside a `tolerations` field in the generated template
    - with this fix: `istio-proxy` is correctly placed inside the `gateway-proxy` deployment containers.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
