### PR TITLE
Add withRawHeader method to http request builder

### DIFF
--- a/changelog/v1.15.0-beta17/add-raw-header-method-for-http-request.yaml
+++ b/changelog/v1.15.0-beta17/add-raw-header-method-for-http-request.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/5058
+    resolvesIssue: false
+    description: >- 
+      Add `WithRawHeader` method for http request builder.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/test/testutils/http_request.go
+++ b/test/testutils/http_request.go
@@ -118,6 +118,14 @@ func (h *HttpRequestBuilder) WithHeader(key, value string) *HttpRequestBuilder {
 	return h
 }
 
+// WithRawHeader accepts multiple header values for a key.
+// Unlike WithHeader, it does not split the value by a headerDelimiter (,) and instead allows for N values to be
+// set as-is.
+func (h *HttpRequestBuilder) WithRawHeader(key string, values ...string) *HttpRequestBuilder {
+	h.headers[key] = values
+	return h
+}
+
 func (h *HttpRequestBuilder) errorIfInvalid() error {
 	if h.scheme == "" {
 		return errors.New("scheme is empty, but required")


### PR DESCRIPTION
# Description

- Add new method `WithRawHeader` which sets the header at a specific key to the values provided afterward.

# Context

There may be instances where the header we are setting has `,` as part of their value - for example HMAC authorization headers are in the form `hmac username="", algorithm="", headers="", signature=""`. 

The existing way of adding headers using our http request builder uses `,` as a delimeter, so adding a new function that handles cases where we _don't_ want to split off a header based on that delimiter. Titled `RawHeader` as we are setting the header to those raw strings without any formating/work done on them.


# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- ~If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff~
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- ~I have added tests that prove my fix is effective or that my feature works~
