### PR TITLE
[1.12.x] Fix non-persisted proxy validation in glooctl check

### DIFF
--- a/changelog/v1.12.55/glooctl-proxy-fix.yaml
+++ b/changelog/v1.12.55/glooctl-proxy-fix.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/7697
+    resolvesIssue: false
+    description: |
+      Updates glooctl check to use the GPRC endpoint for proxy validation.
+      This fixes an issue where the check would report false-positives 
+      for invalid proxies that were not persisted.

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/flagutils"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
@@ -21,7 +22,6 @@ import (
 	ratelimit "github.com/solo-io/gloo/projects/gloo/pkg/api/external/solo/ratelimit"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	rlopts "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
-	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/go-utils/cliutils"
 	"github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -119,7 +119,7 @@ func CheckResources(opts *options.Options) error {
 		}
 	}
 
-	settings, err := getSettings(ctx, opts)
+	settings, err := common.GetSettings(opts)
 	if err != nil {
 		multiErr = multierror.Append(multiErr, err)
 	}
@@ -192,7 +192,7 @@ func CheckResources(opts *options.Options) error {
 	}
 
 	if included := doesNotContain(opts.Top.CheckName, "proxies"); included {
-		err := checkProxies(ctx, opts, namespaces, opts.Metadata.GetNamespace(), deployments, deploymentsIncluded)
+		err := checkProxies(ctx, opts, namespaces, opts.Metadata.GetNamespace(), deployments, deploymentsIncluded, settings)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 		}
@@ -351,14 +351,6 @@ func checkPods(ctx context.Context, opts *options.Options) error {
 	}
 	printer.AppendStatus("pods", "OK")
 	return nil
