### PR TITLE
update kube-state-metrics docs

### DIFF
--- a/changelog/v1.14.0-beta20/kube-state-metrics-docs.yaml
+++ b/changelog/v1.14.0-beta20/kube-state-metrics-docs.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/6833
+    resolvesIssue: false
+    description: >
+      Update the prometheus kube-state-metrics deployment name to `glooe-prometheus-kube-state-metrics-v2` to align with
+      the rename done as part of the k8s 1.25 upgrade.

--- a/docs/content/installation/advanced_configuration/multi-gw-deployment.md
+++ b/docs/content/installation/advanced_configuration/multi-gw-deployment.md
@@ -118,18 +118,18 @@ NAME                                    AGE
 gateway.gateway.solo.io/corp-gw         3m7s
 gateway.gateway.solo.io/public-gw-ssl   3m7s
 
-NAME                                                  READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/discovery                             1/1     1            1           3m8s
-deployment.apps/gateway                               1/1     1            1           3m8s
-deployment.apps/gloo                                  1/1     1            1           3m8s
-deployment.apps/gloo-fed                              1/1     1            1           3m8s
-deployment.apps/gloo-fed-console                      1/1     1            1           3m7s
-deployment.apps/glooe-grafana                         1/1     1            1           3m7s
-deployment.apps/glooe-prometheus-kube-state-metrics   1/1     1            1           3m8s
-deployment.apps/glooe-prometheus-server               1/1     1            1           3m8s
-deployment.apps/observability                         1/1     1            1           3m8s
-deployment.apps/corp-gw                               1/1     1            1           3m8s
-deployment.apps/public-gw                             2/2     2            2           3m8s
+NAME                                                     READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/discovery                                1/1     1            1           3m8s
+deployment.apps/gateway                                  1/1     1            1           3m8s
+deployment.apps/gloo                                     1/1     1            1           3m8s
+deployment.apps/gloo-fed                                 1/1     1            1           3m8s
+deployment.apps/gloo-fed-console                         1/1     1            1           3m7s
+deployment.apps/glooe-grafana                            1/1     1            1           3m7s
+deployment.apps/glooe-prometheus-kube-state-metrics-v2   1/1     1            1           3m8s
+deployment.apps/glooe-prometheus-server                  1/1     1            1           3m8s
+deployment.apps/observability                            1/1     1            1           3m8s
+deployment.apps/corp-gw                                  1/1     1            1           3m8s
+deployment.apps/public-gw                                2/2     2            2           3m8s
 ```
 
 

--- a/docs/content/installation/enterprise/_index.md
+++ b/docs/content/installation/enterprise/_index.md
@@ -253,58 +253,58 @@ kubectl --namespace gloo-system get all
 ```
 
 ```noop
-NAME                                                       READY   STATUS    RESTARTS   AGE
-pod/discovery-6dbb5fd8bc-gk2th                             1/1     Running   0          2m5s
-pod/extauth-68bb4745fc-2rs7b                               1/1     Running   0          2m5s
-pod/gateway-proxy-7c49898fdf-blxps                         1/1     Running   0          2m5s
-pod/gloo-7748b94989-dj85p                                  1/1     Running   0          2m5s
-pod/gloo-fed-76c85d689b-q62k4                              1/1     Running   0          2m5s
-pod/gloo-fed-console-dd5f877bd-jgg8n                       3/3     Running   0          2m5s
-pod/glooe-grafana-6f95948945-pvbcg                         1/1     Running   0          2m4s
-pod/glooe-prometheus-kube-state-metrics-6c79cc9554-hlhns   1/1     Running   0          2m5s
-pod/glooe-prometheus-server-757dc7d8f7-x489q               2/2     Running   0          2m5s
-pod/observability-78cb7bddf7-kcrbm                         1/1     Running   0          2m5s
-pod/rate-limit-5ddd4b69d-84d6b                             1/1     Running   0          2m5s
-pod/redis-888f4d9b5-p76wk                                  1/1     Running   0          2m4s
+NAME                                                          READY   STATUS    RESTARTS   AGE
+pod/discovery-6dbb5fd8bc-gk2th                                1/1     Running   0          2m5s
+pod/extauth-68bb4745fc-2rs7b                                  1/1     Running   0          2m5s
+pod/gateway-proxy-7c49898fdf-blxps                            1/1     Running   0          2m5s
+pod/gloo-7748b94989-dj85p                                     1/1     Running   0          2m5s
+pod/gloo-fed-76c85d689b-q62k4                                 1/1     Running   0          2m5s
+pod/gloo-fed-console-dd5f877bd-jgg8n                          3/3     Running   0          2m5s
+pod/glooe-grafana-6f95948945-pvbcg                            1/1     Running   0          2m4s
+pod/glooe-prometheus-kube-state-metrics-v2-6c79cc9554-hlhns   1/1     Running   0          2m5s
+pod/glooe-prometheus-server-757dc7d8f7-x489q                  2/2     Running   0          2m5s
+pod/observability-78cb7bddf7-kcrbm                            1/1     Running   0          2m5s
+pod/rate-limit-5ddd4b69d-84d6b                                1/1     Running   0          2m5s
+pod/redis-888f4d9b5-p76wk                                     1/1     Running   0          2m4s
 
-NAME                                          TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                AGE
-service/extauth                               ClusterIP      10.xxx.xx.xx    <none>          8083/TCP                                               2m6s
-service/gateway-proxy                         LoadBalancer   10.xxx.xx.xx    34.xx.xxx.xxx   80:30437/TCP,443:31651/TCP                             2m6s
-service/gloo                                  ClusterIP      10.xxx.xx.xx    <none>          9977/TCP,9976/TCP,9988/TCP,9966/TCP,9979/TCP,443/TCP   2m7s
-service/gloo-fed-console                      ClusterIP      10.xxx.xx.xx    <none>          10101/TCP,8090/TCP,8081/TCP                            2m6s
-service/glooe-grafana                         ClusterIP      10.xxx.xx.xxx   <none>          80/TCP                                                 2m6s
-service/glooe-prometheus-kube-state-metrics   ClusterIP      10.xxx.xx.xxx   <none>          8080/TCP                                               2m6s
-service/glooe-prometheus-server               ClusterIP      10.xxx.xx.xx    <none>          80/TCP                                                 2m7s
-service/rate-limit                            ClusterIP      10.xxx.xx.xxx   <none>          18081/TCP                                              2m7s
-service/redis                                 ClusterIP      10.xxx.xx.xx    <none>          6379/TCP                                               2m6s
+NAME                                             TYPE           CLUSTER-IP      EXTERNAL-IP     PORT(S)                                                AGE
+service/extauth                                  ClusterIP      10.xxx.xx.xx    <none>          8083/TCP                                               2m6s
+service/gateway-proxy                            LoadBalancer   10.xxx.xx.xx    34.xx.xxx.xxx   80:30437/TCP,443:31651/TCP                             2m6s
+service/gloo                                     ClusterIP      10.xxx.xx.xx    <none>          9977/TCP,9976/TCP,9988/TCP,9966/TCP,9979/TCP,443/TCP   2m7s
+service/gloo-fed-console                         ClusterIP      10.xxx.xx.xx    <none>          10101/TCP,8090/TCP,8081/TCP                            2m6s
+service/glooe-grafana                            ClusterIP      10.xxx.xx.xxx   <none>          80/TCP                                                 2m6s
+service/glooe-prometheus-kube-state-metrics-v2   ClusterIP      10.xxx.xx.xxx   <none>          8080/TCP                                               2m6s
+service/glooe-prometheus-server                  ClusterIP      10.xxx.xx.xx    <none>          80/TCP                                                 2m7s
+service/rate-limit                               ClusterIP      10.xxx.xx.xxx   <none>          18081/TCP                                              2m7s
+service/redis                                    ClusterIP      10.xxx.xx.xx    <none>          6379/TCP                                               2m6s
 
-NAME                                                  READY   UP-TO-DATE   AVAILABLE   AGE
-deployment.apps/discovery                             1/1     1            1           2m7s
-deployment.apps/extauth                               1/1     1            1           2m7s
-deployment.apps/gateway-proxy                         1/1     1            1           2m7s
-deployment.apps/gloo                                  1/1     1            1           2m7s
-deployment.apps/gloo-fed                              1/1     1            1           2m7s
-deployment.apps/gloo-fed-console                      1/1     1            1           2m7s
-deployment.apps/glooe-grafana                         1/1     1            1           2m7s
-deployment.apps/glooe-prometheus-kube-state-metrics   1/1     1            1           2m7s
-deployment.apps/glooe-prometheus-server               1/1     1            1           2m7s
-deployment.apps/observability                         1/1     1            1           2m7s
-deployment.apps/rate-limit                            1/1     1            1           2m7s
-deployment.apps/redis                                 1/1     1            1           2m7s
+NAME                                                     READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/discovery                                1/1     1            1           2m7s
+deployment.apps/extauth                                  1/1     1            1           2m7s
+deployment.apps/gateway-proxy                            1/1     1            1           2m7s
+deployment.apps/gloo                                     1/1     1            1           2m7s
+deployment.apps/gloo-fed                                 1/1     1            1           2m7s
+deployment.apps/gloo-fed-console                         1/1     1            1           2m7s
+deployment.apps/glooe-grafana                            1/1     1            1           2m7s
+deployment.apps/glooe-prometheus-kube-state-metrics-v2   1/1     1            1           2m7s
+deployment.apps/glooe-prometheus-server                  1/1     1            1           2m7s
+deployment.apps/observability                            1/1     1            1           2m7s
+deployment.apps/rate-limit                               1/1     1            1           2m7s
+deployment.apps/redis                                    1/1     1            1           2m7s
 
-NAME                                                             DESIRED   CURRENT   READY   AGE
-replicaset.apps/discovery-6dbb5fd8bc                             1         1         1       2m6s
-replicaset.apps/extauth-68bb4745fc                               1         1         1       2m7s
-replicaset.apps/gateway-proxy-7c49898fdf                         1         1         1       2m6s
-replicaset.apps/gloo-7748b94989                                  1         1         1       2m7s
-replicaset.apps/gloo-fed-76c85d689b                              1         1         1       2m7s
-replicaset.apps/gloo-fed-console-dd5f877bd                       1         1         1       2m6s
-replicaset.apps/glooe-grafana-6f95948945                         1         1         1       2m6s
-replicaset.apps/glooe-prometheus-kube-state-metrics-6c79cc9554   1         1         1       2m6s
-replicaset.apps/glooe-prometheus-server-757dc7d8f7               1         1         1       2m6s
-replicaset.apps/observability-78cb7bddf7                         1         1         1       2m7s
-replicaset.apps/rate-limit-5ddd4b69d                             1         1         1       2m7s
-replicaset.apps/redis-888f4d9b5                                  1         1         1       2m6s
+NAME                                                                DESIRED   CURRENT   READY   AGE
+replicaset.apps/discovery-6dbb5fd8bc                                1         1         1       2m6s
+replicaset.apps/extauth-68bb4745fc                                  1         1         1       2m7s
+replicaset.apps/gateway-proxy-7c49898fdf                            1         1         1       2m6s
+replicaset.apps/gloo-7748b94989                                     1         1         1       2m7s
+replicaset.apps/gloo-fed-76c85d689b                                 1         1         1       2m7s
+replicaset.apps/gloo-fed-console-dd5f877bd                          1         1         1       2m6s
+replicaset.apps/glooe-grafana-6f95948945                            1         1         1       2m6s
+replicaset.apps/glooe-prometheus-kube-state-metrics-v2-6c79cc9554   1         1         1       2m6s
+replicaset.apps/glooe-prometheus-server-757dc7d8f7                  1         1         1       2m6s
+replicaset.apps/observability-78cb7bddf7                            1         1         1       2m7s
+replicaset.apps/rate-limit-5ddd4b69d                                1         1         1       2m7s
+replicaset.apps/redis-888f4d9b5                                     1         1         1       2m6s
 ```
 
 #### Looking for opened ports?

