### PR TITLE
[v1.13.x] Expand RELEASE_BRANCH properly in push-solo-apis-branch

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -41,7 +41,7 @@ jobs:
         if [[ ${{ github.event_name == 'release' }} = true ]]; then
           RELEASE_BRANCH=${{ github.event.release.target_commitish }}
         fi
-        echo "value=$(echo RELEASE_BRANCH)" >> $GITHUB_OUTPUT
+        echo "value=$(echo $RELEASE_BRANCH)" >> $GITHUB_OUTPUT
   push-to-solo-apis-branch:
     needs: prepare-env
     env:

--- a/changelog/v1.13.15/expand-release-branch-yaml
+++ b/changelog/v1.13.15/expand-release-branch-yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      resolves issue in push-solo-apis release job, in which the `RELEASE_BRANCH`
+      environment variable was not being expanded correctly


### PR DESCRIPTION
# Description
 -  resolves issue in `push-solo-apis-branch` release job, in which the `RELEASE_BRANCH` environment variable was not being expanded correctly