### PR TITLE
1.12 - backport upgrade tests

### DIFF
--- a/changelog/v1.12.48/backport-upgrade-tests.yaml
+++ b/changelog/v1.12.48/backport-upgrade-tests.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    descrption: Backport upgrade tests changes
+    issueLink: https://github.com/solo-io/solo-projects/issues/4611
+    resolvesIssue: false

--- a/test/kube2e/upgrade/README.md
+++ b/test/kube2e/upgrade/README.md
@@ -1,0 +1,26 @@
+# Test Overview 
+- Internet needed for tests to run
+- All upgrade tests run twice. 
+    - current minor last patch -> current code (ex: 1.12.3 -> 1.12.4)
+    - previous minor latest patch -> current code (ex 1.11.latest -> 1.12.4)
+- Each upgrade test installs gloo, upgrades CRDs and then upgrades gloo
+- Each test runs a data setup and validation on installation of gloo and on upgrade of gloo
+
+# Running Tests
+- You will need to generate the `_test` and `_output` folders in order to run these tests locally
+  - running [./ci/deploy-to-kind-cluster.sh](/ci/deploy-to-kind-cluster.sh) is an easy way to set up your environment to run the tests
+- If you are debugging and cancel the test early there may be leftover pods and namespace resources, these commands can help clean things up for you
+
+# remove gloo-system namespace resources and crds
+```
+kubectl delete ns gloo-system && kubectl delete crd --all
+```
+
+# delete old roles and bindings
+You may not need to run all of these as some roles are only created for enterprise installations 
+```
+kubectl delete clusterrolebinding,clusterrole -l app=gloo
+kubectl delete clusterrolebinding,clusterrole -l app.kubernetes.io/instance=gloo
+kubectl delete clusterrolebinding,clusterrole -l app=glooe-prometheus 
+kubectl delete clusterrolebinding,clusterrole -l app.kubernetes.io/instance=gloo-ee
+```

--- a/test/kube2e/upgrade/artifacts/helm.yaml
+++ b/test/kube2e/upgrade/artifacts/helm.yaml
@@ -1,0 +1,37 @@
+global:
+  image:
+    pullPolicy: IfNotPresent
+  glooRbac:
+    namespaced: true
+    nameSuffix: e2e-test-rbac-suffix
+settings:
+  singleNamespace: true
+  create: true
+  invalidConfigPolicy:
+    replaceInvalidRoutes: true
+    invalidRouteResponseCode: 404
+    invalidRouteResponseBody: Gloo Gateway has invalid configuration.
+gateway:
+  persistProxySpec: true
+  logLevel: info
+  validation:
+    allowWarnings: true
+    alwaysAcceptResources: false
+gloo:
+  logLevel: info
+  disableLeaderElection: false
+  deployment:
+    replicas: 2
+    customEnv:
+      # We scale the Gloo component frequently in tests, and need leadership to be established quickly
+      # Therefore, we set values to lower thresholds than the defaults
+      - name: LEADER_ELECTION_LEASE_DURATION
+        value: 4s
+      - name: LEADER_ELECTION_RENEW_PERIOD
+        value: 3s
+      - name: LEADER_ELECTION_RETRY_PERIOD
+        value: 1s
+    livenessProbeEnabled: true
+gatewayProxies:
+  gatewayProxy:
+    healthyPanicThreshold: 0

--- a/test/kube2e/upgrade/artifacts/helm.yaml
+++ b/test/kube2e/upgrade/artifacts/helm.yaml
@@ -27,10 +27,6 @@ gloo:
       # Therefore, we set values to lower thresholds than the defaults
       - name: LEADER_ELECTION_LEASE_DURATION
         value: 4s
-      - name: LEADER_ELECTION_RENEW_PERIOD
-        value: 3s
-      - name: LEADER_ELECTION_RETRY_PERIOD
-        value: 1s
     livenessProbeEnabled: true
 gatewayProxies:
   gatewayProxy:

--- a/test/kube2e/upgrade/upgrade_suite_test.go
+++ b/test/kube2e/upgrade/upgrade_suite_test.go
@@ -1,24 +1,72 @@
 package upgrade_test
 
 import (
-	"os"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/test/kube2e"
+	"github.com/solo-io/gloo/test/kube2e/upgrade"
+	"github.com/solo-io/go-utils/versionutils"
+	"github.com/solo-io/skv2/codegen/util"
+
 	. "github.com/onsi/ginkgo"
-	"github.com/onsi/ginkgo/reporters"
 	"github.com/solo-io/gloo/test/helpers"
-	"github.com/solo-io/go-utils/log"
 	skhelpers "github.com/solo-io/solo-kit/test/helpers"
 )
 
 func TestUpgrade(t *testing.T) {
-	if os.Getenv("KUBE2E_TESTS") != "upgrade" {
-		log.Warnf("This test is disabled. To enable, set KUBE2E_TESTS to 'upgrade' in your env.")
-		return
-	}
 	helpers.RegisterGlooDebugLogPrintHandlerAndClearLogs()
 	skhelpers.RegisterCommonFailHandlers()
 	skhelpers.SetupLog()
-	junitReporter := reporters.NewJUnitReporter("junit.xml")
-	RunSpecsWithDefaultAndCustomReporters(t, "Upgrade Suite", []Reporter{junitReporter})
+	RunSpecs(t, "Upgrade Suite")
 }
