### PR TITLE
Fix percentile logic

### DIFF
--- a/changelog/v1.15.0-beta17/percentile-matcher-fix.yaml
+++ b/changelog/v1.15.0-beta17/percentile-matcher-fix.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/5116
+    resolvesIssue: false
+    description: >-
+      Resolve an off-by-one error introduced in initial implementation of WithPercentile() Transform in #8364 and explicitly
+      state intended percentile method
+
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/test/gomega/transforms/benchmark.go
+++ b/test/gomega/transforms/benchmark.go
@@ -1,17 +1,21 @@
 package transforms
 
 import (
+	"fmt"
 	"sort"
 	"time"
 )
 
 // WithPercentile returns a function that extracts the value at the given percentile from a slice of durations
 func WithPercentile(percentile int) func(durations []time.Duration) time.Duration {
+	if percentile <= 0 || percentile > 100 {
+		panic(fmt.Sprintf("percentile must be >0 and <= 100, given %d", percentile))
+	}
 	return func(durations []time.Duration) time.Duration {
 		sort.Slice(durations, func(i, j int) bool {
 			return durations[i] < durations[j]
 		})
-		return durations[int(float64(len(durations))*(float64(percentile)/float64(100)))]
+		return durations[int(float64(len(durations))*(float64(percentile-1)/float64(100)))]
 	}
 }
 

--- a/test/gomega/transforms/benchmark.go
+++ b/test/gomega/transforms/benchmark.go
@@ -7,9 +7,11 @@ import (
 )
 
 // WithPercentile returns a function that extracts the value at the given percentile from a slice of durations
+// The Nearest Rank Method is used to determine percentiles (https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method)
+// Valid inputs are 0 < n <= 100
 func WithPercentile(percentile int) func(durations []time.Duration) time.Duration {
 	if percentile <= 0 || percentile > 100 {
-		panic(fmt.Sprintf("percentile must be >0 and <= 100, given %d", percentile))
+		panic(fmt.Sprintf("percentile must be > 0 and <= 100, given %d", percentile))
 	}
 	return func(durations []time.Duration) time.Duration {
 		sort.Slice(durations, func(i, j int) bool {


### PR DESCRIPTION
# Description

- Fix off-by-one error in `WithPercentile()` transform logic
  - Add comment to explicitly state which method for determining percentile we intend to implement 

# Context

While working on updating EE benchmarking tests to use performance testing utilities from OSS ([here](https://github.com/solo-io/solo-projects/pull/5142)) I observed that the 80th percentile for a slice of length 5 was giving the max value

This is inconsistent with the intended behavior for determining percentile via the [nearest rank method](https://en.wikipedia.org/wiki/Percentile#The_nearest-rank_method)

When introducing the `WithPercentile()` transform we followed the established pattern of not unit testing, however if reviewers feel that unit tests are warranted for `WithPercentile()` I am willing to add them

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
