### PR TITLE
Stability: Fix Istio Kube2e Flake

### DIFF
--- a/changelog/v1.14.0-beta16/kube2e-test-cleanup.yaml
+++ b/changelog/v1.14.0-beta16/kube2e-test-cleanup.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/7818
+    resolvesIssue: false
+    description: >
+      Update Kube2e tests to use the same pattern of defining helm values in an external file.
+      Disable leader election for suites which are not testing that functionality. By having
+      leader election enabled, with default resync values, we experienced flakes in the Istio suites
+      because statuses weren't updated immediately.

--- a/test/kube2e/gloo/artifacts/helm.yaml
+++ b/test/kube2e/gloo/artifacts/helm.yaml
@@ -1,0 +1,19 @@
+settings:
+  singleNamespace: true
+  create: true
+  invalidConfigPolicy:
+    replaceInvalidRoutes: true
+    invalidRouteResponseCode: 404
+    invalidRouteResponseBody: Gloo Gateway has invalid configuration.
+gateway:
+  persistProxySpec: true
+  logLevel: info
+  validation:
+    allowWarnings: true
+    alwaysAcceptResources: false
+gloo:
+  logLevel: info
+  disableLeaderElection: true
+gatewayProxies:
+  gatewayProxy:
+    healthyPanicThreshold: 0

--- a/test/kube2e/glooctl/artifacts/helm.yaml
+++ b/test/kube2e/glooctl/artifacts/helm.yaml
@@ -2,8 +2,9 @@ gateway:
   persistProxySpec: true
   logLevel: info
   validation:
-    allowWarnings: true
-    alwaysAcceptResources: false
+    # These tests validate the glooctl properly reports errors and warnings on resources
+    # Therefore, we accept all resources in our webhook
+    alwaysAcceptResources: true
 gloo:
   logLevel: info
   disableLeaderElection: true

--- a/test/kube2e/glooctl/artifacts/helm.yaml
+++ b/test/kube2e/glooctl/artifacts/helm.yaml
@@ -1,0 +1,32 @@
+gateway:
+  persistProxySpec: true
+  logLevel: info
+  validation:
+    allowWarnings: true
+    alwaysAcceptResources: false
+gloo:
+  logLevel: info
+  disableLeaderElection: true
+gatewayProxies:
+  publicGw: # Proxy name for public access (Internet facing)
+    disabled: false # overwrite the "default" value in the merge step
+    kind:
+      deployment:
+        replicas: 2
+    service:
+      kubeResourceOverride: # workaround for https://github.com/solo-io/gloo/issues/5297
+        spec:
+          ports:
+            - port: 443
+              protocol: TCP
+              name: https
+              targetPort: 8443
+          type: LoadBalancer
+    gatewaySettings:
+      customHttpsGateway: # using the default HTTPS Gateway
+        virtualServiceSelector:
+          gateway-type: public # label set on the VirtualService
+      disableHttpGateway: true # disable the default HTTP Gateway
+  gatewayProxy:
+    healthyPanicThreshold: 0
+    disabled: false # disable the default gateway-proxy deployment and its 2 default Gateway CRs

--- a/test/kube2e/glooctl/glooctl_suite_test.go
+++ b/test/kube2e/glooctl/glooctl_suite_test.go
@@ -2,10 +2,12 @@ package glooctl_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/solo-io/gloo/test/testutils"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 
@@ -25,36 +27,34 @@ func TestGlooctl(t *testing.T) {
 	helpers.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
-	RunSpecs(t, "glooctl Suite")
+	RunSpecs(t, "Glooctl Suite")
 }
 
 var (
+	namespace = defaults.GlooSystem
+
 	testHelper        *helper.SoloTestHelper
 	resourceClientset *kube2e.KubeResourceClientSet
+
+	ctx    context.Context
+	cancel context.CancelFunc
 )
 
