### PR TITLE
Fix CVEs part 2 [main]

### DIFF
--- a/changelog/v1.15.0-beta11/more-cves.yaml
+++ b/changelog/v1.15.0-beta11/more-cves.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/8346
+  description: Upgrade openssl version in all images to fix CVE-2023-2650.

--- a/jobs/certgen/cmd/Dockerfile
+++ b/jobs/certgen/cmd/Dockerfile
@@ -7,6 +7,9 @@ RUN apk upgrade --update-cache \
     && apk add ca-certificates \
     && rm -rf /var/cache/apk/*
 
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY certgen-linux-$GOARCH /usr/local/bin/certgen
 
 USER 10101

--- a/projects/accesslogger/cmd/Dockerfile
+++ b/projects/accesslogger/cmd/Dockerfile
@@ -2,6 +2,10 @@ FROM alpine:3.17.3
 
 ARG GOARCH=amd64
 RUN apk -U upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*
+
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY access-logger-linux-$GOARCH /usr/local/bin/access-logger
 
 USER 10101

--- a/projects/discovery/cmd/Dockerfile
+++ b/projects/discovery/cmd/Dockerfile
@@ -7,6 +7,9 @@ RUN apk upgrade --update-cache \
     && apk add ca-certificates \
     && rm -rf /var/cache/apk/*
 
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY discovery-linux-$GOARCH /usr/local/bin/discovery
 
 USER 10101

--- a/projects/gloo/Dockerfile
+++ b/projects/gloo/Dockerfile
@@ -35,5 +35,9 @@ RUN CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=linux go build \
 
 
 FROM alpine:3.17.3
+
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 ARG GOARCH
 COPY --from=build-env /go/src/github.com/solo-io/gloo/gloo-linux-${GOARCH} /

--- a/projects/ingress/cmd/Dockerfile
+++ b/projects/ingress/cmd/Dockerfile
@@ -4,6 +4,9 @@ ARG GOARCH=amd64
 
 RUN apk -U upgrade
 
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY ingress-linux-$GOARCH /usr/local/bin/ingress
 
 USER 10101

--- a/projects/sds/cmd/Dockerfile
+++ b/projects/sds/cmd/Dockerfile
@@ -4,6 +4,9 @@ ARG GOARCH=amd64
 
 RUN apk -U upgrade
 
+# Fix for CVE-2023-2650. If alpine upgrades this dep, we can remove this line.
+RUN apk add openssl=3.0.9-r1
+
 COPY sds-linux-$GOARCH /usr/local/bin/sds
 
 USER 10101


### PR DESCRIPTION
Follow-up to https://github.com/solo-io/gloo/pull/8353

Not sure why, but scanning released images shows the openssl cve in a bunch of images (whereas scanning locally-built versions only showed it in one image). To be safe, do the same openssl upgrade for all the alpine 3.17.3-based images.