### PR TITLE
Backport fix generated kube tests flake

### DIFF
--- a/changelog/v1.13.17/envoy-gloo-cross-account-bump.yaml
+++ b/changelog/v1.13.17/envoy-gloo-cross-account-bump.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  description: fixes flake in generated_kube_types_test.go
+  issueLink: https://github.com/solo-io/gloo/issues/8099
+  resolvesIssue: false

--- a/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
+++ b/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/solo-io/solo-kit/test/helpers"
 
+	"github.com/solo-io/solo-kit/test/helpers"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
 
@@ -133,9 +135,19 @@ var _ = Describe("Generated Kube Code", func() {
 			},
 		}
 
+		// this fixes a flake in v1.14.x. This flake occurs when we try to
+		// `glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})` create the resource.
+		// I do not know why this resource already exists, but this fixes it.
+		resourceName := "petstore-static"
+		err := glooV1Client.Upstreams("default").Delete(ctx, resourceName, v1.DeleteOptions{})
+		Expect(err).To(Or(Not(HaveOccurred()), MatchError(ContainSubstring("not found")), MatchError(ContainSubstring("already exists"))))
+		resourceName = "my-routes"
+		err = gatewayV1Client.VirtualServices("default").Delete(ctx, resourceName, v1.DeleteOptions{})
+		Expect(err).To(Or(Not(HaveOccurred()), MatchError(ContainSubstring("not found")), MatchError(ContainSubstring("already exists"))))
+
 		// ensure we can write the with kube clients
 
-		_, err := glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})
+		_, err = glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		_, err = gatewayV1Client.VirtualServices(vs.Namespace).Create(ctx, vs, v1.CreateOptions{})

--- a/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
+++ b/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/solo-io/solo-kit/test/helpers"
 
-	"github.com/solo-io/solo-kit/test/helpers"
-
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
 

--- a/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
+++ b/projects/gateway/pkg/api/v1/kube/generated_kube_types_test.go
@@ -133,9 +133,8 @@ var _ = Describe("Generated Kube Code", func() {
 			},
 		}
 
-		// this fixes a flake in v1.14.x. This flake occurs when we try to
-		// `glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})` create the resource.
-		// I do not know why this resource already exists, but this fixes it.
+		// fix for a flake on `glooV1Client.Upstreams(us.Namespace).Create(ctx, us, v1.CreateOptions{})`
+		// This resource often already exists leading to a failure on create - this aims to fix that error
 		resourceName := "petstore-static"
 		err := glooV1Client.Upstreams("default").Delete(ctx, resourceName, v1.DeleteOptions{})
 		Expect(err).To(Or(Not(HaveOccurred()), MatchError(ContainSubstring("not found")), MatchError(ContainSubstring("already exists"))))


### PR DESCRIPTION
# Description

Fix for https://github.com/solo-io/gloo/issues/8099
Backporting from https://github.com/solo-io/gloo/pull/8170

# Context

Constant flake blocking ci builds