### PR TITLE
Add gRPC migration guide

### DIFF
--- a/changelog/v1.15.0-beta6/migration-guide.yaml
+++ b/changelog/v1.15.0-beta6/migration-guide.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add a user guide to migrate to the gRPC API used in 1.14+.

--- a/docs/content/guides/traffic_management/destination_types/grpc/migration.md
+++ b/docs/content/guides/traffic_management/destination_types/grpc/migration.md
@@ -1,0 +1,55 @@
+---
+title: Migrate discovered gRPC upstreams to 1.14 
+weight: 10
+description: Guide for migrating from the API used for discovered gRPC upstreams in Gloo Edge 1.13 and earlier to the version used in Gloo Edge 1.14
+---
+
+Gloo Edge 1.14 introduced significant changes to the API used for discovered gRPC upstreams. If you have existing gRPC services
+that were discovered by Gloo and want to continue discovering new services/changes to those services, you should follow this guide to migrate to the new API.
+
+## Before you begin
+The steps in this guide are only applicable if you have upstreams with `serviceSpec: grpc` and virtual services with `destinationSpec: grpc`
+
+## Steps 
+1. Upgrade your Gloo Edge installation, being sure to apply the new CRDs.
+2. Ensure that FDS is enabled.
+3. Delete the existing discovered gRPC upstreams and wait for them to be rediscovered.
+4. Update your virtual services to use the new api (link here)
+
+At every step in this process, your routes to gRPC services will continue to work.
+
+## Things to keep in mind
+
+* In order for the migration to work with discovery, the descriptors exposed on your gRPC service should match the routes on your existing virtual services. 
+Using the bookstore example, if `GetShelf` is mapped to `/shelves/{shelf}` with the following `destinationSpec`
+```yaml
+routeAction:
+  single:
+    destinationSpec:
+        grpc:
+          function: GetShelf
+          package: main
+          service: Bookstore
+          parameters:
+            path: /shelves/{shelf}
+```
+then the protos should be:
+```protobuf
+rpc GetShelf(GetShelfRequest) returns (Shelf) {
+    option (google.api.http) = {
+      get: "/shelves/{shelf}"
+    };
+  }
+```
+* The old API ignored `body:` options in the descriptors and always used a wildcard. To ensure there is a 1:1 mapping between request bodies when migrating to the new API, your descriptors should also use wildcards for the request body.
+  In the Bookstore example, the `CreateShelf` methods should be defined as follows:
+```protobuf
+// Creates a new shelf in the bookstore.
+  rpc CreateShelf(CreateShelfRequest) returns (Shelf) {
+    option (google.api.http) = {
+      post: "/shelf"
+      body: "*"
+    };
+  }
+```
+See: https://cloud.google.com/endpoints/docs/grpc/transcoding#use_wildcard_in_body for an explanation about the difference in the requests with and without a wildcard for the request body.


### PR DESCRIPTION
# Description

Write up of the steps required for users that currently are using the existing grpc upstream API to migrate without downtime to the new API. The code changes that enable this migration didn't make it into the release so I assume we will need to update the docs to include the patch version that this goes in. I'm opening this PR to get feedback and/or hand off this guide to the docs team if it needs significant changes.

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:
Doc only change
- [ x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x ] I have made corresponding changes to the documentation

