### PR TITLE
Backport change to allow migrating between grpc APIs without downtime

### DIFF
--- a/changelog/v1.14.4/grpc-migration.yaml
+++ b/changelog/v1.14.4/grpc-migration.yaml
@@ -2,4 +2,4 @@ changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/8080
     resolvesIssue: true
-    description: Backport change to support mismatched versions of the gRPC transcoding API to make migration without downtime possible.
+    description: Backport change to support mismatched versions of the gRPC transcoding API to make upgrade/migration without downtime possible.

--- a/changelog/v1.14.4/grpc-migration.yaml
+++ b/changelog/v1.14.4/grpc-migration.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8080
+    resolvesIssue: true
+    description: Backport change to support mismatched versions of the gRPC transcoding API to make migration without downtime possible.

--- a/changelog/v1.15.0-beta6/grpc-migration.yaml
+++ b/changelog/v1.15.0-beta6/grpc-migration.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8080
+    resolvesIssue: false
+    description: Support mismatched versions of the gRPC transcoding API to make migration without downtime possible.

--- a/changelog/v1.15.0-beta6/grpc-migration.yaml
+++ b/changelog/v1.15.0-beta6/grpc-migration.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/gloo/issues/8080
-    resolvesIssue: false
-    description: Support mismatched versions of the gRPC transcoding API to make migration without downtime possible.

--- a/projects/discovery/pkg/fds/discoveries/grpc/grpc.go
+++ b/projects/discovery/pkg/fds/discoveries/grpc/grpc.go
@@ -194,6 +194,7 @@ func (f *UpstreamFunctionDiscovery) DetectFunctionsOnce(ctx context.Context, url
 		}
 		svcSpec.DescriptorSet = &grpc_json_plugins.GrpcJsonTranscoder_ProtoDescriptorBin{ProtoDescriptorBin: rawDescriptors}
 		svcSpec.Services = servicesDiscovered
+		svcSpec.MatchIncomingRequestRoute = true
 		return nil
 	})
 }

--- a/test/e2e/grpc_discovery_test.go
+++ b/test/e2e/grpc_discovery_test.go
@@ -3,6 +3,9 @@ package e2e_test
 import (
 	"context"
 
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc"
+
 	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 
 	"github.com/solo-io/gloo/test/testutils"
@@ -18,6 +21,7 @@ import (
 	"github.com/solo-io/gloo/test/services"
 	"github.com/solo-io/gloo/test/v1helpers"
 
+	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 )
 
@@ -79,7 +83,25 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
 			}))))
 		})
+		//basically `matchIncomingRequestRoute` needs to be set for this to work
+		It("Routes to GRPC functions with prefix matcher in VS", func() {
+			testContext.PatchDefaultVirtualService(func(vs *v1.VirtualService) *v1.VirtualService {
+				vs.GetVirtualHost().Routes[0].Matchers = []*matchers.Matcher{{
+					PathSpecifier: &matchers.Matcher_Prefix{
+						Prefix: "/test",
+					},
+				}}
+				return vs
+			})
+			body := `"foo"`
+			testRequest := basicReq(body, `{"str":"foo"}`)
 
+			Eventually(testRequest, 30, 1).Should(Succeed())
+
+			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
+				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
+			}))))
+		})
 		It("Routes to GRPC Functions with parameters in URL", func() {
 
 			testRequest := func(g Gomega) {
@@ -106,6 +128,66 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Discovery", func() {
 
 			Eventually(testRequest, 30, 1).Should(Succeed())
 
+			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
+				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
+			}))))
+		})
+	})
+	Context("mismatched APIs", func() {
+		BeforeEach(func() {
+			testContext.ResourcesToCreate().VirtualServices = v1.VirtualServiceList{getGrpcVs(e2e.WriteNamespace, testContext.TestUpstream().Upstream.GetMetadata().Ref())}
+		})
+		// The test vs we generate already has a prefix matcher because that was how this API was documented
+		It("Routes to GRPC Functions", func() {
+
+			body := `"foo"`
+			testRequest := basicReq(body, `{"str":"foo"}`)
+
+			Eventually(testRequest, 30, 1).Should(Succeed())
+
+			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
+				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
+			}))))
+		})
+		It("Routes to GRPC Functions with parameters in URL", func() {
+			testContext.PatchDefaultVirtualService(func(vs *v1.VirtualService) *v1.VirtualService {
+				vs.GetVirtualHost().Routes = []*gatewayv1.Route{
+					{
+						Matchers: []*matchers.Matcher{{
+							PathSpecifier: &matchers.Matcher_Prefix{
+								Prefix: "/t",
+							},
+						}},
+						Action: &gatewayv1.Route_RouteAction{
+							RouteAction: &gloov1.RouteAction{
+								Destination: &gloov1.RouteAction_Single{
+									Single: &gloov1.Destination{
+										DestinationType: &gloov1.Destination_Upstream{
+											Upstream: testContext.TestUpstream().Upstream.GetMetadata().Ref(),
+										},
+										DestinationSpec: &gloov1.DestinationSpec{
+											DestinationType: &gloov1.DestinationSpec_Grpc{
+												Grpc: &grpc.DestinationSpec{
+													Package:  "glootest",
+													Function: "TestParameterMethod",
+													Service:  "TestService",
+												},
+											},
+										},
+									},
+								},
+							},
+						}},
+				}
+				return vs
+			})
+
+			testRequest := func(g Gomega) {
+				// GET request with parameters in URL
+				req := testContext.GetHttpRequestBuilder().WithPath("t/foo").Build()
+				g.Expect(testutils.DefaultHttpClient.Do(req)).Should(testmatchers.HaveExactResponseBody(`{"str":"foo"}`))
+			}
+			Eventually(testRequest, 30, 1).Should(Succeed())
 			Eventually(testContext.TestUpstream().C).Should(Receive(PointTo(MatchFields(IgnoreExtras, Fields{
 				"GRPCRequest": PointTo(MatchFields(IgnoreExtras, Fields{"Str": Equal("foo")})),
 			}))))

--- a/test/e2e/grpc_plugin_test.go
+++ b/test/e2e/grpc_plugin_test.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/solo-io/gloo/test/e2e"
+
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
@@ -143,7 +145,7 @@ var _ = Describe("GRPC to JSON Transcoding Plugin - Gloo API", func() {
 func getGrpcVs(writeNamespace string, usRef *core.ResourceRef) *gatewayv1.VirtualService {
 	return &gatewayv1.VirtualService{
 		Metadata: &core.Metadata{
-			Name:      "default",
+			Name:      e2e.DefaultVirtualServiceName,
 			Namespace: writeNamespace,
 		},
 		VirtualHost: &gatewayv1.VirtualHost{


### PR DESCRIPTION
# Description

Original PR: https://github.com/solo-io/gloo/pull/8138#event-9192944019

This is work that was originally targeted for (and initially tested on) 1.14 but wasn't finished by the original release. The change is for users who have gRPC upstreams who are upgrading to 1.14.
# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/8080