### PR TITLE
[v1.12.x] Bump envoy-gloo to v1.23.11-patch1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.9-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.11-patch1
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.12.57/bump-envoy-gloo.yaml
+++ b/changelog/v1.12.57/bump-envoy-gloo.yaml
@@ -6,5 +6,6 @@ changelog:
   dependencyTag: v1.23.11-patch1
 - type: FIX
   issueLink: https://github.com/solo-io/solo-projects/issues/5138
+  resolvesIssue: false
   description: >
     Pulls in upstream Envoy v1.23.11, which includes a fix for CVE-2023-35945

--- a/changelog/v1.12.57/bump-envoy-gloo.yaml
+++ b/changelog/v1.12.57/bump-envoy-gloo.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  description: Bump envoy gloo to latest v1.23.11-patch1
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-gloo
+  dependencyTag: v1.23.11-patch1

--- a/changelog/v1.12.57/bump-envoy-gloo.yaml
+++ b/changelog/v1.12.57/bump-envoy-gloo.yaml
@@ -5,5 +5,6 @@ changelog:
   dependencyRepo: envoy-gloo
   dependencyTag: v1.23.11-patch1
 - type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/5138
   description: >
     Pulls in upstream Envoy v1.23.11, which includes a fix for CVE-2023-35945

--- a/changelog/v1.12.57/bump-envoy-gloo.yaml
+++ b/changelog/v1.12.57/bump-envoy-gloo.yaml
@@ -4,3 +4,6 @@ changelog:
   dependencyOwner: solo-io
   dependencyRepo: envoy-gloo
   dependencyTag: v1.23.11-patch1
+- type: FIX
+  description: >
+    Pulls in upstream Envoy v1.23.11, which includes a fix for CVE-2023-35945


### PR DESCRIPTION
# Description
 - Bump envoy-gloo to v1.23.11-patch1, pulling in fixes which resolve CVE-2023-35945
