### PR TITLE
Ensure that grpc transcoding works with new US API and old VS API

### DIFF
--- a/projects/discovery/pkg/fds/discoveries/grpc/grpc.go
+++ b/projects/discovery/pkg/fds/discoveries/grpc/grpc.go
@@ -194,6 +194,7 @@ func (f *UpstreamFunctionDiscovery) DetectFunctionsOnce(ctx context.Context, url
 		}
 		svcSpec.DescriptorSet = &grpc_json_plugins.GrpcJsonTranscoder_ProtoDescriptorBin{ProtoDescriptorBin: rawDescriptors}
 		svcSpec.Services = servicesDiscovered
+		svcSpec.MatchIncomingRequestRoute = true
 		return nil
 	})
 }

--- a/projects/gloo/pkg/plugins/grpc/plugin.go
+++ b/projects/gloo/pkg/plugins/grpc/plugin.go
@@ -78,7 +78,13 @@ func (p *plugin) ProcessUpstream(params plugins.Params, in *v1.Upstream, out *en
 	if upstreamType.GetServiceSpec() == nil {
 		return nil
 	}
-
+	// If the upstream uses the new API we should record that it exists for use in `ProcessRoute` but not make any changes
+	_, ok = upstreamType.GetServiceSpec().GetPluginType().(*glooplugins.ServiceSpec_GrpcJsonTranscoder)
+	if ok {
+		contextutils.LoggerFrom(params.Ctx).Infof("ELC, recording grpsjson us")
+		p.recordedUpstreams[translator.UpstreamToClusterName(in.GetMetadata().Ref())] = in
+		return nil
+	}
 	grpcWrapper, ok := upstreamType.GetServiceSpec().GetPluginType().(*glooplugins.ServiceSpec_Grpc)
 	if !ok {
 		return nil
@@ -183,7 +189,14 @@ func (p *plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *env
 			if upstream == nil {
 				return nil, errors.New(fmt.Sprintf("upstream %v was not recorded for grpc route", upstreamRef))
 			}
+			upstreamType, ok := upstream.GetUpstreamType().(v1.ServiceSpecGetter)
 
+			// If the upstream uses the new API we assume the descriptors and vs match and do not do any transformations
+			_, ok = upstreamType.GetServiceSpec().GetPluginType().(*glooplugins.ServiceSpec_GrpcJsonTranscoder)
+			if ok {
+				contextutils.LoggerFrom(params.Ctx).Infof("ELC vs points to new API, we can direct straight to us")
+				return nil, nil
+			}
 			// create the transformation for the route
 			outPath := httpPath(upstream, fullServiceName, methodName)
 

--- a/test/e2e/grpc_discovery_test.go
+++ b/test/e2e/grpc_discovery_test.go
@@ -3,6 +3,9 @@ package e2e_test
 import (
 	"context"
 
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc"
+
 	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 
 	"github.com/solo-io/gloo/test/testutils"
@@ -18,6 +21,7 @@ import (
 	"github.com/solo-io/gloo/test/services"
 	"github.com/solo-io/gloo/test/v1helpers"
 
+	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 )
 
@@ -68,7 +72,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 		}
 	}
 	Context("New API", func() {
-		It("Routes to GRPC Functions", func() {
+		FIt("Routes to GRPC Functions", func() {
 
 			body := `"foo"`
 			testRequest := basicReq(body, `{"str":"foo"}`)
@@ -79,7 +83,25 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
 			}))))
 		})
+		//basically `matchIncomingRequestRoute` needs to be set for this to work
+		FIt("Routes to GRPC functions with prefix matcher in VS", func() {
+			testContext.PatchDefaultVirtualService(func(vs *v1.VirtualService) *v1.VirtualService {
+				vs.GetVirtualHost().Routes[0].Matchers = []*matchers.Matcher{{
+					PathSpecifier: &matchers.Matcher_Prefix{
+						Prefix: "/test",
+					},
+				}}
+				return vs
+			})
+			body := `"foo"`
+			testRequest := basicReq(body, `{"str":"foo"}`)
 
+			Eventually(testRequest, 30, 1).Should(Succeed())
+
+			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
+				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
+			}))))
+		})
 		It("Routes to GRPC Functions with parameters in URL", func() {
 
 			testRequest := func(g Gomega) {
@@ -106,6 +128,66 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 
 			Eventually(testRequest, 30, 1).Should(Succeed())
 
+			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
+				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
+			}))))
+		})
+	})
+	Context("mismatched APIs", func() {
+		BeforeEach(func() {
+			testContext.ResourcesToCreate().VirtualServices = v1.VirtualServiceList{getGrpcVs(e2e.WriteNamespace, testContext.TestUpstream().Upstream.GetMetadata().Ref())}
+		})
+		// The test vs we generate already has a prefix matcher because that was how this API was documented
+		FIt("Routes to GRPC Functions", func() {
+
+			body := `"foo"`
+			testRequest := basicReq(body, `{"str":"foo"}`)
+
+			Eventually(testRequest, 30, 1).Should(Succeed())
+
+			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
+				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
+			}))))
+		})
+		FIt("Routes to GRPC Functions with parameters in URL", func() {
+			testContext.PatchDefaultVirtualService(func(vs *v1.VirtualService) *v1.VirtualService {
+				vs.GetVirtualHost().Routes = []*gatewayv1.Route{
+					{
+						Matchers: []*matchers.Matcher{{
+							PathSpecifier: &matchers.Matcher_Prefix{
+								Prefix: "/t",
+							},
+						}},
+						Action: &gatewayv1.Route_RouteAction{
+							RouteAction: &gloov1.RouteAction{
+								Destination: &gloov1.RouteAction_Single{
+									Single: &gloov1.Destination{
+										DestinationType: &gloov1.Destination_Upstream{
+											Upstream: testContext.TestUpstream().Upstream.GetMetadata().Ref(),
+										},
+										DestinationSpec: &gloov1.DestinationSpec{
+											DestinationType: &gloov1.DestinationSpec_Grpc{
+												Grpc: &grpc.DestinationSpec{
+													Package:  "glootest",
+													Function: "TestParameterMethod",
+													Service:  "TestService",
+												},
+											},
+										},
+									},
+								},
+							},
+						}},
+				}
+				return vs
+			})
+
+			testRequest := func(g Gomega) {
+				// GET request with parameters in URL
+				req := testContext.GetHttpRequestBuilder().WithPath("t/foo").Build()
+				g.Expect(testutils.DefaultHttpClient.Do(req)).Should(testmatchers.HaveExactResponseBody(`{"str":"foo"}`))
+			}
+			Eventually(testRequest, 30, 1).Should(Succeed())
 			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
 				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
 			}))))

