### PR TITLE
[1.13.x] Fix non-persisted proxy validation in glooctl check

### DIFF
--- a/changelog/v1.13.19/glooctl-proxy-fix.yaml
+++ b/changelog/v1.13.19/glooctl-proxy-fix.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7697
+    resolvesIssue: false
+    description: |
+      Updates glooctl check to use the GPRC endpoint for proxy validation.
+      This fixes an issue where the check would report false-positives 
+      for invalid proxies that were not persisted.

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/flagutils"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
@@ -21,7 +22,6 @@ import (
 	ratelimit "github.com/solo-io/gloo/projects/gloo/pkg/api/external/solo/ratelimit"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	rlopts "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
-	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/go-utils/cliutils"
 	"github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -121,7 +121,7 @@ func CheckResources(opts *options.Options) error {
 		}
 	}
 
-	settings, err := getSettings(ctx, opts)
+	settings, err := common.GetSettings(opts)
 	if err != nil {
 		multiErr = multierror.Append(multiErr, err)
 	}
@@ -211,7 +211,7 @@ func CheckResources(opts *options.Options) error {
 	}
 
 	if included := doesNotContain(opts.Top.CheckName, "proxies"); included {
-		err := checkProxies(ctx, opts, namespaces, opts.Metadata.GetNamespace(), deployments, deploymentsIncluded)
+		err := checkProxies(ctx, opts, namespaces, opts.Metadata.GetNamespace(), deployments, deploymentsIncluded, settings)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 		}
@@ -376,14 +376,6 @@ func checkPods(ctx context.Context, opts *options.Options) error {
 		printer.AppendStatus("pods", "OK")
 	}
 	return nil
-}
-
-func getSettings(ctx context.Context, opts *options.Options) (*v1.Settings, error) {
-	client, err := helpers.SettingsClient(ctx, []string{opts.Metadata.GetNamespace()})
-	if err != nil {
-		return nil, err
-	}
-	return client.Read(opts.Metadata.GetNamespace(), defaults.SettingsName, clients.ReadOpts{})
 }
 
 func getNamespaces(ctx context.Context, settings *v1.Settings) ([]string, error) {
@@ -831,7 +823,7 @@ func checkGateways(ctx context.Context, opts *options.Options, namespaces []stri
 	return nil
 }
 
-func checkProxies(ctx context.Context, opts *options.Options, namespaces []string, glooNamespace string, deployments *appsv1.DeploymentList, deploymentsIncluded bool) error {
+func checkProxies(ctx context.Context, opts *options.Options, namespaces []string, glooNamespace string, deployments *appsv1.DeploymentList, deploymentsIncluded bool, settings *v1.Settings) error {
 	printer.AppendCheck("Checking proxies... ")
 	if !deploymentsIncluded {
 		printer.AppendStatus("proxies", "Skipping proxies because deployments were excluded")
@@ -843,12 +835,7 @@ func checkProxies(ctx context.Context, opts *options.Options, namespaces []strin
 	}
 	var multiErr *multierror.Error
 	for _, ns := range namespaces {
-		proxyClient, err := helpers.ProxyClient(ctx, []string{ns})
-		if err != nil {
-			multiErr = multierror.Append(multiErr, err)
-			continue
-		}
-		proxies, err := proxyClient.List(ns, clients.ListOpts{})
+		proxies, err := common.ListProxiesFromSettings(ns, opts, settings)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 			continue


### PR DESCRIPTION
# Description
 - Backport #8228 to 1.13.x
 - Updates `glooctl check` to use the GPRC endpoint for proxy validation, ala `glooctl get proxies`.
 - This fixes an issue where the check would report false-positives for invalid proxies that were not persisted.
   - Prior to this change, glooctl check used a k8s client to obtain proxy resources
   - Since 1.12.x, proxy resources are not persisted by default, so this k8s client failed to obtain proxies, and in turn failed to report errors on proxy resources