### PR TITLE
[v1.11.x] Update go-version-file field in push-solo-apis-branch workflow

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -85,7 +85,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version-file: "go.mod"
+          go-version-file: gloo/go.mod
         id: go
       - name: Install Protoc
         uses: arduino/setup-protoc@master

--- a/changelog/v1.11.57/update-mod-location.yaml
+++ b/changelog/v1.11.57/update-mod-location.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Update the `go-version-file` field to a valid path in the push-solo-apis-branch workflow.


### PR DESCRIPTION
# Description
 - the `go-version-file` field in the `Set up Go` step in the `Push API Changes to solo-apis` workflow was pointing to an invalid file path
 - Gloo is checked out into the `gloo` directory, not at the root of the repo
 - This PR updates the `go-version-file` field to point to `gloo/go.mod`, which is the correct path