### PR TITLE
release placeholder [1.11]

### DIFF
--- a/changelog/v1.11.49/placeholder.yaml
+++ b/changelog/v1.11.49/placeholder.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Placeholder to retry failed release


### PR DESCRIPTION
adding a changelog so we can try re-releasing 1.11 (last release attempt failed)