### PR TITLE
Upgrade tests not on prs

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -63,37 +63,38 @@ jobs:
         ref: v1.13.x
     - uses: ./.github/actions/regression-tests
 
-  regression_tests_12:
-    name: v1.12.x regression tests
-    if: github.event.schedule == '7 7 * * 1'
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
-        kube-version: [ { node: 'v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1', kubectl: 'v1.21.14', kind: 'v0.17.0', helm: 'v3.9.4' },
-                        { node: 'v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315', kubectl: 'v1.24.7', kind: 'v0.17.0', helm: 'v3.9.4' } ]
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: v1.12.x
-    - uses: ./.github/actions/regression-tests
-
-  regression_tests_11:
-    name: v1.11.x regression tests
-    if: github.event.schedule == '8 8 * * 1'
-    runs-on: ubuntu-22.04
-    strategy:
-      fail-fast: false
-      matrix:
-        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
-        kube-version: [ { node: 'v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1', kubectl: 'v1.21.14', kind: 'v0.17.0', helm: 'v3.9.4' },
-                        { node: 'v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315', kubectl: 'v1.24.7', kind: 'v0.17.0', helm: 'v3.9.4' } ]
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        ref: v1.11.x
-    - uses: ./.github/actions/regression-tests
+# removing 11 and 12 for now to focus on the stability of 13+
+#  regression_tests_12:
+#    name: v1.12.x regression tests
+#    if: github.event.schedule == '7 7 * * 1'
+#    runs-on: ubuntu-22.04
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
+#        kube-version: [ { node: 'v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1', kubectl: 'v1.21.14', kind: 'v0.17.0', helm: 'v3.9.4' },
+#                        { node: 'v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315', kubectl: 'v1.24.7', kind: 'v0.17.0', helm: 'v3.9.4' } ]
+#    steps:
+#    - uses: actions/checkout@v3
+#      with:
+#        ref: v1.12.x
+#    - uses: ./.github/actions/regression-tests
+#
+#  regression_tests_11:
+#    name: v1.11.x regression tests
+#    if: github.event.schedule == '8 8 * * 1'
+#    runs-on: ubuntu-22.04
+#    strategy:
+#      fail-fast: false
+#      matrix:
+#        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
+#        kube-version: [ { node: 'v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1', kubectl: 'v1.21.14', kind: 'v0.17.0', helm: 'v3.9.4' },
+#                        { node: 'v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315', kubectl: 'v1.24.7', kind: 'v0.17.0', helm: 'v3.9.4' } ]
+#    steps:
+#    - uses: actions/checkout@v3
+#      with:
+#        ref: v1.11.x
+#    - uses: ./.github/actions/regression-tests
 
   publish_results:
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -7,9 +7,7 @@ on:
   schedule:
     - cron: "0 5 * * 1-5"   # weekdays @ 00:00 EST, run tests against latest dev
     - cron: "10 10 * * 1"   # monday   @ 05:10 EST, run expanded tests against v1.14.x
-    - cron: "6 6 * * 1"     # monday   @ 01:06 EST, run expanded tests against v1.13.x 
-    - cron: "7 7 * * 1"     # monday   @ 02:07 EST, run expanded tests against v1.12.x
-    - cron: "8 8 * * 1"     # monday   @ 03:08 EST, run expanded tests against v1.11.x
+    - cron: "6 6 * * 1"     # monday   @ 01:06 EST, run expanded tests against v1.13.x
   workflow_dispatch:
 jobs:
   regression_tests_latest_dev:
@@ -62,44 +60,10 @@ jobs:
       with:
         ref: v1.13.x
     - uses: ./.github/actions/regression-tests
