### PR TITLE
[1.11] CVE 2023 0464

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.21.5-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.21.5-patch2
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.11.58/cves.yaml
+++ b/changelog/v1.11.58/cves.yaml
@@ -5,4 +5,10 @@ changelog:
   dependencyTag: 3.17.3
   issueLink: https://github.com/solo-io/gloo/issues/8125
   description: >-
-    Bump alpine in kubectl to fix CVE-2023-0464
+    Bump alpine to fix CVE-2023-0464
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-gloo
+  dependencyTag: v1.21.5-patch2
+  description: >-
+    Bump envoy-gloo to gain access to rebuilt image with CVE fixes

--- a/changelog/v1.11.58/cves.yaml
+++ b/changelog/v1.11.58/cves.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: linux
+  dependencyRepo: alpine
+  dependencyTag: 3.17.3
+  issueLink: https://github.com/solo-io/gloo/issues/8125
+  description: >-
+    Bump alpine in kubectl to fix CVE-2023-0464

--- a/docs/content/guides/security/tls/Dockerfile
+++ b/docs/content/guides/security/tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 COPY cert.pem /cert.pem
 COPY key.pem /key.pem

--- a/docs/examples/session-affinity/Dockerfile
+++ b/docs/examples/session-affinity/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/docs/examples/xslt-guide/Dockerfile
+++ b/docs/examples/xslt-guide/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates curl \

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/jobs/certgen/cmd/Dockerfile
+++ b/jobs/certgen/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 ARG GOARCH=amd64
 

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,5 +1,5 @@
 FROM bitnami/kubectl:1.22.12 as kubectl
 
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/

--- a/projects/accesslogger/cmd/Dockerfile
+++ b/projects/accesslogger/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 ARG GOARCH=amd64
 RUN apk -U upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*

--- a/projects/discovery/cmd/Dockerfile
+++ b/projects/discovery/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 ARG GOARCH=amd64
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/projects/gateway/cmd/Dockerfile
+++ b/projects/gateway/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 ARG GOARCH=amd64
 

--- a/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
+++ b/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
@@ -94,6 +94,18 @@ var _ = Describe("Generated Kube Code", func() {
 		cancel()
 	})
 
+	JustBeforeEach(func() {
+		us, _ := upstreamClient.Read("default", "petstore-static", clients.ReadOpts{})
+		if us != nil {
+			upstreamClient.Delete("default", "petstore-static", clients.DeleteOpts{})
+		}
+
+		vs, _ := virtualServiceClient.Read("default", "my-routes", clients.ReadOpts{})
+		if vs != nil {
+			virtualServiceClient.Delete("default", "my-routes", clients.DeleteOpts{})
+		}
+	})
+
 	It("can read and write a gloo resource as a typed kube object", func() {
 		us := &gloov1kubetypes.Upstream{
 			ObjectMeta: v1.ObjectMeta{Name: "petstore-static", Namespace: "default"},

--- a/projects/ingress/cmd/Dockerfile
+++ b/projects/ingress/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 ARG GOARCH=amd64
 

--- a/projects/sds/cmd/Dockerfile
+++ b/projects/sds/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.2
+FROM alpine:3.17.3
 
 ARG GOARCH=amd64
 


### PR DESCRIPTION
# Description

Bump Alpine dependency in the `kubectl` image for CVE-2023-0464.

Can be tested by running the following commands:
`docker run --rm alpine:3.17.2 apk info libssl3 libcrypto3`
`docker run --rm alpine:3.17.3 apk info libssl3 libcrypto3`


# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/8125