### PR TITLE
revert cloudbuild bumps

### DIFF
--- a/changelog/v1.10.45/fix-cloudbuild.yaml
+++ b/changelog/v1.10.45/fix-cloudbuild.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Revert most recent cloudbuild go-mod-make upgrades, because they use go 1.18 and we are still on 1.16.
+      This should fix a glooctl cluster registration panic https://github.com/json-iterator/go/issues/608

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
 # gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo,_PR_NUM=<<insert PR Number here>> --project solo-public
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.4.15'
   args:
     - "--repo-name"
     - "$REPO_NAME"
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.15'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['prepare-workspace']
   id: 'get-envoy'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.15'
   entrypoint: 'bash'
   args: ['-c', 'make proxycontroller']
   dir: '/workspace/gloo/example/proxycontroller'
@@ -82,7 +82,7 @@ steps:
   waitFor: ['set-gcr-zone']
   id: 'get-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.15'
   args: ['install-go-tools']
   dir: *dir
   id: 'install-go-tools'
@@ -117,7 +117,7 @@ steps:
   id: 'docker-login'
 
   # 1) Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.15'
   args: ['docker-push-extended']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -138,7 +138,7 @@ steps:
   waitFor: ['docker-push-extended']
   id: 'gcr-auth'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.15'
   args: ['fetch-package-and-save-helm', 'render-manifests', 'upload-github-release-assets', 'push-chart-to-registry', '-B']
   env:
     - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -152,7 +152,7 @@ steps:
   id: 'release-chart'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.15'
   args: ['docker-push-retag']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'


### PR DESCRIPTION
Revert the cloud-builders version bumps done in https://github.com/solo-io/gloo/pull/7721, except for the `e2e-go-mod-ginkgo` upgrade, which is still needed to fix the gke issue.

Bumping `go-mod-make` to 0.4.28 had caused our release assets to be built using go 1.18, which resulted in a glooctl cluster registration bug/panic. Building glooctl with go 1.16 (which our 1.10.x branch uses) resolves the panic.