### PR TITLE
cli: context todo cleanup for gleak

### DIFF
--- a/changelog/v1.14.0-beta9/cli-context-leak.yaml
+++ b/changelog/v1.14.0-beta9/cli-context-leak.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  descrption: Harden the cli code to not leak on kube caches. Useful when using the code not as a standalone call.
+  issueLink: https://github.com/solo-io/solo-projects/issues/4312
+  resolvesIssue: false

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -474,7 +474,7 @@ func RouteTableClient(ctx context.Context, namespaces []string) (gatewayv1.Route
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx)
 	routeTableClient, err := gatewayv1.NewRouteTableClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                gatewayv1.RouteTableCrd,
 		Cfg:                cfg,
@@ -661,7 +661,7 @@ func AuthConfigClient(ctx context.Context, namespaces []string) (extauth.AuthCon
 	if err != nil {
 		return nil, errors.Wrapf(err, "getting kube config")
 	}
-	cache := kube.NewKubeCache(context.TODO())
+	cache := kube.NewKubeCache(ctx)
 	authConfigClient, err := extauth.NewAuthConfigClient(ctx, &factory.KubeResourceClientFactory{
 		Crd:                extauth.AuthConfigCrd,
 		Cfg:                cfg,


### PR DESCRIPTION
Clean up the last todos in the kube caches that were causing failures under race when using this code