### PR TITLE
ci: bump go to 1.18.6 to prevent possible denial of service to control plane stats end point CVE-2022-27664

### DIFF
--- a/.github/actions/regression-tests/action.yaml
+++ b/.github/actions/regression-tests/action.yaml
@@ -29,7 +29,7 @@ runs:
   - name: Set up Go
     uses: actions/setup-go@v2
     with:
-      go-version: 1.18.2
+      go-version: 1.18.6
     id: go
   - uses: actions/cache@v1
     with:

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.2
+          go-version: 1.18.6
         id: go
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -86,7 +86,7 @@ jobs:
       if: needs.prepare_env.outputs.should-pass-docs != 'true'
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.2
+        go-version: 1.18.6
       id: go
     - name: Setup Hugo
       if: needs.prepare_env.outputs.should-pass-docs != 'true'

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -53,7 +53,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18.2
+        go-version: 1.18.6
       id: go
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.2
+          go-version: 1.18.6
         id: go
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -73,7 +73,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.2
+          go-version: 1.18.6
       - uses: actions/download-artifact@v3
       - name: Set pull_request_url
         run: echo "pull_request_url=$(cat ${{ github.event_path }} | jq --raw-output .pull_request._links.html.href)" >> $GITHUB_ENV

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.18.2
+          go-version: 1.18.6
         id: go
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2

--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ ifeq ($(GOOS),)
 endif
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=$(GOARCH)
-GOLANG_VERSION := golang:1.18.2-alpine
+GOLANG_VERSION := golang:1.18.6-alpine
 
 # Passed by cloudbuild
 GCLOUD_PROJECT_ID := $(GCLOUD_PROJECT_ID)

--- a/changelog/v1.13.10/go-bump.yaml
+++ b/changelog/v1.13.10/go-bump.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.18.6

--- a/changelog/v1.13.10/go-bump.yaml
+++ b/changelog/v1.13.10/go-bump.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: DEPENDENCY_BUMP
-    dependencyOwner: golang
-    dependencyRepo: go
-    dependencyTag: v1.18.6

--- a/changelog/v1.13.9/go-bump.yaml
+++ b/changelog/v1.13.9/go-bump.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.18.6

--- a/changelog/v1.13.9/go-bump.yaml
+++ b/changelog/v1.13.9/go-bump.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: DEPENDENCY_BUMP
-    dependencyOwner: golang
-    dependencyRepo: go
-    dependencyTag: v1.18.6

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -8,17 +8,17 @@ steps:
     path: '/go/pkg'
   id: 'untar-mod-cache'
 
-- name: 'golang:1.18.2'
+- name: 'golang:1.18.6'
   args: ['go', 'mod', 'download']
   volumes: *vol
   id: 'download'
 
-- name: 'golang:1.18.2'
+- name: 'golang:1.18.6'
   args: ['go', 'mod', 'tidy']
   volumes: *vol
   id: 'tidy'
 
-- name: 'golang:1.18.2'
+- name: 'golang:1.18.6'
   entrypoint: 'bash'
   volumes: *vol
   args: ['-c', ' cd /go/pkg && tar -zvcf gloo-mod.tar.gz mod']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
 # gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo,_PR_NUM=<<insert PR Number here>> --project solo-public
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.4.29'
   args:
     - "--repo-name"
     - "$REPO_NAME"
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['prepare-workspace']
   id: 'get-envoy'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
   entrypoint: 'bash'
   args: ['-c', 'make proxycontroller']
   dir: '/workspace/gloo/example/proxycontroller'
@@ -68,7 +68,7 @@ steps:
 
 # Docker related setup
 # grab this container immediately in parallel
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.4.29'
   entrypoint: ls
   waitFor: ['-']
   id: 'grab-ginkgo-container'
@@ -82,12 +82,12 @@ steps:
   waitFor: ['set-gcr-zone']
   id: 'get-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
   args: ['install-go-tools']
   dir: *dir
   id: 'install-go-tools'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.4.29'
   entrypoint: make
   env:
   - 'ACK_GINKGO_RC=true'
@@ -117,7 +117,7 @@ steps:
   id: 'docker-login'
 
   # 1) Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
   args: ['docker-push-extended']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -138,7 +138,7 @@ steps:
   waitFor: ['docker-push-extended']
   id: 'gcr-auth'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
   args: ['fetch-package-and-save-helm', 'render-manifests', 'upload-github-release-assets', 'push-chart-to-registry', '-B']
   env:
     - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -152,7 +152,7 @@ steps:
   id: 'release-chart'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.28'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
   args: ['docker-push-retag']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'


### PR DESCRIPTION
Bump cloud builders and github actions (might as well keep them in sync).
This prevents the possible denial of service to control plane http end points (stats end point) CVE-2022-27664