### PR TITLE
Adding RespectDnsTtl & DnsRefreshRate to Upstream.proto

### DIFF
--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/upstream.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/upstream.proto.sk.md
@@ -62,6 +62,8 @@ Each upstream type is handled by a corresponding Gloo plugin. (plugins currently
 "httpConnectSslConfig": .gloo.solo.io.UpstreamSslConfig
 "httpConnectHeaders": []gloo.solo.io.HeaderValue
 "ignoreHealthOnHostRemoval": .google.protobuf.BoolValue
+"RespectDnsTtl": .google.protobuf.BoolValue
+"DnsRefreshRate": .google.protobuf.Duration
 
 ```
 
@@ -94,6 +96,8 @@ Each upstream type is handled by a corresponding Gloo plugin. (plugins currently
 | `httpConnectSslConfig` | [.gloo.solo.io.UpstreamSslConfig](../ssl.proto.sk/#upstreamsslconfig) | HttpConnectSslConfig contains the options necessary to configure envoy to originate TLS to an HTTP Connect proxy. If you also want to ensure the bytes proxied by the HTTP Connect proxy are encrypted, you should also specify `ssl_config`. |
 | `httpConnectHeaders` | [[]gloo.solo.io.HeaderValue](../upstream.proto.sk/#headervalue) | HttpConnectHeaders specifies the headers sent with the initial HTTP Connect request. |
 | `ignoreHealthOnHostRemoval` | [.google.protobuf.BoolValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/bool-value) | (bool) If set to true, Envoy will ignore the health value of a host when processing its removal from service discovery. This means that if active health checking is used, Envoy will not wait for the endpoint to go unhealthy before removing it. |
+| `RespectDnsTtl` | [.google.protobuf.BoolValue](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/bool-value) | (bool) If set to true, cluster’s DNS refresh rate will be set to resource record’s TTL which comes from DNS resolution. If minimum TTL is 0 DnsRefreshRate will be used instead. |
+| `DnsRefreshRate` | [.google.protobuf.Duration](https://developers.google.com/protocol-buffers/docs/reference/csharp/class/google/protobuf/well-known-types/duration) | (Duration) if the DNS refresh rate is specified and the cluster type is either STRICT_DNS, or LOGICAL_DNS, this value is used as the cluster’s DNS refresh rate. The value configured must be at least 1ms. If this setting is not specified, the value defaults to 5000ms. |
 
 
 

--- a/install/helm/gloo/crds/gloo.solo.io_v1_Upstream.yaml
+++ b/install/helm/gloo/crds/gloo.solo.io_v1_Upstream.yaml
@@ -721,6 +721,12 @@ spec:
               ignoreHealthOnHostRemoval:
                 nullable: true
                 type: boolean
+              RespectDnsTtl:
+                nullable: true
+                type: boolean
+              DnsRefreshRate:
+                nullable: true
+                type: string
               initialConnectionWindowSize:
                 maximum: 4294967295
                 minimum: 0

--- a/projects/gloo/api/v1/upstream.proto
+++ b/projects/gloo/api/v1/upstream.proto
@@ -161,6 +161,13 @@ message Upstream {
     // (bool) If set to true, Envoy will ignore the health value of a host when processing its removal from service discovery.
     // This means that if active health checking is used, Envoy will not wait for the endpoint to go unhealthy before removing it.
     google.protobuf.BoolValue ignore_health_on_host_removal = 22;
+
+    // (bool) If set to true, Service Discovery update period will be triggered once the TTL is expired.
+	// If minimum TTL of all records is 0 then dns_refresh_rate will be used.
+	google.protobuf.BoolValue respect_dns_ttl= 39;
+	// (Duration) Service Discovery DNS Refresh Rate, if unset it defaults to 5 seconds.
+	// Minimum value is 1 ms
+	google.protobufDuration dns_refresh_rate = 16;
 }
 
 // created by discovery services

--- a/projects/gloo/pkg/api/v1/upstream.pb.go
+++ b/projects/gloo/pkg/api/v1/upstream.pb.go
@@ -24,6 +24,7 @@ import (
 	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
+	duration "github.com/golang/protobuf/ptypes/duration"
 )
 
 const (
@@ -184,6 +185,12 @@ type Upstream struct {
 	// (bool) If set to true, Envoy will ignore the health value of a host when processing its removal from service discovery.
 	// This means that if active health checking is used, Envoy will not wait for the endpoint to go unhealthy before removing it.
 	IgnoreHealthOnHostRemoval *wrappers.BoolValue `protobuf:"bytes,22,opt,name=ignore_health_on_host_removal,json=ignoreHealthOnHostRemoval,proto3" json:"ignore_health_on_host_removal,omitempty"`
+	// (bool) If set to true, Service Discovery update period will be triggered once the TTL is expired.
+	// If minimum TTL of all records is 0 then dns_refresh_rate will be used.
+	RespectDnsTtl *wrappers.BoolValue `protobuf:"varint,39,opt,name=respect_dns_ttl,json=respectDnsTtl,proto3" json:"respect_dns_ttl,omitempty"`
+	// (Duration) Service Discovery DNS Refresh Rate, if unset it defaults to 5 seconds.
+	// Minimum value is 1 ms
+	DnsRefreshRate *duration.Duration `protobuf:"bytes,16,opt,name=dns_refresh_rate,json=dnsRefreshRate,proto3" json:"dns_refresh_rate,omitempty"`
 }
 
 func (x *Upstream) Reset() {
@@ -410,6 +417,20 @@ func (x *Upstream) GetHttpConnectHeaders() []*HeaderValue {
 func (x *Upstream) GetIgnoreHealthOnHostRemoval() *wrappers.BoolValue {
 	if x != nil {
 		return x.IgnoreHealthOnHostRemoval
+	}
+	return nil
+}
+
+func (x *Upstream) GetRespectDnsTtl() *wrappers.BoolValue {
+	if x != nil {
+		return x.RespectDnsTtl
+	}
+	return nil
+}
+
+func (x *Upstream) GetDnsRefreshRate() *duration.Duration {
+	if x != nil {
+		return x.DnsRefreshRate
 	}
 	return nil
 }

--- a/projects/gloo/pkg/api/v1/upstream.pb.hash.go
+++ b/projects/gloo/pkg/api/v1/upstream.pb.hash.go
@@ -411,6 +411,46 @@ func (m *Upstream) Hash(hasher hash.Hash64) (uint64, error) {
 		}
 	}
 
+	if h, ok := interface{}(m.GetRespectDnsTtl()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("RespectDnsTtl")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetRespectDnsTtl(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("RespectDnsTtl")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	if h, ok := interface{}(m.GetDnsRefreshRate()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("DnsRefreshRate")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetDnsRefreshRate(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("DnsRefreshRate")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
 	switch m.UpstreamType.(type) {
 
 	case *Upstream_Kube:

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/solo-io/gloo/pkg/utils/settingsutil"
+	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -500,6 +501,24 @@ var _ = Describe("UdsConvert", func() {
 						Value: true,
 					},
 				}),
+				Entry("Using RespectDnsTtl", map[string]string{
+					serviceconverter.GlooAnnotationPrefix: `{
+						"respect_dns_ttl": true
+					}`,
+				}, &v1.Upstream{
+					RespectDnsTtl: &wrappers.BoolValue{
+						Value: true,
+					},
+				}),
+				Entry("Using DnsRefreshRate", map[string]string{
+					serviceconverter.GlooAnnotationPrefix: `{
+						"dns_refresh_rate": 10s
+					}`,
+				}, &v1.Upstream{
+					DnsRefreshRate: &durationpb.Duration{
+						Seconds: 10,
+					},
+				}),
 				Entry("Using CircuitBreakers", map[string]string{
 					serviceconverter.GlooAnnotationPrefix: `{
 						"circuit_breakers": {
@@ -599,6 +618,24 @@ var _ = Describe("UdsConvert", func() {
 				}, &v1.Upstream{
 					IgnoreHealthOnHostRemoval: &wrappers.BoolValue{
 						Value: true,
+					},
+				}),
+				Entry("Using RespectDnsTtl", map[string]string{
+					serviceconverter.GlooAnnotationPrefix: `{
+						"respectDnsTtl": true
+					}`,
+				}, &v1.Upstream{
+					RespectDnsTtl: &wrappers.BoolValue{
+						Value: true,
+					},
+				}),
+				Entry("Using DnsRefreshRate", map[string]string{
+					serviceconverter.GlooAnnotationPrefix: `{
+						"dnsRefreshRate": 10s
+					}`,
+				}, &v1.Upstream{
+					DnsRefreshRate: &durationpb.Duration{
+						Seconds: 10,
 					},
 				}),
 				Entry("Using CircuitBreakers", map[string]string{

--- a/projects/gloo/pkg/plugins/utils/update_upstream_spec.go
+++ b/projects/gloo/pkg/plugins/utils/update_upstream_spec.go
@@ -72,4 +72,12 @@ func UpdateUpstream(original, desired *v1.Upstream) {
 	if desired.GetIgnoreHealthOnHostRemoval() == nil {
 		desired.IgnoreHealthOnHostRemoval = original.GetIgnoreHealthOnHostRemoval()
 	}
+
+	if desired.GetRespectDnsTtl() == nil {
+		desired.RespectDnsTtl = original.GetRespectDnsTtl()
+	}
+
+	if desired.GetDnsRefreshRate() == nil {
+		desired.DnsRefreshRate = original.GetDnsRefreshRate()
+	}
 }

--- a/projects/gloo/pkg/translator/clusters.go
+++ b/projects/gloo/pkg/translator/clusters.go
@@ -102,6 +102,8 @@ func (t *translatorInstance) initializeCluster(
 		ConnectTimeout:            ptypes.DurationProto(ClusterConnectionTimeout),
 		Http2ProtocolOptions:      getHttp2options(upstream),
 		IgnoreHealthOnHostRemoval: upstream.GetIgnoreHealthOnHostRemoval().GetValue(),
+		RespectDnsTtl:             upstream.GetRespectDnsTtl().GetValue(),
+		DnsRefreshRate:            upstream.GetDnsRefreshRate(),
 	}
 
 	if sslConfig := upstream.GetSslConfig(); sslConfig != nil {


### PR DESCRIPTION
# Description

Include `respect_dns_ttl` and `dns_refresh_rate` to the Upstream.proto

This bug fixes ... \ This new feature can be used to ...

# Context

Request in this https://github.com/solo-io/gloo/issues/6402 

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
