### PR TITLE
build(push-solo-apis): run setup steps from gloo directory

### DIFF
--- a/.github/workflows/composite-actions/prep-go-runner/action.yaml
+++ b/.github/workflows/composite-actions/prep-go-runner/action.yaml
@@ -1,5 +1,10 @@
 name: Prep Go Runner
 description: common setup steps for gloo actions
+inputs:
+  working-directory:
+    description: 'directory to run setup steps in'
+    required: false
+    default: '.'
 runs:
   using: "composite"
   steps:
@@ -28,5 +33,5 @@ runs:
   - name: Set up Go
     uses: actions/setup-go@v4
     with:
-      go-version-file: go.mod
+      go-version-file: ${{ inputs.working-directory }}/go.mod
     id: go

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -65,7 +65,9 @@ jobs:
           repository: solo-io/gloo
           path: gloo
           ref: ${{ env.SOURCE_COMMIT }}
-      - uses: ./.github/workflows/composite-actions/prep-go-runner
+      - uses: ./gloo/.github/workflows/composite-actions/prep-go-runner
+        with:
+          working-directory: gloo
       - name: Install Protoc
         uses: arduino/setup-protoc@master
         with:

--- a/changelog/v1.15.0-beta8/cd-go-runner.yaml
+++ b/changelog/v1.15.0-beta8/cd-go-runner.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: restore solo-apis publish job by running setup steps in the same directory as gloo


### PR DESCRIPTION
# Description
The prior https://github.com/solo-io/gloo/pull/8229 PR had a flaw, in that it assumed that all workflows that called `prep-go-runner` were running from inside of a `gloo` repository.  Added a new `working-directory` arg (with a default value of `.`) to rectify this

Testing:
ran a [manual job of push-solo-apis-to-branch](https://github.com/solo-io/gloo/actions/runs/5014530230) with these args:
<img width="337" alt="Screen Shot 2023-05-18 at 9 37 37 AM" src="https://github.com/solo-io/gloo/assets/92050522/06babe7e-b6ef-4725-bda1-6bd36ae96feb">

# Checklist:
- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