--- a/docs/content/installation/platform_configuration/cluster_setup.md
+++ b/docs/content/installation/platform_configuration/cluster_setup.md
@@ -91,7 +91,7 @@ If you plan to install Gloo Edge Enterprise, you will need to enable certain per
 
 ```bash
 oc adm policy add-scc-to-user anyuid  -z glooe-prometheus-server -n gloo-system 
-oc adm policy add-scc-to-user anyuid  -z glooe-prometheus-kube-state-metrics  -n gloo-system 
+oc adm policy add-scc-to-user anyuid  -z glooe-prometheus-kube-state-metrics-v2 -n gloo-system 
 oc adm policy add-scc-to-user anyuid  -z default -n gloo-system 
 oc adm policy add-scc-to-user anyuid  -z glooe-grafana -n gloo-system
 ```

--- a/docs/content/operations/debugging_gloo/_index.md
+++ b/docs/content/operations/debugging_gloo/_index.md
@@ -164,20 +164,20 @@ gloo-66fb8974c9-8sgll            1/1     Running   0          15h
 You will see more components for the [Enterprise installation]({{< versioned_link_path fromRoot="/installation/enterprise/" >}})
 
 ```bash
-NAME                                                  READY   STATUS    RESTARTS   AGE
-discovery-68dbd794-ssx7b                               1/1     Running   0          107m
-extauth-67557744dd-5wc2p                               1/1     Running   0          107m
-gateway-595cc67f54-tr6ps                               1/1     Running   0          107m
-gateway-proxy-79c9f44b5d-cprg7                         1/1     Running   0          107m
-gloo-74bb8b9df7-72t8m                                  1/1     Running   0          107m
-gloo-fed-857964dd9f-gq8np                              1/1     Running   0          107m
-gloo-fed-console-6f99dddccd-ls64k                      3/3     Running   0          107m
-glooe-grafana-865bb9cd45-cdshq                         1/1     Running   0          107m
-glooe-prometheus-kube-state-metrics-55ffc89cbb-kr8jx   1/1     Running   0          107m
-glooe-prometheus-server-7d5b85764c-2nl2w               2/2     Running   0          107m
-observability-5f8ffc8bdc-zggxb                         1/1     Running   0          107m
-rate-limit-6d66688567-5tcx8                            1/1     Running   3          107m
-redis-57fd559c5c-hcd6n                                 1/1     Running   0          107m
+NAME                                                      READY   STATUS    RESTARTS   AGE
+discovery-68dbd794-ssx7b                                  1/1     Running   0          107m
+extauth-67557744dd-5wc2p                                  1/1     Running   0          107m
+gateway-595cc67f54-tr6ps                                  1/1     Running   0          107m
+gateway-proxy-79c9f44b5d-cprg7                            1/1     Running   0          107m
+gloo-74bb8b9df7-72t8m                                     1/1     Running   0          107m
+gloo-fed-857964dd9f-gq8np                                 1/1     Running   0          107m
+gloo-fed-console-6f99dddccd-ls64k                         3/3     Running   0          107m
+glooe-grafana-865bb9cd45-cdshq                            1/1     Running   0          107m
+glooe-prometheus-kube-state-metrics-v2-55ffc89cbb-kr8jx   1/1     Running   0          107m
+glooe-prometheus-server-7d5b85764c-2nl2w                  2/2     Running   0          107m
+observability-5f8ffc8bdc-zggxb                            1/1     Running   0          107m
+rate-limit-6d66688567-5tcx8                               1/1     Running   3          107m
+redis-57fd559c5c-hcd6n                                    1/1     Running   0          107m
 ```
 
 Each component logs the sync loops that it runs, such as syncing with various environment signals like the Kubernetes API, Consul, etc. 

