### PR TITLE
[v1.15.x/main] Bump envoy-gloo to v1.25.8-patch1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ z := $(shell mkdir -p $(OUTPUT_DIR))
 VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:v1.25.8-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.25.8-patch1
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ z := $(shell mkdir -p $(OUTPUT_DIR))
 VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.25.6-patch4
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:v1.25.8-patch1
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/changelog/v1.15.0-beta19/bump-envoy-gloo.yaml
+++ b/changelog/v1.15.0-beta19/bump-envoy-gloo.yaml
@@ -1,0 +1,10 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  description: Bump envoy gloo to latest v1.25.8-patch1
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-gloo
+  dependencyTag: v1.25.8-patch1
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/5138
+  description: >
+    Pulls in upstream Envoy v1.25.8-patch1, which includes a fix for CVE-2023-35945

--- a/changelog/v1.15.0-beta19/bump-envoy-gloo.yaml
+++ b/changelog/v1.15.0-beta19/bump-envoy-gloo.yaml
@@ -6,5 +6,6 @@ changelog:
   dependencyTag: v1.25.8-patch1
 - type: FIX
   issueLink: https://github.com/solo-io/solo-projects/issues/5138
+  resolvesIssue: false
   description: >
     Pulls in upstream Envoy v1.25.8-patch1, which includes a fix for CVE-2023-35945


### PR DESCRIPTION
# Description
 - Bump envoy-gloo to v1.25.8-patch1, pulling in fixes which resolve CVE-2023-35945