### PR TITLE
Refactor test services download logic

### DIFF
--- a/changelog/v1.15.0-beta12/refactor-docker-service-download.yaml
+++ b/changelog/v1.15.0-beta12/refactor-docker-service-download.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Extract logic for downloading test service binaries into a helper to de-duplicate
+    and increase the readability of the factory code.

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -69,6 +69,7 @@ var _ = Describe("AWS Lambda", func() {
 	)
 
 	BeforeEach(func() {
+		testutils.ValidateRequirementsAndNotifyGinkgo(testutils.AwsCredentials())
 		httpClient = http.DefaultClient
 		httpClient.Timeout = 10 * time.Second
 		runOptions = &services.RunOptions{

--- a/test/services/utils/download.go
+++ b/test/services/utils/download.go
@@ -1,0 +1,78 @@
+package utils
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/onsi/ginkgo/v2"
+)
+
+type GetBinaryParams struct {
+	Filename    string // the name of the binary on the $PATH or in the docker container
+	DockerImage string // the docker image to use if Env or Local are not present
+	DockerPath  string // the location of the binary in the docker container, including the filename
+	EnvKey      string // the environment var to look at for a user-specified service binary
+	TmpDir      string // the temp directory to store a downloaded binary if needed
+}
+
+// GetBinary uses the passes params structure to get a binary for the service in the first found of 3 locations:
+//
+// 1. specified via environment variable
+//
+// 2. matching binary already on path TODO(jbohanon) assess the validity of this since we could inadvertently use a bad/old version
+//
+// 3. download the hard-coded version via docker and extract the binary from that
+func GetBinary(params GetBinaryParams) (string, error) {
+	// first check if an environment variable was specified for the binary location
+	envPath := os.Getenv(params.EnvKey)
+	if envPath != "" {
+		log.Printf("Using %s specified in environment variable %s: %s", params.Filename, params.EnvKey, envPath)
+		return envPath, nil
+	}
+
+	// next check if we have a matching binary on $PATH
+	localPath, err := exec.LookPath(params.Filename)
+	if err == nil {
+		log.Printf("Using %s from PATH: %s", params.Filename, localPath)
+		return localPath, nil
+	}
+
+	// finally, try to grab one from docker
+	return dockerDownload(params.TmpDir, params)
+
+}
+
+func dockerDownload(tmpdir string, params GetBinaryParams) (string, error) {
+	log.Printf("Using %s from docker image: %s", params.Filename, params.DockerImage)
+	bash := fmt.Sprintf(`
+set -ex
+CID=$(docker run -d  %s /bin/sh -c exit)
+
+# just print the image sha for repoducibility
+echo "Using %s Image:"
+docker inspect %s -f "{{.RepoDigests}}"
+
+docker cp $CID:%s ./%s
+docker rm -f $CID
+    `, params.DockerImage, params.Filename, params.DockerImage, params.DockerPath, params.Filename)
+	scriptFile := filepath.Join(tmpdir, "get_binary.sh")
+
+	err := os.WriteFile(scriptFile, []byte(bash), 0755)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := exec.Command("bash", scriptFile)
+	cmd.Dir = tmpdir
+	cmd.Stdout = ginkgo.GinkgoWriter
+	cmd.Stderr = ginkgo.GinkgoWriter
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	return filepath.Join(tmpdir, params.Filename), nil
+
+}

--- a/test/testutils/env.go
+++ b/test/testutils/env.go
@@ -44,6 +44,12 @@ const (
 
 	// EnvoyBinary is used in e2e tests to specify the path to the envoy binary to use for the tests
 	EnvoyBinary = "ENVOY_BINARY"
+
+	// ConsulBinary is used in e2e tests to specify the path to the consul binary to use for the tests
+	ConsulBinary = "CONSUL_BINARY"
+
+	// VaultBinary is used in e2e tests to specify the path to the vault binary to use for the tests
+	VaultBinary = "VAULT_BINARY"
 )
 
 // ShouldTearDown returns true if any assets that were created before a test (for example Gloo being installed)


### PR DESCRIPTION
# Description

Factor out the code for acquiring a test service binary. The behavior is unchanged, simply refactored. We first check for a specific environment variable specifying where to find the binary, then check the test executor's `$PATH`, then resort to running a docker container and extracting the binary from the running container. By using this docker method, we can leverage docker's local image cache to avoid downloading the dependency every time the tests are run without having to specify any additional environment variables when running locally and rapidly iterating.

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
