### PR TITLE
Check for malformed values in HEADER_SECRET_REF_NS_MATCHES_US env var

### DIFF
--- a/changelog/v1.15.0-beta23/env-err.yaml
+++ b/changelog/v1.15.0-beta23/env-err.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Add a check for invalid values in the environment variable to require that secrets be in the same namespace as upstreams.

--- a/projects/gloo/pkg/plugins/headers/plugin_test.go
+++ b/projects/gloo/pkg/plugins/headers/plugin_test.go
@@ -260,6 +260,14 @@ var _ = Describe("Plugin", func() {
 			err := p.ProcessRoute(routeParamsWithSecret, singleRouteToGoodUpstream, out)
 			Expect(err).NotTo(HaveOccurred())
 		})
+		It("Errors with a malformed value for setting", func() {
+			os.Setenv(api_conversion.MatchingNamespaceEnv, "tr")
+			routeParamsWithSecret := plugins.RouteParams{VirtualHostParams: plugins.VirtualHostParams{Params: paramsWithSecret}}
+			out := &envoy_config_route_v3.Route{}
+			singleRouteToGoodUpstream.Options = &v1.RouteOptions{HeaderManipulation: testHeaderManipWithSecrets}
+			err := p.ProcessRoute(routeParamsWithSecret, singleRouteToGoodUpstream, out)
+			Expect(err).Should(MatchError("strconv.ParseBool: parsing \"tr\": invalid syntax"))
+		})
 		AfterEach(func() {
 			os.Clearenv()
 			p = NewPlugin()

--- a/projects/gloo/pkg/translator/translator.go
+++ b/projects/gloo/pkg/translator/translator.go
@@ -144,7 +144,15 @@ func (t *translatorInstance) translateClusterSubsystemComponents(params plugins.
 
 	// endpoints and listeners are shared between listeners
 	logger.Debugf("computing envoy clusters for proxy: %v", proxy.GetMetadata().GetName())
-	shouldEnforceNamespaceMatch, _ := strconv.ParseBool(os.Getenv(api_conversion.MatchingNamespaceEnv))
+	shouldEnforceStr := os.Getenv(api_conversion.MatchingNamespaceEnv)
+	shouldEnforceNamespaceMatch := false
+	if shouldEnforceStr != "" {
+		var err error
+		shouldEnforceNamespaceMatch, err = strconv.ParseBool(shouldEnforceStr)
+		if err != nil {
+			reports.AddError(proxy, err)
+		}
+	}
 	clusters, clusterToUpstreamMap := t.computeClusters(params, reports, upstreamRefKeyToEndpoints, proxy, shouldEnforceNamespaceMatch)
 	logger.Debugf("computing envoy endpoints for proxy: %v", proxy.GetMetadata().GetName())
 


### PR DESCRIPTION
# Description
Error when the value of HEADER_SECRET_REF_NS_MATCHES_US is non-empty and can't be parsed as a boolean. 

# Context

Forward port of change that I made as a result of this comment: https://github.com/solo-io/gloo/pull/8522#pullrequestreview-1552196329


