### PR TITLE
Stability: Fix Push Solo-Apis GHA

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -43,7 +43,7 @@ jobs:
       run: |
         TARGET_BRANCH=${{ github.event.inputs.target-branch }}
         if [[ ${{ github.event_name == 'release' }} = true ]]; then
-          TARGET_BRANCH=${{ github.event.release.SOURCE_COMMITish }}
+          TARGET_BRANCH=${{ github.event.release.target_commitish }}
         fi
         echo "value=$TARGET_BRANCH" >> $GITHUB_OUTPUT
   push-to-solo-apis-branch:

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -85,7 +85,7 @@ jobs:
         with:
           repository: solo-io/gloo
           path: gloo
-          ref: ${{ env.RELEASE_TAG_NAME }}
+          ref: ${{ env.SOURCE_COMMIT }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:


### PR DESCRIPTION
# Description

Ensure the push-to-solo-apis GHA works properly

# Context

Slack context: https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1682360742297699?thread_ts=1682349377.057149&cid=G01EERAK3KJ

A bad find/replace was merged in https://github.com/solo-io/gloo/pull/8114

https://github.com/solo-io/gloo/blob/458fcc763ed3332b76554c9280874c27c811b951/.github/workflows/push-solo-apis-branch.yaml#L42 shows what this value was before the above PR

## Testing
Create a manual run using:
<img width="312" alt="Screen Shot 2023-04-24 at 2 50 20 PM" src="https://user-images.githubusercontent.com/5279627/234088676-c3c33371-be6d-431b-b1c1-9b8f0239fa21.png">

Logs: https://github.com/solo-io/gloo/actions/runs/4789975107

Solo-Apis generated PR: https://github.com/solo-io/solo-apis/pull/810

This doesn't test everything, as where we failed was actually code that only runs on releases

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
