### PR TITLE
Improve istio plugin translation time

### DIFF
--- a/changelog/v1.14.0-beta16/istio-plugin-speedup.yaml
+++ b/changelog/v1.14.0-beta16/istio-plugin-speedup.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7960
+    resolvesIssue: false
+    description: Speed up the istio integration plugin translation time by reading from the input snapshot instead of using an upstream client.

--- a/projects/gloo/pkg/plugins/istio_integration/istio_suite_test.go
+++ b/projects/gloo/pkg/plugins/istio_integration/istio_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestHeaders(t *testing.T) {
+func TestIstioIntegration(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Istio Integration Suite")
 }

--- a/projects/gloo/pkg/plugins/istio_integration/plugin_test.go
+++ b/projects/gloo/pkg/plugins/istio_integration/plugin_test.go
@@ -1,16 +1,11 @@
 package istio_integration_test
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	kubeplugin "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/kubernetes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/istio_integration"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
-	"github.com/solo-io/solo-kit/pkg/api/v1/clients/memory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
@@ -22,25 +17,15 @@ var _ = Describe("Plugin", func() {
 		upstreamName     = "test-us"
 		glooNamespace    = "ns"
 	)
+
 	var (
-		usClient     v1.UpstreamClient
-		kubeUpstream *v1.Upstream
-		cancel       context.CancelFunc
-		ctx          context.Context
-		err          error
+		upstreams v1.UpstreamList
 	)
+
 	BeforeEach(func() {
-		ctx, cancel = context.WithCancel(context.Background())
-		resourceClientFactory := &factory.MemoryResourceClientFactory{
-			Cache: memory.NewInMemoryResourceCache(),
-		}
-		usClient, err = v1.NewUpstreamClient(ctx, resourceClientFactory)
-		Expect(err).NotTo(HaveOccurred())
-		kubeUpstream = makeKubeUpstream(upstreamName, glooNamespace, serviceName, serviceNamespace)
-		_, err = usClient.Write(kubeUpstream, clients.WriteOpts{})
-		Expect(err).NotTo(HaveOccurred())
+		upstreams = v1.UpstreamList{makeKubeUpstream(upstreamName, glooNamespace, serviceName, serviceNamespace)}
 	})
-	AfterEach(func() { cancel() })
+
 	It("Gets the host from a kube destination", func() {
 		destination := &v1.RouteAction_Single{
 			Single: &v1.Destination{
@@ -54,7 +39,7 @@ var _ = Describe("Plugin", func() {
 				},
 			},
 		}
-		host, err := istio_integration.GetHostFromDestination(destination, usClient)
+		host, err := istio_integration.GetHostFromDestination(destination, upstreams)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(host).To(Equal(rewrittenHost))
 	})
@@ -69,7 +54,7 @@ var _ = Describe("Plugin", func() {
 				},
 			},
 		}
-		host, err := istio_integration.GetHostFromDestination(destination, usClient)
+		host, err := istio_integration.GetHostFromDestination(destination, upstreams)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(host).To(Equal(rewrittenHost))
 	})

--- a/projects/gloo/pkg/plugins/registry/registry.go
+++ b/projects/gloo/pkg/plugins/registry/registry.go
@@ -117,9 +117,7 @@ func Plugins(opts bootstrap.Opts) []plugins.Plugin {
 	istioEnabled := found && strings.ToLower(lookupResult) == "true"
 	if istioEnabled {
 		istioPlugin := istio_integration.NewPlugin(opts.WatchOpts.Ctx)
-		if istioPlugin != nil {
-			glooPlugins = append(glooPlugins, istioPlugin)
-		}
+		glooPlugins = append(glooPlugins, istioPlugin)
 	}
 	return glooPlugins
 }

--- a/projects/gloo/pkg/plugins/registry/registry.go
+++ b/projects/gloo/pkg/plugins/registry/registry.go
@@ -116,7 +116,7 @@ func Plugins(opts bootstrap.Opts) []plugins.Plugin {
 	lookupResult, found := os.LookupEnv("ENABLE_ISTIO_INTEGRATION")
 	istioEnabled := found && strings.ToLower(lookupResult) == "true"
 	if istioEnabled {
-		istioPlugin := istio_integration.NewPlugin(opts.WatchOpts.Ctx, opts.Upstreams)
+		istioPlugin := istio_integration.NewPlugin(opts.WatchOpts.Ctx)
 		if istioPlugin != nil {
 			glooPlugins = append(glooPlugins, istioPlugin)
 		}


### PR DESCRIPTION
# Description

Speed up the Istio integration plugin's `ProcessRoute` by getting upstreams directly from the api snapshot, instead of using an upstream client to look them up. In local testing with 20 VirtualServices and 100 RouteTables (and istio integration enabled), this resulted in about a 100-200x speedup in translation time.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
