### PR TITLE
Centralize where go version is specified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ endif
 GOOS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=$(GOARCH)
-GOLANG_VERSION := golang:1.20.1-alpine
+GOLANG_ALPINE_IMAGE_NAME = golang:$(shell go version | egrep -o '([0-9]+\.[0-9]+)')-alpine
 
 # Passed by cloudbuild
 GCLOUD_PROJECT_ID := $(GCLOUD_PROJECT_ID)
@@ -470,7 +470,7 @@ $(GLOO_RACE_OUT_DIR)/Dockerfile.build: $(GLOO_DIR)/Dockerfile
 $(GLOO_RACE_OUT_DIR)/.gloo-race-docker-build: $(GLOO_SOURCES) $(GLOO_RACE_OUT_DIR)/Dockerfile.build
 	docker buildx build --load $(PLATFORM) -t $(IMAGE_REGISTRY)/gloo-race-build-container:$(VERSION) \
 		-f $(GLOO_RACE_OUT_DIR)/Dockerfile.build \
-		--build-arg GO_BUILD_IMAGE=$(GOLANG_VERSION) \
+		--build-arg GO_BUILD_IMAGE=$(GOLANG_ALPINE_IMAGE_NAME) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GCFLAGS=$(GCFLAGS) \
 		--build-arg LDFLAGS=$(LDFLAGS) \

--- a/changelog/v1.15.0-beta3/golang-version-location.yaml
+++ b/changelog/v1.15.0-beta3/golang-version-location.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/7926
+    description: Reduce the number of places we specify the go version
+    resolvesIssue: false

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -1,3 +1,7 @@
+options:
+  env:
+    - "_GO_VERSION=1.20.1"
+
 steps:
 - name: gcr.io/cloud-builders/gsutil
   entrypoint: 'bash'
@@ -8,21 +12,13 @@ steps:
     path: '/go/pkg'
   id: 'untar-mod-cache'
 
-- name: 'golang:1.20.1'
-  args: ['go', 'mod', 'download']
-  volumes: *vol
-  id: 'download'
-
-- name: 'golang:1.20.1'
-  args: ['go', 'mod', 'tidy']
-  volumes: *vol
-  id: 'tidy'
-
-- name: 'golang:1.20.1'
+- name: 'golang:${_GO_VERSION}'
   entrypoint: 'bash'
+  args:
+    - '-c'
+    - 'go mod download && go mod tidy && cd /go/pkg && tar -zvcf gloo-mod.tar.gz mod'
   volumes: *vol
-  args: ['-c', ' cd /go/pkg && tar -zvcf gloo-mod.tar.gz mod']
-  id: 'tar-cache'
+  id: 'download-tidy-cache'
 
 - name: gcr.io/cloud-builders/gsutil
   args: ['cp', '/go/pkg/gloo-mod.tar.gz', 'gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz']

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/solo-io/gloo
 
 go 1.20
 
+// Note for developers: upgrading go will also require upgrading go in the following files:
+// ./cloudbuild-cache.yaml,
+
 require (
 	github.com/Masterminds/semver/v3 v3.2.0
 	github.com/Netflix/go-expect v0.0.0-20180928190340-9d1f4485533b


### PR DESCRIPTION
# Description

Whenever we upgrade Go in this repo, we have to update the version across multiple files. This PR aims to make some of the simplest changes that reduce the number of places we define our go version. Many of these hardcodings are impractical to change so they are left in with comments in the go.mod for future developers who upgrade go.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
