### PR TITLE
refactor: re-adds namedExtauth to settings resource

### DIFF
--- a/changelog/v1.15.0-beta8/re-add-named-extauth-to-settings.yaml
+++ b/changelog/v1.15.0-beta8/re-add-named-extauth-to-settings.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: HELM
+    issueLink: TBA
+    resolvesIssue: true
+    description: >-
+      In previous versions of Gloo, it was possible to enable custom authentication (in Enterprise) through 
+      Helm values - even though this was undocumented.
+      For backwards compatibility, this is re-added.
+      

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -158,6 +158,10 @@ spec:
 {{- end }}
 {{- end }}
 {{- end -}}
+{{- if .Values.global.extensions.namedExtauth }}
+  namedExtauth:
+{{- toYaml .Values.global.extensions.namedExtauth | nindent 4 }}
+{{- end }}
 
 {{- if .Values.global.extraSpecs }}
 {{- include "gloo.extraSpecs"  . }}


### PR DESCRIPTION
# Description

Previous releases of Gloo/EE have allowed us to configure our `customAuth` using the `namedExtauth` property in `Helm Values` (for example: Gloo: 1.10.x). This feature seems to have been removed, possibly unintentionally.

Adding back this for consistency.

# Context

As outlined in description.

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves TBA