### PR TITLE
[v1.12.x] Pull in fix for resource-based cross-account lambda invocation (#8140)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.7-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.7-patch2
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.12.52/envoy-gloo-cross-account-bump.yaml
+++ b/changelog/v1.12.52/envoy-gloo-cross-account-bump.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    description: Fixes a bug which prevented users from using resource-based policies to invoke cross-account lambda functions.
+    issueLink: https://github.com/solo-io/gloo/issues/7965
+    resolvesIssue: false
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: 1.23.7-patch2

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 
 	"github.com/solo-io/gloo/test/services"
 
@@ -57,14 +58,25 @@ var _ = Describe("AWS Lambda", func() {
 		envoyInstance *services.EnvoyInstance
 		secret        *gloov1.Secret
 		upstream      *gloov1.Upstream
+		runOptions    *services.RunOptions
 	)
+
+	BeforeEach(func() {
+		runOptions = &services.RunOptions{
+			WhatToRun: services.What{
+				DisableFds: false,
+				DisableUds: false,
+			},
+		}
+	})
 
 	setupEnvoy := func(justGloo bool) {
 		ctx, cancel = context.WithCancel(context.Background())
 		defaults.HttpPort = services.NextBindPort()
 		defaults.HttpsPort = services.NextBindPort()
 
-		testClients = services.RunGateway(ctx, justGloo)
+		runOptions.WhatToRun.DisableGateway = justGloo
+		testClients = services.RunGlooGatewayUdsFds(ctx, runOptions)
 
 		err := helpers.WriteDefaultGateways(defaults.GlooSystem, testClients.GatewayClient)
 		Expect(err).NotTo(HaveOccurred(), "Should be able to write default gateways")
@@ -187,6 +199,39 @@ var _ = Describe("AWS Lambda", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		validateLambdaUppercase(defaults.HttpPort)
+	}
+
+	addCrossAccountUpstream := func() {
+		upstream = &gloov1.Upstream{
+			Metadata: &core.Metadata{
+				Namespace: "default",
+				Name:      "cross-account-us",
+			},
+			UpstreamType: &gloov1.Upstream_Aws{
+				Aws: &aws_plugin.UpstreamSpec{
+					Region:    region,
+					SecretRef: secret.Metadata.Ref(),
+					// this is a separate account ID from the one that all other lambda
+					// functions tested in this file are in
+					AwsAccountId: "986112284769",
+					LambdaFunctions: []*aws_plugin.LambdaFunctionSpec{
+						{
+							LogicalName:        "resource-based-cross-account-hello",
+							LambdaFunctionName: "resource-based-cross-account-hello",
+						},
+					},
+				},
+			},
+		}
+
+		var opts clients.WriteOpts
+		_, err := testClients.UpstreamClient.Write(upstream, opts)
+		Expect(err).NotTo(HaveOccurred())
+
+		// wait for the upstream to be created
+		helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+			return testClients.UpstreamClient.Read(upstream.Metadata.Namespace, upstream.Metadata.Name, clients.ReadOpts{})
+		}, "30s", "1s")
 	}
 
 	testProxyWithResponseTransform := func() {
@@ -347,6 +392,57 @@ var _ = Describe("AWS Lambda", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		validateLambda(1, defaults.HttpPort, `"\"solo.io\""`)
+	}
+
+	testProxyWithCrossAccountLambda := func() {
+		err := envoyInstance.RunWithRole(services.DefaultProxyName, testClients.GlooPort)
+		Expect(err).NotTo(HaveOccurred())
+
+		proxy := &gloov1.Proxy{
+			Metadata: &core.Metadata{
+				Name:      "proxy",
+				Namespace: "default",
+			},
+			Listeners: []*gloov1.Listener{{
+				Name:        "listener",
+				BindAddress: "::",
+				BindPort:    defaults.HttpPort,
+				ListenerType: &gloov1.Listener_HttpListener{
+					HttpListener: &gloov1.HttpListener{
+						VirtualHosts: []*gloov1.VirtualHost{{
+							Name:    "virt1",
+							Domains: []string{"*"},
+							Routes: []*gloov1.Route{{
+								Action: &gloov1.Route_RouteAction{
+									RouteAction: &gloov1.RouteAction{
+										Destination: &gloov1.RouteAction_Single{
+											Single: &gloov1.Destination{
+												DestinationType: &gloov1.Destination_Upstream{
+													Upstream: upstream.Metadata.Ref(),
+												},
+												DestinationSpec: &gloov1.DestinationSpec{
+													DestinationType: &gloov1.DestinationSpec_Aws{
+														Aws: &aws_plugin.DestinationSpec{
+															LogicalName: "resource-based-cross-account-hello",
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							}},
+						}},
+					},
+				},
+			}},
+		}
+
+		var opts clients.WriteOpts
+		_, err = testClients.ProxyClient.Write(proxy, opts)
+		Expect(err).NotTo(HaveOccurred())
+
+		validateLambda(1, defaults.HttpPort, `"\"Hello from Lambda!\""`)
 	}
 
 	testLambdaWithVirtualService := func() {
@@ -571,6 +667,16 @@ var _ = Describe("AWS Lambda", func() {
 			It("should be able to call lambda via gateway", testLambdaWithVirtualService)
 
 			It("should be able to call lambda transformation and regular transformation", testLambdaTransformations)
+		})
+		Context("Resource-based cross-account lambda", func() {
+			BeforeEach(func() {
+				runOptions.WhatToRun.DisableFds = true
+				setupEnvoy(true)
+				addBasicCredentials()
+				addCrossAccountUpstream()
+			})
+
+			It("should be able to interact with resource-based cross-account lambda", testProxyWithCrossAccountLambda)
 		})
 	})
 	Context("Temporary Credentials", func() {


### PR DESCRIPTION
# Description
 - Pull in envoy-gloo v1.23.7-patch2 to to fix the resource-based cross-account lambda scenario
 - This is essentially a backport of https://github.com/solo-io/gloo/pull/8140