### PR TITLE
Fix instructions for installing OIDC with Dex 

### DIFF
--- a/changelog/v1.14.0-beta18/oidc-docs.yaml
+++ b/changelog/v1.14.0-beta18/oidc-docs.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update the example config values and repo for the test Dex installation.

--- a/docs/content/guides/security/auth/extauth/oauth/dex/_index.md
+++ b/docs/content/guides/security/auth/extauth/oauth/dex/_index.md
@@ -97,7 +97,6 @@ config:
   # This is the canonical URL that all clients MUST use to refer to dex. If a
   # path is provided, dex's HTTP service will listen at a non-root URL.
   issuer: http://dex.gloo-system.svc.cluster.local:32000
-
   # Instead of reading from an external storage, use this list of clients.
   staticClients:
   - id: gloo
@@ -105,7 +104,10 @@ config:
     - 'http://localhost:8080/callback'
     name: 'GlooApp'
     secret: secretvalue
-  
+  # Allow dex to store the static list of clients in memory
+  enablePasswordDB: true
+    storage:
+      type: memory 
   # A static list of passwords to login the end user. By identifying here, dex
   # won't look in its underlying storage for passwords.
   staticPasswords:
@@ -123,15 +125,15 @@ Note that the above configuration uses unsecured http traffic without SSL certif
 
 Using this configuration, we can deploy Dex to our cluster using Helm.
 
-If `helm repo list` doesn't list the `stable` repo, invoke:
+If `helm repo list` doesn't list the `dex` repo, invoke:
 
 ```shell
-helm repo add stable https://charts.helm.sh/stable
+helm repo add dex https://charts.dexidp.io
 ```
 
 And then install dex (helm 3 command follows):
 ```shell
-helm install dex --namespace gloo-system stable/dex -f dex-values.yaml
+helm install dex --namespace gloo-system dex/dex -f dex-values.yaml
 ```
 
 #### Make the client secret accessible to Gloo Edge


### PR DESCRIPTION
# Description
Newer versions of Dex require extra configuration to install with a static list of users. The version in the `https://charts.helm.sh/stable` doesn't seem to work on newer versions of K8s.
In this change, start pulling dex from `dexidp.io` and update the config values so that it installs correctly. 

# Context

Ran into this while testing OIDC. 

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
