### PR TITLE
Correct Envoy-Gloo image name in e2e tests

### DIFF
--- a/changelog/v1.15.0-beta11/correct-envoy-gloo-image-name.yaml
+++ b/changelog/v1.15.0-beta11/correct-envoy-gloo-image-name.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/7577
+    description: | 
+      Resolves a typo in factory.go which caused the gateway-proxy image
+      to be set to `envoy-gloo-wrapper` instead of `gloo-envoy-wrapper`
+      when running e2e tests

--- a/changelog/v1.15.0-beta11/correct-envoy-gloo-image-name.yaml
+++ b/changelog/v1.15.0-beta11/correct-envoy-gloo-image-name.yaml
@@ -5,3 +5,4 @@ changelog:
       Resolves a typo in factory.go which caused the gateway-proxy image
       to be set to `envoy-gloo-wrapper` instead of `gloo-envoy-wrapper`
       when running e2e tests
+    resolvesIssue: false

--- a/test/services/envoy/factory.go
+++ b/test/services/envoy/factory.go
@@ -60,7 +60,7 @@ func NewFactory() Factory {
 	case "darwin":
 		log.Printf("Using docker to Run envoy")
 
-		image := fmt.Sprintf("quay.io/solo-io/envoy-gloo-wrapper:%s", mustGetEnvoyWrapperTag())
+		image := fmt.Sprintf("quay.io/solo-io/gloo-envoy-wrapper:%s", mustGetEnvoyWrapperTag())
 		return NewDockerFactory(bootstrapTemplate, image)
 
 	case "linux":


### PR DESCRIPTION
# Description
 - Resolves an error introduced in https://github.com/solo-io/gloo/pull/8365 that caused e2e tests to attempt to use `quay.io/solo-io/envoy-gloo-wrapper` instead of `quay.io/solo-io/gloo-envoy-wrapper` when running e2e tests
 - I encountered this error when trying to run e2e tests using a locally built gloo-envoy-wrapper image
   - The command I used was `ENVOY_IMAGE_TAG=<TAG> TEST_PKG=./test/e2e make test`
 - see here: https://github.com/solo-io/gloo/blob/686422e2a33688ddd3cf95cb74f87a388f184f2c/Makefile#L515 the image should be called `gloo-envoy-wrapper`