### PR TITLE
Document behavior around removing hosts with valid health checks

### DIFF
--- a/changelog/v1.15.0-beta6/healthcheck-docs.yaml
+++ b/changelog/v1.15.0-beta6/healthcheck-docs.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/7996
+    resolvesIssue: true
+    description: Add a note to the documentation for active health checking to clarify behavior around removing hosts.

--- a/docs/content/guides/traffic_management/request_processing/upstream_health_checks/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/upstream_health_checks/_index.md
@@ -6,6 +6,9 @@ description: Automatically monitor the status of Upstreams by configuring health
 
 As part of configuring an Upstream, Gloo Edge provides the option of adding *health checks* that periodically assess the readiness of the Upstream to receive requests. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.14.1/intro/arch_overview/upstream/health_checking#arch-overview-health-checking) for more information. 
 
+{{% notice note %}}
+If you want to be able to remove an Upstream with a working health check from Envoy's service directory, you need to set the `ignoreHealthOnHostRemoval` setting on that Upstream.
+{{% /notice %}}
 ## Configuration
 
 Descriptions of the options available for configuring health checks can be found {{< protobuf name="solo.io.envoy.api.v2.core.HealthCheck" display="here" >}}.

--- a/docs/content/guides/traffic_management/request_processing/upstream_health_checks/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/upstream_health_checks/_index.md
@@ -7,7 +7,7 @@ description: Automatically monitor the status of Upstreams by configuring health
 As part of configuring an Upstream, Gloo Edge provides the option of adding *health checks* that periodically assess the readiness of the Upstream to receive requests. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.14.1/intro/arch_overview/upstream/health_checking#arch-overview-health-checking) for more information. 
 
 {{% notice note %}}
-If you want to be able to remove an Upstream with a working health check from Envoy's service directory, you need to set the `ignoreHealthOnHostRemoval` setting on that Upstream.
+Upstreams with working health checks will not be removed from Envoy's service directory, even on configuration changes unless `ignoreHealthOnHostRemoval` is set on that Upstream.
 {{% /notice %}}
 ## Configuration
 

--- a/docs/content/guides/traffic_management/request_processing/upstream_health_checks/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/upstream_health_checks/_index.md
@@ -7,7 +7,7 @@ description: Automatically monitor the status of Upstreams by configuring health
 As part of configuring an Upstream, Gloo Edge provides the option of adding *health checks* that periodically assess the readiness of the Upstream to receive requests. See the [Envoy documentation](https://www.envoyproxy.io/docs/envoy/v1.14.1/intro/arch_overview/upstream/health_checking#arch-overview-health-checking) for more information. 
 
 {{% notice note %}}
-Upstreams with working health checks will not be removed from Envoy's service directory, even on configuration changes unless `ignoreHealthOnHostRemoval` is set on that Upstream.
+Upstreams with working health checks will not be removed from Envoy's service directory, even due to configuration changes. To allow them to be removed, set `ignoreHealthOnHostRemoval` in the Upstream's configuration.
 {{% /notice %}}
 ## Configuration
 


### PR DESCRIPTION
# Description

Add a notice to the Upstream Health Check docs (https://docs.solo.io/gloo-edge/latest/guides/traffic_management/request_processing/upstream_health_checks/) to call out the fact that envoy will not remove hosts with successful health checks unless the `ignoreHealthOnHostRemoval` field is set.
# Context

A customer ran into this when trying to use tags to determine which EC2 instances should be used. They expected that when they removed a tag from an instance, traffic wouldn't go to that instance. However, since those instances still looked "healthy" envoy continued sending traffic to them.

# Checklist:
(doc only change)
- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/master/changelogutils) which references the issue that is resolved.
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I have made corresponding changes to the documentation


BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/7996