### PR TITLE
Remove CVE-2022-37315 from trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -3,11 +3,6 @@
 # https://github.com/emicklei/go-restful/pull/503
 CVE-2022-1996
 
-# https://github.com/advisories/GHSA-h3qm-jrrf-cgj3
-# This CVE is not exploitable in Gloo Edge, and a fix is not yet available in the library
-# https://github.com/solo-io/solo-projects/issues/4016
-CVE-2022-37315
-
 # These CVEs only impacts install of Gloo-Edge from Glooctl CLI.
 # Also Helm module is used in testing, which has no impact on exploitation.
 # Gloo-Edge data and control planes are not impacted at all by the helm module.

--- a/changelog/v1.15.0-beta4/go-graphql-bump.yaml
+++ b/changelog/v1.15.0-beta4/go-graphql-bump.yaml
@@ -1,5 +1,0 @@
-changelog:
-    - type: NON_USER_FACING
-      description: Remove CVE-2022-37315 as v0.8.1 resolves this
-      resolvesIssue: false
-      issueLink: https://github.com/solo-io/solo-projects/issues/4016

--- a/changelog/v1.15.0-beta4/go-graphql-bump.yaml
+++ b/changelog/v1.15.0-beta4/go-graphql-bump.yaml
@@ -1,0 +1,5 @@
+changelog:
+    - type: FIX
+      description: Remove CVE-2022-37315 as v0.8.1 resolves this
+      resolvesIssue: false
+      issueLink: https://github.com/solo-io/solo-projects/issues/4016

--- a/changelog/v1.15.0-beta4/go-graphql-bump.yaml
+++ b/changelog/v1.15.0-beta4/go-graphql-bump.yaml
@@ -1,5 +1,5 @@
 changelog:
-    - type: FIX
+    - type: NON_USER_FACING
       description: Remove CVE-2022-37315 as v0.8.1 resolves this
       resolvesIssue: false
       issueLink: https://github.com/solo-io/solo-projects/issues/4016

--- a/changelog/v1.15.0-beta5/go-graphql-bump.yaml
+++ b/changelog/v1.15.0-beta5/go-graphql-bump.yaml
@@ -1,0 +1,5 @@
+changelog:
+    - type: NON_USER_FACING
+      description: Remove CVE-2022-37315 as v0.8.1 resolves this
+      resolvesIssue: false
+      issueLink: https://github.com/solo-io/solo-projects/issues/4016


### PR DESCRIPTION
# Description

This CVE has been resolved by the `graphql-go/gaphql@v0.8.1` release.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
