### PR TITLE
upgrade retry-go

### DIFF
--- a/changelog/v1.14.0-beta16/bump-retry-go.yaml
+++ b/changelog/v1.14.0-beta16/bump-retry-go.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: avast
+    dependencyRepo: retry-go
+    dependencyTag: v4.3.3
+    description: Update to latest retry-go version, which supports additional options like infinite retry.
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/7814
+    resolvesIssue: false
+    description: Needed for Gloo Fed retries.

--- a/docs/content/static/content/osa_provided.md
+++ b/docs/content/static/content/osa_provided.md
@@ -2,7 +2,7 @@ Name|Version|License
 ---|---|---
 [semver/v3](https://github.com/Masterminds/semver)|v3.1.1|MIT License
 [Netflix/go-expect](https://github.com/Netflix/go-expect)|v0.0.0-20180928190340-9d1f4485533b|Apache License 2.0
-[avast/retry-go](https://github.com/avast/retry-go)|v2.4.3+incompatible|MIT License
+[retry-go/v4](https://github.com/avast/retry-go)|v4.3.3|MIT License
 [aws/aws-sdk-go](https://github.com/aws/aws-sdk-go)|v1.34.9|Apache License 2.0
 [census-instrumentation/opencensus-proto](https://github.com/census-instrumentation/opencensus-proto)|v0.2.0|Apache License 2.0
 [cratonica/2goarray](https://github.com/cratonica/2goarray)|v0.0.0-20190331194516-514510793eaa|MIT License

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.20
 require (
 	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/Netflix/go-expect v0.0.0-20180928190340-9d1f4485533b
-	github.com/avast/retry-go v2.4.3+incompatible
+	github.com/avast/retry-go v2.4.3+incompatible // indirect
+	github.com/avast/retry-go/v4 v4.3.3
 	github.com/aws/aws-sdk-go v1.34.9
 	github.com/census-instrumentation/opencensus-proto v0.4.1
 	github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa

--- a/go.sum
+++ b/go.sum
@@ -205,6 +205,8 @@ github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535/go.mod h1:o
 github.com/avast/retry-go v2.2.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/avast/retry-go v2.4.3+incompatible h1:c/FTk2POrEQyZfaHBMkMrXdu3/6IESJUHwu8r3k1JEU=
 github.com/avast/retry-go v2.4.3+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/avast/retry-go/v4 v4.3.3 h1:G56Bp6mU0b5HE1SkaoVjscZjlQb0oy4mezwY/cGH19w=
+github.com/avast/retry-go/v4 v4.3.3/go.mod h1:rg6XFaiuFYII0Xu3RDbZQkxCofFwruZKW8oEF1jpWiU=
 github.com/aws/aws-lambda-go v1.13.3/go.mod h1:4UKl9IzQMoD+QF79YdCuzCwp8VbmG4VAQwij/eHl5CU=
 github.com/aws/aws-sdk-go v1.15.11/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.26.7/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/projects/gateway/pkg/api/v1/kube/generated_kube_suite_test.go
+++ b/projects/gateway/pkg/api/v1/kube/generated_kube_suite_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/test/kube2e"

--- a/projects/gateway/pkg/validation/robust_client.go
+++ b/projects/gateway/pkg/validation/robust_client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"sync"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	"github.com/solo-io/go-utils/contextutils"

--- a/projects/gloo/cli/pkg/cmd/install/knative.go
+++ b/projects/gloo/cli/pkg/cmd/install/knative.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options/contextoptions"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/k8s-utils/kubeutils"

--- a/projects/gloo/pkg/plugins/consul/eds.go
+++ b/projects/gloo/pkg/plugins/consul/eds.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	consulapi "github.com/hashicorp/consul/api"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/constants"

--- a/projects/gloo/pkg/upstreams/consul/watcher.go
+++ b/projects/gloo/pkg/upstreams/consul/watcher.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	consulapi "github.com/hashicorp/consul/api"
 	glooconsul "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/consul"
 	"github.com/solo-io/go-utils/errutils"

--- a/projects/sds/cmd/main.go
+++ b/projects/sds/cmd/main.go
@@ -10,7 +10,7 @@ import (
 	"github.com/solo-io/gloo/projects/sds/pkg/server"
 	"github.com/solo-io/go-utils/contextutils"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	"github.com/kelseyhightower/envconfig"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"

--- a/projects/sds/pkg/server/server.go
+++ b/projects/sds/pkg/server/server.go
@@ -8,7 +8,7 @@ import (
 	"io/ioutil"
 	"net"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_service_secret_v3 "github.com/envoyproxy/go-control-plane/envoy/service/secret/v3"

--- a/test/helpers/snapshot_writer.go
+++ b/test/helpers/snapshot_writer.go
@@ -3,7 +3,7 @@ package helpers
 import (
 	"time"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/errors"

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -9,7 +9,7 @@ import (
 
 	kubeutils2 "github.com/solo-io/gloo/test/testutils"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 
 	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 

--- a/test/kube2e/gloo/gloo_suite_test.go
+++ b/test/kube2e/gloo/gloo_suite_test.go
@@ -9,7 +9,7 @@ import (
 
 	glootestutils "github.com/solo-io/gloo/test/testutils"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/k8s-utils/kubeutils"
 

--- a/test/kube2e/gloomtls/gloo_mtls_suite_test.go
+++ b/test/kube2e/gloomtls/gloo_mtls_suite_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/avast/retry-go"
+	"github.com/avast/retry-go/v4"
 	"github.com/solo-io/k8s-utils/kubeutils"
 
 	"github.com/solo-io/gloo/test/kube2e"


### PR DESCRIPTION
Upgrade to latest retry-go. We are upgrading it in solo-projects to pick up new features, and solo-projects relies on gloo for some test utils that use retry-go, and it's easier if they're both on the same version.