### PR TITLE
build(nightly-tests): combine/simplify slack alerts

### DIFF
--- a/.github/workflows/helpers/notify-from-json.go
+++ b/.github/workflows/helpers/notify-from-json.go
@@ -46,7 +46,7 @@ func main() {
 
 func send_success() {
 	message_slack(Payload{
-		Channel: SLACK_CHANNEL, // hange to SLACK_TESTING_CHANNEL to not spam standard watch channel
+		Channel: SLACK_CHANNEL, // change to SLACK_TESTING_CHANNEL to not spam standard watch channel
 		Text:    os.ExpandEnv(":large_green_circle: <$PARENT_JOB_URL|Gloo OSS nightlies> have all passed!"),
 	})
 }
@@ -58,7 +58,7 @@ func send_failure(jobs []Job) {
 	text = text[:len(text)-2] + ")"
 
 	message_slack(Payload{
-		Channel: SLACK_TESTING_CHANNEL,
+		Channel: SLACK_CHANNEL, // change to SLACK_TESTING_CHANNEL to not spam standard watch channel
 		Text:    os.ExpandEnv(text),
 	})
 }

--- a/.github/workflows/helpers/notify-from-json.go
+++ b/.github/workflows/helpers/notify-from-json.go
@@ -1,0 +1,76 @@
+// helper script designed to...
+//   1. read in all failed json artifacts from a matrix of github jobs
+//   2. assemble (and send) a cohesive slack notification
+//
+// Representative JSON which could be passed in as an argument to this script:
+// 	 all failures: '[{"url":"https://github.com/solo-io/gloo/actions/runs/3886431530","name":"gateway"},{"url":"https://github.com/solo-io/gloo/actions/runs/3886431530","name":"gloo"},{"url":"https://github.com/solo-io/gloo/actions/runs/3886431530","name":"glooctl"},{"url":"https://github.com/solo-io/gloo/actions/runs/3886431530","name":"gloomtls"},{"url":"https://github.com/solo-io/gloo/actions/runs/3886431530","name":"helm"},{"url":"https://github.com/solo-io/gloo/actions/runs/3886431530","name":"ingress"},{"url":"https://github.com/solo-io/gloo/actions/runs/3886431530","name":"upgrade"}]'
+// 	 all successes: '[]'
+//
+// Example usage:
+//   test_results="'""$(cat */test-out.json | jq -c --slurp .)""'"
+//   PARENT_JOB_URL="https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}" SLACKBOT_BEARER=${{ secrets.SLACKBOT_BEARER }} go run .github/workflows/helpers/notify-from-json.go $test_results
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+type Job struct {
+	Url  string
+	Name string
+}
+
+type Payload struct {
+	Channel string `json:"channel"`
+	Text    string `json:"text"`
+}
+
+const SLACK_TESTING_CHANNEL = "C0314KESVNV" // # slack-integration-testing
+const SLACK_CHANNEL = "C04CJMXAH7A"         // # edge-nightly-results
+
+func main() {
+	var jobs []Job
+	json.Unmarshal([]byte(os.Args[1]), &jobs)
+
+	if len(jobs) == 0 {
+		send_success()
+	} else {
+		send_failure(jobs)
+	}
+}
+
+func send_success() {
+	message_slack(Payload{
+		Channel: SLACK_CHANNEL, // hange to SLACK_TESTING_CHANNEL to not spam standard watch channel
+		Text:    os.ExpandEnv(":large_green_circle: <$PARENT_JOB_URL|Gloo OSS nightlies> have all passed!"),
+	})
+}
+func send_failure(jobs []Job) {
+	text := fmt.Sprintf(":red_circle: <$PARENT_JOB_URL|Gloo OSS nightlies> have failed in %v test suites: (", len(jobs))
+	for _, job := range jobs {
+		text += fmt.Sprintf("<%s|%s>, ", job.Url, job.Name)
+	}
+	text = text[:len(text)-2] + ")"
+
+	message_slack(Payload{
+		Channel: SLACK_TESTING_CHANNEL,
+		Text:    os.ExpandEnv(text),
+	})
+}
+
+func message_slack(data Payload) {
+	payloadBytes, _ := json.Marshal(data)
+	body := bytes.NewReader(payloadBytes)
+
+	req, _ := http.NewRequest("POST", "https://slack.com/api/chat.postMessage", body)
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("Authorization", os.ExpandEnv("Bearer $SLACKBOT_BEARER"))
+
+	resp, _ := http.DefaultClient.Do(req)
+	defer resp.Body.Close()
+}

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -13,6 +13,7 @@ jobs:
       uses: styfle/cancel-workflow-action@0.4.1
       with:
         access_token: ${{ github.token }}
+
   regression_tests:
     name: k8s regression tests
     needs: prepare_env
@@ -103,21 +104,28 @@ jobs:
         # see what's in the cluster if we failed
         kubectl get all -A
         kubectl get configmaps -A
-    - name: Send Fail Message
-      id: message-on-failure
+    - name: save results
       if: ${{ failure() }}
-      shell: bash
-      run: |
-        curl -X POST https://slack.com/api/chat.postMessage\
-              -H "Content-Type: application/json; charset=utf-8"\
-              -H "Authorization: Bearer ${{ secrets.SLACKBOT_BEARER }}"\
-              -d '{"channel":"C04CJMXAH7A","text":":red_circle: ${{ matrix.kube-e2e-test-type }} failed. <https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}|Full Results>"}'
-    - name: Send Success Message
-      id: message-on-success
-      if: ${{ success() }}
-      shell: bash
-      run: |
-        curl -X POST https://slack.com/api/chat.postMessage\
-              -H "Content-Type: application/json; charset=utf-8"\
-              -H "Authorization: Bearer ${{ secrets.SLACKBOT_BEARER }}"\
-              -d '{"channel":"C04CJMXAH7A","text":":large_green_circle: ${{ matrix.kube-e2e-test-type }} succeeded. <https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}|Full Results>"}'
+      run: echo '{"url":"https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}",
+              "name":"${{matrix.kube-e2e-test-type}}"}' > test-out.json
+    - uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: ${{ matrix.kube-e2e-test-type }}
+        path: test-out.json
+        if-no-files-found: warn
+
+  publish_results:
+    runs-on:  ubuntu-22.04
+    if: ${{ always() }}
+    needs: [ regression_tests ]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.2
+      - uses: actions/download-artifact@v3
+      - run: |
+          test_results="$(cat */test-out.json | jq -c --slurp .)"
+          echo $test_results
+          PARENT_JOB_URL="https://github.com/solo-io/gloo/actions/runs/${{github.run_id}}" SLACKBOT_BEARER=${{secrets.SLACKBOT_BEARER}} go run .github/workflows/helpers/notify-from-json.go $test_results

--- a/changelog/v1.14.0-beta6/combine-nightly-logs.yaml
+++ b/changelog/v1.14.0-beta6/combine-nightly-logs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/4410
+    description: Combine slack messages from nightly github runs


### PR DESCRIPTION
# Description
Added a data aggregation step prior to slack notification for nightly builds.  Enables slack posts to be prettier (and combined)

<img width="864" alt="Screen Shot 2023-01-11 at 11 31 04 AM" src="https://user-images.githubusercontent.com/92050522/211862224-c2fe91a6-4aa6-4752-b9e9-bddc63d75860.png">

# Testing
Performed with a simplified branch job: **Actions Testing**
* [workflow definition](https://github.com/solo-io/gloo/blob/cron-compression/.github/workflows/test-job.yaml)
* [example runs](https://github.com/solo-io/gloo/actions/workflows/test-job.yaml)
* slackbot posts (`#slack-integration-testing`)


# Context
necessary prep work for adding _even more_ slack posts based on CRON jobs

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/4410