### PR TITLE
Stability: Unit Test Custom Matchers

### DIFF
--- a/test/gomega/matchers/contain_headers.go
+++ b/test/gomega/matchers/contain_headers.go
@@ -19,11 +19,7 @@ func ContainHeaders(headers http.Header) types.GomegaMatcher {
 	}
 	headerMatchers := make([]types.GomegaMatcher, 0, len(headers))
 	for k, v := range headers {
-		vals := make([]interface{}, len(v))
-		for i := range v {
-			vals[i] = v[i]
-		}
-		headerMatchers = append(headerMatchers, gomega.WithTransform(transforms.WithHeaderValues(k), gomega.ContainElements(vals...)))
+		headerMatchers = append(headerMatchers, gomega.WithTransform(transforms.WithHeaderValues(k), gomega.ContainElements(v)))
 	}
 	return gomega.And(headerMatchers...)
 }

--- a/test/gomega/matchers/contain_headers_test.go
+++ b/test/gomega/matchers/contain_headers_test.go
@@ -1,0 +1,63 @@
+package matchers_test
+
+import (
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/test/gomega/matchers"
+)
+
+var _ = Describe("ContainHeaders", func() {
+
+	DescribeTable("HttpResponse contains headers",
+		func(expectedHeaders http.Header) {
+			actualHeaders := http.Header{}
+			actualHeaders.Add("east", "east-1")
+			actualHeaders.Add("east", "east-2")
+			actualHeaders.Add("west", "west-1")
+			actualHeaders.Add("west", "west-2")
+
+			httpResponse := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     actualHeaders,
+			}
+			Expect(httpResponse).To(matchers.ContainHeaders(expectedHeaders))
+		},
+		Entry("empty headers", http.Header{}),
+		Entry("nil headers", nil),
+		Entry("subset of headers", http.Header{
+			"east": []string{"east-1", "east-2"},
+		}),
+		Entry("multiple subset of headers", http.Header{
+			"east": []string{"east-1"},
+			"west": []string{"west-2"},
+		}),
+	)
+
+	DescribeTable("HttpResponse does not contain headers",
+		func(expectedHeaders http.Header) {
+			actualHeaders := http.Header{}
+			actualHeaders.Add("east", "east-1")
+			actualHeaders.Add("east", "east-2")
+			actualHeaders.Add("west", "west-1")
+			actualHeaders.Add("west", "west-2")
+
+			httpResponse := &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     actualHeaders,
+			}
+			Expect(httpResponse).NotTo(matchers.ContainHeaders(expectedHeaders))
+		},
+		Entry("missing header", http.Header{
+			"south": []string{""},
+		}),
+		Entry("empty header value", http.Header{
+			"east": []string{""},
+		}),
+		Entry("missing header value", http.Header{
+			"east": []string{"east-missing"},
+		}),
+	)
+
+})

--- a/test/gomega/matchers/contain_substrings.go
+++ b/test/gomega/matchers/contain_substrings.go
@@ -22,8 +22,8 @@ func ContainSubstrings(substrings []string) types.GomegaMatcher {
 	}
 
 	substringMatchers := make([]types.GomegaMatcher, 0, len(substrings))
-	for i := range substrings {
-		substringMatchers = append(substringMatchers, gomega.ContainSubstring(substrings[i]))
+	for _, str := range substrings {
+		substringMatchers = append(substringMatchers, gomega.ContainSubstring(str))
 	}
 	return gomega.And(substringMatchers...)
 }

--- a/test/gomega/matchers/contain_substrings.go
+++ b/test/gomega/matchers/contain_substrings.go
@@ -22,8 +22,8 @@ func ContainSubstrings(substrings []string) types.GomegaMatcher {
 	}
 
 	substringMatchers := make([]types.GomegaMatcher, 0, len(substrings))
-	for _, str := range substrings {
-		substringMatchers = append(substringMatchers, gomega.ContainSubstring(str))
+	for i := range substrings {
+		substringMatchers = append(substringMatchers, gomega.ContainSubstring(substrings[i]))
 	}
 	return gomega.And(substringMatchers...)
 }

--- a/test/gomega/matchers/contain_substrings_test.go
+++ b/test/gomega/matchers/contain_substrings_test.go
@@ -16,7 +16,7 @@ var _ = Describe("ContainSubstrings", func() {
 		Entry("empty list", []string{}),
 		Entry("empty string", []string{""}),
 		Entry("single substring", []string{"this"}),
-		Entry("multiple substrings", []string{"this", "is", "the"}),
+		Entry("multiple substrings", []string{"the", "is", "this"}),
 	)
 
 	DescribeTable("does not contain substrings",

--- a/test/gomega/matchers/contain_substrings_test.go
+++ b/test/gomega/matchers/contain_substrings_test.go
@@ -1,0 +1,31 @@
+package matchers_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/test/gomega/matchers"
+)
+
+var _ = Describe("ContainSubstrings", func() {
+
+	DescribeTable("contains substrings",
+		func(expectedSubstrings []string) {
+			actualString := "this is the string"
+			Expect(actualString).To(matchers.ContainSubstrings(expectedSubstrings))
+		},
+		Entry("empty list", []string{}),
+		Entry("empty string", []string{""}),
+		Entry("single substring", []string{"this"}),
+		Entry("multiple substrings", []string{"this", "is", "the"}),
+	)
+
+	DescribeTable("does not contain substrings",
+		func(expectedSubstrings []string) {
+			actualString := "this is the string"
+			Expect(actualString).NotTo(matchers.ContainSubstrings(expectedSubstrings))
+		},
+		Entry("missing substring", []string{"missing"}),
+		Entry("substring and missing substring", []string{"this", "missing"}),
+	)
+
+})

--- a/test/gomega/matchers/matchers_suite_test.go
+++ b/test/gomega/matchers/matchers_suite_test.go
@@ -1,0 +1,14 @@
+package matchers_test
+
+import (
+	"testing"
+
+	"github.com/solo-io/go-utils/testutils"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+func TestMatchers(t *testing.T) {
+	testutils.RegisterCommonFailHandlers()
+	RunSpecs(t, "Matchers Suite")
+}


### PR DESCRIPTION
# Description

We rely on custom matchers in our e2e tests, this PR adds some tests to improve confidence those matchers behave as we would expect

# Context

We've hit some response assertion panics in our aws tests and opened https://github.com/solo-io/gloo/issues/8003 as a result. One of them was the result of an update we needed to make to this custom matcher.

My hope was that if we added tests we might see what is causing the current (infrequent) panic. It didn't demonstrate this, but the side effect is now we have test to demonstrate these utilities work as expected.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
