### PR TITLE
Fix CVEs [1.12]

### DIFF
--- a/changelog/v1.12.56/cves.yaml
+++ b/changelog/v1.12.56/cves.yaml
@@ -1,0 +1,10 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: docker
+  dependencyRepo: distribution
+  dependencyTag: v2.8.2+incompatible
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/8348
+  description: >
+    Upgrade docker distribution dependency to fix CVE-2023-2253.
+    Upgrade openssl version in kubectl image to fix CVE-2023-2650.

--- a/go.mod
+++ b/go.mod
@@ -129,7 +129,7 @@ require (
 	github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd // indirect
 	github.com/deislabs/oras v0.11.1 // indirect
 	github.com/docker/cli v20.10.9+incompatible // indirect
-	github.com/docker/distribution v2.7.1+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.3 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -344,8 +344,9 @@ github.com/docker/cli v20.10.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHv
 github.com/docker/cli v20.10.9+incompatible h1:OJ7YkwQA+k2Oi51lmCojpjiygKpi76P7bg91b2eJxYU=
 github.com/docker/cli v20.10.9+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
-github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -2,4 +2,7 @@ FROM bitnami/kubectl:1.24.7 as kubectl
 
 FROM alpine:3.17.3
 
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/


### PR DESCRIPTION
Same changes as #8355

To verify locally:

Before fixes (on clean branch):
```
rm -rf _output
make VERSION=0.0.0-before docker-local
for img in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL quay.io/solo-io/$img:0.0.0-before; done
```

After fixes (from this branch):
```
rm -rf _output
make VERSION=0.0.0-after docker-local
for img in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL quay.io/solo-io/$img:0.0.0-after; done
```
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/8348