### PR TITLE
build: resolved GHA warnings

### DIFF
--- a/.github/actions/regression-tests/action.yaml
+++ b/.github/actions/regression-tests/action.yaml
@@ -5,7 +5,7 @@ runs:
   using: "composite"
   steps:
   - name: Cancel Previous Actions
-    uses: styfle/cancel-workflow-action@0.4.1
+    uses: styfle/cancel-workflow-action@0.11.0
     with:
       access_token: ${{ github.token }}
   - name: Free disk space

--- a/.github/workflows/add-pr-label.yaml
+++ b/.github/workflows/add-pr-label.yaml
@@ -14,7 +14,8 @@ jobs:
         shell: bash
         run: |
           echo "Pull Request is from a fork. Setting IS_COMMUNITY_PR to true"
-          echo "::set-output name=IS_COMMUNITY_PR::true"
+          echo "IS_COMMUNITY_PR=true" >> $GITHUB_OUTPUT
+
       - name: Add PR label
         uses: christianvuerings/add-labels@v1
         if: ${{ !steps.community-pr-check.outputs.IS_COMMUNITY_PR }}

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Actions
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Free disk space

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -121,7 +121,7 @@ jobs:
           fi
 
           echo "Setting PREAMBLE as $preamble"
-          echo "::set-output name=preamble::$(echo $preamble)"
+          echo "preamble=$preamble" >> $GITHUB_OUTPUT
       - uses: actions/setup-go@v2
         with:
           go-version: 1.20.1

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -34,14 +34,14 @@ jobs:
         if [[ ${{ github.event_name == 'release' }} = true ]]; then
           RELEASE_TAG_NAME=${{ github.event.release.tag_name }}
         fi
-        echo "::set-output name=value::$(echo $RELEASE_TAG_NAME)"
+        echo "value=$RELEASE_TAG_NAME" >> $GITHUB_OUTPUT
     - id: release-branch
       run: |
         RELEASE_BRANCH=${{ github.event.inputs.release-branch }}
         if [[ ${{ github.event_name == 'release' }} = true ]]; then
           RELEASE_BRANCH=${{ github.event.release.target_commitish }}
         fi
-        echo "::set-output name=value::$(echo $RELEASE_BRANCH)"
+        echo "value=$RELEASE_BRANCH" >> $GITHUB_OUTPUT
   push-to-solo-apis-branch:
     needs: prepare-env
     env:
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Actions
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Free disk space

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -18,21 +18,21 @@ jobs:
       should-pass-regression-tests: ${{ steps.regression-tests.outputs.pass_value }}
     steps:
     - name: Cancel Previous Actions
-      uses: styfle/cancel-workflow-action@0.4.1
+      uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
     - id: is-draft-pr
       name: Process draft Pull Requests
       if: ${{ github.event.pull_request.draft }}
-      run: echo "::set-output name=value::$(echo true)"
+      run: echo "value=true" >> $GITHUB_OUTPUT
     - id: signal-ci-comment
       name: Process comments on Pull Request to signal CI
       if:  ${{ github.event.issue.pull_request }}
-      run: echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/sig-ci') }})"
+      run: echo "value=${{ contains(github.event.comment.body, '/sig-ci') }}" >> $GITHUB_OUTPUT
     - id: skip-ci-comment
       name: Process comments on Pull Request to skip CI
       if: ${{ github.event.issue.pull_request }}
-      run: echo "::set-output name=value::$(echo ${{ contains(github.event.comment.body, '/skip-ci') }})"
+      run: echo "value=${{ contains(github.event.comment.body, '/skip-ci') }}" >> $GITHUB_OUTPUT
     - id: regression-tests
       name: Determine how to run regression tests
       run: |
@@ -54,7 +54,7 @@ jobs:
         fi
 
         echo "Should run regression tests? $should_run"
-        echo "::set-output name=run_value::$(echo $should_run)"
+        echo "run_value=$should_run" >> $GITHUB_OUTPUT
 
   regression_tests:
     name: k8s regression tests (${{matrix.kube-e2e-test-type}})

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Cancel Previous Actions
-        uses: styfle/cancel-workflow-action@0.4.1
+        uses: styfle/cancel-workflow-action@0.11.0
         with:
           access_token: ${{ github.token }}
       - name: Free disk space

--- a/changelog/v1.14.0-beta18/remove-gha-warnings.yaml
+++ b/changelog/v1.14.0-beta18/remove-gha-warnings.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: remove GHA warnings for "set-output".  It is breaking starting May '23


### PR DESCRIPTION
# Description
* updated instances of [set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* updated `cancel-actions` to `latest` to resolve "node 12 is not supported"

# Context
A couple of our GHA warnings were threatening to tick over into full-blown errors.  Resolved them, now, rather than waiting for CI to fail in a couple of months.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