+
+var (
+	suiteCtx    context.Context
+	suiteCancel context.CancelFunc
+
+	crdDir                string
+	chartUri              string
+	targetReleasedVersion string
+
+	// Versions to upgrade from
+	// ex: current branch is 1.13.10 - this would be the latest patch release of 1.12
+	LastPatchMostRecentMinorVersion *versionutils.Version
+
+	// ex:current branch is 1.13.10 - this would be 1.13.9
+	CurrentPatchMostRecentMinorVersion *versionutils.Version
+	firstReleaseOfMinor                bool
+)
+
+var _ = BeforeSuite(func() {
+	suiteCtx, suiteCancel = context.WithCancel(context.Background())
+
+	testHelper, err := kube2e.GetTestHelper(suiteCtx, namespace)
+	Expect(err).NotTo(HaveOccurred())
+
+	crdDir = filepath.Join(util.GetModuleRoot(), "install", "helm", "gloo", "crds")
+	targetReleasedVersion = kube2e.GetTestReleasedVersion(suiteCtx, "gloo")
+	if targetReleasedVersion != "" {
+		chartUri = "gloo/gloo"
+	} else {
+		chartUri = filepath.Join(testHelper.RootDir, testHelper.TestAssetDir, testHelper.HelmChartName+"-"+testHelper.ChartVersion()+".tgz")
+	}
+
+	LastPatchMostRecentMinorVersion, CurrentPatchMostRecentMinorVersion, err = upgrade.GetUpgradeVersions(suiteCtx, "gloo")
+	if err != nil {
+		if strings.Contains(err.Error(), upgrade.FirstReleaseError) {
+			firstReleaseOfMinor = true
+		} else {
+			fmt.Println(err.Error())
+			Fail(err.Error())
+		}
+	}
+})
+
+var _ = AfterSuite(func() {
+	suiteCancel()
+})

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -8,10 +8,13 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
 	"time"
+
+	"github.com/solo-io/gloo/test/kube2e/upgrade"
 
 	"github.com/solo-io/gloo/test/helpers"
 
@@ -302,6 +305,44 @@ func GetSimpleTestRunnerHttpResponse() string {
 		return SimpleTestRunnerHttpResponseArm
 	} else {
 		return SimpleTestRunnerHttpResponse
+	}
+}
+
+// For nightly runs, we want to install a released version rather than using a locally built chart
+// To do this, set the environment variable RELEASED_VERSION with either a version name or "LATEST" to get the last release
+func GetTestReleasedVersion(ctx context.Context, repoName string) string {
+	var useVersion string
+	if useVersion = os.Getenv("RELEASED_VERSION"); useVersion != "" {
+		if useVersion == "LATEST" {
+			_, current, err := upgrade.GetUpgradeVersions(ctx, repoName)
+			fmt.Println("found latest version %v", current)
+			Expect(err).NotTo(HaveOccurred())
+			useVersion = current.String()
+		}
+	}
+	return useVersion
+}
+func GetTestHelper(ctx context.Context, namespace string) (*helper.SoloTestHelper, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return nil, err
+	}
+	if useVersion := GetTestReleasedVersion(ctx, "gloo"); useVersion != "" {
+		return helper.NewSoloTestHelper(func(defaults helper.TestConfig) helper.TestConfig {
+			defaults.RootDir = filepath.Join(cwd, "../../..")
+			defaults.InstallNamespace = namespace
+			defaults.ReleasedVersion = useVersion
+			defaults.Verbose = true
+			return defaults
+		})
+	} else {
+		return helper.NewSoloTestHelper(func(defaults helper.TestConfig) helper.TestConfig {
+			defaults.RootDir = filepath.Join(cwd, "../../..")
+			defaults.HelmChartName = "gloo"
+			defaults.InstallNamespace = namespace
+			defaults.Verbose = true
+			return defaults
+		})
 	}
 }
 


### PR DESCRIPTION
# Description
Backporting updates to upgrade tests 
there is also a small backport of test/kube2e/utils methods

Most changes are represented in 
- https://github.com/solo-io/gloo/pull/7821
- https://github.com/solo-io/gloo/pull/7869

Corresponding 1.13 backport - https://github.com/solo-io/gloo/pull/7929

This is not a cherry-pick but a copy and paste as after minor updates over many PRs it made more sense to copy and paste the changes to older branches. 

This also undoes the changes made to enable ginkgo v2 on the current mainline branch of 1.14
# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

