### PR TITLE
docs: enterprise proto docs now generate based on minor version

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -103,6 +103,9 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: master
+    - name: Override master checkout if deploying PR test
+      if: ${{ github.event_name == 'pull_request' }}
+      uses: actions/checkout@v3
     - name: Detect Community PR
       id: community-pr-check
       if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != 'solo-io/gloo' }}

--- a/changelog/v1.14.0-beta15/ee-proto-docs-fix.yaml
+++ b/changelog/v1.14.0-beta15/ee-proto-docs-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: true
+    issueLink: https://github.com/solo-io/gloo/issues/7887
+    description: enterprise proto docs are now based on the corect minor version (as opposed to _always_ latest)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -39,6 +39,8 @@ site-common: clean gloo-enterprise-version
 	cat content/static/content/gloo-security-scan.docgen
 	./split-file-by-delimiter.sh content/static/content/gloo-security-scan.docgen \\\*\\\*\\\*
 	./split-file-by-delimiter.sh content/static/content/glooe-security-scan.docgen \\\*\\\*\\\*
+
+	# get enterprise helm values based on contents of _output/gloo-enterprise-version
 	GO111MODULE=on go run cmd/generate_docs.go get-enterprise-helm-values > content/static/content/glooe-values.docgen
 	rm -f opensource.out enterprise.out
 
@@ -90,9 +92,8 @@ install-tools:
 build-site: clean
 	./build-docs.sh
 
-# Generate _output/gloo-enterprise-version.
-# NOTE: file paths in hack/find_latest_enterprise_version.go assume the current working 
-# directory is the root of the project, so we need to navigate up one level first.
+# Generate _output/gloo-enterprise-version based on the latest patch enterprise version
+# corresponding to content in changelog directory.
 .PHONY: gloo-enterprise-version
 gloo-enterprise-version:
 	cd .. && GO111MODULE=on go run hack/find_latest_enterprise_version.go

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -58,6 +58,7 @@ EOF
 workingDir=$(pwd)
 docsSiteDir=$workingDir/ci
 tempContentDir=$docsSiteDir/temp
+tempChangelogDir=$docsSiteDir/temp_changelogs
 repoDir=$workingDir/gloo-temp
 
 mkdir -p $docsSiteDir
@@ -123,6 +124,11 @@ function generateSiteForVersion() {
   mkdir $repoDir/docs/content
   cp -a $tempContentDir/$version/. $repoDir/docs/content/
 
+  # replace the master's changelog directory with the changelogs for the version we're building
+  rm -r $repoDir/changelog
+  mkdir $repoDir/changelog
+  cp -a $tempChangelogDir/$version/. $repoDir/changelog/
+
   # Remove the file responsible for the "security scan too large" bug if necessary
   guilty_path="./content/reference/security-updates"
   if cat $guilty_path/enterprise/_index.md | grep -q "glooe-security-scan-0"; then
@@ -172,6 +178,9 @@ function getContentForVersion() {
   fi
 
   cp -a $repoDir/docs/content/. $tempContentDir/$version/
+
+  mkdir -p $tempChangelogDir/$version
+  cp -a $repoDir/changelog/. $tempChangelogDir/$version/
 }
 
 # We build docs for all active and old version of Gloo, on pull requests (and merges) to master.


### PR DESCRIPTION
# Description
When generating docs for LTS branches copy the `changelog` dirs to allow generation to run correctly


# Context
When users consume our [enterprise helm reference](https://docs.solo.io/gloo-edge/1.11.52/reference/helm_chart_values/enterprise_helm_chart_values/), they were previously seeing _only_ the reference for the `latest` release, as opposed to the specific minor version of the site which was being viewed

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/7887