### PR TITLE
Fix yaml separation for ssl default gw

### DIFF
--- a/install/helm/gloo/templates/_8-default-gateways.tpl
+++ b/install/helm/gloo/templates/_8-default-gateways.tpl
@@ -154,7 +154,7 @@ spec:
 {{- if not $gatewaySettings.disableGeneratedGateways }}
 {{- if not $gatewaySettings.disableHttpGateway }}
 {{- $defaultGatewayOverride := $spec.gatewaySettings.httpGatewayKubeOverride }}
-{{- "---" }}
+---
 {{- include "gloo.util.merge" (list $ctx $defaultGatewayOverride "defaultGateway.gateway") -}}
 {{- end }}{{/* if not $gatewaySettings.disableHttpGateway */}}
 {{- if not $gatewaySettings.disableHttpsGateway }}


### PR DESCRIPTION
# Description

Fixes YAML separation characters for SSL default gateways
https://github.com/solo-io/gloo/issues/8404

# Context

When setting SSL Default Gateways with Helm bad line break placements broke the ssl gateway creation

