### PR TITLE
Update Http Passthrough Auth Doc

### DIFF
--- a/docs/content/guides/security/auth/extauth/passthrough_auth/http/_index.md
+++ b/docs/content/guides/security/auth/extauth/passthrough_auth/http/_index.md
@@ -60,7 +60,7 @@ kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Service
 metadata:
-  name: example-grpc-auth-service
+  name: example-http-auth-service
   labels:
       app: http-extauth
 spec:


### PR DESCRIPTION
# Description

The doc for Http Passthrough Auth is creating a service with the wrong name for the example auth service. 
It uses example-grpc-auth-service instead of example-http-auth-service


# Context

Users ran into this bug doing ... \ Users needed this feature to ...

# Checklist:

- [ ] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [ ] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [ ] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [ ] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
