### PR TITLE
Regex Fixes 1.13

### DIFF
--- a/changelog/v1.13.17/routeoptions-regex-validation.yaml
+++ b/changelog/v1.13.17/routeoptions-regex-validation.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8091
+    resolvesIssue: false
+    description: >-
+      Adds regex validation to gloo.solo.io.RouteOptions.prefixRewrite and gloo.solo.io.RouteOptions.hostRewritePathRegex to prevent leaking invalid regex to envoy

--- a/changelog/v1.13.17/routeoptions-regex-validation.yaml
+++ b/changelog/v1.13.17/routeoptions-regex-validation.yaml
@@ -3,4 +3,4 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/8091
     resolvesIssue: false
     description: >-
-      Adds regex validation to gloo.solo.io.RouteOptions.prefixRewrite and gloo.solo.io.RouteOptions.hostRewritePathRegex to prevent leaking invalid regex to envoy
+      Adds regex validation to gloo.solo.io.RouteOptions.prefixRewrite to prevent leaking invalid regex to envoy

--- a/projects/gateway/pkg/translator/http_translator_test.go
+++ b/projects/gateway/pkg/translator/http_translator_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	. "github.com/solo-io/gloo/projects/gateway/pkg/translator"
+	v3 "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/type/matcher/v3"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	gloov1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
@@ -541,6 +542,18 @@ var _ = Describe("Http Translator", func() {
 
 			It("should error when a virtual service has invalid regex", func() {
 				snap.VirtualServices[0].VirtualHost.Routes[0].Matchers[0] = &matchers.Matcher{PathSpecifier: &matchers.Matcher_Regex{Regex: "["}}
+				params := NewTranslatorParams(ctx, snap, reports)
+
+				_ = translator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])
+				Expect(reports.Validate()).To(HaveOccurred())
+
+				errs := reports.ValidateStrict()
+				Expect(errs).To(HaveOccurred())
+				Expect(errs.Error()).To(ContainSubstring("missing closing ]: `[`"))
+			})
+			It("should error when a virtual service has invalid regex in regexRewrite options", func() {
+				regexRewriteOption := &gloov1.RouteOptions{RegexRewrite: &v3.RegexMatchAndSubstitute{Pattern: &v3.RegexMatcher{Regex: "["}}}
+				snap.VirtualServices[0].VirtualHost.Routes[0].Options = regexRewriteOption
 				params := NewTranslatorParams(ctx, snap, reports)
 
 				_ = translator.ComputeListener(params, defaults.GatewayProxyName, snap.Gateways[0])

--- a/projects/gateway/pkg/translator/virtual_service_translator.go
+++ b/projects/gateway/pkg/translator/virtual_service_translator.go
@@ -293,7 +293,7 @@ func (v *VirtualServiceTranslator) virtualServiceToVirtualHost(vs *v1.VirtualSer
 		Options: vs.GetVirtualHost().GetOptions(),
 	}
 
-	validateRoutes(vs, vh, reports)
+	validateRoutesRegex(vs, vh, reports)
 
 	if v.WarnOnRouteShortCircuiting {
 		validateRouteShortCircuiting(vs, vh, reports)
@@ -330,13 +330,22 @@ func VirtualHostName(vs *v1.VirtualService) string {
 	return fmt.Sprintf("%v.%v", vs.GetMetadata().GetNamespace(), vs.GetMetadata().GetName())
 }
 
-// this function is written with the assumption that the routes will not be modified afterwards,
+// this function is written with the assumption that the routes will not be modified afterward,
 // and are in their final sorted form
-func validateRoutes(vs *v1.VirtualService, vh *gloov1.VirtualHost, reports reporter.ResourceReports) {
+func validateRoutesRegex(vs *v1.VirtualService, vh *gloov1.VirtualHost, reports reporter.ResourceReports) {
 	for _, rt := range vh.GetRoutes() {
+		options := rt.GetOptions()
+		if options != nil {
+			if options.GetRegexRewrite() != nil {
+				_, err := regexp.Compile(options.GetRegexRewrite().GetPattern().GetRegex())
+				if err != nil {
+					reports.AddError(vs, InvalidRegexErr(vs.GetMetadata().Ref().Key(), err.Error()))
+				}
+			}
+		}
 		for _, matcher := range rt.GetMatchers() {
 			_, err := regexp.Compile(matcher.GetRegex())
-			if matcher.GetRegex() != "" && err != nil {
+			if err != nil {
 				reports.AddError(vs, InvalidRegexErr(vs.GetMetadata().Ref().Key(), err.Error()))
 			}
 		}


### PR DESCRIPTION
# Description
hand cherrypick changes from [PR: 8143](https://github.com/solo-io/gloo/pull/8143/files)

RouteOptions HostRewriteType_RewritePathRegex does not exist in 1.13 but does in 1.14 onwards so these changes had to be excluded 
