### PR TITLE
allow QP on re-writes (#7771)

### DIFF
--- a/changelog/v1.10.44/allow-query-parameters-on-re-writes.yaml
+++ b/changelog/v1.10.44/allow-query-parameters-on-re-writes.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/7715#issuecomment-1410014270
+  resolvesIssue: false
+  description: >-
+    No longer fail validation when specifying query parameters on re-writes.

--- a/projects/gloo/pkg/translator/route_config.go
+++ b/projects/gloo/pkg/translator/route_config.go
@@ -3,6 +3,7 @@ package translator
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"regexp"
 	"strings"
 	"unicode"
@@ -228,11 +229,11 @@ func validateEnvoyRoute(r *envoy_config_route_v3.Route, routeReport *validationa
 	name := r.GetName()
 	validatePath(match.GetPath(), name, routeReport)
 	validatePath(match.GetPrefix(), name, routeReport)
-	validatePath(route.GetPrefixRewrite(), name, routeReport)
-	validatePath(re.GetPrefixRewrite(), name, routeReport)
 	validatePath(re.GetPathRedirect(), name, routeReport)
 	validatePath(re.GetHostRedirect(), name, routeReport)
 	validatePath(re.GetSchemeRedirect(), name, routeReport)
+	validatePrefixRewrite(route.GetPrefixRewrite(), name, routeReport)
+	validatePrefixRewrite(re.GetPrefixRewrite(), name, routeReport)
 }
 
 // utility function to transform gloo matcher to envoy route matcher
@@ -819,6 +820,21 @@ func validatePath(path, name string, routeReport *validationapi.RouteReport) {
 	if err := ValidateRoutePath(path); err != nil {
 		validation.AppendRouteError(routeReport, validationapi.RouteReport_Error_ProcessingError, err.Error(), name)
 	}
+}
+
+func validatePrefixRewrite(rewrite, name string, routeReport *validationapi.RouteReport) {
+	if err := ValidatePrefixRewrite(rewrite); err != nil {
+		validation.AppendRouteError(routeReport, validationapi.RouteReport_Error_ProcessingError, errors.Wrapf(err, "the rewrite is invalid: %s", rewrite).Error(), name)
+	}
+}
+
+// ValidatePrefixRewrite will validate the rewrite using url.Parse. Then it will evaluate the Path of the rewrite.
+func ValidatePrefixRewrite(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+	return ValidateRoutePath(u.Path)
 }
 
 // ValidateRoutePath will validate a string for all characters according to RFC 3986

--- a/projects/gloo/pkg/translator/route_config_test.go
+++ b/projects/gloo/pkg/translator/route_config_test.go
@@ -74,4 +74,19 @@ var _ = Describe("Route Configs", func() {
 		}
 	})
 
+	DescribeTable("path rewrites", func(s string, pass bool) {
+		err := translator.ValidatePrefixRewrite(s)
+		if pass {
+			Expect(err).ToNot(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+		}
+	},
+		Entry("allow query parameters", "some/site?a=data&b=location&c=searchterm", true),
+		Entry("allow fragments", "some/site#framgentedinfo", true),
+		Entry("invalid", "some/site<hello", false),
+		Entry("invalid", "some/site{hello", false),
+		Entry("invalid", "some/site}hello", false),
+		Entry("invalid", "some/site[hello", false),
+	)
 })


### PR DESCRIPTION
* allow QP on re writes

* unit tests on validate re-write

* Update changelog/v1.14.0-beta8/allow-query-parameters-on-re-writes.yaml

Co-authored-by: Nathan Fudenberg <nathan.fudenberg@solo.io>

---------

Co-authored-by: soloio-bulldozer[bot] <48420018+soloio-bulldozer[bot]@users.noreply.github.com>
Co-authored-by: Nathan Fudenberg <nathan.fudenberg@solo.io>

# Description

Please include a summary of the changes.

This bug fixes ... \ This new feature can be used to ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
