### PR TITLE
Docs: Clarify Usage of kind-reload

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -29,7 +29,7 @@ To test this on the default main branch:
 - The LTS branch that these API changes are targeted for: `master`
 
 To test this on 1.13.x branch:
-- Use Workflow From: `master`
+- Use Workflow From: `v1.13.x`
 - The branch that contains the relevant API change: `feature/new-api`
 - The LTS branch that these API changes are targeted for: `v1.13.x`
 

--- a/Makefile
+++ b/Makefile
@@ -799,6 +799,9 @@ kind-reload-gloo-envoy-wrapper: kind-build-and-load-gloo-envoy-wrapper
 # using the same tag so that tests can be re-run
 # Depends on: IMAGE_REGISTRY, VERSION, INSTALL_NAMESPACE , CLUSTER_NAME
 # Envoy image may be specified via ENVOY_GLOO_IMAGE on the command line or at the top of this file
+# We restart the deployment, to ensure that the newly built/tagged image is started in the new Pod
+# It is important to ensure that the image you built, has the same tag as the deployment image
+# Otherwise you will build a new image, and the deployment will still reference the old image
 kind-reload-%: kind-build-and-load-% ## Use to build specified image, load it into kind, and restart its deployment
 	kubectl rollout restart deployment/$* -n $(INSTALL_NAMESPACE)
 

--- a/Makefile
+++ b/Makefile
@@ -791,7 +791,7 @@ kind-build-and-load-%: %-docker kind-load-% ; ## Use to build specified image an
 # Update the docker image used by a deployment
 # This works for most of our deployments because the deployment name and container name both match
 kind-set-image-%:
-	 kubectl set image deployment/$* $*=$(IMAGE_REGISTRY)/$*:$(VERSION) -n $(INSTALL_NAMESPACE)
+	kubectl set image deployment/$* $*=$(IMAGE_REGISTRY)/$*:$(VERSION) -n $(INSTALL_NAMESPACE)
 
 # Reload an image in KinD
 # This is useful to developers when changing a single component

--- a/Makefile
+++ b/Makefile
@@ -795,13 +795,10 @@ kind-set-image-%:
 
 # Reload an image in KinD
 # This is useful to developers when changing a single component
-# You can reload an image, which means it will be rebuilt and reloaded into the kind cluster
-# using the same tag so that tests can be re-run
+# You can reload an image, which means it will be rebuilt and reloaded into the kind cluster, and the deployment
+# will be updated to reference it
 # Depends on: IMAGE_REGISTRY, VERSION, INSTALL_NAMESPACE , CLUSTER_NAME
 # Envoy image may be specified via ENVOY_GLOO_IMAGE on the command line or at the top of this file
-# We restart the deployment, to ensure that the newly built/tagged image is started in the new Pod
-# It is important to ensure that the image you built, has the same tag as the deployment image
-# Otherwise you will build a new image, and the deployment will still reference the old image
 kind-reload-%: kind-build-and-load-% kind-set-image-% ; ## Use to build specified image, load it into kind, and restart its deployment
 
 # This is an alias to remedy the fact that the deployment is called gateway-proxy


### PR DESCRIPTION
# Description

Clarify kind-load behavior per recommendation from recent demo

# Testing
Create a kind cluster
```
kind create cluster --name kind-demo
```

Install gloo
```
helm install -n gloo-system gloo gloo/gloo --create-namespace --version 1.14.0-rc1
````

Reload the gateway-proxy deployment
```
CLUSTER_NAME=kind-demo VERSION=1.0.0-sh make kind-reload-gloo-envoy-wrapper
```

Reload the gloo deployment
```
CLUSTER_NAME=kind-demo VERSION=1.0.0-sh make kind-reload-gloo
```

**Note: In the reload steps, version is no longer required**

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
