### PR TITLE
fix go mod path for push solo-apis action

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: go.mod
+          go-version-file: gloo/go.mod
         id: go
       - name: Install Protoc
         uses: arduino/setup-protoc@v1.1.2


### PR DESCRIPTION
we do the gloo checkout at path `gloo` so the go.mod should be at `gloo/go.mod`

this should fix the push solo-apis [failure](https://github.com/solo-io/gloo/actions/runs/4599755409) for next time

already fixed the latest push manually so don't need to do another release