### PR TITLE
fix make target for kind-reload-gloo-envoy-wrapper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -779,6 +779,11 @@ kind-load-%:
 # Depends on: IMAGE_REGISTRY, VERSION, CLUSTER_NAME
 kind-build-and-load-%: %-docker kind-load-% ;
 
+# This is an alias to remedy the fact that the deployment is called gateway-proxy
+# but our make targets refer to gloo-envoy-wrapper
+kind-reload-gloo-envoy-wrapper: kind-build-and-load-gloo-envoy-wrapper
+	kubectl rollout restart deployment/gateway-proxy -n $(INSTALL_NAMESPACE)
+
 # Reload an image in KinD
 # This is useful to developers when changing a single component
 # You can reload an image, which means it will be rebuilt and reloaded into the kind cluster


### PR DESCRIPTION
# Description

Added alias to remedy the issue where the command `make kind-reload-gloo-envoy-wrapper` yielded the error

```log
kubectl rollout restart deployment/gloo-envoy-wrapper -n gloo-system
Error from server (NotFound): deployments.apps "gloo-envoy-wrapper" not found
make: *** [Makefile:788: kind-reload-gloo-envoy-wrapper] Error 1
```

This can be tested by running the command above, seeing the error, then running on the branch and observing the deployment restart

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