-}
-
-func getSettings(ctx context.Context, opts *options.Options) (*v1.Settings, error) {
-	client, err := helpers.SettingsClient(ctx, []string{opts.Metadata.GetNamespace()})
-	if err != nil {
-		return nil, err
-	}
-	return client.Read(opts.Metadata.GetNamespace(), defaults.SettingsName, clients.ReadOpts{})
 }
 
 func getNamespaces(ctx context.Context, settings *v1.Settings) ([]string, error) {
@@ -806,7 +798,7 @@ func checkGateways(ctx context.Context, opts *options.Options, namespaces []stri
 	return nil
 }
 
-func checkProxies(ctx context.Context, opts *options.Options, namespaces []string, glooNamespace string, deployments *appsv1.DeploymentList, deploymentsIncluded bool) error {
+func checkProxies(ctx context.Context, opts *options.Options, namespaces []string, glooNamespace string, deployments *appsv1.DeploymentList, deploymentsIncluded bool, settings *v1.Settings) error {
 	printer.AppendCheck("Checking proxies... ")
 	if !deploymentsIncluded {
 		printer.AppendStatus("proxies", "Skipping proxies because deployments were excluded")
@@ -818,12 +810,7 @@ func checkProxies(ctx context.Context, opts *options.Options, namespaces []strin
 	}
 	var multiErr *multierror.Error
 	for _, ns := range namespaces {
-		proxyClient, err := helpers.ProxyClient(ctx, []string{ns})
-		if err != nil {
-			multiErr = multierror.Append(multiErr, err)
-			continue
-		}
-		proxies, err := proxyClient.List(ns, clients.ListOpts{})
+		proxies, err := common.ListProxiesFromSettings(ns, opts, settings)
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 			continue

--- a/projects/gloo/cli/pkg/common/get.go
+++ b/projects/gloo/cli/pkg/common/get.go
@@ -116,9 +116,16 @@ func GetUpstreamGroups(name string, opts *options.Options) (gloov1.UpstreamGroup
 	return list, nil
 }
 
+func GetSettings(opts *options.Options) (*gloov1.Settings, error) {
+	client, err := helpers.SettingsClient(opts.Top.Ctx, []string{opts.Metadata.GetNamespace()})
+	if err != nil {
+		return nil, err
+	}
+	return client.Read(opts.Metadata.GetNamespace(), defaults.SettingsName, clients.ReadOpts{Ctx: opts.Top.Ctx})
+}
+
 func GetProxies(name string, opts *options.Options) (gloov1.ProxyList, error) {
-	settingsClient := helpers.MustNamespacedSettingsClient(opts.Top.Ctx, opts.Metadata.GetNamespace())
-	settings, err := settingsClient.Read(opts.Metadata.GetNamespace(), defaults.SettingsName, clients.ReadOpts{Ctx: opts.Top.Ctx})
+	settings, err := GetSettings(opts)
 	if err != nil {
 		return nil, err
 	}
@@ -128,6 +135,17 @@ func GetProxies(name string, opts *options.Options) (gloov1.ProxyList, error) {
 	}
 	return getProxiesFromK8s(name, opts)
 }
+
+// ListProxiesFromSettings retrieves proxies from the proxy debug endpoint, or from kubernetes if the proxy debug endpoint is not available
+// Takes in a settings object to determine whether the proxy debug endpoint is available
+func ListProxiesFromSettings(namespace string, opts *options.Options, settings *gloov1.Settings) (gloov1.ProxyList, error) {
+	proxyEndpointPort := computeProxyEndpointPort(opts.Top.Ctx, settings)
+	if proxyEndpointPort != "" {
+		return getProxiesFromGrpc("", namespace, opts, proxyEndpointPort)
+	}
+	return getProxiesFromK8s("", opts)
+}
+
 func computeProxyEndpointPort(ctx context.Context, settings *gloov1.Settings) string {
 
 	proxyEndpointAddress := settings.GetGloo().GetProxyDebugBindAddr()
@@ -141,6 +159,7 @@ func computeProxyEndpointPort(ctx context.Context, settings *gloov1.Settings) st
 }
 
 // This is necessary for older versions of gloo
+// if name is empty, return all proxies
 func getProxiesFromK8s(name string, opts *options.Options) (gloov1.ProxyList, error) {
 	var list gloov1.ProxyList
 	pxClient := helpers.MustNamespacedProxyClient(opts.Top.Ctx, opts.Metadata.GetNamespace())
@@ -162,6 +181,9 @@ func getProxiesFromK8s(name string, opts *options.Options) (gloov1.ProxyList, er
 
 	return list, nil
 }
+
+// Used to retrieve proxies from the proxy debug endpoint in newer versions of gloo
+// if name is empty, return all proxies
 func getProxiesFromGrpc(name string, namespace string, opts *options.Options, proxyEndpointPort string) (gloov1.ProxyList, error) {
 	options := []grpc.CallOption{
 		// Some proxies can become very large and exceed the default 100Mb limit
@@ -174,7 +196,7 @@ func getProxiesFromGrpc(name string, namespace string, opts *options.Options, pr
 		return nil, err
 	}
 	localPort := strconv.Itoa(freePort)
-	portFwdCmd, err := cliutil.PortForward(namespace, "deployment/gloo",
+	portFwdCmd, err := cliutil.PortForward(opts.Metadata.GetNamespace(), "deployment/gloo",
 		localPort, proxyEndpointPort, opts.Top.Verbose)
 	if portFwdCmd.Process != nil {
 		defer portFwdCmd.Process.Release()
@@ -208,7 +230,7 @@ func getProxiesFromGrpc(name string, namespace string, opts *options.Options, pr
 			pxClient := debug.NewProxyEndpointServiceClient(cc)
 			r, err := pxClient.GetProxies(opts.Top.Ctx, &debug.ProxyEndpointRequest{
 				Name:      name,
-				Namespace: opts.Metadata.GetNamespace(),
+				Namespace: namespace,
 			}, options...)
 			if err != nil {
 				errs <- err


### PR DESCRIPTION
# Description
 - Backport #8228 to 1.12.x
 - Updates `glooctl check` to use the GPRC endpoint for proxy validation, ala `glooctl get proxies`.
 - This fixes an issue where the check would report false-positives for invalid proxies that were not persisted.
   - Prior to this change, glooctl check used a k8s client to obtain proxy resources
   - Since 1.12.x, proxy resources are not persisted by default, so this k8s client failed to obtain proxies, and in turn failed to report errors on proxy resources