-var ctx, _ = context.WithCancel(context.Background())
-var namespace = defaults.GlooSystem
 var _ = BeforeSuite(StartTestHelper)
 var _ = AfterSuite(TearDownTestHelper)
 
 func StartTestHelper() {
+	ctx, cancel = context.WithCancel(context.Background())
+
 	var err error
 	testHelper, err = kube2e.GetTestHelper(ctx, namespace)
 	Expect(err).NotTo(HaveOccurred())
 	// Register additional fail handlers
 	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, "istio-system", testHelper.InstallNamespace))
 
-	// Define helm overrides
-	valuesOverrideFile, cleanupFunc := getHelmValuesOverrideFile()
-	defer cleanupFunc()
-
-	// Install Gloo
-	err = testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", valuesOverrideFile))
-	Expect(err).NotTo(HaveOccurred())
-
-	// Check that everything is OK
-	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
+	if !testutils.ShouldSkipInstall() {
+		installGloo()
+	}
 
 	// Create KubeResourceClientSet
 	cfg, err := kubeutils.GetConfig("", "")
@@ -64,51 +64,30 @@ func StartTestHelper() {
 	Expect(err).NotTo(HaveOccurred())
 }
 
-func getHelmValuesOverrideFile() (filename string, cleanup func()) {
-	values, err := ioutil.TempFile("", "values-*.yaml")
-	Expect(err).NotTo(HaveOccurred())
-
-	// disabling panic threshold
-	// https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/panic_threshold.html
-	_, err = values.Write([]byte(`
-gatewayProxies:
-  publicGw: # Proxy name for public access (Internet facing)
-    disabled: false # overwrite the "default" value in the merge step
-    kind:
-      deployment:
-        replicas: 2
-    service:
-      kubeResourceOverride: # workaround for https://github.com/solo-io/gloo/issues/5297
-        spec:
-          ports:
-            - port: 443
-              protocol: TCP
-              name: https
-              targetPort: 8443
-          type: LoadBalancer
-    gatewaySettings:
-      customHttpsGateway: # using the default HTTPS Gateway
-        virtualServiceSelector:
-          gateway-type: public # label set on the VirtualService
-      disableHttpGateway: true # disable the default HTTP Gateway
-  gatewayProxy:
-    healthyPanicThreshold: 0
-    disabled: false # disable the default gateway-proxy deployment and its 2 default Gateway CRs
-`))
-	Expect(err).NotTo(HaveOccurred())
-
-	err = values.Close()
-	Expect(err).NotTo(HaveOccurred())
-
-	return values.Name(), func() { _ = os.Remove(values.Name()) }
+func TearDownTestHelper() {
+	if testutils.ShouldTearDown() {
+		uninstallGloo()
+	}
+	cancel()
 }
 
-func TearDownTestHelper() {
-	if os.Getenv("TEAR_DOWN") == "true" {
-		Expect(testHelper).ToNot(BeNil())
-		err := testHelper.UninstallGloo()
-		Expect(err).NotTo(HaveOccurred())
-		_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(ctx, testHelper.InstallNamespace, metav1.GetOptions{})
-		Expect(apierrors.IsNotFound(err)).To(BeTrue())
-	}
+func installGloo() {
+	cwd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred(), "working dir could not be retrieved while installing gloo")
+	helmValuesFile := filepath.Join(cwd, "artifacts", "helm.yaml")
+
+	// Install Gloo
+	err = testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", helmValuesFile))
+	Expect(err).NotTo(HaveOccurred())
+
+	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
+	kube2e.EventuallyReachesConsistentState(testHelper.InstallNamespace)
+}
+
+func uninstallGloo() {
+	Expect(testHelper).ToNot(BeNil())
+	err := testHelper.UninstallGloo()
+	Expect(err).NotTo(HaveOccurred())
+	_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(ctx, testHelper.InstallNamespace, metav1.GetOptions{})
+	Expect(apierrors.IsNotFound(err)).To(BeTrue())
 }

--- a/test/kube2e/istio/artifacts/helm.yaml
+++ b/test/kube2e/istio/artifacts/helm.yaml
@@ -1,0 +1,24 @@
+global:
+  # Set up gloo with istio integration enabled (through `enableIstioSidecarOnGateway`)
+  istioIntegration:
+    enableIstioSidecarOnGateway: true
+    disableAutoinjection: true
+    labelInstallNamespace: true
+gloo:
+  logLevel: info
+  disableLeaderElection: true
+  deployment:
+    #  We have limited GitHub action resources which can cause containers to not create
+    # therefore we lessen the cpu resource requests values from the default (500m) to 100m.
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+gatewayProxies:
+  gatewayProxy:
+    podTemplate:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+    healthyPanicThreshold: 0

--- a/test/kube2e/istio/istio_suite_test.go
+++ b/test/kube2e/istio/istio_suite_test.go
@@ -2,10 +2,12 @@ package istio_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
+
+	testutils2 "github.com/solo-io/gloo/test/testutils"
 
 	"github.com/solo-io/go-utils/testutils/exec"
 
@@ -14,12 +16,10 @@ import (
 	"github.com/solo-io/gloo/test/kube2e"
 	"github.com/solo-io/k8s-utils/kubeutils"
 
-	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
-	"github.com/solo-io/solo-kit/pkg/utils/statusutils"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/pkg/cliutil"
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/go-utils/testutils"
 	"github.com/solo-io/k8s-utils/testutils/helper"
@@ -29,6 +29,7 @@ import (
 const (
 	gatewayProxy = gatewaydefaults.GatewayProxyName
 	gatewayPort  = int(80)
+	namespace    = defaults.GlooSystem
 )
 
 func TestIstio(t *testing.T) {
@@ -44,7 +45,6 @@ var (
 	ctx        context.Context
 	cancel     context.CancelFunc
 
-	namespace         = defaults.GlooSystem
 	resourceClientSet *kube2e.KubeResourceClientSet
 )
 
@@ -58,29 +58,15 @@ var _ = BeforeSuite(func() {
 
 	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
 
-	values, cleanup := getHelmOverrides()
-	defer cleanup()
-
 	err = testutils.Kubectl("create", "ns", testHelper.InstallNamespace)
 	Expect(err).NotTo(HaveOccurred())
 
 	err = testutils.Kubectl("label", "namespace", testHelper.InstallNamespace, "istio-injection=enabled")
 	Expect(err).NotTo(HaveOccurred())
 
-	// Install Gloo
-	err = testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", values))
-	Expect(err).NotTo(HaveOccurred())
-
-	// patch only the gateway-proxy to be istio inject-able
-	err = testutils.Kubectl("patch", "-n", testHelper.InstallNamespace, "deployment", "gateway-proxy", "--patch", "{\"spec\": {\"template\": {\"metadata\": {\"labels\": {\"sidecar.istio.io/inject\": \"true\"}}}}}")
-	Expect(err).NotTo(HaveOccurred())
-
-	// Check that everything is OK
-	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
-
-	// Ensure gloo reaches valid state and doesn't continually resync
-	// we can consider doing the same for leaking go-routines after resyncs
-	kube2e.EventuallyReachesConsistentState(testHelper.InstallNamespace)
+	if !testutils2.ShouldSkipInstall() {
+		installGloo()
+	}
 
 	// delete test-runner Service, as the tests create and manage their own
 	err = testutils.Kubectl("delete", "service", helper.TestrunnerName, "-n", namespace)
@@ -103,22 +89,46 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = AfterSuite(func() {
-	err := os.Unsetenv(statusutils.PodNamespaceEnvName)
-	Expect(err).NotTo(HaveOccurred())
-	if os.Getenv("TEAR_DOWN") == "true" {
-		err := testHelper.UninstallGlooAll()
-		Expect(err).NotTo(HaveOccurred())
-
-		// glooctl should delete the namespace. we do it again just in case it failed
-		// ignore errors
-		_ = testutils.Kubectl("delete", "namespace", testHelper.InstallNamespace)
-
-		EventuallyWithOffset(1, func() error {
-			return testutils.Kubectl("get", "namespace", testHelper.InstallNamespace)
-		}, "60s", "1s").Should(HaveOccurred())
+	if testutils2.ShouldTearDown() {
+		uninstallGloo()
 	}
+
 	cancel()
 })
+
+func installGloo() {
+	cwd, err := os.Getwd()
+	Expect(err).NotTo(HaveOccurred(), "working dir could not be retrieved while installing gloo")
+	helmValuesFile := filepath.Join(cwd, "artifacts", "helm.yaml")
+
+	// Install Gloo
+	err = testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", helmValuesFile))
+	Expect(err).NotTo(HaveOccurred())
+
+	// patch only the gateway-proxy to be istio inject-able
+	err = testutils.Kubectl("patch", "-n", testHelper.InstallNamespace, "deployment", "gateway-proxy", "--patch", "{\"spec\": {\"template\": {\"metadata\": {\"labels\": {\"sidecar.istio.io/inject\": \"true\"}}}}}")
+	Expect(err).NotTo(HaveOccurred())
+
+	// Check that everything is OK
+	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")
+
+	// Ensure gloo reaches valid state and doesn't continually resync
+	// we can consider doing the same for leaking go-routines after resyncs
+	kube2e.EventuallyReachesConsistentState(testHelper.InstallNamespace)
+}
+
+func uninstallGloo() {
+	err := testHelper.UninstallGlooAll()
+	Expect(err).NotTo(HaveOccurred())
+
+	// glooctl should delete the namespace. we do it again just in case it failed
+	// ignore errors
+	_ = testutils.Kubectl("delete", "namespace", testHelper.InstallNamespace)
+
+	EventuallyWithOffset(1, func() error {
+		return testutils.Kubectl("get", "namespace", testHelper.InstallNamespace)
+	}, "60s", "1s").Should(HaveOccurred())
+}
 
 // expects gateway-proxy and testrunner to have the istio-proxy sidecar
 func expectIstioInjected() {
@@ -130,39 +140,4 @@ func expectIstioInjected() {
 	istioContainer, err = exec.RunCommandOutput(testHelper.RootDir, false, "kubectl", "get", "-n", testHelper.InstallNamespace, "pods", helper.TestrunnerName, "-o", `jsonpath='{.spec.containers[?(@.name == "istio-proxy")].name}'`)
 	ExpectWithOffset(1, istioContainer).To(Equal("'istio-proxy'"), "istio-proxy container should be present on the testrunner after injection")
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-}
-
-func getHelmOverrides() (filename string, cleanup func()) {
-	values, err := ioutil.TempFile("", "*.yaml")
-	Expect(err).NotTo(HaveOccurred())
-	// Set up gloo with istio integration enabled (through `enableIstioSidecarOnGateway`)
-	// We have limited GitHub action resources which can cause containers to not create, therefore we lessen the cpu resource requests values from the default (500m) to 100m.
-	_, err = values.Write([]byte(`
-global:
-  istioIntegration:
-    enableIstioSidecarOnGateway: true
-    disableAutoinjection: true
-    labelInstallNamespace: true
-gloo:
-  deployment:
-    resources:
-      requests:
-        cpu: 100m
-        memory: 256Mi
-gatewayProxies:
-  gatewayProxy:
-    podTemplate:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-    healthyPanicThreshold: 0
-`))
-	Expect(err).NotTo(HaveOccurred())
-	err = values.Close()
-	Expect(err).NotTo(HaveOccurred())
-
-	return values.Name(), func() {
-		_ = os.Remove(values.Name())
-	}
 }


### PR DESCRIPTION
# Description

Attempt to fix the Istio kube2e test flake by disabling leader election explicitly

# Context

## Test Code Consolidation
In [recent work](https://github.com/solo-io/gloo/pull/7882) we cleaned up the Gateway test suite, and clarified which helm values are being applied at install time, by defining them in an external file.

I updated the `gloo`, `istio` and `glooctl` suites to follow the same pattern. They also were updated to use the utilities for skipping install and tearing down, instead of redefining the same logic.

## Resolve Istio Flake
The istio flake, is it is documented on the issue is that a status is not reported on a resource when we expect one to be.

See https://github.com/solo-io/gloo/pull/7897 for details about how we de-flaked a similiar behavior in the Gateway tests.

The difference is just that those tests are validating the leader election functionality. These tests are not, so it is easier to just disable leader election. An alternative would be to apply the same solution and lower the retry timeouts for a new leader to be elected.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
