### PR TITLE
refactor(upgrade): simplify return branches of GetUpgradeVersions

### DIFF
--- a/changelog/v1.15.0-beta4/upgrade-utils-refactor.yaml
+++ b/changelog/v1.15.0-beta4/upgrade-utils-refactor.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/4312
+    resolvesIssue: false
+    description: simplify return branches of upgrade.GetUpgradeVersions

--- a/test/kube2e/upgrade/upgrade_suite_test.go
+++ b/test/kube2e/upgrade/upgrade_suite_test.go
@@ -2,7 +2,6 @@ package upgrade_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -10,7 +9,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/test/kube2e"
 	"github.com/solo-io/gloo/test/kube2e/upgrade"
-	"github.com/solo-io/gloo/test/testutils/version"
 	"github.com/solo-io/go-utils/versionutils"
 	"github.com/solo-io/skv2/codegen/util"
 
@@ -55,22 +53,22 @@ var _ = BeforeSuite(func() {
 
 	crdDir = filepath.Join(util.GetModuleRoot(), "install", "helm", "gloo", "crds")
 	targetReleasedVersion = kube2e.GetTestReleasedVersion(suiteCtx, "gloo")
-	if targetReleasedVersion != "" {
-		chartUri = "gloo/gloo"
-	} else {
+
+	chartUri = "gloo/gloo"
+	if targetReleasedVersion == "" {
 		chartUri = filepath.Join(testHelper.RootDir, testHelper.TestAssetDir, testHelper.HelmChartName+"-"+testHelper.ChartVersion()+".tgz")
 	}
-	skipIfFirstMinorFunc = func() {}
+
 	LastPatchPreviousMinorVersion, CurrentPatchMostRecentMinorVersion, err = upgrade.GetUpgradeVersions(suiteCtx, "gloo")
-	if err != nil && errors.Is(err, version.FirstReleaseError) {
-		firstReleaseOfMinor = true
+	Expect(err).NotTo(HaveOccurred())
+
+	skipIfFirstMinorFunc = func() {}
+	if CurrentPatchMostRecentMinorVersion == nil {
 		fmt.Println("First release of minor, skipping some upgrade tests")
 		CurrentPatchMostRecentMinorVersion = versionutils.NewVersion(0, 0, 0, "", 0)
 		skipIfFirstMinorFunc = func() {
 			Skip("First release of minor, skipping some upgrade tests")
 		}
-	} else if err != nil {
-		Expect(err).NotTo(HaveOccurred())
 	}
 })
 

--- a/test/kube2e/upgrade/upgrade_utils.go
+++ b/test/kube2e/upgrade/upgrade_utils.go
@@ -23,7 +23,7 @@ import (
 //
 // Originally intended for use in upgrade testing, it can return any of:
 //   - (prevLtsRelease, latestRelease, nil): all release versions computable
-//   - (prevLtsRelease, nil, nil):           only prevLtsRelease computable
+//   - (prevLtsRelease, nil, nil):           only prevLtsRelease computable (ie current branch has never been released)
 //   - (nil, nil, err):                      unable to fetch versions for upgrade test
 func GetUpgradeVersions(ctx context.Context, repoName string) (*versionutils.Version, *versionutils.Version, error) {
 	// get the latest and upcoming releases of the current branch

--- a/test/kube2e/upgrade/upgrade_utils.go
+++ b/test/kube2e/upgrade/upgrade_utils.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"time"
 
@@ -15,72 +14,47 @@ import (
 	"github.com/solo-io/go-utils/changelogutils"
 	"github.com/solo-io/go-utils/githubutils"
 	"github.com/solo-io/go-utils/versionutils"
+	"github.com/solo-io/skv2/codegen/util"
 )
 
 // GetUpgradeVersions for the given repo.
-// This will return the lastminor, currentminor, and an error
-// This may return lastminor + currentminor, or just lastminor and an error or a just an error
-func GetUpgradeVersions(ctx context.Context, repoName string) (lastMinorLatestPatchVersion *versionutils.Version, currentMinorLatestPatchVersion *versionutils.Version, err error) {
-
-	twoBack, currentBranch, curMinorErr := getLastReleaseOfCurrentMinor()
-	currentMinorLatestPatchVersion = twoBack
-	if errors.Is(curMinorErr, version.FirstReleaseError) {
-		// we are on the first release of a minor
-		// we should use this branch rather than the last release
-		currentMinorLatestPatchVersion = currentBranch
-	} else if curMinorErr != nil {
-		return nil, nil, curMinorErr
+// This will return the (prevLtsRelease, latestRelease, err)
+// return possiblities (from best-case to worst-case):
+//   - 😃 (prevLtsRelease, latestRelease, nil)
+//   - 😐 (prevLtsRelease, nil, nil)
+//   - 😔 (nil, nil, err)
+func GetUpgradeVersions(ctx context.Context, repoName string) (*versionutils.Version, *versionutils.Version, error) {
+	// read in changelog directory for later use
+	files, changelogReadErr := os.ReadDir(filepath.Join(util.GetModuleRoot(), changelogutils.ChangelogDirectory))
+	if changelogReadErr != nil {
+		return nil, nil, changelogutils.ReadChangelogDirError(changelogReadErr)
 	}
 
-	// TODO(nfuden): Update goutils to not use a struct but rather interface
-	// so we can test this more easily.
-	client, err := githubutils.GetClient(ctx)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "unable to create github client")
+	// TODO(nfuden): Update goutils to not use a struct but rather interface so we can test this more easily.
+	client, githubClientErr := githubutils.GetClient(ctx)
+	if githubClientErr != nil {
+		return nil, nil, errors.Wrapf(githubClientErr, "unable to create github client")
 	}
 
-	var currentMinorLatestRelease *versionutils.Version
-	// we dont believe there should be a minor release yet so its ok to not do this extra computation
-	if curMinorErr == nil {
-		var currentMinorLatestReleaseError error
-		// we may get a changelog value that does not have a github release - get the latest release for current minor
-		currentMinorLatestRelease, currentMinorLatestReleaseError = getLatestReleasedPatchVersion(ctx, client, repoName, currentMinorLatestPatchVersion.Major, currentMinorLatestPatchVersion.Minor)
-		if currentMinorLatestReleaseError != nil {
-			return nil, lastMinorLatestPatchVersion, currentMinorLatestReleaseError
-		}
+	// get the latest and upcoming releases of the current branch
+	latestRelease, upcomingRelease, upcomingReleaseErr := version.ChangelogDirForLatestRelease(files...)
+	if upcomingReleaseErr != nil && !errors.Is(upcomingReleaseErr, version.FirstReleaseError) {
+		return nil, nil, upcomingReleaseErr
 	}
 
-	lastMinorLatestPatchVersion, lastMinorErr := getLatestReleasedPatchVersion(ctx, client, repoName, currentMinorLatestPatchVersion.Major, currentMinorLatestPatchVersion.Minor-1)
-	if lastMinorErr != nil {
-		// a true error lets return that.
-		return nil, nil, lastMinorErr
+	// get latest release of previous LTS branch
+	prevLtsRelease, prevLtsReleaseErr := getLatestReleasedPatchVersion(ctx, client, repoName, upcomingRelease.Major, upcomingRelease.Minor-1)
+	if prevLtsReleaseErr != nil {
+		return nil, nil, prevLtsReleaseErr
 	}
 
-	// last minor should never be nil, currentMinor and curMinorerr MAY be nil
-	return lastMinorLatestPatchVersion, currentMinorLatestRelease, curMinorErr
-}
-
-func getLastReleaseOfCurrentMinor() (*versionutils.Version, *versionutils.Version, error) {
-	// pull out to const
-	_, filename, _, _ := runtime.Caller(0) //get info about what is calling the function
-	fParts := strings.Split(filename, string(os.PathSeparator))
-	splitIdx := 0
-	// In all cases the home of the project will be one level above test - this handles forks as well as the standard case /home/runner/work/gloo/gloo/test/kube2e/upgrade/junit.xml
-	for idx, dir := range fParts {
-		if dir == "test" {
-			splitIdx = idx - 1
-		}
+	if upcomingReleaseErr != nil {
+		// if we don't yet have a release for the current branch, we can only upgrade from prevLtsRelease
+		return prevLtsRelease, nil, nil
+	} else {
+		// otherwise, we can upgrade from both prevLtsRelease -and- latestRelease
+		return prevLtsRelease, latestRelease, nil
 	}
-	pathToChangelogs := filepath.Join(fParts[:splitIdx+1]...)
-	pathToChangelogs = filepath.Join(pathToChangelogs, changelogutils.ChangelogDirectory)
-	pathToChangelogs = string(os.PathSeparator) + pathToChangelogs
-
-	files, err := os.ReadDir(pathToChangelogs)
-	if err != nil {
-		return nil, nil, changelogutils.ReadChangelogDirError(err)
-	}
-
-	return version.ChangelogDirForLatestRelease(files...)
 }
 
 type latestPatchForMinorPredicate struct {


### PR DESCRIPTION
# Description
Fixed a bug where `changelog` directory would always be dependent on `gloo` repository

_and_

offered a refactor of said method to make it easier to develop on

# Checklist:
- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
