### PR TITLE
Fix CVEs [1.14]

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -25,3 +25,9 @@ CVE-2022-23526
 # No handlers exposed by the control plane fall victim to this attack
 # because we do not use the maxBytesHandler
 CVE-2022-41721
+
+# https://github.com/distribution/distribution/security/advisories/GHSA-hqxw-f8mx-cpmw
+# This CVE has not yet been patched in the kubectl version we are using, however it should not
+# affect us as kubernetes does not use the affected code path (see description in
+# https://github.com/kubernetes/kubernetes/pull/118036).
+CVE-2023-2253

--- a/changelog/v1.14.8/cves.yaml
+++ b/changelog/v1.14.8/cves.yaml
@@ -1,0 +1,12 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: docker
+  dependencyRepo: distribution
+  dependencyTag: v2.8.2+incompatible
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/8346
+  resolvesIssue: false
+  description: >
+    Upgrade docker distribution dependency which fixes CVE-2023-2253 for all images except kubectl.
+    Also add the CVE to .trivyignore because kubectl does not have a fixed version yet and kubectl
+    is not vulnerable. Upgrade openssl version in kubectl image to fix CVE-2023-2650.

--- a/go.mod
+++ b/go.mod
@@ -131,7 +131,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/daviddengcn/go-colortext v1.0.0 // indirect
 	github.com/docker/cli v20.10.21+incompatible // indirect
-	github.com/docker/distribution v2.8.1+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.21+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.7.0 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -368,8 +368,9 @@ github.com/docker/cli v20.10.21+incompatible h1:qVkgyYUnOLQ98LtXBrwd/duVqPT2X4SH
 github.com/docker/cli v20.10.21+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -2,4 +2,7 @@ FROM bitnami/kubectl:1.25.9 as kubectl
 
 FROM alpine:3.17.3
 
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/


### PR DESCRIPTION
backport #8353

To verify locally:

Before fixes (on clean branch):
```
rm -rf _output
make VERSION=0.0.0-before docker-local
make VERSION=0.0.0-before scan-version
cat _output/scans/0.0.0-before/*  # shows CVEs for several images
```

After fixes (from this branch):
```
rm -rf _output
make VERSION=0.0.0-after docker
make VERSION=0.0.0-after scan-version
cat _output/scans/0.0.0-after/*  # comes out clean
```