### PR TITLE
[v1.13.x] Bump envoy-gloo to v1.23.12-patch1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.11-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.12-patch1
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.13.23/bump-envoy-gloo.yaml
+++ b/changelog/v1.13.23/bump-envoy-gloo.yaml
@@ -1,0 +1,12 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  description: Bump envoy gloo to latest v1.23.12-patch1
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-gloo
+  dependencyTag: v1.23.12-patch1
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/5138
+  resolvesIssue: false
+  description: >
+    Pulls in upstream Envoy v1.23.12, which includes fixes for
+    CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945.


### PR DESCRIPTION
 - Pulls in upstream Envoy v1.23.12, which includes fixes for
    CVE-2023-35941, CVE-2023-35942, CVE-2023-35944, and CVE-2023-35945.