### PR TITLE
[1.12] Fix Istio Crash When Using Headless Services

### DIFF
--- a/projects/gloo/pkg/plugins/kubernetes/eds.go
+++ b/projects/gloo/pkg/plugins/kubernetes/eds.go
@@ -270,6 +270,8 @@ type Epkey struct {
 	Name        string
 	Namespace   string
 	UpstreamRef *core.ResourceRef
+	// While we can use the upstream ref to get the upstream and service, if there are too many upstreams that could be slow.
+	IsHeadless bool
 }
 
 // Returns first matching port in the namespace and boolean value of true if the
@@ -287,6 +289,15 @@ func findPortForService(services []*kubev1.Service, spec *kubeplugin.UpstreamSpe
 		}
 	}
 	return nil, false
+}
+
+func getServiceFromUpstreamSpec(spec *kubeplugin.UpstreamSpec, services []*kubev1.Service) *kubev1.Service {
+	for _, svc := range services {
+		if svc.Namespace == spec.GetServiceNamespace() && svc.Name == spec.GetServiceName() {
+			return svc
+		}
+	}
+	return nil
 }
 
 func filterEndpoints(
@@ -324,13 +335,17 @@ func filterEndpoints(
 					continue
 				}
 
-				if istioIntegrationEnabled {
+				svc := getServiceFromUpstreamSpec(spec, services)
+				isHeadlessSvc := svc.Spec.ClusterIP == "None"
+				// Istio uses the service's port for routing requests
+				// Headless services don't have a cluster IP, so we'll resort to pod IP endpoints
+				if istioIntegrationEnabled && !isHeadlessSvc {
 					hostname := fmt.Sprintf("%v.%v", spec.GetServiceName(), spec.GetServiceNamespace())
-					key := Epkey{hostname, port, spec.GetServiceName(), spec.GetServiceNamespace(), usRef}
 					copyRef := *usRef
+					key := Epkey{hostname, port, spec.GetServiceName(), spec.GetServiceNamespace(), &copyRef, isHeadlessSvc}
 					endpointsMap[key] = append(endpointsMap[key], &copyRef)
 				} else {
-					warnings := processSubsetAddresses(subset, spec, podMap, usRef, port, endpointsMap)
+					warnings := processSubsetAddresses(subset, spec, podMap, usRef, port, endpointsMap, isHeadlessSvc)
 					warnsToLog = append(warnsToLog, warnings...)
 				}
 			}
@@ -342,7 +357,7 @@ func filterEndpoints(
 	return endpoints, warnsToLog, errorsToLog
 }
 
-func processSubsetAddresses(subset kubev1.EndpointSubset, spec *kubeplugin.UpstreamSpec, pods *podMap, usRef *core.ResourceRef, port uint32, endpointsMap map[Epkey][]*core.ResourceRef) []string {
+func processSubsetAddresses(subset kubev1.EndpointSubset, spec *kubeplugin.UpstreamSpec, pods *podMap, usRef *core.ResourceRef, port uint32, endpointsMap map[Epkey][]*core.ResourceRef, isHeadlessService bool) []string {
 	var warnings []string
 	for _, addr := range subset.Addresses {
 		var podName, podNamespace string
@@ -369,7 +384,7 @@ func processSubsetAddresses(subset kubev1.EndpointSubset, spec *kubeplugin.Upstr
 				continue
 			}
 		}
-		key := Epkey{addr.IP, port, podName, podNamespace, usRef}
+		key := Epkey{addr.IP, port, podName, podNamespace, usRef, isHeadlessService}
 		copyRef := *usRef
 		endpointsMap[key] = append(endpointsMap[key], &copyRef)
 	}
@@ -417,7 +432,8 @@ func generateFilteredEndpointList(
 		endpointName := fmt.Sprintf("ep-%v-%v-%x", dnsname, addr.Port, hasher.Sum64())
 
 		var ep *v1.Endpoint
-		if istioIntegrationEnabled {
+		// While istio integration requires the Service VIP, headless services require the pod IP, as there is no Cluster IP
+		if istioIntegrationEnabled && !addr.IsHeadless {
 			// Istio integration requires assigning endpoints the Kub service VIP rather than pod address
 			service, _ := getServiceForHostname(addr.Address, addr.Name, addr.Namespace, services)
 			ep = createEndpoint(writeNamespace, endpointName, refs, service.Spec.ClusterIP, addr.Port, service.GetObjectMeta().GetLabels()) // TODO: labels may be nil


### PR DESCRIPTION
_backport of #7804_

# Description

- Fixes issue with our istio integration code by only using the Service/Cluster IP if istio integration is enabled **and** it's not a headless service (No cluster ip).

# Context

Users where running into an issue when enabling istioIntegration `enableIstioSidecarOnGateway` with headless services in their environment, where their `gateway-proxy` logs were flooded with:
```
[warning][config] [external/envoy/source/common/config/grpc_subscription_impl.cc:126] gRPC config for type.googleapis.com/envoy.config.endpoint.v3.ClusterLoadAssignment rejected: malformed IP address: None. Consider setting resolver_name or setting cluster type to 'STRICT_DNS' or 'LOGICAL_DNS'
```

# TODO
- [ ] Write tests

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
