### PR TITLE
test(gateway): clean up secrets after tests

### DIFF
--- a/changelog/v1.14.0-beta8/secret-existing-failure.yaml
+++ b/changelog/v1.14.0-beta8/secret-existing-failure.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/4516
+  resolvesIssue: false
+  description: address "secret already exists" flake by always cleaning up secret

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -1666,6 +1666,11 @@ var _ = Describe("Kube2e: gateway", func() {
 
 			})
 
+			AfterEach(func() {
+				err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, "secret", metav1.DeleteOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
 			It("correctly routes to the service (tcp/tls)", func() {
 				responseString := fmt.Sprintf(`"hostname":"%s"`, httpEchoClusterName)
 


### PR DESCRIPTION
# Description
Repaired test suite by always cleaning up secret after use.  (Previously, if this suite would run out-of-order, it would fail)

# Context
With the addition of https://github.com/solo-io/gloo/pull/7768, a new crop of flakes have presented themselves.  This PR is addressing _one_ such flake (possibly as an example to be referenced later)

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
