### PR TITLE
[v1.11.x] Ensure that RELEASE_BRANCH is set

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -41,7 +41,7 @@ jobs:
         if [[ ${{ github.event_name == 'release' }} = true ]]; then
           RELEASE_BRANCH=${{ github.event.release.target_commitish }}
         fi
-        echo "value=$(echo $RELEASE_TAG_NAME)" >> $GITHUB_OUTPUT
+        echo "value=$(echo $RELEASE_BRANCH)" >> $GITHUB_OUTPUT
   push-to-solo-apis-branch:
     needs: prepare-env
     env:

--- a/changelog/v1.11.58/fix-release-branch
+++ b/changelog/v1.11.58/fix-release-branch
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Resolves an issue in the `push-solo-apis-branch` release workflow that
+      caused the `RELEASE_BRANCH` environment variable to be unset


### PR DESCRIPTION
# Description
 - Resolves an issue in the `push-solo-apis-branch` release workflow that caused the `RELEASE_BRANCH` environment variable to be unset