### PR TITLE
Add user guide for cross-account lambda functionality

### DIFF
--- a/changelog/v1.15.0-beta6/cross-account-lambda-docs.yaml
+++ b/changelog/v1.15.0-beta6/cross-account-lambda-docs.yaml
@@ -2,3 +2,7 @@ changelog:
   - type: NON_USER_FACING
     description: Add user guide for cross-account lambda support
     issueLink: https://github.com/solo-io/gloo/issues/7965
+  - type: FIX
+    description: fixes flake in generated_kube_types_test.go
+    issueLink: https://github.com/solo-io/gloo/issues/7965
+    resolvesIssue: false

--- a/changelog/v1.15.0-beta6/cross-account-lambda-docs.yaml
+++ b/changelog/v1.15.0-beta6/cross-account-lambda-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add user guide for cross-account lambda support
+    issueLink: https://github.com/solo-io/gloo/issues/7965

--- a/changelog/v1.15.0-beta6/cross-account-lambda-docs.yaml
+++ b/changelog/v1.15.0-beta6/cross-account-lambda-docs.yaml
@@ -4,5 +4,5 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/7965
   - type: FIX
     description: fixes flake in generated_kube_types_test.go
-    issueLink: https://github.com/solo-io/gloo/issues/7965
+    issueLink: https://github.com/solo-io/gloo/issues/8099
     resolvesIssue: false

--- a/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
+++ b/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
@@ -13,17 +13,17 @@ description: |
 
 # IAM Roles for Service Accounts (IRSA) Configuration
  - This is the recommended workflow for using cross-account Lambda functions with Gloo Edge