--- a/docs/content/operations/production_deployment/_index.md
+++ b/docs/content/operations/production_deployment/_index.md
@@ -292,18 +292,18 @@ Some metrics that may be useful to monitor (listed in Prometheus format):
 A common issue in production (or environments with high traffic) is to have sizing issues. This will result in an abnormal number of restarts like this:
 ```shell
 $ kubectl get all -n gloo-system
-NAME                                                       READY   STATUS             RESTARTS   AGE
-pod/discovery-9d4c7fb4c-5wq5m                              1/1     Running            13         35d
-pod/extauth-77bb4fc79b-dsl6q                               1/1     Running            0          35d
-pod/gateway-f774b4d5b-jfhwn                                1/1     Running            0          35d
-pod/gateway-proxy-7656d9df87-qtn2s                         1/1     Running            0          35d
-pod/gloo-db4fb8c4-lfcrp                                    1/1     Running            13         35d
-pod/glooe-grafana-78c6f96db-wgl5k                          1/1     Running            0          41d
-pod/glooe-prometheus-kube-state-metrics-5dd77b76fc-s8prb   1/1     Running            0          41d
-pod/glooe-prometheus-server-59dcf7bc5b-jt654               1/2     CrashLoopBackOff   10692      41d
-pod/observability-656d47787-2fskq                          0/1     CrashLoopBackOff   9558       33d
-pod/rate-limit-7d6cf64fbf-ldgbp                            1/1     Running            0          35d
-pod/redis-55d6dbb6b7-ql89p                                 1/1     Running            0          41d
+NAME                                                          READY   STATUS             RESTARTS   AGE
+pod/discovery-9d4c7fb4c-5wq5m                                 1/1     Running            13         35d
+pod/extauth-77bb4fc79b-dsl6q                                  1/1     Running            0          35d
+pod/gateway-f774b4d5b-jfhwn                                   1/1     Running            0          35d
+pod/gateway-proxy-7656d9df87-qtn2s                            1/1     Running            0          35d
+pod/gloo-db4fb8c4-lfcrp                                       1/1     Running            13         35d
+pod/glooe-grafana-78c6f96db-wgl5k                             1/1     Running            0          41d
+pod/glooe-prometheus-kube-state-metrics-v2-5dd77b76fc-s8prb   1/1     Running            0          41d
+pod/glooe-prometheus-server-59dcf7bc5b-jt654                  1/2     CrashLoopBackOff   10692      41d
+pod/observability-656d47787-2fskq                             0/1     CrashLoopBackOff   9558       33d
+pod/rate-limit-7d6cf64fbf-ldgbp                               1/1     Running            0          35d
+pod/redis-55d6dbb6b7-ql89p                                    1/1     Running            0          41d
 ```
 
 Looking at the cause of these restarts, we can see that the PV is exhausted:

--- a/docs/content/reference/gloo_port_reference.md
+++ b/docs/content/reference/gloo_port_reference.md
@@ -117,7 +117,7 @@ The following table lists the services backed by the deployed pods.
 | gloo-fed-console | 8081 | healthcheck |
 | extauth | 8083 | extauth | 8083 | External authentication |
 | glooe-grafana | 80 | grafana | 3000 | Grafana UI |
-| glooe-prometheus-kube-state-metrics | 80 | prometheus-kube-state-metrics | 8080 | Kubernetes metric collection |
+| glooe-prometheus-kube-state-metrics-v2 | 80 | prometheus-kube-state-metrics | 8080 | Kubernetes metric collection |
 | glooe-prometheus-server | 80 | prometheus-server | 9090 | Prometheus server |
 | rate-limit | 18081 | rate-limit | 18081 | Rate-limiting |
 | redis | 6379 | redis | 6379 | Rate-limiting |


### PR DESCRIPTION
The default deployment name we use for prometheus kube-state-metrics had to be renamed as part of https://github.com/solo-io/solo-projects/pull/4727. Updating the docs to reflect that.