### PR TITLE
1.13/cli safe testing

### DIFF
--- a/changelog/v1.13.6/cli-leak-hardening.yaml
+++ b/changelog/v1.13.6/cli-leak-hardening.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  descrption: Harden the cli code to not leak. Useful when using the code not as a standalone call.
+  issueLink: https://github.com/solo-io/solo-projects/issues/4312
+  resolvesIssue: false

--- a/changelog/v1.13.6/cli-leak-hardening.yaml
+++ b/changelog/v1.13.6/cli-leak-hardening.yaml
@@ -1,5 +1,5 @@
 changelog:
 - type: NON_USER_FACING
-  descrption: Harden the cli code to not leak. Useful when using the code not as a standalone call.
+  descrption: Harden the cli code to not leak on kube caches. Useful when using the code not as a standalone call.
   issueLink: https://github.com/solo-io/solo-projects/issues/4312
   resolvesIssue: false

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -225,7 +225,7 @@ func UpstreamClient(ctx context.Context, namespaces []string) (v1.UpstreamClient
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	upstreamClient, err := v1.NewUpstreamClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.UpstreamCrd,
 		Cfg:                cfg,
@@ -268,7 +268,7 @@ func UpstreamGroupClient(ctx context.Context, namespaces []string) (v1.UpstreamG
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	upstreamGroupClient, err := v1.NewUpstreamGroupClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.UpstreamGroupCrd,
 		Cfg:                cfg,
@@ -311,7 +311,7 @@ func ProxyClient(ctx context.Context, namespaces []string) (v1.ProxyClient, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	proxyClient, err := v1.NewProxyClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.ProxyCrd,
 		Cfg:                cfg,
@@ -354,7 +354,7 @@ func GatewayClient(ctx context.Context, namespaces []string) (gatewayv1.GatewayC
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	gatewayClient, err := gatewayv1.NewGatewayClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.GatewayCrd,
 		Cfg:                cfg,
@@ -397,7 +397,7 @@ func VirtualServiceClient(ctx context.Context, namespaces []string) (gatewayv1.V
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	virtualServiceClient, err := gatewayv1.NewVirtualServiceClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.VirtualServiceCrd,
 		Cfg:                cfg,
@@ -440,7 +440,7 @@ func RouteTableClient(ctx context.Context, namespaces []string) (gatewayv1.Route
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	routeTableClient, err := gatewayv1.NewRouteTableClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.RouteTableCrd,
 		Cfg:                cfg,
@@ -483,7 +483,7 @@ func SettingsClient(ctx context.Context, namespaces []string) (v1.SettingsClient
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	settingsClient, err := v1.NewSettingsClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.SettingsCrd,
 		Cfg:                cfg,
@@ -616,7 +616,7 @@ func AuthConfigClient(ctx context.Context, namespaces []string) (extauth.AuthCon
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	authConfigClient, err := extauth.NewAuthConfigClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                extauth.AuthConfigCrd,
 		Cfg:                cfg,
@@ -655,7 +655,7 @@ func RateLimitConfigClient(ctx context.Context, namespaces []string) (v1alpha1.R
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	kubeCache := kube.NewKubeCache(context.TODO())
+	kubeCache := kube.NewKubeCache(ctx))
 	rlConfigClient, err := v1alpha1.NewRateLimitConfigClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1alpha1.RateLimitConfigCrd,
 		Cfg:                cfg,
@@ -697,7 +697,7 @@ func VirtualHostOptionClient(ctx context.Context, namespaces []string) (gatewayv
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	virtualHostOptClient, err := gatewayv1.NewVirtualHostOptionClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.VirtualHostOptionCrd,
 		Cfg:                cfg,
@@ -739,7 +739,7 @@ func RouteOptionClient(ctx context.Context, namespaces []string) (gatewayv1.Rout
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx))
 	routeOptClient, err := gatewayv1.NewRouteOptionClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.RouteOptionCrd,
 		Cfg:                cfg,

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -225,7 +225,7 @@ func UpstreamClient(ctx context.Context, namespaces []string) (v1.UpstreamClient
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	upstreamClient, err := v1.NewUpstreamClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.UpstreamCrd,
 		Cfg:                cfg,
@@ -268,7 +268,7 @@ func UpstreamGroupClient(ctx context.Context, namespaces []string) (v1.UpstreamG
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	upstreamGroupClient, err := v1.NewUpstreamGroupClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.UpstreamGroupCrd,
 		Cfg:                cfg,
@@ -311,7 +311,7 @@ func ProxyClient(ctx context.Context, namespaces []string) (v1.ProxyClient, erro
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	proxyClient, err := v1.NewProxyClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.ProxyCrd,
 		Cfg:                cfg,
@@ -354,7 +354,7 @@ func GatewayClient(ctx context.Context, namespaces []string) (gatewayv1.GatewayC
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	gatewayClient, err := gatewayv1.NewGatewayClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.GatewayCrd,
 		Cfg:                cfg,
@@ -397,7 +397,7 @@ func VirtualServiceClient(ctx context.Context, namespaces []string) (gatewayv1.V
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	virtualServiceClient, err := gatewayv1.NewVirtualServiceClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.VirtualServiceCrd,
 		Cfg:                cfg,
@@ -440,7 +440,7 @@ func RouteTableClient(ctx context.Context, namespaces []string) (gatewayv1.Route
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	routeTableClient, err := gatewayv1.NewRouteTableClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.RouteTableCrd,
 		Cfg:                cfg,
@@ -483,7 +483,7 @@ func SettingsClient(ctx context.Context, namespaces []string) (v1.SettingsClient
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	settingsClient, err := v1.NewSettingsClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1.SettingsCrd,
 		Cfg:                cfg,
@@ -616,7 +616,7 @@ func AuthConfigClient(ctx context.Context, namespaces []string) (extauth.AuthCon
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	authConfigClient, err := extauth.NewAuthConfigClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                extauth.AuthConfigCrd,
 		Cfg:                cfg,
@@ -655,7 +655,7 @@ func RateLimitConfigClient(ctx context.Context, namespaces []string) (v1alpha1.R
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	kubeCache := kube.NewKubeCache(ctx))
+	kubeCache := kube.NewKubeCache(ctx)
 	rlConfigClient, err := v1alpha1.NewRateLimitConfigClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                v1alpha1.RateLimitConfigCrd,
 		Cfg:                cfg,
@@ -697,7 +697,7 @@ func VirtualHostOptionClient(ctx context.Context, namespaces []string) (gatewayv
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	virtualHostOptClient, err := gatewayv1.NewVirtualHostOptionClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.VirtualHostOptionCrd,
 		Cfg:                cfg,
@@ -739,7 +739,7 @@ func RouteOptionClient(ctx context.Context, namespaces []string) (gatewayv1.Rout
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(ctx))
+	cache := kube.NewKubeCache(ctx)
 	routeOptClient, err := gatewayv1.NewRouteOptionClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.RouteOptionCrd,
 		Cfg:                cfg,

--- a/test/kube2e/upgrade/upgrade_utils.go
+++ b/test/kube2e/upgrade/upgrade_utils.go
@@ -48,7 +48,6 @@ func GetUpgradeVersions(ctx context.Context, repoName string) (lastMinorLatestPa
 func getLastReleaseOfCurrentMinor(repoName string) (*versionutils.Version, error) {
 	// pull out to const
 	_, filename, _, _ := runtime.Caller(0) //get info about what is calling the function
-	fmt.Printf(filename)
 	fParts := strings.Split(filename, string(os.PathSeparator))
 	splitIdx := 0
 	//we can end up in a situation where the path contains the repo_name twice when running in ci - keep going until we find the last use ex: /home/runner/work/gloo/gloo/test/kube2e/upgrade/junit.xml


### PR DESCRIPTION
# Description

CLI calls as a library would not clean up after themselves. This led to a leak in goroutines which fails under race builds.
