### PR TITLE
Update security context include

### DIFF
--- a/changelog/v1.15.0-beta7/update-securityContext-helm-include.yaml
+++ b/changelog/v1.15.0-beta7/update-securityContext-helm-include.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update helm securityContext to make type safe

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -101,16 +101,19 @@ It takes 2 values:
   In a merge, the values in .values will override the defaults, following the logic of helm's merge function.
 Because of this, if a value is "true" in defaults it can not be modified with this method.
 */ -}}
-{{- define "gloo.securityContext" }}
+{{- define "gloofed.securityContext" }}
 {{- $securityContext := dict -}}
 {{- $overwrite := true -}}
 {{- if .values -}}
-  {{- if eq .values.mergePolicy "helm-merge" -}}
-    {{- $overwrite = false -}}
-  {{- else if and .values.mergePolicy (ne .values.mergePolicy "no-merge") -}}
-  {{- fail printf "value '%s' is not an allowed value for mergePolicy. Allowed values are 'no-merge', 'helm-merge', or an empty string" .values.mergePolicy }}
-  {{- end -}}
+  {{- if .values.mergePolicy }}
+    {{- if eq .values.mergePolicy "helm-merge" -}}
+      {{- $overwrite = false -}}
+    {{- else if ne .values.mergePolicy "no-merge" -}}
+      {{- fail printf "value '%s' is not an allowed value for mergePolicy. Allowed values are 'no-merge', 'helm-merge', or an empty string" .values.mergePolicy }}
+    {{- end -}}
+  {{- end }}
 {{- end -}}
+
 {{- if $overwrite -}}
   {{- $securityContext = or .values .defaults (dict) -}}
 {{- else -}}


### PR DESCRIPTION
# Description

Better type safeguarding in security context include.

This bug fixes ... \ This new feature can be used to ...
There was a data condition ("mergePolicy" not being a string) that led to `helm template` crashes when undefined.

Users ran into this bug doing ... \ Users needed this feature to ...
This command will trigger the error:
`helm template install/helm/gloo --set-string gloo.deployment.podSecurityContext.runAsUser=10101`

after this PR is applied it will successfully render the chart.

# Checklist:

- [X] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [NA] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [X] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [X] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [NA] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
