### PR TITLE
Stability: Port Kube2e Changes to Open Source

### DIFF
--- a/changelog/v1.15.0-beta23/vs-labels.yaml
+++ b/changelog/v1.15.0-beta23/vs-labels.yaml
@@ -1,0 +1,6 @@
+changelog:
+  type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/5232
+  resolvesIssue: false
+  description: >-
+    Support setting labels using the VS builder

--- a/changelog/v1.15.0-beta23/vs-labels.yaml
+++ b/changelog/v1.15.0-beta23/vs-labels.yaml
@@ -1,5 +1,5 @@
 changelog:
-  type: NON_USER_FACING
+- type: NON_USER_FACING
   issueLink: https://github.com/solo-io/solo-projects/issues/5232
   resolvesIssue: false
   description: >-

--- a/docs/content/static/content/osa_provided.md
+++ b/docs/content/static/content/osa_provided.md
@@ -21,6 +21,7 @@ Name|Version|License
 [golang/protobuf](https://github.com/golang/protobuf)|v1.5.3|BSD 3-clause "New" or "Revised" License
 [google/go-github](https://github.com/google/go-github)|v17.0.0+incompatible|BSD 3-clause "New" or "Revised" License
 [go-github/v32](https://github.com/google/go-github)|v32.0.0|BSD 3-clause "New" or "Revised" License
+[google/uuid](https://github.com/google/uuid)|v1.3.0|BSD 3-clause "New" or "Revised" License
 [gorilla/mux](https://github.com/gorilla/mux)|v1.8.0|BSD 3-clause "New" or "Revised" License
 [grpc-ecosystem/go-grpc-middleware](https://github.com/grpc-ecosystem/go-grpc-middleware)|v1.3.0|Apache License 2.0
 [hinshun/vt10x](https://github.com/hinshun/vt10x)|v0.0.0-20180809195222-d55458df857c|MIT License

--- a/go.mod
+++ b/go.mod
@@ -89,6 +89,7 @@ require (
 )
 
 require (
+	github.com/google/uuid v1.3.0
 	golang.org/x/exp v0.0.0-20220921164117-439092de6870
 	google.golang.org/genproto/googleapis/api v0.0.0-20230526203410-71b5a4ffd15e
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230526203410-71b5a4ffd15e
@@ -172,7 +173,6 @@ require (
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.3.0 // indirect
 	github.com/goph/emperror v0.17.1 // indirect
 	github.com/gosuri/uitable v0.0.4 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect

--- a/test/helpers/snapshot_writer.go
+++ b/test/helpers/snapshot_writer.go
@@ -311,12 +311,14 @@ func (s *SnapshotWriterImpl) waitForProxiesToBeDeleted(deleteOptions clients.Del
 		}
 		return nil
 	},
+		// Proxies should be deleted almost instantly, so we can use a short backoff (we retry every 200ms for 5s total)
+		// If the proxies are not deleted by then, something else is wrong and we should fail the test
 		retry.RetryIf(func(err error) bool {
 			return err != nil
 		}),
 		retry.LastErrorOnly(true),
-		retry.Attempts(5),
-		retry.Delay(time.Millisecond*500),
+		retry.Attempts(10),
+		retry.Delay(time.Millisecond*200),
 		retry.DelayType(retry.FixedDelay),
 	)
 }

--- a/test/helpers/snapshot_writer.go
+++ b/test/helpers/snapshot_writer.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
-
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 
 	"github.com/avast/retry-go"
@@ -280,7 +279,7 @@ func (s *SnapshotWriterImpl) doDeleteSnapshot(snapshot *gloosnapshot.ApiSnapshot
 		}
 	}
 
-	return nil
+	return s.waitForProxiesToBeDeleted(deleteOptions)
 }
 
 func (s *SnapshotWriterImpl) isContinuableDeleteError(deleteError error) bool {
@@ -291,4 +290,33 @@ func (s *SnapshotWriterImpl) isContinuableDeleteError(deleteError error) bool {
 	// Since we delete resources in bulk, with retries, we may hit a case where a resource doesn't exist
 	// We can ignore that error and continue to try to delete other resources in the Snapshot
 	return errors.IsNotExist(deleteError)
+}
+
+func (s *SnapshotWriterImpl) waitForProxiesToBeDeleted(deleteOptions clients.DeleteOpts) error {
+	return retry.Do(func() error {
+		if deleteOptions.Ctx.Err() != nil {
+			// intentionally return early if context is already done
+			// this is a backoff loop; by the time we get here ctx may be done
+			return nil
+		}
+		proxies, err := s.ProxyClient().List(s.writeNamespace, clients.ListOpts{
+			Ctx:     deleteOptions.Ctx,
+			Cluster: deleteOptions.Cluster,
+		})
+		if err != nil {
+			return err
+		}
+		if len(proxies) > 0 {
+			return errors.Errorf("expected proxies to be deleted, but found %d", len(proxies))
+		}
+		return nil
+	},
+		retry.RetryIf(func(err error) bool {
+			return err != nil
+		}),
+		retry.LastErrorOnly(true),
+		retry.Attempts(5),
+		retry.Delay(time.Millisecond*500),
+		retry.DelayType(retry.FixedDelay),
+	)
 }

--- a/test/helpers/virtual_services.go
+++ b/test/helpers/virtual_services.go
@@ -16,6 +16,7 @@ import (
 type VirtualServiceBuilder struct {
 	name      string
 	namespace string
+	labels    map[string]string
 
 	domains            []string
 	virtualHostOptions *gloov1.VirtualHostOptions
@@ -23,14 +24,16 @@ type VirtualServiceBuilder struct {
 	sslConfig          *ssl.SslConfig
 }
 
+// BuilderFromVirtualService creates a new VirtualServiceBuilder from an existing VirtualService
 func BuilderFromVirtualService(vs *v1.VirtualService) *VirtualServiceBuilder {
 	builder := &VirtualServiceBuilder{
 		name:               vs.GetMetadata().GetName(),
 		namespace:          vs.GetMetadata().GetNamespace(),
+		labels:             vs.GetMetadata().GetLabels(),
 		domains:            vs.GetVirtualHost().GetDomains(),
 		virtualHostOptions: vs.GetVirtualHost().GetOptions(),
 		sslConfig:          vs.GetSslConfig(),
-		routesByName:       make(map[string]*v1.Route, 10),
+		routesByName:       make(map[string]*v1.Route, len(vs.GetVirtualHost().GetRoutes())),
 	}
 	for _, r := range vs.GetVirtualHost().GetRoutes() {
 		builder.WithRoute(r.GetName(), r)
@@ -38,8 +41,10 @@ func BuilderFromVirtualService(vs *v1.VirtualService) *VirtualServiceBuilder {
 	return builder
 }
 
+// NewVirtualServiceBuilder creates an empty VirtualServiceBuilder
 func NewVirtualServiceBuilder() *VirtualServiceBuilder {
 	return &VirtualServiceBuilder{
+		labels:       make(map[string]string, 2),
 		routesByName: make(map[string]*v1.Route, 10),
 	}
 }
@@ -56,6 +61,11 @@ func (b *VirtualServiceBuilder) WithName(name string) *VirtualServiceBuilder {
 
 func (b *VirtualServiceBuilder) WithNamespace(namespace string) *VirtualServiceBuilder {
 	b.namespace = namespace
+	return b
+}
+
+func (b *VirtualServiceBuilder) WithLabel(key, value string) *VirtualServiceBuilder {
+	b.labels[key] = value
 	return b
 }
 
@@ -216,10 +226,15 @@ func (b *VirtualServiceBuilder) Clone() *VirtualServiceBuilder {
 
 	clone.name = b.name
 	clone.namespace = b.namespace
+	clone.labels = make(map[string]string, len(b.labels))
+	for key, value := range b.labels {
+		clone.labels[key] = value
+	}
+
 	clone.domains = nil
 	clone.domains = append(clone.domains, b.domains...)
 	clone.virtualHostOptions = b.virtualHostOptions.Clone().(*gloov1.VirtualHostOptions)
-	clone.routesByName = make(map[string]*v1.Route)
+	clone.routesByName = make(map[string]*v1.Route, len(b.routesByName))
 	for key, value := range b.routesByName {
 		clone.routesByName[key] = value.Clone().(*v1.Route)
 	}
@@ -244,6 +259,7 @@ func (b *VirtualServiceBuilder) Build() *v1.VirtualService {
 		Metadata: &core.Metadata{
 			Name:      b.name,
 			Namespace: b.namespace,
+			Labels:    b.labels,
 		},
 		VirtualHost: &v1.VirtualHost{
 			Domains: b.domains,

--- a/test/helpers/virtual_services.go
+++ b/test/helpers/virtual_services.go
@@ -70,7 +70,11 @@ func (b *VirtualServiceBuilder) WithLabel(key, value string) *VirtualServiceBuil
 }
 
 func (b *VirtualServiceBuilder) WithDomain(domain string) *VirtualServiceBuilder {
-	b.domains = []string{domain}
+	return b.WithDomains([]string{domain})
+}
+
+func (b *VirtualServiceBuilder) WithDomains(domains []string) *VirtualServiceBuilder {
+	b.domains = domains
 	return b
 }
 

--- a/test/helpers/virtual_services_test.go
+++ b/test/helpers/virtual_services_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/solo-io/solo-kit/test/matchers"
 )
 
-var _ = FDescribe("VirtualServiceBuilder", func() {
+var _ = Describe("VirtualServiceBuilder", func() {
 
 	It("will fail if the virtual service builder has a new top level field", func() {
 		// This test is important as it checks whether the virtual service builder has a new top level field.

--- a/test/helpers/virtual_services_test.go
+++ b/test/helpers/virtual_services_test.go
@@ -1,6 +1,9 @@
 package helpers_test
 
 import (
+	"hash"
+	"reflect"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
@@ -9,11 +12,9 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
 	"github.com/solo-io/gloo/test/helpers"
 	"github.com/solo-io/solo-kit/test/matchers"
-
-	"reflect"
 )
 
-var _ = Describe("VirtualServiceBuilder", func() {
+var _ = FDescribe("VirtualServiceBuilder", func() {
 
 	It("will fail if the virtual service builder has a new top level field", func() {
 		// This test is important as it checks whether the virtual service builder has a new top level field.
@@ -21,7 +22,7 @@ var _ = Describe("VirtualServiceBuilder", func() {
 		// most likely needs to change to support this new field
 
 		Expect(reflect.TypeOf(helpers.VirtualServiceBuilder{}).NumField()).To(
-			Equal(6),
+			Equal(7),
 			"wrong number of fields found",
 		)
 	})
@@ -30,6 +31,7 @@ var _ = Describe("VirtualServiceBuilder", func() {
 		originalBuilder := helpers.NewVirtualServiceBuilder().
 			WithName("original-name").
 			WithNamespace("original-namespace").
+			WithLabel("original-label", "original-value").
 			WithDomain("original.com").
 			WithVirtualHostOptions(&gloov1.VirtualHostOptions{
 				Cors: &cors.CorsPolicy{
@@ -46,6 +48,7 @@ var _ = Describe("VirtualServiceBuilder", func() {
 		clonedBuilder := originalBuilder.Clone().
 			WithName("cloned-name").
 			WithNamespace("cloned-namespace").
+			WithLabel("original-label", "cloned-value").
 			WithDomain("cloned.com").
 			WithVirtualHostOptions(&gloov1.VirtualHostOptions{
 				Cors: &cors.CorsPolicy{
@@ -71,6 +74,9 @@ var _ = Describe("VirtualServiceBuilder", func() {
 		Expect(originalVirtualService.GetMetadata().GetNamespace()).To(Equal("original-namespace"))
 		Expect(clonedVirtualService.GetMetadata().GetNamespace()).To(Equal("cloned-namespace"))
 
+		Expect(originalVirtualService.GetMetadata().GetLabels()["original-label"]).To(Equal("original-value"))
+		Expect(clonedVirtualService.GetMetadata().GetLabels()["original-label"]).To(Equal("cloned-value"))
+
 		Expect(originalVirtualService.GetSslConfig().GetSniDomains()).To(Equal([]string{"original.com"}))
 		Expect(clonedVirtualService.GetSslConfig().GetSniDomains()).To(Equal([]string{"cloned.com"}))
 
@@ -90,6 +96,26 @@ var _ = Describe("VirtualServiceBuilder", func() {
 		Expect(clonedVirtualHost.GetRoutes()[0]).To(matchers.MatchProto(&gatewayv1.Route{
 			Name: "cloned-route",
 		}))
+	})
+
+	It("hashes virtual services with different labels to different values", func() {
+		var hasher hash.Hash64
+
+		originalBuilder := helpers.NewVirtualServiceBuilder().
+			WithName("original-name").
+			WithNamespace("original-namespace").
+			WithLabel("original-label", "original-value").
+			WithDomain("original.com")
+		modifiedLabelBuilder := originalBuilder.Clone().
+			WithLabel("original-label", "modified-value")
+
+		originalVsHash, err := originalBuilder.Build().Hash(hasher)
+		Expect(err).NotTo(HaveOccurred())
+
+		vsWithModifiedLabelHash, err := modifiedLabelBuilder.Build().Hash(hasher)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(originalVsHash).NotTo(Equal(vsWithModifiedLabelHash), "Hashes should be different, due to label differences")
 	})
 
 })

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -1155,7 +1155,14 @@ var _ = Describe("Kube2e: gateway", func() {
 			setWatchLabels(nil)
 		})
 
-		It("should preserve discovery", func() {
+		It("should preserve discovery", FlakeAttempts(5), func() {
+			// This test has flaked before with the following error:
+			// 	Failed to validate Proxy [namespace: gloo-system, name: gateway-proxy] with gloo validation:
+			//	Listener Error: SSLConfigError. Reason: SSL secret not found: list did not find secret gloo-system.secret-native-ssl\n\n",
+			// This seems to be the result of test pollution since the secret is created in a separate test
+			// This has only caused this test, which depends on discovery to flake, so in the meantime, we are adding
+			// a flake decorator
+
 			createServicesForPod(helper.TestrunnerName, helper.TestRunnerPort)
 
 			for _, svc := range createdServices {

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/compress"
 
 	"github.com/solo-io/gloo/test/ginkgo/parallel"
@@ -99,6 +101,7 @@ var _ = Describe("Kube2e: gateway", func() {
 		testRunnerVs = helpers.NewVirtualServiceBuilder().
 			WithName(helper.TestrunnerName).
 			WithNamespace(testHelper.InstallNamespace).
+			WithLabel(kube2e.UniqueTestResourceLabel, uuid.New().String()).
 			WithDomain(helper.TestrunnerName).
 			WithRoutePrefixMatcher(helper.TestrunnerName, "/").
 			WithRouteActionToSingleDestination(helper.TestrunnerName, testRunnerDestination).

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -59,7 +59,7 @@ import (
 	glootransformation "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
 	defaults2 "github.com/solo-io/gloo/projects/gloo/pkg/defaults"
-	kubernetes2 "github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
+	kubernetesplugin "github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/linkerd"
 	"github.com/solo-io/gloo/projects/gloo/pkg/translator"
 	"github.com/solo-io/gloo/test/helpers"
@@ -401,7 +401,7 @@ var _ = Describe("Kube2e: gateway", func() {
 					DestinationType: &gloov1.Destination_Upstream{
 						Upstream: &core.ResourceRef{
 							Namespace: testHelper.InstallNamespace,
-							Name:      kubernetes2.UpstreamName(testHelper.InstallNamespace, helper.HttpEchoName, helper.HttpEchoPort),
+							Name:      kubernetesplugin.UpstreamName(testHelper.InstallNamespace, helper.HttpEchoName, helper.HttpEchoPort),
 						},
 					},
 				}
@@ -1135,7 +1135,7 @@ var _ = Describe("Kube2e: gateway", func() {
 		}
 
 		getUpstream := func(svcname string) (*gloov1.Upstream, error) {
-			upstreamName := kubernetes2.UpstreamName(testHelper.InstallNamespace, svcname, helper.TestRunnerPort)
+			upstreamName := kubernetesplugin.UpstreamName(testHelper.InstallNamespace, svcname, helper.TestRunnerPort)
 			return resourceClientset.UpstreamClient().Read(testHelper.InstallNamespace, upstreamName, clients.ReadOpts{})
 		}
 
@@ -1168,7 +1168,7 @@ var _ = Describe("Kube2e: gateway", func() {
 					ctx,
 					&core.ResourceRef{
 						Namespace: testHelper.InstallNamespace,
-						Name:      kubernetes2.UpstreamName(testHelper.InstallNamespace, svc, helper.TestRunnerPort),
+						Name:      kubernetesplugin.UpstreamName(testHelper.InstallNamespace, svc, helper.TestRunnerPort),
 					},
 					func(resource resources.Resource) resources.Resource {
 						upstream := resource.(*gloov1.Upstream)
@@ -1285,7 +1285,7 @@ var _ = Describe("Kube2e: gateway", func() {
 
 			httpEchoClusterName = translator.UpstreamToClusterName(&core.ResourceRef{
 				Namespace: testHelper.InstallNamespace,
-				Name:      kubernetes2.UpstreamName(testHelper.InstallNamespace, helper.HttpEchoName, helper.HttpEchoPort),
+				Name:      kubernetesplugin.UpstreamName(testHelper.InstallNamespace, helper.HttpEchoName, helper.HttpEchoPort),
 			})
 		})
 
@@ -1465,7 +1465,7 @@ var _ = Describe("Kube2e: gateway", func() {
 			service, err = resourceClientset.KubeClients().CoreV1().Services(testHelper.InstallNamespace).Create(ctx, service, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
-			upstreamName = kubernetes2.UpstreamName(testHelper.InstallNamespace, service.Name, 5678)
+			upstreamName = kubernetesplugin.UpstreamName(testHelper.InstallNamespace, service.Name, 5678)
 			upstreamRef := &core.ResourceRef{
 				Name:      upstreamName,
 				Namespace: testHelper.InstallNamespace,
@@ -2257,7 +2257,7 @@ spec:
 						WithRoutePrefixMatcher("route", "/").
 						WithRouteActionToUpstreamRef("route",
 							&core.ResourceRef{
-								Name:      kubernetes2.UpstreamName(testHelper.InstallNamespace, helper.TestrunnerName, helper.TestRunnerPort),
+								Name:      kubernetesplugin.UpstreamName(testHelper.InstallNamespace, helper.TestrunnerName, helper.TestRunnerPort),
 								Namespace: testHelper.InstallNamespace,
 							}).
 						Build()
@@ -2364,7 +2364,7 @@ spec:
 					)
 
 					BeforeEach(func() {
-						petstoreUpstreamName = kubernetes2.UpstreamName(testHelper.InstallNamespace, petstoreName, 8080)
+						petstoreUpstreamName = kubernetesplugin.UpstreamName(testHelper.InstallNamespace, petstoreName, 8080)
 						petstoreDeployment, petstoreSvc = petstore(testHelper.InstallNamespace)
 
 						// disable FDS for the petstore, create it without functions

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -398,7 +398,7 @@ var _ = Describe("Kube2e: gateway", func() {
 					DestinationType: &gloov1.Destination_Upstream{
 						Upstream: &core.ResourceRef{
 							Namespace: testHelper.InstallNamespace,
-							Name:      fmt.Sprintf("%s-%s-%v", testHelper.InstallNamespace, helper.HttpEchoName, helper.HttpEchoPort),
+							Name:      kubernetes2.UpstreamName(testHelper.InstallNamespace, helper.HttpEchoName, helper.HttpEchoPort),
 						},
 					},
 				}
@@ -1132,7 +1132,7 @@ var _ = Describe("Kube2e: gateway", func() {
 		}
 
 		getUpstream := func(svcname string) (*gloov1.Upstream, error) {
-			upstreamName := fmt.Sprintf("%s-%s-%v", testHelper.InstallNamespace, svcname, helper.TestRunnerPort)
+			upstreamName := kubernetes2.UpstreamName(testHelper.InstallNamespace, svcname, helper.TestRunnerPort)
 			return resourceClientset.UpstreamClient().Read(testHelper.InstallNamespace, upstreamName, clients.ReadOpts{})
 		}
 
@@ -1165,7 +1165,7 @@ var _ = Describe("Kube2e: gateway", func() {
 					ctx,
 					&core.ResourceRef{
 						Namespace: testHelper.InstallNamespace,
-						Name:      fmt.Sprintf("%s-%s-%v", testHelper.InstallNamespace, svc, helper.TestRunnerPort),
+						Name:      kubernetes2.UpstreamName(testHelper.InstallNamespace, svc, helper.TestRunnerPort),
 					},
 					func(resource resources.Resource) resources.Resource {
 						upstream := resource.(*gloov1.Upstream)
@@ -2254,7 +2254,7 @@ spec:
 						WithRoutePrefixMatcher("route", "/").
 						WithRouteActionToUpstreamRef("route",
 							&core.ResourceRef{
-								Name:      fmt.Sprintf("%s-%s-%v", testHelper.InstallNamespace, helper.TestrunnerName, helper.TestRunnerPort),
+								Name:      kubernetes2.UpstreamName(testHelper.InstallNamespace, helper.TestrunnerName, helper.TestRunnerPort),
 								Namespace: testHelper.InstallNamespace,
 							}).
 						Build()
@@ -2361,7 +2361,7 @@ spec:
 					)
 
 					BeforeEach(func() {
-						petstoreUpstreamName = fmt.Sprintf("%s-%s-%v", testHelper.InstallNamespace, petstoreName, 8080)
+						petstoreUpstreamName = kubernetes2.UpstreamName(testHelper.InstallNamespace, petstoreName, 8080)
 						petstoreDeployment, petstoreSvc = petstore(testHelper.InstallNamespace)
 
 						// disable FDS for the petstore, create it without functions

--- a/test/kube2e/gateway/robustness_test.go
+++ b/test/kube2e/gateway/robustness_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
 
@@ -107,6 +109,7 @@ var _ = Describe("Robustness tests", func() {
 		appVs = helpers.NewVirtualServiceBuilder().
 			WithName(appName).
 			WithNamespace(testHelper.InstallNamespace).
+			WithLabel(kube2e.UniqueTestResourceLabel, uuid.New().String()).
 			WithDomain("app").
 			WithRoutePrefixMatcher("route", "/1").
 			WithRouteActionToSingleDestination("route",

--- a/test/kube2e/gloo/gloo_resources_test.go
+++ b/test/kube2e/gloo/gloo_resources_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/uuid"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes/serviceconverter"
@@ -55,6 +57,7 @@ var _ = Describe("GlooResourcesTest", func() {
 		testRunnerVs = helpers.NewVirtualServiceBuilder().
 			WithName(helper.TestrunnerName).
 			WithNamespace(testHelper.InstallNamespace).
+			WithLabel(kube2e.UniqueTestResourceLabel, uuid.New().String()).
 			WithDomain(helper.TestrunnerName).
 			WithRoutePrefixMatcher(helper.TestrunnerName, "/").
 			WithRouteActionToSingleDestination(helper.TestrunnerName, testRunnerDestination).

--- a/test/kube2e/gloo/snapshot_writer_test.go
+++ b/test/kube2e/gloo/snapshot_writer_test.go
@@ -1,9 +1,11 @@
 package gloo_test
 
 import (
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
+	"github.com/solo-io/gloo/test/kube2e"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
@@ -38,6 +40,7 @@ var _ = Describe("SnapshotWriter Test", func() {
 		testRunnerVs := helpers.NewVirtualServiceBuilder().
 			WithName(helper.TestrunnerName).
 			WithNamespace(testHelper.InstallNamespace).
+			WithLabel(kube2e.UniqueTestResourceLabel, uuid.New().String()).
 			WithDomain(helper.TestrunnerName).
 			WithRoutePrefixMatcher(helper.TestrunnerName, "/").
 			WithRouteActionToSingleDestination(helper.TestrunnerName, testRunnerDestination).

--- a/test/kube2e/gloomtls/gloo_mtls_test.go
+++ b/test/kube2e/gloomtls/gloo_mtls_test.go
@@ -3,6 +3,8 @@ package gloomtls_test
 import (
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/solo-io/gloo/test/helpers"
 
@@ -43,6 +45,7 @@ var _ = Describe("Kube2e: mTLS", func() {
 		testRunnerVs := helpers.NewVirtualServiceBuilder().
 			WithName(helper.TestrunnerName).
 			WithNamespace(testHelper.InstallNamespace).
+			WithLabel(kube2e.UniqueTestResourceLabel, uuid.New().String()).
 			WithDomain(helper.TestrunnerName).
 			WithRoutePrefixMatcher(helper.TestrunnerName, "/").
 			WithRouteActionToSingleDestination(helper.TestrunnerName, testRunnerDestination).

--- a/test/kube2e/istio/istio_integration_test.go
+++ b/test/kube2e/istio/istio_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
-	kubernetes2 "github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
+	kubernetesplugin "github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -65,8 +65,8 @@ var _ = Describe("Gloo + Istio integration tests", func() {
 
 	Context("port settings", func() {
 		BeforeEach(func() {
-			serviceRef = core.ResourceRef{Name: helper.TestrunnerName, Namespace: "gloo-system"}
-			virtualServiceRef = core.ResourceRef{Name: helper.TestrunnerName, Namespace: "gloo-system"}
+			serviceRef = core.ResourceRef{Name: helper.TestrunnerName, Namespace: defaults.GlooSystem}
+			virtualServiceRef = core.ResourceRef{Name: helper.TestrunnerName, Namespace: defaults.GlooSystem}
 		})
 
 		// Sets up services
@@ -107,8 +107,8 @@ var _ = Describe("Gloo + Istio integration tests", func() {
 
 			// the upstream should be created by discovery service
 			upstreamRef = core.ResourceRef{
-				Name:      kubernetes2.UpstreamName(defaults.GlooSystem, helper.TestrunnerName, port),
-				Namespace: "gloo-system",
+				Name:      kubernetesplugin.UpstreamName(defaults.GlooSystem, helper.TestrunnerName, port),
+				Namespace: defaults.GlooSystem,
 			}
 			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
 				return resourceClientSet.UpstreamClient().Read(upstreamRef.Namespace, upstreamRef.Name, clients.ReadOpts{})
@@ -209,7 +209,7 @@ var _ = Describe("Gloo + Istio integration tests", func() {
 
 			// the upstream should be created by discovery service
 			upstreamRef = core.ResourceRef{
-				Name:      kubernetes2.UpstreamName(serviceRef.Namespace, serviceRef.Name, helper.TestRunnerPort),
+				Name:      kubernetesplugin.UpstreamName(serviceRef.Namespace, serviceRef.Name, helper.TestRunnerPort),
 				Namespace: defaults.GlooSystem,
 			}
 			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {

--- a/test/kube2e/istio/istio_integration_test.go
+++ b/test/kube2e/istio/istio_integration_test.go
@@ -5,6 +5,9 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
+	kubernetes2 "github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 
 	v1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
@@ -104,7 +107,7 @@ var _ = Describe("Gloo + Istio integration tests", func() {
 
 			// the upstream should be created by discovery service
 			upstreamRef = core.ResourceRef{
-				Name:      fmt.Sprintf("%s-%s-%d", "gloo-system", helper.TestrunnerName, port),
+				Name:      kubernetes2.UpstreamName(defaults.GlooSystem, helper.TestrunnerName, port),
 				Namespace: "gloo-system",
 			}
 			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
@@ -206,8 +209,8 @@ var _ = Describe("Gloo + Istio integration tests", func() {
 
 			// the upstream should be created by discovery service
 			upstreamRef = core.ResourceRef{
-				Name:      fmt.Sprintf("%s-%s-%d", serviceRef.Namespace, serviceRef.Name, helper.TestRunnerPort),
-				Namespace: "gloo-system",
+				Name:      kubernetes2.UpstreamName(serviceRef.Namespace, serviceRef.Name, helper.TestRunnerPort),
+				Namespace: defaults.GlooSystem,
 			}
 			helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
 				return resourceClientSet.UpstreamClient().Read(upstreamRef.Namespace, upstreamRef.Name, clients.ReadOpts{})

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -33,6 +33,14 @@ import (
 	"k8s.io/client-go/kubernetes"
 )
 
+const (
+	// UniqueTestResourceLabel can be assigned to the resources used by kube2e tests
+	// This unique label per test run ensures that the generated snapshot is different on subsequent runs
+	// We have previously seen flakes where a resource is deleted and re-created with the same hash and thus
+	// the emitter can miss the update
+	UniqueTestResourceLabel = "gloo-kube2e-test-id"
+)
+
 func GetHttpEchoImage() string {
 	httpEchoImage := "hashicorp/http-echo"
 	if runtime.GOARCH == "arm64" {


### PR DESCRIPTION
# Description

Support setting the labels on a VS, using the VS builder

# Context

## VS Builder
Setting the label is helpful for kube tests, to ensure we have unique resources across test cases

## WaitForProxy
Added a wait to ensure that after deleting a proxy, we only proceed if they have been successfully removed

# Checklist:

- [x] I included a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) which references the issue that is resolved.
- [x] If I updated APIs (our protos) or helm values, I ran `make -B install-go-tools generated-code` to ensure there will be no code diff
- [x] I followed guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- [x] I opened a draft PR or added the work in progress label if my PR is not ready for review
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