--- a/test/e2e/grpc_discovery_test.go
+++ b/test/e2e/grpc_discovery_test.go
@@ -72,7 +72,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 		}
 	}
 	Context("New API", func() {
-		FIt("Routes to GRPC Functions", func() {
+		It("Routes to GRPC Functions", func() {
 
 			body := `"foo"`
 			testRequest := basicReq(body, `{"str":"foo"}`)
@@ -84,7 +84,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 			}))))
 		})
 		//basically `matchIncomingRequestRoute` needs to be set for this to work
-		FIt("Routes to GRPC functions with prefix matcher in VS", func() {
+		It("Routes to GRPC functions with prefix matcher in VS", func() {
 			testContext.PatchDefaultVirtualService(func(vs *v1.VirtualService) *v1.VirtualService {
 				vs.GetVirtualHost().Routes[0].Matchers = []*matchers.Matcher{{
 					PathSpecifier: &matchers.Matcher_Prefix{
@@ -138,7 +138,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 			testContext.ResourcesToCreate().VirtualServices = v1.VirtualServiceList{getGrpcVs(e2e.WriteNamespace, testContext.TestUpstream().Upstream.GetMetadata().Ref())}
 		})
 		// The test vs we generate already has a prefix matcher because that was how this API was documented
-		FIt("Routes to GRPC Functions", func() {
+		It("Routes to GRPC Functions", func() {
 
 			body := `"foo"`
 			testRequest := basicReq(body, `{"str":"foo"}`)
@@ -149,7 +149,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
 			}))))
 		})
-		FIt("Routes to GRPC Functions with parameters in URL", func() {
+		It("Routes to GRPC Functions with parameters in URL", func() {
 			testContext.PatchDefaultVirtualService(func(vs *v1.VirtualService) *v1.VirtualService {
 				vs.GetVirtualHost().Routes = []*gatewayv1.Route{
 					{

--- a/test/e2e/grpc_plugin_test.go
+++ b/test/e2e/grpc_plugin_test.go
@@ -143,7 +143,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Gloo API", func() {
 func getGrpcVs(writeNamespace string, usRef *core.ResourceRef) *gatewayv1.VirtualService {
 	return &gatewayv1.VirtualService{
 		Metadata: &core.Metadata{
-			Name:      "default",
+			Name:      "vs-test",
 			Namespace: writeNamespace,
 		},
 		VirtualHost: &gatewayv1.VirtualHost{

--- a/test/e2e/test_context.go
+++ b/test/e2e/test_context.go
@@ -115,7 +115,7 @@ func (c *TestContext) BeforeEach() {
 		WithName(DefaultVirtualServiceName).
 		WithNamespace(WriteNamespace).
 		WithDomain(DefaultHost).
-		WithRoutePrefixMatcher(DefaultRouteName, "/").
+		WithRoutePrefixMatcher(DefaultRouteName, "/test").
 		WithRouteActionToUpstream(DefaultRouteName, c.testUpstream.Upstream).
 		Build()
 


### PR DESCRIPTION
# Description

When processing routes with the grpc destination spec defined with a destination upstream that is using the `GrpcJsonTranscoder` serviceSpec, we should not error but also we don't need to create any of the transformations required by the old plugin structure. 
This will allow users to take the following steps during upgrade:

1.  Use discovery to generate grpc upstreams and routes with the grpc destination spec set.
2. Upgrade to 1.14 - discovery will not overwrite the old upstreams
3. Delete the old upstreams and allow them to be recreated with the new API - the old routes will continue to work
4. Swap out routes for the new API

This does assume that the exposed descriptors match the routes defined on the VS but that seems like a reasonable requirement. If anyone objects, we can look into their use case and see there is a config workaround or if we need to implement additional transformations in the plugin.

Also set `matchIncomingRequestRoute = true` on discovered upstreams to allow matchers besides `/`


# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
