### PR TITLE
Pull in fix for resource-based cross-account lambda invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,6 @@ else
   endif
 endif
 
-# WIP envoy image -- this must be update to a release tag before merging this PR
 ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.25.4-patch3
 
 # The full SHA of the currently checked out commit

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ else
 endif
 
 # WIP envoy image -- this must be update to a release tag before merging this PR
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:02612466efc5861a853e7b32339d99f9d75ba019
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.25.4-patch3
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,8 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.25.4-patch1
+# WIP envoy image -- this must be update to a release tag before merging this PR
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:02612466efc5861a853e7b32339d99f9d75ba019
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.15.0-beta5/envoy-gloo-cross-account-bump.yaml
+++ b/changelog/v1.15.0-beta5/envoy-gloo-cross-account-bump.yaml
@@ -6,4 +6,4 @@ changelog:
   - type: DEPENDENCY_BUMP
     dependencyOwner: solo-io
     dependencyRepo: envoy-gloo
-    dependencyTag: <NOT YET RELEASED>
+    dependencyTag: 1.25.4-patch3

--- a/changelog/v1.15.0-beta5/envoy-gloo-cross-account-bump.yaml
+++ b/changelog/v1.15.0-beta5/envoy-gloo-cross-account-bump.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    description: Fixes a bug which prevented users from using resource-based policies to invoke cross-account lambda functions.
+    issueLink: https://github.com/solo-io/gloo/issues/7965
+    resolvesIssue: false
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: <NOT YET RELEASED>


### PR DESCRIPTION
# Description
 - Pulls in changes introduced in https://github.com/solo-io/envoy-gloo/pull/228 to fix the resource-based cross-account lambda scenario
 - Prior to the PR linked above, envoy-gloo was not encoding fully-qualified ARNs properly in canonical requests sent to AWS. We only use a fully-qualified ARN when the `AwsAccountId` field is specified on a lambda upstream, which only occurs during the resource-based cross-account scenario, so this change effectively fixes that workflow
   - See here -- `functionName` is only set to a fully-qualified ARN if `awsAccountId` is set https://github.com/solo-io/gloo/blob/44951547286262905c33d4ae5d5e24a51bb81a19/projects/gloo/pkg/plugins/aws/plugin.go#L386-L396