### PR TITLE
Check go version before building docker images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ fmt-changed:
 
 # must be a seperate target so that make waits for it to complete before moving on
 .PHONY: mod-download
-mod-download:
+mod-download: check-go-version
 	go mod download all
 
 
@@ -324,6 +324,12 @@ $(OUTPUT_DIR)/.generated-code:
 verify-enterprise-protos:
 	@echo Verifying validity of generated enterprise files...
 	$(GO_BUILD_FLAGS) GOOS=linux go build projects/gloo/pkg/api/v1/enterprise/verify.go $(STDERR_SILENCE_REDIRECT)
+	
+# makes sure you are running codegen with the correct Go version
+.PHONY: check-go-version
+check-go-version:
+	./ci/check-go-version.sh
+
 
 #----------------------------------------------------------------------------------
 # Generate mocks
@@ -730,6 +736,7 @@ docker-push-%:
 
 # Build docker images using the defined IMAGE_REGISTRY, VERSION
 .PHONY: docker
+docker: check-go-version
 docker: gloo-docker
 docker: discovery-docker
 docker: gloo-envoy-wrapper-docker

--- a/changelog/v1.15.0-beta4/check-go-version.yaml
+++ b/changelog/v1.15.0-beta4/check-go-version.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    description: Check go version before building docker images, other small fixes
+    issueLink: https://github.com/solo-io/gloo/issues/7926
+    resolvesIssue: false

--- a/ci/check-go-version.sh
+++ b/ci/check-go-version.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Make sure the minor Go version that we are running matches the version specified in go.mod
+goVersion=$(go version | # looks something like "go version go1.20.1 darwin/amd64"
+  awk '{print $3}' |     # get the 3rd word -> "go1.20.1"
+  sed "s/go//" )         # remove the "go" part -> "1.20.1"
+goModVersion=$(grep -m 1 go go.mod | cut -d' ' -f2)
+
+if [[ "$goVersion" == "$goModVersion"* ]]; then
+    echo "Using Go version $goVersion"
+else
+    echo "Your Go version ($goVersion) does not match the version from go.mod ($goModVersion)".
+    echo "Please update your Go version to $goModVersion and re-run."
+    exit 1;
+fi


### PR DESCRIPTION
make docker now also runs the check-go-version make target as well. Other small bug fixes and improvements

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