-
-# removing 11 and 12 for now to focus on the stability of 13+
-#  regression_tests_12:
-#    name: v1.12.x regression tests
-#    if: github.event.schedule == '7 7 * * 1'
-#    runs-on: ubuntu-22.04
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
-#        kube-version: [ { node: 'v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1', kubectl: 'v1.21.14', kind: 'v0.17.0', helm: 'v3.9.4' },
-#                        { node: 'v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315', kubectl: 'v1.24.7', kind: 'v0.17.0', helm: 'v3.9.4' } ]
-#    steps:
-#    - uses: actions/checkout@v3
-#      with:
-#        ref: v1.12.x
-#    - uses: ./.github/actions/regression-tests
-#
-#  regression_tests_11:
-#    name: v1.11.x regression tests
-#    if: github.event.schedule == '8 8 * * 1'
-#    runs-on: ubuntu-22.04
-#    strategy:
-#      fail-fast: false
-#      matrix:
-#        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
-#        kube-version: [ { node: 'v1.21.14@sha256:9d9eb5fb26b4fbc0c6d95fa8c790414f9750dd583f5d7cee45d92e8c26670aa1', kubectl: 'v1.21.14', kind: 'v0.17.0', helm: 'v3.9.4' },
-#                        { node: 'v1.24.7@sha256:577c630ce8e509131eab1aea12c022190978dd2f745aac5eb1fe65c0807eb315', kubectl: 'v1.24.7', kind: 'v0.17.0', helm: 'v3.9.4' } ]
-#    steps:
-#    - uses: actions/checkout@v3
-#      with:
-#        ref: v1.11.x
-#    - uses: ./.github/actions/regression-tests
-
   publish_results:
     runs-on: ubuntu-22.04
     if: ${{ always() }}
-    needs: [ regression_tests_latest_dev, regression_tests_14, regression_tests_13, regression_tests_12, regression_tests_11 ]
+    needs: [ regression_tests_latest_dev, regression_tests_14, regression_tests_13 ]
     steps:
       - uses: actions/checkout@v3
       - name: compute-preamble
@@ -110,10 +74,6 @@ jobs:
           if [[ ${{github.event_name == 'workflow_dispatch'}} = true ]]; then
             preamble="Gloo OSS nightlies (manual run)"
             echo "SLACK_CHANNEL=C0314KESVNV" >> $GITHUB_ENV   #slack-integration-testing if manually run
-          elif [[ ${{github.event.schedule == '8 8 * * 1'}} = true ]]; then
-              preamble="Gloo OSS weeklies (v1.11.x)"
-          elif [[ ${{github.event.schedule == '7 7 * * 1'}} = true ]]; then
-              preamble="Gloo OSS weeklies (v1.12.x)"
           elif [[ ${{github.event.schedule == '6 6 * * 1'}} = true ]]; then
               preamble="Gloo OSS weeklies (v1.13.x)"
           elif [[ ${{github.event.schedule == '10 10 * * 1'}} = true ]]; then

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -77,7 +77,8 @@ jobs:
       fail-fast: false
       matrix:
         # upgrade tests are run on LTS but not on master branch, for master they are run nightly
