### PR TITLE
Fix CVEs [1.11]

### DIFF
--- a/changelog/v1.11.59/cves.yaml
+++ b/changelog/v1.11.59/cves.yaml
@@ -1,0 +1,10 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: docker
+  dependencyRepo: distribution
+  dependencyTag: v2.8.2+incompatible
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/8349
+  description: >
+    Upgrade docker distribution dependency to fix CVE-2023-2253.
+    Upgrade openssl version in kubectl image to fix CVE-2023-2650.

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/bshuster-repo/logrus-logstash-hook v1.0.0 // indirect
 	github.com/cratonica/2goarray v0.0.0-20190331194516-514510793eaa
 	github.com/docker/cli v20.10.10+incompatible // indirect
+	github.com/docker/distribution v2.8.2+incompatible // indirect
 	github.com/docker/docker v20.10.3+incompatible // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect
 	github.com/elazarl/goproxy v0.0.0-20210110162100-a92cc753f88e // indirect

--- a/go.sum
+++ b/go.sum
@@ -347,8 +347,9 @@ github.com/docker/cli v20.10.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHv
 github.com/docker/cli v20.10.10+incompatible h1:kcbwdgWbrBOH8QwQzaJmyriHwF7XIl4HT1qh0HTRys4=
 github.com/docker/cli v20.10.10+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v0.0.0-20191216044856-a8371794149d/go.mod h1:0+TTO4EOBfRPhZXAeF1Vu+W3hHZ8eLp8PgKVZlcvtFY=
-github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
+github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker-credential-helpers v0.6.3 h1:zI2p9+1NQYdnG6sMU26EX4aVGlqbInSQxQXLvzJ4RPQ=
 github.com/docker/docker-credential-helpers v0.6.3/go.mod h1:WRaJzqw3CTB9bk10avuGsjVBZsD05qeibJ1/TYlvc0Y=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -2,4 +2,7 @@ FROM bitnami/kubectl:1.22.12 as kubectl
 
 FROM alpine:3.17.3
 
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/


### PR DESCRIPTION
Same changes as #8356

To verify locally:

Before fixes (on clean branch):
```
rm -rf _output
make VERSION=0.0.0-before discovery-docker gateway-docker gloo-docker \
                gloo-envoy-wrapper-docker certgen-docker sds-docker \
                ingress-docker access-logger-docker kubectl-docker
for img in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl gateway; do trivy image --severity HIGH,CRITICAL quay.io/solo-io/$img:0.0.0-before; done
```

After fixes (from this branch):
```
rm -rf _output
make VERSION=0.0.0-after discovery-docker gateway-docker gloo-docker \
                gloo-envoy-wrapper-docker certgen-docker sds-docker \
                ingress-docker access-logger-docker kubectl-docker
for img in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl gateway; do trivy image --severity HIGH,CRITICAL quay.io/solo-io/$img:0.0.0-after; done
```
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/8349