- - The configuration is essentially a modified version of the AWS Lambda with EKS ServiceAccounts [guide](https://docs.solo.io/gloo-edge/latest/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/)
+ - The configuration is essentially a modified version of the AWS Lambda with EKS ServiceAccounts [guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/" >}})
 ## AWS Configuration
 ### Primary Account
-  - Follow the steps in the [AWS Lambda with EKS ServiceAccounts guide](https://docs.solo.io/gloo-edge/latest/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/)
-    - As part of this guide, you will create a role which will be associated with the ServiceAccount in your cluster. This role will be used to assume the role in the target account, which will be used to invoke the Lambda function.
+  - Follow the steps in the [AWS Lambda with EKS ServiceAccounts guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/" >}})
+    - As part of this guide, you will create a role which will be associated with the ServiceAccount in your cluster. This role will be used to assume the role in the target account, which will be used to invoke the Lambda function. Make sure to note the `ARN` of this role to use when configuring the target account's role later.
 ### Target Account
  - Create a Lambda function in the target account
  - Create a role which:
-   1. Can be used to invoke the Lambda function -- this role should have the `lambda:InvokeFunction` permission
+   1. Can be used to invoke the Lambda function, which requires the `lambda:InvokeFunction` permission
    1. Can be assumed by the role associated with the ServiceAccount in the primary account
-     - in order to do this, specify the following trust policy on the role:
+     - To do so, specify the following trust policy on the role with the `ARN` of the primary account's role that you previously retrieved:
        ```json
         {
             "Version": "2012-10-17",
@@ -41,12 +41,12 @@ description: |
        ```
     
 ## Gloo Edge Configuration
- - Disable Function Discovery (FDS). This can be used to automatically discover functions in the user's primary AWS account, but since we are using a secondary account, we will need to manually configure the functions.
+ - Disable Function Discovery (FDS), which automatically discovers functions in your primary AWS account. Because you want to route to Lambdas in more than one account, you must disable discovery and instead manually configure the functions.
    - This can be done via the `gloo.discovery.fdsMode` setting to `DISABLED` in the enterprise Helm chart
    - Alternatively, you can set `spec.discovery.fdsMode` to `DISABLED` in the `gloo.solo.io/v1.Settings` custom resource
  - Specify the Lambda functions in the target account that you wish to route to on the upstream
    - These are defined under the `spec.aws.LambdaFunctions` field of the upstream
-- Configure the `spec.aws.roleArn` field of the upstream to point to the IAM role that will be used to invoke the Lambda functions (I.E., the role created in the target account)
+- Configure the `spec.aws.roleArn` field of the upstream to point to the IAM role that will be used to invoke the Lambda functions, which is the role that you created in the target account
   - This role should have the `lambda:InvokeFunction` permission
   - Example Upstream:
       ```yaml

--- a/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
+++ b/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
@@ -1,0 +1,111 @@
+---
+title: Using Cross-Account Lambda Functions
+weight: 101
+description: |
+  This guide describes how to configure Gloo Edge to route to AWS Lambda functions in different accounts than the one used to authenticate with AWS.
+---
+
+# Overview
+ - Gloo Edge supports routing to AWS Lambda functions in different accounts than the one used to authenticate with AWS
+ - There are two strategies that can be used to configure this behavior:
+   1. [IAM Roles for Service Accounts (IRSA) Configuration](#iam-roles-for-service-accounts-irsa-configuration) (Recommended)
+   2. [Resource-Based Configuration](#resource-based-configuration)
+
+# IAM Roles for Service Accounts (IRSA) Configuration
+ - This is the recommended workflow for using cross-account Lambda functions with Gloo Edge
+ - The configuration is essentially a modified version of the AWS Lambda with EKS ServiceAccounts [guide](https://docs.solo.io/gloo-edge/latest/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/)
+## AWS Configuration
+### Primary Account
+  - Follow the steps in the [AWS Lambda with EKS ServiceAccounts guide](https://docs.solo.io/gloo-edge/latest/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/)
+    - As part of this guide, you will create a role which will be associated with the ServiceAccount in your cluster. This role will be used to assume the role in the target account, which will be used to invoke the Lambda function.
+### Target Account
+ - Create a Lambda function in the target account
+ - Create a role which:
+   1. Can be used to invoke the Lambda function -- this role should have the `lambda:InvokeFunction` permission
+   1. Can be assumed by the role associated with the ServiceAccount in the primary account
+     - in order to do this, specify the following trust policy on the role:
+       ```json
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {
+                        "AWS": <ARN OF PRIMARY ACCOUNT ROLE>,
+                    },
+                    "Action": "sts:AssumeRole",
+                    "Condition": {}
+                }
+            ]
+        }
+       ```
+    
+## Gloo Edge Configuration
+ - Disable Function Discovery (FDS). This can be used to automatically discover functions in the user's primary AWS account, but since we are using a secondary account, we will need to manually configure the functions.
+   - This can be done via the `gloo.discovery.fdsMode` setting to `DISABLED` in the enterprise Helm chart
+   - Alternatively, you can set `spec.discovery.fdsMode` to `DISABLED` in the `gloo.solo.io/v1.Settings` custom resource
+ - Specify the Lambda functions in the target account that you wish to route to on the upstream
+   - These are defined under the `spec.aws.LambdaFunctions` field of the upstream
+- Configure the `spec.aws.roleArn` field of the upstream to point to the IAM role that will be used to invoke the Lambda functions (I.E., the role created in the target account)
+  - This role should have the `lambda:InvokeFunction` permission
+  - Example Upstream:
+      ```yaml
+      apiVersion: gloo.solo.io/v1
+      kind: Upstream
+      metadata:
+        name: aws-upstream
+        namespace: gloo-system
+      spec:
+        aws:
+          region: us-east-1
+          secretRef:
+            name: aws-creds
+            namespace: gloo-system
+          roleArn: arn:aws:iam::123456789012:role/lambda-role
+          # because we have disabled FDS, we need to hardcode the lambda functions in the upstream spec
+          lambdaFunctions:
+          - lambdaFunctionName: target-name
+            logicalName: target-name
+      ```
+
+# Resource-Based Configuration
+## AWS Configuration
+### Primary Account
+ - Create a user or role in the primary account that will be used to invoke the Lambda functions in the secondary account
+   - Give the user the `lambda:InvokeFunction` permission
+   - Create an access key for the user
+### Target Account
+ - Create a Lambda function in the target account
+ - Define a Resource-based policy statement for the function, which will allow the user in the Primary account to invoke it
+   - In the AWS console, select the Lambda function, and click the "Configuration" tab
+   - From there, click the "Permissions" tab in the sidebar, and scroll down to the "Resource-based policy statements" section
+   - Click "Add Permissions", and select "AWS account" as the entity which will invoke the function
+   - Use the ARN of the user or role in the primary account as the principal
+   - Select `lambda:InvokeFunction` as the action
+## Gloo Edge Configuration
+ - Disable Function Discovery (FDS). This can be used to automatically discover functions in the user's primary AWS account, but since we are using a secondary account, we will need to manually configure the functions.
+   - This can be done via the `gloo.discovery.fdsMode` setting to `DISABLED` in the enterprise Helm chart
+   - Alternatively, you can set `spec.discovery.fdsMode` to `DISABLED` in the `gloo.solo.io/v1.Settings` custom resource
+ - Specify the Lambda functions in the target account that you wish to route to on the upstream
+   - These are defined under the `spec.aws.LambdaFunctions` field of the upstream 
+ - Specify the target account ID in the upstream
+   - This is defined under the `spec.aws.awsAccountId` field of the upstream
+ - Example Upstream:
+     ```yaml
+     apiVersion: gloo.solo.io/v1
+     kind: Upstream
+     metadata:
+       name: aws-upstream
+       namespace: gloo-system
+     spec:
+       aws:
+         region: us-east-1
+         secretRef:
+           name: aws-creds
+           namespace: gloo-system
+         awsAccountId: "123456789012"
+         # because we have disabled FDS, we need to hardcode the lambda functions in the upstream spec
+         lambdaFunctions:
+         - lambdaFunctionName: target-name
+           logicalName: target-name
+     ```

--- a/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
+++ b/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
@@ -87,7 +87,7 @@ description: |
    - This can be done via the `gloo.discovery.fdsMode` setting to `DISABLED` in the enterprise Helm chart
    - Alternatively, you can set `spec.discovery.fdsMode` to `DISABLED` in the `gloo.solo.io/v1.Settings` custom resource
  - Configure an AWS secret, using the access key and secret key of the user in the primary account
-   - See the [AWS Lambda guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda/_index/" >}}) for more information on how to do this
+   - See the [AWS Lambda guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda/" >}}) for more information on how to do this
    - This secret will be used to authenticate with AWS when invoking the Lambda functions
  - Specify the Lambda functions in the target account that you wish to route to on the upstream
    - These are defined under the `spec.aws.LambdaFunctions` field of the upstream 
@@ -112,3 +112,5 @@ description: |
          - lambdaFunctionName: target-name
            logicalName: target-name
      ```
+## Validation
+ - To validate that the configuration is correct, you can follow the steps in the [AWS Lambda guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda#step-3-create-an-upstream-and-virtual-service" >}}) to create a virtual service that routes to the Lambda function via the AWS upstream

--- a/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
+++ b/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
@@ -8,13 +8,14 @@ description: |
 # Overview
  - Gloo Edge supports routing to AWS Lambda functions in different accounts than the one used to authenticate with AWS
  - There are two strategies that can be used to configure this behavior:
-   1. [IAM Roles for Service Accounts (IRSA) Configuration](#iam-roles-for-service-accounts-irsa-configuration) (Recommended)
+   1. [IAM Roles for Service Accounts/Role-Chained Configuration](#iam-roles-for-service-accounts-irsa-configuration) (Recommended)
    2. [Resource-Based Configuration](#resource-based-configuration)
 
-# IAM Roles for Service Accounts (IRSA) Configuration
+# IAM Roles for Service Accounts/Role-Chained Configuration
  - This is the recommended workflow for using cross-account Lambda functions with Gloo Edge
  - The configuration is essentially a modified version of the AWS Lambda with EKS ServiceAccounts [guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/" >}})
 ## AWS Configuration
+- For this configuration you will need to create two roles, one in the primary account and one in the target account. The primary account is the account that you will use to authenticate with AWS, and the target account is the account that contains the Lambda functions that you wish to route to. The role in the primary account will be used to assume the role in the target account, which will be used to invoke the Lambda function.
 ### Primary Account
   - Follow the steps in the [AWS Lambda with EKS ServiceAccounts guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/" >}})
     - As part of this guide, you will create a role which will be associated with the ServiceAccount in your cluster. This role will be used to assume the role in the target account, which will be used to invoke the Lambda function. Make sure to note the `ARN` of this role to use when configuring the target account's role later.
@@ -70,6 +71,7 @@ description: |
 
 # Resource-Based Configuration
 ## AWS Configuration
+- For this configuration you will need to create a user or role in the primary account, and a Lambda function in the target account. The Lambda function will have a resource-based policy statement which will allow the user or role in the primary account to invoke it.
 ### Primary Account
  - Create a user or role in the primary account that will be used to invoke the Lambda functions in the secondary account
    - Give the user the `lambda:InvokeFunction` permission

--- a/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
+++ b/docs/content/guides/traffic_management/destination_types/aws_lambda/cross-account.md
@@ -73,7 +73,7 @@ description: |
 ### Primary Account
  - Create a user or role in the primary account that will be used to invoke the Lambda functions in the secondary account
    - Give the user the `lambda:InvokeFunction` permission
-   - Create an access key for the user
+   - Create an access key for the user. This will be used to authenticate with AWS when invoking the Lambda functions
 ### Target Account
  - Create a Lambda function in the target account
  - Define a Resource-based policy statement for the function, which will allow the user in the Primary account to invoke it
@@ -86,6 +86,9 @@ description: |
  - Disable Function Discovery (FDS). This can be used to automatically discover functions in the user's primary AWS account, but since we are using a secondary account, we will need to manually configure the functions.
    - This can be done via the `gloo.discovery.fdsMode` setting to `DISABLED` in the enterprise Helm chart
    - Alternatively, you can set `spec.discovery.fdsMode` to `DISABLED` in the `gloo.solo.io/v1.Settings` custom resource
+ - Configure an AWS secret, using the access key and secret key of the user in the primary account
+   - See the [AWS Lambda guide]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/aws_lambda/_index/" >}}) for more information on how to do this
+   - This secret will be used to authenticate with AWS when invoking the Lambda functions
  - Specify the Lambda functions in the target account that you wish to route to on the upstream
    - These are defined under the `spec.aws.LambdaFunctions` field of the upstream 
  - Specify the target account ID in the upstream

--- a/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
+++ b/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
@@ -3,9 +3,11 @@ package kube_test
 import (
 	"context"
 
+	"github.com/solo-io/gloo/test/testutils"
+	"github.com/solo-io/solo-kit/test/helpers"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
-	"github.com/solo-io/gloo/test/testutils"
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gatewayv1kubetypes "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
@@ -23,27 +25,39 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/factory"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube"
 
+	apiext "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = Describe("Generated Kube Code", func() {
 	var (
-		ctx    context.Context
-		cancel context.CancelFunc
-
+		apiExts         apiext.Interface
 		glooV1Client    gloov1kube.GlooV1Interface       // upstreams
 		gatewayV1Client gatewayv1kube.GatewayV1Interface // virtual service
 
 		upstreamClient       gloov1.UpstreamClient
 		virtualServiceClient gatewayv1.VirtualServiceClient
+		ctx                  context.Context
+		cancel               context.CancelFunc
 	)
 
 	BeforeEach(func() {
 		if !testutils.ShouldRunKubeTests() {
 			Skip("This test creates kubernetes resources and is disabled by default. To enable, set RUN_KUBE_TESTS=1 in your env.")
 		}
+
 		ctx, cancel = context.WithCancel(context.Background())
 		cfg, err := kubeutils.GetConfig("", "")
+		Expect(err).NotTo(HaveOccurred())
+
+		// register the crds
+		apiExts, err = apiext.NewForConfig(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = helpers.AddAndRegisterCrd(ctx, gloov1.UpstreamCrd, apiExts)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = helpers.AddAndRegisterCrd(ctx, gatewayv1.VirtualServiceCrd, apiExts)
 		Expect(err).NotTo(HaveOccurred())
 
 		glooV1Client, err = gloov1kube.NewForConfig(cfg)
@@ -71,8 +85,9 @@ var _ = Describe("Generated Kube Code", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 	})
-
 	AfterEach(func() {
+		_ = apiExts.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(ctx, gloov1.UpstreamCrd.FullName(), v1.DeleteOptions{})
+		_ = apiExts.ApiextensionsV1beta1().CustomResourceDefinitions().Delete(ctx, gatewayv1.VirtualServiceCrd.FullName(), v1.DeleteOptions{})
 		cancel()
 	})
 
@@ -115,9 +130,19 @@ var _ = Describe("Generated Kube Code", func() {
 			},
 		}
 
+		// this fixes a flake in v1.14.x. This flake occurs when we try to
+		// `glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})` create the resource.
+		// I do not know why this resource already exists, but this fixes it.
+		resourceName := "petstore-static"
+		err := glooV1Client.Upstreams("default").Delete(ctx, resourceName, v1.DeleteOptions{})
+		Expect(err).To(Or(Not(HaveOccurred()), MatchError(ContainSubstring("not found")), MatchError(ContainSubstring("already exists"))))
+		resourceName = "my-routes"
+		err = gatewayV1Client.VirtualServices("default").Delete(ctx, resourceName, v1.DeleteOptions{})
+		Expect(err).To(Or(Not(HaveOccurred()), MatchError(ContainSubstring("not found")), MatchError(ContainSubstring("already exists"))))
+
 		// ensure we can write the with kube clients
 
-		_, err := glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})
+		_, err = glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = gatewayV1Client.VirtualServices(vs.Namespace).Create(ctx, vs, v1.CreateOptions{})


### PR DESCRIPTION
# Description
 - Adds a user guide for cross-account lambda functionality
   - Includes details on Gloo and AWS configuration
   - Includes two strategies for configuring cross-account lambda functionality -- IRSA and resource-based
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/7965