### PR TITLE
build(publish-glooctl): explicitly pass VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ IMAGE_REGISTRY ?= quay.io/solo-io
 # Kind of a hack to make sure _output exists
 z := $(shell mkdir -p $(OUTPUT_DIR))
 
+# a semver resembling 1.0.1-dev.  Most calling jobs customize this.  Ex:  v1.15.0-pr8278
+VERSION ?= 1.0.1-dev
+
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.25.6-patch1
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
@@ -597,8 +600,6 @@ endif
 
 # controller variable for the "Publish Artifacts" section.  Defines which targets exist.  Possible Values: NONE, RELEASE, PULL_REQUEST
 PUBLISH_CONTEXT ?= NONE
-# a semver resembling 1.0.1-dev.  Most calling jobs customize this.  Ex:  v1.15.0-pr8278
-VERSION ?= 1.0.1-dev
 # specify which bucket to upload helm chart to
 HELM_BUCKET ?= gs://solo-public-tagged-helm
 # modifier to docker builds which can auto-delete docker images after a set time
@@ -622,7 +623,7 @@ publish-docker-retag: docker-retag docker-push
 
 # publish glooctl
 publish-glooctl: build-cli
-	GO111MODULE=on go run ci/upload_github_release_assets.go true
+	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go true
 endif # RELEASE exclusive make targets
 
 

--- a/changelog/v1.15.0-beta9/repair-publish-glooctl.yaml
+++ b/changelog/v1.15.0-beta9/repair-publish-glooctl.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/5037
+    resolvesIssue: false
+    description: |
+      repair publish-glooctl by passing VERSION as a named variable (as opposed to forgetting about it as a Makefile)
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/ci/upload_github_release_assets.go
+++ b/ci/upload_github_release_assets.go
@@ -195,11 +195,14 @@ func validateReleaseVersionOfCli() {
 
 // stolen from "github.com/solo-io/go-utils/versionutils", but changed the hardcoding of "TAGGED_VERSION" to "VERSION"
 func getReleaseVersionOrExitGracefully() *versionutils.Version {
-	tag, present := os.LookupEnv("VERSION")
-	if !present || tag == "" {
+	versionStr, present := os.LookupEnv("VERSION")
+	if !present || versionStr == "" {
 		fmt.Printf("VERSION not found in environment.\n")
 		os.Exit(1)
 	}
+
+	tag := "v" + versionStr
+
 	version, err := versionutils.ParseVersion(tag)
 	if err != nil {
 		fmt.Printf("VERSION %s is not a valid semver version.\n", tag)


### PR DESCRIPTION
# Description
when [attempting a test release](https://solo-io-corp.slack.com/archives/CFK0DQADU/p1685648551095939) for `v1.15.0-beta9`, we encountered a build error with `make publish-glooctl`.  The error was centered around an expected `TAGGED_VERSION` environment variable having been set

# Testing
This PR resolves said issue and (locally) can run `PUBLISH_CONTEXT=RELEASE make publish-glooctl`

# Checklist:
- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
