### PR TITLE
refactor: fix indentation in RBAC resources

### DIFF
--- a/changelog/v1.15.0-beta8/helm-indentation.yaml
+++ b/changelog/v1.15.0-beta8/helm-indentation.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/8268
+    resolvesIssue: false
+    description: Fix indentation in RBAC resources

--- a/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
+++ b/install/helm/gloo/templates/20-namespace-clusterrole-gateway.yaml
@@ -4,13 +4,13 @@
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: kube-resource-watcher{{ include "gloo.rbacNameSuffix" . }}
-{{- if .Values.global.glooRbac.namespaced }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-    labels:
-        app: gloo
-        gloo: rbac
+  name: kube-resource-watcher{{ include "gloo.rbacNameSuffix" . }}
+  {{- if .Values.global.glooRbac.namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: gloo
+    gloo: rbac
 rules:
 - apiGroups:
   - ""
@@ -53,13 +53,13 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-upstream-mutator{{ include "gloo.rbacNameSuffix" . }}
-{{- if .Values.global.glooRbac.namespaced }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-    labels:
-      app: gloo
-      gloo: rbac
+  name: gloo-upstream-mutator{{ include "gloo.rbacNameSuffix" . }}
+  {{- if .Values.global.glooRbac.namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: gloo
+    gloo: rbac
 rules:
 - apiGroups:
   - gloo.solo.io
@@ -77,13 +77,13 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-resource-reader{{ include "gloo.rbacNameSuffix" . }}
-{{- if .Values.global.glooRbac.namespaced }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-    labels:
-      app: gloo
-      gloo: rbac
+  name: gloo-resource-reader{{ include "gloo.rbacNameSuffix" . }}
+  {{- if .Values.global.glooRbac.namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: gloo
+    gloo: rbac
 rules:
 - apiGroups:
   - gloo.solo.io
@@ -131,13 +131,13 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: settings-user{{ include "gloo.rbacNameSuffix" . }}
-{{- if .Values.global.glooRbac.namespaced }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-    labels:
-      app: gloo
-      gloo: rbac
+  name: settings-user{{ include "gloo.rbacNameSuffix" . }}
+  {{- if .Values.global.glooRbac.namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: gloo
+    gloo: rbac
 rules:
 - apiGroups:
   - gloo.solo.io
@@ -151,13 +151,13 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gloo-resource-mutator{{ include "gloo.rbacNameSuffix" . }}
-{{- if .Values.global.glooRbac.namespaced }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-    labels:
-      app: gloo
-      gloo: rbac
+  name: gloo-resource-mutator{{ include "gloo.rbacNameSuffix" . }}
+  {{- if .Values.global.glooRbac.namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: gloo
+    gloo: rbac
 rules:
 - apiGroups:
   - gloo.solo.io
@@ -175,13 +175,13 @@ rules:
 kind: {{ include "gloo.roleKind" . }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-    name: gateway-resource-reader{{ include "gloo.rbacNameSuffix" . }}
-{{- if .Values.global.glooRbac.namespaced }}
-    namespace: {{ .Release.Namespace }}
-{{- end }}
-    labels:
-      app: gloo
-      gloo: rbac
+  name: gateway-resource-reader{{ include "gloo.rbacNameSuffix" . }}
+  {{- if .Values.global.glooRbac.namespaced }}
+  namespace: {{ .Release.Namespace }}
+  {{- end }}
+  labels:
+    app: gloo
+    gloo: rbac
 rules:
 - apiGroups:
   - gateway.solo.io


### PR DESCRIPTION
# Description

Fixes indentations in `20-namespace-clusterrole-gateway.yaml` file.
Mostly cosmetics as these do not change the resources' definition, however these were not playing well with some Tilt extensions used for local development.

# Context

When deploying Gloo edge locally using [Tilt](https://docs.tilt.dev/api.html) via the `helm_resource` extension, Tilt would effectively complain about the indentation issues fixed in this PR. Even though Tilt should handle them gracefully, fixing them is simpler than handling these in Tilt code.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