-        kube-e2e-test-type: ${{ env.IS_MASTER == 'true' ? env.TEST_MATRIX_MASTER : env.TEST_MATRIX_LTS }}
+        # this is the github action version of ternary op
+        kube-e2e-test-type: ${{ env.IS_MASTER == 'true' && env.TEST_MATRIX_MASTER || env.TEST_MATRIX_LTS }}
         kube-version: [{ node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' }]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -75,10 +75,10 @@ jobs:
         # this is the github action version of ternary op
         kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
         kube-version: [ { node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' } ]
-        is-master:
+        merge-to-master:
           - ${{ github.event.pull_request.base.ref == 'master' }}
         exclude:
-          - is-master: 'true'
+          - merge-to-master: true
             kube-e2e-test-type: upgrade
     steps:
     - name: check values

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -64,7 +64,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade', 'istio']
+        # upgrade tests removed from PRs
+        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio']
         kube-version: [{ node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' }]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -75,7 +75,7 @@ jobs:
         kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
         kube-version: [ { node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' } ]
         is-master:
-          - ${{ contains(github.ref, 'master') }}
+          - ${{ github.event.pull_request.base.ref == 'master' }}
         exclude:
           - is-master: 'true'
             kube-e2e-test-type: upgrade

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -8,7 +8,6 @@ on:
 env:
   VERSION: '1.0.0-ci'
   GITHUB_TOKEN: ${{ github.token }} # necessary to pass upgrade tests
-  IS_MASTER: false
 
 jobs:
   prepare_env:

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -22,6 +22,7 @@ jobs:
         echo ${{ github.ref }}
         echo ${{ contains(github.ref, 'master') }}
         echo $GITHUB_HEAD_REF
+        echo ${{ github.event.pull_request.base.ref }}
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.11.0
       with:

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: check github
       run: |
-        echo ${{ github.ref }}"
+        echo ${{ github.ref }}
         echo ${{ contains(github.ref, 'master') }}
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -9,7 +9,7 @@ env:
   VERSION: '1.0.0-ci'
   GITHUB_TOKEN: ${{ github.token }} # necessary to pass upgrade tests
   IS_MASTER: false
-  TEST_MATRIX_MASTER: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio']
+  TEST_MATRIX_MASTER:
   TEST_MATRIX_LTS: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
 
 jobs:
@@ -24,15 +24,6 @@ jobs:
       uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
-    - id: check-if-master
-      name: Check branch name
-      run: |
-        if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-          echo "Branch is master"
-          echo "IS_MASTER=true" >> $GITHUB_ENV
-        else
-          echo "Branch is not master"
-        fi
     - id: is-draft-pr
       name: Process draft Pull Requests
       if: ${{ github.event.pull_request.draft }}
@@ -71,20 +62,26 @@ jobs:
   regression_tests:
     name: k8s regression tests (${{matrix.kube-e2e-test-type}})
     needs: prepare_env
-    if: needs.prepare_env.outputs.should-run-regression-tests == 'true'
     runs-on: ubuntu-22.04
+    if: needs.prepare_env.outputs.should-run-regression-tests == 'true'
     strategy:
       fail-fast: false
       matrix:
         # upgrade tests are run on LTS but not on master branch, for master they are run nightly
         # this is the github action version of ternary op
-        kube-e2e-test-type: ${{ env.IS_MASTER == 'true' && env.TEST_MATRIX_MASTER || env.TEST_MATRIX_LTS }}
-        kube-version: [{ node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' }]
+        kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
+        kube-version: [ { node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' } ]
+        is-master:
+          - ${{ contains(github.ref, 'master') }}
+        exclude:
+          - is-master: true
+            kube-e2e-test-type: upgrade
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/regression-tests
 
   notify_slack:
+    name: Notify slack
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'pull_request' && failure() }}
     needs: [ regression_tests ]

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -21,6 +21,7 @@ jobs:
       run: |
         echo ${{ github.ref }}
         echo ${{ contains(github.ref, 'master') }}
+        echo $GITHUB_HEAD_REF
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.11.0
       with:

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -17,6 +17,10 @@ jobs:
       should-run-regression-tests: ${{ steps.regression-tests.outputs.run_value }}
       should-pass-regression-tests: ${{ steps.regression-tests.outputs.pass_value }}
     steps:
+    - name: check github
+      run: |
+        echo ${{ github.ref }}"
+        echo ${{ contains(github.ref, 'master') }}
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.11.0
       with:

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -23,7 +23,7 @@ jobs:
         echo ${{ contains(github.ref, 'master') }}
         echo $GITHUB_HEAD_REF
         echo ${{ github.event.pull_request.base.ref }}
-        echo ${{ github.event.pull_request.base.ref == 'master' }}
+        echo ${{ contains(github.event.pull_request.base.ref, 'master') }}
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.11.0
       with:

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -68,7 +68,8 @@ jobs:
         # this is the github action version of ternary op
         kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
         kube-version: [ { node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' } ]
-        is-master: ${{ contains(github.ref, 'master') }}
+        is-master:
+          - ${{ contains(github.ref, 'master') }}
         exclude:
           - is-master: 'true'
             kube-e2e-test-type: upgrade

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -23,6 +23,7 @@ jobs:
         echo ${{ contains(github.ref, 'master') }}
         echo $GITHUB_HEAD_REF
         echo ${{ github.event.pull_request.base.ref }}
+        echo ${{ github.event.pull_request.base.ref == 'master' }}
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.11.0
       with:
@@ -80,6 +81,9 @@ jobs:
           - is-master: 'true'
             kube-e2e-test-type: upgrade
     steps:
+    - name: check values
+      run: |
+        echo ${{ matrix.is-master }}
     - uses: actions/checkout@v3
     - uses: ./.github/actions/regression-tests
 

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -17,13 +17,6 @@ jobs:
       should-run-regression-tests: ${{ steps.regression-tests.outputs.run_value }}
       should-pass-regression-tests: ${{ steps.regression-tests.outputs.pass_value }}
     steps:
-    - name: check github
-      run: |
-        echo ${{ github.ref }}
-        echo ${{ contains(github.ref, 'master') }}
-        echo $GITHUB_HEAD_REF
-        echo ${{ github.event.pull_request.base.ref }}
-        echo ${{ contains(github.event.pull_request.base.ref, 'master') }}
     - name: Cancel Previous Actions
       uses: styfle/cancel-workflow-action@0.11.0
       with:
@@ -81,9 +74,6 @@ jobs:
           - merge-to-master: true
             kube-e2e-test-type: upgrade
     steps:
-    - name: check values
-      run: |
-        echo ${{ matrix.is-master }}
     - uses: actions/checkout@v3
     - uses: ./.github/actions/regression-tests
 

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -68,10 +68,9 @@ jobs:
         # this is the github action version of ternary op
         kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
         kube-version: [ { node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' } ]
-        is-master:
-          - ${{ contains(github.ref, 'master') }}
+        is-master: ${{ contains(github.ref, 'master') }}
         exclude:
-          - is-master: true
+          - is-master: 'true'
             kube-e2e-test-type: upgrade
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -8,6 +8,9 @@ on:
 env:
   VERSION: '1.0.0-ci'
   GITHUB_TOKEN: ${{ github.token }} # necessary to pass upgrade tests
+  IS_MASTER: false
+  TEST_MATRIX_MASTER: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio']
+  TEST_MATRIX_LTS: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
 
 jobs:
   prepare_env:
@@ -21,6 +24,15 @@ jobs:
       uses: styfle/cancel-workflow-action@0.11.0
       with:
         access_token: ${{ github.token }}
+    - id: check-if-master
+      name: Check branch name
+      run: |
+        if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+          echo "Branch is master"
+          echo "IS_MASTER=true" >> $GITHUB_ENV
+        else
+          echo "Branch is not master"
+        fi
     - id: is-draft-pr
       name: Process draft Pull Requests
       if: ${{ github.event.pull_request.draft }}
@@ -64,8 +76,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # upgrade tests removed from PRs
-        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio']
+        # upgrade tests are run on LTS but not on master branch, for master they are run nightly
+        kube-e2e-test-type: ${{ env.IS_MASTER == 'true' ? env.TEST_MATRIX_MASTER : env.TEST_MATRIX_LTS }}
         kube-version: [{ node: 'v1.25.3@sha256:f52781bc0d7a19fb6c405c2af83abfeb311f130707a0e219175677e366cc45d1', kubectl: 'v1.25.8', kind: 'v0.17.0', helm: 'v3.11.2' }]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -9,8 +9,6 @@ env:
   VERSION: '1.0.0-ci'
   GITHUB_TOKEN: ${{ github.token }} # necessary to pass upgrade tests
   IS_MASTER: false
-  TEST_MATRIX_MASTER:
-  TEST_MATRIX_LTS: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
 
 jobs:
   prepare_env:

--- a/changelog/v1.15.0-beta6/remove-upgrade-tests-from-prs.yaml
+++ b/changelog/v1.15.0-beta6/remove-upgrade-tests-from-prs.yaml
@@ -2,4 +2,6 @@ changelog:
   - type: NON_USER_FACING
     issueLink: https://github.com/solo-io/solo-projects/issues/4901
     resolvesIssue: false
-    description: We will no longer run upgrade tests on PRs
+    description:  >-
+      We will no longer run upgrade tests on PRs to master, all other branches will still run upgrades
+      We will no longer run nightlies for 1.12 and 1.11 - the focus will be on the stability of tests 1.13+

--- a/changelog/v1.15.0-beta6/remove-upgrade-tests-from-prs.yaml
+++ b/changelog/v1.15.0-beta6/remove-upgrade-tests-from-prs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/4901
+    resolvesIssue: false
+    description: We will no longer run upgrade tests on PRs


### PR DESCRIPTION
# Description
Upgrade Tests will run nightly on master branch
Upgrade Tests will run per pr for LTS branches 
Only run nightlies 1.13+

# Context
The idea was that upgrade tests run on every PR, but rarely do they test things that were introduced in PRs, so I made the argument that we could reduce cost by running them in our nightly tests and still keep our consistency. The downside is that IF someone introduces a change that would break the test, the PR can still merge. But with our nightly tests, we would see this in <24 hours and be able to revert

For nightlies, 1.13+ branches have the "most" stable tests. We want to get to a point where our weekly tests all pass. We have decided to run a subset first, and then future work will be to expand these tests should we want.
# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
