### PR TITLE
[1.14] Fix yaml separation for mult. default gw

### DIFF
--- a/install/helm/gloo/templates/_8-default-gateways.tpl
+++ b/install/helm/gloo/templates/_8-default-gateways.tpl
@@ -154,7 +154,7 @@ spec:
 {{- if not $gatewaySettings.disableGeneratedGateways }}
 {{- if not $gatewaySettings.disableHttpGateway }}
 {{- $defaultGatewayOverride := $spec.gatewaySettings.httpGatewayKubeOverride }}
-{{- "---" }}
+---
 {{- include "gloo.util.merge" (list $ctx $defaultGatewayOverride "defaultGateway.gateway") -}}
 {{- end }}{{/* if not $gatewaySettings.disableHttpGateway */}}
 {{- if not $gatewaySettings.disableHttpsGateway }}


### PR DESCRIPTION
# Description

Fixes YAML separation characters for multiple defined default gateways
#8475

Basically the same issue as #8404 but for multiple GW

# Context

When defining multiple Default Gateways with Helm bad line break rendering breaks the gateway CRD creation