### PR TITLE
Gloohelpers measure

### DIFF
--- a/changelog/v1.15.0-beta18/gloohelpers-measure.yaml
+++ b/changelog/v1.15.0-beta18/gloohelpers-measure.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/5038
+    resolvesIssue: false
+    description: >-
+      Add Measure function to gloohelpers for cases where we do not care about the 0ns error
+
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/test/helpers/benchmark_darwin.go
+++ b/test/helpers/benchmark_darwin.go
@@ -9,12 +9,8 @@ import (
 // performance when running on the Linux GHA runner we use for Nightly tests
 // Ignore will always be false
 func MeasureIgnore0ns(f func()) (Result, bool, error) {
-	before := time.Now()
-	f()
-	elapsed := time.Since(before)
-	return Result{
-		Total: elapsed,
-	}, false, nil
+	res, err := Measure(f)
+	return res, false, err
 }
 
 // Measure as implemented here for Mac/Darwin is meant to be used in performance tests when developing locally

--- a/test/helpers/benchmark_darwin.go
+++ b/test/helpers/benchmark_darwin.go
@@ -7,6 +7,7 @@ import (
 // MeasureIgnore0ns as implemented here for Mac/Darwin is meant to be used in performance tests when developing locally
 // It is a less-precise method for measuring than the Linux implementation, and targets should be derived based on
 // performance when running on the Linux GHA runner we use for Nightly tests
+// Ignore will always be false
 func MeasureIgnore0ns(f func()) (Result, bool, error) {
 	before := time.Now()
 	f()
@@ -14,4 +15,16 @@ func MeasureIgnore0ns(f func()) (Result, bool, error) {
 	return Result{
 		Total: elapsed,
 	}, false, nil
+}
+
+// Measure as implemented here for Mac/Darwin is meant to be used in performance tests when developing locally
+// It is a less-precise method for measuring than the Linux implementation, and targets should be derived based on
+// performance when running on the Linux GHA runner we use for Nightly tests
+func Measure(f func()) (Result, error) {
+	before := time.Now()
+	f()
+	elapsed := time.Since(before)
+	return Result{
+		Total: elapsed,
+	}, nil
 }

--- a/test/helpers/benchmark_linux.go
+++ b/test/helpers/benchmark_linux.go
@@ -11,7 +11,7 @@ import (
 // The 0ns error occurs when measuring very short durations (~100µs) when measurements may round down to 0ns
 // This function should be used in circumstances where we want to ignore that particular error but not others
 func MeasureIgnore0ns(f func()) (benchmarking.Result, bool, error) {
-	res, err := benchmarking.Measure(f)
+	res, err := Measure(f)
 	if err != nil && strings.Contains(err.Error(), "total execution time was 0 ns") {
 		return res, true, nil
 	}

--- a/test/helpers/benchmark_linux.go
+++ b/test/helpers/benchmark_linux.go
@@ -6,10 +6,20 @@ import (
 	"github.com/solo-io/go-utils/testutils/benchmarking"
 )
 
+// MeasureIgnore0ns wraps benchmarking.Measure, checking error values for the 0ns error and returning true as the middle
+// argument if that is the error
+// The 0ns error occurs when measuring very short durations (~100µs) when measurements may round down to 0ns
+// This function should be used in circumstances where we want to ignore that particular error but not others
 func MeasureIgnore0ns(f func()) (benchmarking.Result, bool, error) {
 	res, err := benchmarking.Measure(f)
 	if err != nil && strings.Contains(err.Error(), "total execution time was 0 ns") {
 		return res, true, nil
 	}
 	return res, false, err
+}
+
+// Measure wraps benchmarking.Measure 1:1
+// It is redefined here so that we can build with a darwin-compatible version depending on the machine being used
+func Measure(f func()) (benchmarking.Result, error) {
+	return benchmarking.Measure(f)
 }

--- a/test/helpers/certs.go
+++ b/test/helpers/certs.go
@@ -24,7 +24,7 @@ import (
 	kubev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
@@ -74,7 +74,7 @@ type Params struct {
 func GetCerts(params Params) (string, string) {
 
 	if len(params.Hosts) == 0 {
-		Fail("Missing required --host parameter")
+		ginkgo.Fail("Missing required --host parameter")
 	}
 
 	var priv interface{}
@@ -98,7 +98,7 @@ func GetCerts(params Params) (string, string) {
 		case "P521":
 			priv, err = ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
 		default:
-			Fail(fmt.Sprintf("Unrecognized elliptic curve: %q", params.EcdsaCurve))
+			ginkgo.Fail(fmt.Sprintf("Unrecognized elliptic curve: %q", params.EcdsaCurve))
 		}
 		Expect(err).NotTo(HaveOccurred())
 	}
@@ -120,7 +120,7 @@ func GetCerts(params Params) (string, string) {
 	serialNumberLimit := new(big.Int).Lsh(big.NewInt(1), 128)
 	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
 	if err != nil {
-		Fail(fmt.Sprintf("failed to generate serial number: %s", err))
+		ginkgo.Fail(fmt.Sprintf("failed to generate serial number: %s", err))
 	}
 
 	template := x509.Certificate{
@@ -153,7 +153,7 @@ func GetCerts(params Params) (string, string) {
 
 	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, publicKey(priv), priv)
 	if err != nil {
-		Fail(fmt.Sprintf("Failed to create certificate: %s", err))
+		ginkgo.Fail(fmt.Sprintf("Failed to create certificate: %s", err))
 	}
 
 	var certOut bytes.Buffer

--- a/test/helpers/util_test.go
+++ b/test/helpers/util_test.go
@@ -3,37 +3,37 @@ package helpers_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	. "github.com/solo-io/gloo/test/helpers"
+	"github.com/solo-io/gloo/test/helpers"
 )
 
 var _ = Describe("PercentileIndex", func() {
 	It("panics on percentile <= 0", func() {
-		Expect(func() { PercentileIndex(100, -1) }).To(Panic())
+		Expect(func() { helpers.PercentileIndex(100, -1) }).To(Panic())
 	})
 
 	It("panics on percentile > 100", func() {
-		Expect(func() { PercentileIndex(100, 101) }).To(Panic())
+		Expect(func() { helpers.PercentileIndex(100, 101) }).To(Panic())
 	})
 
 	It("returns 0 for 1st percentile for len <=100", func() {
 		for i := 1; i <= 100; i++ {
-			Expect(PercentileIndex(i, 1)).To(Equal(0))
+			Expect(helpers.PercentileIndex(i, 1)).To(Equal(0))
 		}
 	})
 
 	It("returns 1 for 1st percentile for len >100, <=200", func() {
 		for i := 101; i <= 200; i++ {
-			Expect(PercentileIndex(i, 1)).To(Equal(1))
+			Expect(helpers.PercentileIndex(i, 1)).To(Equal(1))
 		}
 	})
 
 	It("always returns len-1 for 100th percentile", func() {
 		for i := 1; i <= 200; i++ {
-			Expect(PercentileIndex(i, 100)).To(Equal(i - 1))
+			Expect(helpers.PercentileIndex(i, 100)).To(Equal(i - 1))
 		}
 	})
 
 	It("returns index 3 for 80th percentile and length 5", func() {
-		Expect(PercentileIndex(5, 80)).To(Equal(3))
+		Expect(helpers.PercentileIndex(5, 80)).To(Equal(3))
 	})
 })

--- a/test/testutils/env.go
+++ b/test/testutils/env.go
@@ -56,7 +56,7 @@ const (
 
 	// GithubAction is used by Github Actions and is the name of the currently running action or ID of a step
 	// https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
-	GithubAction = "GITHUB_ACITON"
+	GithubAction = "GITHUB_ACTION"
 
 	// GcloudBuildId is used by Cloudbuild to identify the build id
 	// This is set when running tests in Cloudbuild


### PR DESCRIPTION
# Description

- Add `Measure()` function to gloohelpers with darwin and linux implementations
  - Undo dot-import of ginkgo in `helpers` package which causes conflict on re-declaration of `Measure()`

# Context

We don't always care about the `ignore` value returned by `MeasureIgnore0ns()`
That function returns `true` if the linux-compatible `benchmark.Measure()` returns an error due to recording 0ns as the duration for the given function's runtime
This is relatively common for cases where the function being measured runs very quickly (~100µs) and the measurement may round down
In cases where our expected runtimes are orders of magnitude higher we probably do want to error if we get a 0ns measurement

See [this conversation](https://github.com/solo-io/solo-projects/pull/5142#discussion_r1258931031) about a case where we'd prefer to use `Measure()`

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
