### PR TITLE
[1.14.x] Fix non-persisted proxy validation in glooctl check

### DIFF
--- a/changelog/v1.14.4/glooctl-proxy-fix.yaml
+++ b/changelog/v1.14.4/glooctl-proxy-fix.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7697
+    resolvesIssue: false
+    description: |
+      Updates glooctl check to use the GPRC endpoint for proxy validation.
+      This fixes an issue where the check would report false-positives 
+      for invalid proxies that were not persisted.

--- a/projects/gloo/cli/pkg/cmd/check/check_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/check_test.go
@@ -51,6 +51,9 @@ var _ = Describe("Check", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      appName,
 					Namespace: "gloo-system",
+					Labels: map[string]string{
+						"gloo": "gloo",
+					},
 				},
 				Spec: appsv1.DeploymentSpec{},
 			}, metav1.CreateOptions{})


### PR DESCRIPTION
# Description
 - Backport #8228 to 1.14.x
 - Updates `glooctl check` to use the GPRC endpoint for proxy validation, ala `glooctl get proxies`.
 - This fixes an issue where the check would report false-positives for invalid proxies that were not persisted.
   - Prior to this change, glooctl check used a k8s client to obtain proxy resources
   - Since 1.12.x, proxy resources are not persisted by default, so this k8s client failed to obtain proxies, and in turn failed to report errors on proxy resources