### PR TITLE
Upgrade tests run changes

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -64,7 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade', 'istio']
+        # upgrade tests removed from PRs
+        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio']
         kube-version: [{ node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' }]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -8,6 +8,9 @@ on:
 env:
   VERSION: '1.0.0-ci'
   GITHUB_TOKEN: ${{ github.token }} # necessary to pass upgrade tests
+  IS_MASTER: false
+  TEST_MATRIX_MASTER: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio']
+  TEST_MATRIX_LTS: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
 
 jobs:
   prepare_env:
@@ -21,6 +24,15 @@ jobs:
       uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
+    - id: check-if-master
+      name: Check branch name
+      run: |
+        if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "Branch is master"
+          echo "IS_MASTER=true" >> $GITHUB_ENV
+        else
+          echo "Branch is not master"
+        fi
     - id: is-draft-pr
       name: Process draft Pull Requests
       if: ${{ github.event.pull_request.draft }}
@@ -64,8 +76,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # upgrade tests removed from PRs
-        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio']
+        # upgrade tests are run on LTS but not on master branch, for master they are run nightly
+        kube-e2e-test-type: ${{ env.IS_MASTER == 'true' ? env.TEST_MATRIX_MASTER : env.TEST_MATRIX_LTS }}
         kube-version: [{ node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' }]
     steps:
     - uses: actions/checkout@v3

--- a/changelog/v1.15.0-beta6/remove-upgrade-tests-from-prs.yaml
+++ b/changelog/v1.15.0-beta6/remove-upgrade-tests-from-prs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/4901
+    resolvesIssue: false
+    description: We will no longer run upgrade tests on PRs


### PR DESCRIPTION
# Description
Upgrade Tests will run nightly on master branch
Upgrade Tests will run per pr for LTS branches 

# Context
The idea was that upgrade tests run on every PR, but rarely do they test things that were introduced in PRs, so I made the argument that we could reduce cost by running them in our nightly tests and still keep our consistency. The downside is that IF someone introduces a change that would break the test, the PR can still merge. But with our nightly tests, we would see this in <24 hours and be able to revert

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
