### PR TITLE
1.13 : mod: Update to go 1.20 for building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ ifeq ($(GOOS),)
 endif
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=$(GOARCH)
-GOLANG_VERSION := golang:1.18.6-alpine
+GOLANG_VERSION := golang:1.20-alpine
 
 # Passed by cloudbuild
 GCLOUD_PROJECT_ID := $(GCLOUD_PROJECT_ID)

--- a/Makefile
+++ b/Makefile
@@ -595,10 +595,8 @@ package-chart: generate-helm-files
 
 .PHONY: push-chart-to-registry
 push-chart-to-registry: generate-helm-files
-	mkdir -p $(HELM_REPOSITORY_CACHE)
-	cp $(DOCKER_CONFIG)/config.json $(HELM_REPOSITORY_CACHE)/config.json
-	HELM_EXPERIMENTAL_OCI=1 helm chart save $(HELM_DIR) gcr.io/solo-public/gloo-helm:$(VERSION)
-	HELM_EXPERIMENTAL_OCI=1 helm chart push gcr.io/solo-public/gloo-helm:$(VERSION)
+	helm package $(HELM_DIR)
+	helm push --registry-config $(DOCKER_CONFIG)/config.json gloo-$(VERSION).tgz oci://gcr.io/solo-public/gloo-helm
 
 .PHONY: fetch-package-and-save-helm
 fetch-package-and-save-helm: generate-helm-files

--- a/changelog/v1.13.24/bump-envoy-gloo.yaml
+++ b/changelog/v1.13.24/bump-envoy-gloo.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    description: Updated go to 1.20
+    dependencyOwner: golang
+    dependencyRepo: go
+  - type: FIX
+    description: Bump golang to 1.20. This requires all plugins to be rebuilt.

--- a/changelog/v1.13.24/bump-envoy-gloo.yaml
+++ b/changelog/v1.13.24/bump-envoy-gloo.yaml
@@ -3,5 +3,6 @@ changelog:
     description: Updated go to 1.20
     dependencyOwner: golang
     dependencyRepo: go
+    dependencyTag: go1.20
   - type: FIX
     description: Bump golang to 1.20. This requires all plugins to be rebuilt.

--- a/changelog/v1.13.24/bump-go-1.20.yaml
+++ b/changelog/v1.13.24/bump-go-1.20.yaml
@@ -8,3 +8,5 @@ changelog:
     resolvesIssue: false
   - type: FIX
     description: Bump golang to 1.20. This requires all plugins to be rebuilt.
+    issueLink: https://github.com/solo-io/solo-projects/issues/5215
+    resolvesIssue: false

--- a/changelog/v1.13.24/bump-go-1.20.yaml
+++ b/changelog/v1.13.24/bump-go-1.20.yaml
@@ -4,5 +4,7 @@ changelog:
     dependencyOwner: golang
     dependencyRepo: go
     dependencyTag: go1.20
+    issueLink: https://github.com/solo-io/solo-projects/issues/5215
+    resolvesIssue: false
   - type: FIX
     description: Bump golang to 1.20. This requires all plugins to be rebuilt.

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -8,17 +8,17 @@ steps:
     path: '/go/pkg'
   id: 'untar-mod-cache'
 
-- name: 'golang:1.18.6'
+- name: 'golang:1.20'
   args: ['go', 'mod', 'download']
   volumes: *vol
   id: 'download'
 
-- name: 'golang:1.18.6'
+- name: 'golang:1.20'
   args: ['go', 'mod', 'tidy']
   volumes: *vol
   id: 'tidy'
 
-- name: 'golang:1.18.6'
+- name: 'golang:1.20'
   entrypoint: 'bash'
   volumes: *vol
   args: ['-c', ' cd /go/pkg && tar -zvcf gloo-mod.tar.gz mod']

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
 # gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo,_PR_NUM=<<insert PR Number here>> --project solo-public
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.4'
   args:
     - "--repo-name"
     - "$REPO_NAME"
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['prepare-workspace']
   id: 'get-envoy'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   entrypoint: 'bash'
   args: ['-c', 'make proxycontroller']
   dir: '/workspace/gloo/example/proxycontroller'
@@ -68,7 +68,7 @@ steps:
 
 # Docker related setup
 # grab this container immediately in parallel
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
   entrypoint: ls
   waitFor: ['-']
   id: 'grab-ginkgo-container'
@@ -82,12 +82,12 @@ steps:
   waitFor: ['set-gcr-zone']
   id: 'get-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   args: ['install-go-tools']
   dir: *dir
   id: 'install-go-tools'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
   entrypoint: make
   env:
   - 'ACK_GINKGO_RC=true'
@@ -117,7 +117,7 @@ steps:
   id: 'docker-login'
 
   # 1) Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   args: ['docker-push-extended']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -138,7 +138,7 @@ steps:
   waitFor: ['docker-push-extended']
   id: 'gcr-auth'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   args: ['fetch-package-and-save-helm', 'render-manifests', 'upload-github-release-assets', 'push-chart-to-registry', '-B']
   env:
     - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -152,7 +152,7 @@ steps:
   id: 'release-chart'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   args: ['docker-push-retag']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
 # gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo,_PR_NUM=<<insert PR Number here>> --project solo-public
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.3'
   args:
     - "--repo-name"
     - "$REPO_NAME"
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['prepare-workspace']
   id: 'get-envoy'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
   entrypoint: 'bash'
   args: ['-c', 'make proxycontroller']
   dir: '/workspace/gloo/example/proxycontroller'
@@ -68,7 +68,7 @@ steps:
 
 # Docker related setup
 # grab this container immediately in parallel
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.3'
   entrypoint: ls
   waitFor: ['-']
   id: 'grab-ginkgo-container'
@@ -82,12 +82,12 @@ steps:
   waitFor: ['set-gcr-zone']
   id: 'get-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
   args: ['install-go-tools']
   dir: *dir
   id: 'install-go-tools'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.3'
   entrypoint: make
   env:
   - 'ACK_GINKGO_RC=true'
@@ -117,7 +117,7 @@ steps:
   id: 'docker-login'
 
   # 1) Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
   args: ['docker-push-extended']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -138,7 +138,7 @@ steps:
   waitFor: ['docker-push-extended']
   id: 'gcr-auth'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
   args: ['fetch-package-and-save-helm', 'render-manifests', 'upload-github-release-assets', 'push-chart-to-registry', '-B']
   env:
     - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -152,7 +152,7 @@ steps:
   id: 'release-chart'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.4.29'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.3'
   args: ['docker-push-retag']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo
 
-go 1.18
+go 1.20
 
 require (
 	github.com/Masterminds/semver/v3 v3.1.1

--- a/projects/gateway/pkg/api/v1/external_options.pb.go
+++ b/projects/gateway/pkg/api/v1/external_options.pb.go
@@ -25,7 +25,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//
 // The **VirtualHostOption** holds `options` configuration for a VirtualHost.
 // VirtualHosts can inherit `options` config from `VirtualHostOption` objects by delegating to them.
 //
@@ -39,80 +38,94 @@ const (
 // apiVersion: gateway.solo.io/v1
 // kind: VirtualService
 // metadata:
-//   name: http
-//   namespace: gloo-system
+//
+//	name: http
+//	namespace: gloo-system
+//
 // spec:
-//   virtualHost:
-//     domains:
-//     - '*'
-//     options:
-//       headerManipulation:
-//         requestHeadersToRemove: "header-from-vhost"
-//     delegateOptions:
-//       - name: virtualhost-external-options-1
-//         namespace: opt-namespace
-//       - name: virtualhost-external-options-2
-//         namespace: opt-namespace
+//
+//	virtualHost:
+//	  domains:
+//	  - '*'
+//	  options:
+//	    headerManipulation:
+//	      requestHeadersToRemove: "header-from-vhost"
+//	  delegateOptions:
+//	    - name: virtualhost-external-options-1
+//	      namespace: opt-namespace
+//	    - name: virtualhost-external-options-2
+//	      namespace: opt-namespace
+//
 // ```
 //
 // ```yaml
 // apiVersion: gateway.solo.io/v1
 // kind: VirtualHostOption
 // metadata:
-//   name: virtualhost-external-options-1
-//   namespace: opt-namespace
+//
+//	name: virtualhost-external-options-1
+//	namespace: opt-namespace
+//
 // spec:
-//   options:
-//     headerManipulation:
-//       requestHeadersToRemove: "header-from-external-options1"
-//     corsPolicy:
-//       exposeHeaders:
-//         - header-from-extopt1
+//
+//	options:
+//	  headerManipulation:
+//	    requestHeadersToRemove: "header-from-external-options1"
+//	  corsPolicy:
+//	    exposeHeaders:
+//	      - header-from-extopt1
+//
 // ```
 //
 // ```yaml
 // apiVersion: gateway.solo.io/v1
 // kind: VirtualHostOption
 // metadata:
-//   name: virtualhost-external-options-2
-//   namespace: opt-namespace
+//
+//	name: virtualhost-external-options-2
+//	namespace: opt-namespace
+//
 // spec:
-//   options:
-//     headerManipulation:
-//       requestHeadersToRemove: "header-from-external-options2"
-//     corsPolicy:
-//       exposeHeaders:
-//         - header-from-extopt2
-//       maxAge: 2s
-//     transformations:
-//       requestTransformation:
-//         transformationTemplate:
-//           headers:
-//             x-header-added-in-opt2:
-//               value: this header was added in the VirtualHostOption object - #2
+//
+//	options:
+//	  headerManipulation:
+//	    requestHeadersToRemove: "header-from-external-options2"
+//	  corsPolicy:
+//	    exposeHeaders:
+//	      - header-from-extopt2
+//	    maxAge: 2s
+//	  transformations:
+//	    requestTransformation:
+//	      transformationTemplate:
+//	        headers:
+//	          x-header-added-in-opt2:
+//	            value: this header was added in the VirtualHostOption object - #2
+//
 // ```
 //
 // The final virtual host options (visible in the Proxy CR) would be:
 // ```yaml
 // spec:
-//   virtualHost:
-//     domains:
-//     - '*'
-//     options:
-//       # from Virtual host options
-//       headerManipulation:
-//         requestHeadersToRemove: "header-from-vhost"
-//       # from delegated virtualhost-external-options-1
-//       corsPolicy:
-//         exposeHeaders:
-//           - header-from-extopt1
-//       # from delegated virtualhost-external-options-2
-//       transformations:
-//         requestTransformation:
-//           transformationTemplate:
-//             headers:
-//               x-header-added-in-opt2:
-//                 value: this header was added in the VirtualHostOption object - #2
+//
+//	virtualHost:
+//	  domains:
+//	  - '*'
+//	  options:
+//	    # from Virtual host options
+//	    headerManipulation:
+//	      requestHeadersToRemove: "header-from-vhost"
+//	    # from delegated virtualhost-external-options-1
+//	    corsPolicy:
+//	      exposeHeaders:
+//	        - header-from-extopt1
+//	    # from delegated virtualhost-external-options-2
+//	    transformations:
+//	      requestTransformation:
+//	        transformationTemplate:
+//	          headers:
+//	            x-header-added-in-opt2:
+//	              value: this header was added in the VirtualHostOption object - #2
+//
 // ```
 //
 // Notice how the order of VirtualHostOption delegations matters, and that the VirtualHost-level config overrides all delegated configs.
@@ -183,7 +196,6 @@ func (x *VirtualHostOption) GetOptions() *v1.VirtualHostOptions {
 	return nil
 }
 
-//
 // The **RouteOption** holds `options` configuration for a Route.
 // Routes can inherit `options` config from `RouteOption` objects by delegating to them.
 //
@@ -197,82 +209,95 @@ func (x *VirtualHostOption) GetOptions() *v1.VirtualHostOptions {
 // apiVersion: gateway.solo.io/v1
 // kind: VirtualService
 // metadata:
-//   name: http
-//   namespace: gloo-system
+//
+//	name: http
+//	namespace: gloo-system
+//
 // spec:
-//   virtualHost:
-//     domains:
-//     - '*'
-//     routes:
-//     - matchers:
-//       - prefix: /
-//       options:
-//         headerManipulation:
-//           requestHeadersToRemove: "header-from-route"
-//       delegateOptions:
-//         - name: route-external-options-1
-//           namespace: opt-namespace
-//         - name: route-external-options-2
-//           namespace: opt-namespace
+//
+//	virtualHost:
+//	  domains:
+//	  - '*'
+//	  routes:
+//	  - matchers:
+//	    - prefix: /
+//	    options:
+//	      headerManipulation:
+//	        requestHeadersToRemove: "header-from-route"
+//	    delegateOptions:
+//	      - name: route-external-options-1
+//	        namespace: opt-namespace
+//	      - name: route-external-options-2
+//	        namespace: opt-namespace
+//
 // ```
 //
 // ```yaml
 // apiVersion: gateway.solo.io/v1
 // kind: RouteOption
 // metadata:
-//   name: route-external-options-1
-//   namespace: opt-namespace
+//
+//	name: route-external-options-1
+//	namespace: opt-namespace
+//
 // spec:
-//   options:
-//     headerManipulation:
-//       requestHeadersToRemove: "header-from-external-options1"
-//     corsPolicy:
-//       exposeHeaders:
-//         - header-from-extopt1
+//
+//	options:
+//	  headerManipulation:
+//	    requestHeadersToRemove: "header-from-external-options1"
+//	  corsPolicy:
+//	    exposeHeaders:
+//	      - header-from-extopt1
+//
 // ```
 //
 // ```yaml
 // apiVersion: gateway.solo.io/v1
 // kind: RouteOption
 // metadata:
-//   name: route-external-options-2
-//   namespace: opt-namespace
+//
+//	name: route-external-options-2
+//	namespace: opt-namespace
+//
 // spec:
-//   options:
-//     headerManipulation:
-//       requestHeadersToRemove: "header-from-external-options2"
-//     corsPolicy:
-//       exposeHeaders:
-//         - header-from-extopt2
-//       maxAge: 2s
-//     transformations:
-//       requestTransformation:
-//         transformationTemplate:
-//           headers:
-//             x-header-added-in-opt2:
-//               value: this header was added in the RouteOption object - #2
+//
+//	options:
+//	  headerManipulation:
+//	    requestHeadersToRemove: "header-from-external-options2"
+//	  corsPolicy:
+//	    exposeHeaders:
+//	      - header-from-extopt2
+//	    maxAge: 2s
+//	  transformations:
+//	    requestTransformation:
+//	      transformationTemplate:
+//	        headers:
+//	          x-header-added-in-opt2:
+//	            value: this header was added in the RouteOption object - #2
+//
 // ```
 //
 // The final route options would bewould be:
 // ```yaml
 // routes:
 //   - matchers:
-//     - prefix: /
+//   - prefix: /
 //     options:
-//       # from Route options
-//       headerManipulation:
-//         requestHeadersToRemove: "header-from-route"
-//       # from delegated route-external-options-1
-//       corsPolicy:
-//         exposeHeaders:
-//           - header-from-extopt1
-//       # from delegated route-external-options-2
-//       transformations:
-//         requestTransformation:
-//           transformationTemplate:
-//             headers:
-//               x-header-added-in-opt2:
-//                 value: this header was added in the Route object - #2
+//     # from Route options
+//     headerManipulation:
+//     requestHeadersToRemove: "header-from-route"
+//     # from delegated route-external-options-1
+//     corsPolicy:
+//     exposeHeaders:
+//   - header-from-extopt1
+//     # from delegated route-external-options-2
+//     transformations:
+//     requestTransformation:
+//     transformationTemplate:
+//     headers:
+//     x-header-added-in-opt2:
+//     value: this header was added in the Route object - #2
+//
 // ```
 //
 // Notice how the order of RouteOption delegations matters, and that the Route-level option config overrides all delegated option configs.

--- a/projects/gateway/pkg/api/v1/gateway.pb.go
+++ b/projects/gateway/pkg/api/v1/gateway.pb.go
@@ -29,9 +29,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//
-//A Gateway describes a single Listener (bind address:port)
-//and the routing configuration to upstreams that are reachable via a specific port on the Gateway Proxy itself.
+// A Gateway describes a single Listener (bind address:port)
+// and the routing configuration to upstreams that are reachable via a specific port on the Gateway Proxy itself.
 type Gateway struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -64,11 +63,11 @@ type Gateway struct {
 	// HybridGateway creates a listener with any number of filter chains that each may have either an http_connection_manager or a tcp proxy filter
 	//
 	// Types that are assignable to GatewayType:
+	//
 	//	*Gateway_HttpGateway
 	//	*Gateway_TcpGateway
 	//	*Gateway_HybridGateway
 	GatewayType isGateway_GatewayType `protobuf_oneof:"GatewayType"`
-	//
 	// Names of the [`Proxy`](https://docs.solo.io/gloo-edge/latest/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk/)
 	// resources to generate from this gateway. If other gateways exist which point to the same proxy,
 	// Gloo will join them together.
@@ -87,7 +86,6 @@ type Gateway struct {
 	//
 	// Defaults to `["gateway-proxy"]`
 	ProxyNames []string `protobuf:"bytes,12,rep,name=proxy_names,json=proxyNames,proto3" json:"proxy_names,omitempty"`
-	//
 	// Route configuration options that live under Envoy's [RouteConfigurationOptions](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto#config-route-v3-routeconfiguration)
 	RouteOptions *v1.RouteConfigurationOptions `protobuf:"bytes,13,opt,name=route_options,json=routeOptions,proto3" json:"route_options,omitempty"`
 }
@@ -366,6 +364,7 @@ type DelegatedHttpGateway struct {
 	// How to select MatchableHttpGateways
 	//
 	// Types that are assignable to SelectionType:
+	//
 	//	*DelegatedHttpGateway_Ref
 	//	*DelegatedHttpGateway_Selector
 	SelectionType isDelegatedHttpGateway_SelectionType `protobuf_oneof:"selection_type"`
@@ -486,6 +485,7 @@ type MatchedGateway struct {
 	// Empty Matchers are effectively catch-alls, and there can be no more than one empty Matcher per HybridGateway
 	Matcher *Matcher `protobuf:"bytes,1,opt,name=matcher,proto3" json:"matcher,omitempty"`
 	// Types that are assignable to GatewayType:
+	//
 	//	*MatchedGateway_HttpGateway
 	//	*MatchedGateway_TcpGateway
 	GatewayType isMatchedGateway_GatewayType `protobuf_oneof:"GatewayType"`

--- a/projects/gateway/pkg/api/v1/http_gateway.pb.go
+++ b/projects/gateway/pkg/api/v1/http_gateway.pb.go
@@ -200,9 +200,9 @@ func (x *HttpGateway) GetOptions() *v1.HttpListenerOptions {
 // Expressions to define which virtual services to select
 // Example:
 // expressions:
-//    - key: domain
-//      operator: in
-//      values: example.com
+//   - key: domain
+//     operator: in
+//     values: example.com
 type VirtualServiceSelectorExpressions struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gateway/pkg/api/v1/matchable_http_gateway.pb.go
+++ b/projects/gateway/pkg/api/v1/matchable_http_gateway.pb.go
@@ -25,14 +25,13 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// A MatchableHttpGateway describes a single FilterChain configured with:
+// - The HttpConnectionManager NetworkFilter
+// - A FilterChainMatch and TransportSocket that support TLS configuration and Source IP matching
 //
-//A MatchableHttpGateway describes a single FilterChain configured with:
-//- The HttpConnectionManager NetworkFilter
-//- A FilterChainMatch and TransportSocket that support TLS configuration and Source IP matching
-//
-//A Gateway CR may select one or more MatchableHttpGateways on a single listener.
-//This enables separate teams to own Listener configuration (Gateway CR)
-//and FilterChain configuration (MatchableHttpGateway CR)
+// A Gateway CR may select one or more MatchableHttpGateways on a single listener.
+// This enables separate teams to own Listener configuration (Gateway CR)
+// and FilterChain configuration (MatchableHttpGateway CR)
 type MatchableHttpGateway struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -122,8 +121,8 @@ type MatchableHttpGateway_Matcher struct {
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-cidrrange
 	SourcePrefixRanges []*v3.CidrRange `protobuf:"bytes,1,rep,name=source_prefix_ranges,json=sourcePrefixRanges,proto3" json:"source_prefix_ranges,omitempty"`
 	// Ssl configuration applied to the FilterChain:
-	//  - FilterChainMatch: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto#config-listener-v3-filterchainmatch)
-	//  - TransportSocket: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-transportsocket
+	//   - FilterChainMatch: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener_components.proto#config-listener-v3-filterchainmatch)
+	//   - TransportSocket: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/base.proto#envoy-v3-api-msg-config-core-v3-transportsocket
 	SslConfig *ssl.SslConfig `protobuf:"bytes,2,opt,name=ssl_config,json=sslConfig,proto3" json:"ssl_config,omitempty"`
 }
 

--- a/projects/gateway/pkg/api/v1/route_table.pb.go
+++ b/projects/gateway/pkg/api/v1/route_table.pb.go
@@ -24,8 +24,6 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//
-//
 // The **RouteTable** is a child routing object for the Gloo Gateway.
 //
 // A **RouteTable** gets built into the complete routing configuration when it is referenced by a `delegateAction`,
@@ -59,32 +57,35 @@ const (
 //
 // *would* be valid.
 //
-//
 // A complete configuration might look as follows:
 //
 // ```yaml
 // apiVersion: gateway.solo.io/v1
 // kind: VirtualService
 // metadata:
-//   name: 'any'
-//   namespace: 'any'
+//
+//	name: 'any'
+//	namespace: 'any'
+//
 // spec:
-//   virtualHost:
-//     domains:
-//     - 'any.com'
-//     routes:
-//     - matchers:
-//       - prefix: '/a' # delegate ownership of routes for `any.com/a`
-//       delegateAction:
-//         ref:
-//           name: 'a-routes'
-//           namespace: 'a'
-//     - matchers:
-//       - prefix: '/b' # delegate ownership of routes for `any.com/b`
-//       delegateAction:
-//         ref:
-//           name: 'b-routes'
-//           namespace: 'b'
+//
+//	virtualHost:
+//	  domains:
+//	  - 'any.com'
+//	  routes:
+//	  - matchers:
+//	    - prefix: '/a' # delegate ownership of routes for `any.com/a`
+//	    delegateAction:
+//	      ref:
+//	        name: 'a-routes'
+//	        namespace: 'a'
+//	  - matchers:
+//	    - prefix: '/b' # delegate ownership of routes for `any.com/b`
+//	    delegateAction:
+//	      ref:
+//	        name: 'b-routes'
+//	        namespace: 'b'
+//
 // ```
 //
 // * A root-level **VirtualService** which delegates routing to to the `a-routes` and `b-routes` **RouteTables**.
@@ -94,24 +95,28 @@ const (
 // apiVersion: gateway.solo.io/v1
 // kind: RouteTable
 // metadata:
-//   name: 'a-routes'
-//   namespace: 'a'
-// spec:
-//   routes:
-//     - matchers:
-//       # the path matchers in this RouteTable must begin with the prefix `/a/`
-//       - prefix: '/a/1'
-//       routeAction:
-//         single:
-//           upstream:
-//             name: 'foo-upstream'
 //
-//     - matchers:
-//       - prefix: '/a/2'
-//       routeAction:
-//         single:
-//           upstream:
-//             name: 'bar-upstream'
+//	name: 'a-routes'
+//	namespace: 'a'
+//
+// spec:
+//
+//	routes:
+//	  - matchers:
+//	    # the path matchers in this RouteTable must begin with the prefix `/a/`
+//	    - prefix: '/a/1'
+//	    routeAction:
+//	      single:
+//	        upstream:
+//	          name: 'foo-upstream'
+//
+//	  - matchers:
+//	    - prefix: '/a/2'
+//	    routeAction:
+//	      single:
+//	        upstream:
+//	          name: 'bar-upstream'
+//
 // ```
 //
 // * A **RouteTable** which defines two routes.
@@ -120,48 +125,53 @@ const (
 // apiVersion: gateway.solo.io/v1
 // kind: RouteTable
 // metadata:
-//   name: 'b-routes'
-//   namespace: 'b'
+//
+//	name: 'b-routes'
+//	namespace: 'b'
+//
 // spec:
-//   routes:
-//     - matchers:
-//       # the path matchers in this RouteTable must begin with the prefix `/b/`
-//       - regex: '/b/3'
-//       routeAction:
-//         single:
-//           upstream:
-//             name: 'bar-upstream'
-//     - matchers:
-//       - prefix: '/b/c/'
-//       # routes in the RouteTable can perform any action, including a delegateAction
-//       delegateAction:
-//         ref:
-//           name: 'c-routes'
-//           namespace: 'c'
+//
+//	routes:
+//	  - matchers:
+//	    # the path matchers in this RouteTable must begin with the prefix `/b/`
+//	    - regex: '/b/3'
+//	    routeAction:
+//	      single:
+//	        upstream:
+//	          name: 'bar-upstream'
+//	  - matchers:
+//	    - prefix: '/b/c/'
+//	    # routes in the RouteTable can perform any action, including a delegateAction
+//	    delegateAction:
+//	      ref:
+//	        name: 'c-routes'
+//	        namespace: 'c'
 //
 // ```
 //
 // * A **RouteTable** which both *defines a route* and *delegates to* another **RouteTable**.
 //
-//
 // ```yaml
 // apiVersion: gateway.solo.io/v1
 // kind: RouteTable
 // metadata:
-//   name: 'c-routes'
-//   namespace: 'c'
+//
+//	name: 'c-routes'
+//	namespace: 'c'
+//
 // spec:
-//   routes:
-//     - matchers:
-//       - exact: '/b/c/4'
-//       routeAction:
-//         single:
-//           upstream:
-//             name: 'qux-upstream'
+//
+//	routes:
+//	  - matchers:
+//	    - exact: '/b/c/4'
+//	    routeAction:
+//	      single:
+//	        upstream:
+//	          name: 'qux-upstream'
+//
 // ```
 //
 // * A RouteTable which is a child of another route table.
-//
 //
 // Would produce the following route config for `mydomain.com`:
 //
@@ -171,7 +181,6 @@ const (
 // /b/3 -> baz-upstream
 // /b/c/4 -> qux-upstream
 // ```
-//
 type RouteTable struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gateway/pkg/api/v1/virtual_service.pb.go
+++ b/projects/gateway/pkg/api/v1/virtual_service.pb.go
@@ -104,8 +104,6 @@ func (RouteTableSelector_Expression_Operator) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_solo_io_gloo_projects_gateway_api_v1_virtual_service_proto_rawDescGZIP(), []int{5, 1, 0}
 }
 
-//
-//
 // The **VirtualService** is the root routing object for the Gloo Gateway.
 // A virtual service describes the set of routes to match for a set of domains.
 //
@@ -127,21 +125,24 @@ func (RouteTableSelector_Expression_Operator) EnumDescriptor() ([]byte, []int) {
 // apiVersion: gateway.solo.io/v1
 // kind: VirtualService
 // metadata:
-//   name: 'http'
-//   namespace: 'usernamespace'
+//
+//	name: 'http'
+//	namespace: 'usernamespace'
+//
 // spec:
-//   virtualHost:
-//     domains:
-//     - '*.mydomain.com'
-//     - 'mydomain.com'
-//     routes:
-//     - matchers:
-//       - prefix: '/'
-//       # delegate all traffic to the `shared-routes` RouteTable
-//       delegateAction:
-//         ref:
-//           name: 'shared-routes'
-//           namespace: 'usernamespace'
+//
+//	virtualHost:
+//	  domains:
+//	  - '*.mydomain.com'
+//	  - 'mydomain.com'
+//	  routes:
+//	  - matchers:
+//	    - prefix: '/'
+//	    # delegate all traffic to the `shared-routes` RouteTable
+//	    delegateAction:
+//	      ref:
+//	        name: 'shared-routes'
+//	        namespace: 'usernamespace'
 //
 // ```
 //
@@ -150,25 +151,28 @@ func (RouteTableSelector_Expression_Operator) EnumDescriptor() ([]byte, []int) {
 // apiVersion: gateway.solo.io/v1
 // kind: VirtualService
 // metadata:
-//   name: 'https'
-//   namespace: 'usernamespace'
+//
+//	name: 'https'
+//	namespace: 'usernamespace'
+//
 // spec:
-//   virtualHost:
-//     domains:
-//     - '*.mydomain.com'
-//     - 'mydomain.com'
-//     routes:
-//     - matchers:
-//       - prefix: '/'
-//       # delegate all traffic to the `shared-routes` RouteTable
-//       delegateAction:
-//         ref:
-//           name: 'shared-routes'
-//           namespace: 'usernamespace'
-//   sslConfig:
-//     secretRef:
-//       name: gateway-tls
-//       namespace: gloo-system
+//
+//	virtualHost:
+//	  domains:
+//	  - '*.mydomain.com'
+//	  - 'mydomain.com'
+//	  routes:
+//	  - matchers:
+//	    - prefix: '/'
+//	    # delegate all traffic to the `shared-routes` RouteTable
+//	    delegateAction:
+//	      ref:
+//	        name: 'shared-routes'
+//	        namespace: 'usernamespace'
+//	sslConfig:
+//	  secretRef:
+//	    name: gateway-tls
+//	    namespace: gloo-system
 //
 // ```
 //
@@ -177,17 +181,21 @@ func (RouteTableSelector_Expression_Operator) EnumDescriptor() ([]byte, []int) {
 // apiVersion: gateway.solo.io/v1
 // kind: RouteTable
 // metadata:
-//   name: 'shared-routes'
-//   namespace: 'usernamespace'
+//
+//	name: 'shared-routes'
+//	namespace: 'usernamespace'
+//
 // spec:
-//   routes:
-//     - matchers:
-//       - prefix: '/some-route'
-//       routeAction:
-//         single:
-//           upstream:
-//             name: 'some-upstream'
-//      ...
+//
+//	routes:
+//	  - matchers:
+//	    - prefix: '/some-route'
+//	    routeAction:
+//	      single:
+//	        upstream:
+//	          name: 'some-upstream'
+//	   ...
+//
 // ```
 //
 // **Delegated Routes** are routes that use the `delegateAction` routing action. Delegated Routes obey the following
@@ -196,7 +204,6 @@ func (RouteTableSelector_Expression_Operator) EnumDescriptor() ([]byte, []int) {
 // - delegate routes must use `prefix` path matchers
 // - delegated routes cannot specify header, query, or methods portion of the normal route matcher.
 // - `routeOptions` configuration will be inherited from parent routes, but can be overridden by the child
-//
 type VirtualService struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -288,16 +295,14 @@ func (x *VirtualService) GetMetadata() *core.Metadata {
 	return nil
 }
 
+// Virtual Hosts serve an ordered list of routes for a set of domains.
 //
-//Virtual Hosts serve an ordered list of routes for a set of domains.
+// An HTTP request is first matched to a virtual host based on its host header, then to a route within the virtual host.
 //
-//An HTTP request is first matched to a virtual host based on its host header, then to a route within the virtual host.
+// If a request is not matched to any virtual host or a route therein, the target proxy will reply with a 404.
 //
-//If a request is not matched to any virtual host or a route therein, the target proxy will reply with a 404.
-//
-//Unlike the [Gloo Virtual Host]({{< versioned_link_path fromRoot="/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk/#virtualhost" >}}),
-//_Gateway_ Virtual Hosts can delegate their routes to `RouteTables`.
-//
+// Unlike the [Gloo Virtual Host]({{< versioned_link_path fromRoot="/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/proxy.proto.sk/#virtualhost" >}}),
+// _Gateway_ Virtual Hosts can delegate their routes to `RouteTables`.
 type VirtualHost struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -318,6 +323,7 @@ type VirtualHost struct {
 	// Some configuration here can be overridden by Route Options.
 	Options *v1.VirtualHostOptions `protobuf:"bytes,4,opt,name=options,proto3" json:"options,omitempty"`
 	// Types that are assignable to ExternalOptionsConfig:
+	//
 	//	*VirtualHost_OptionsConfigRefs
 	ExternalOptionsConfig isVirtualHost_ExternalOptionsConfig `protobuf_oneof:"external_options_config"`
 }
@@ -395,19 +401,18 @@ type isVirtualHost_ExternalOptionsConfig interface {
 
 type VirtualHost_OptionsConfigRefs struct {
 	// Delegate the VirtualHost options to an external VirtualHostOption Resource.
-	//Any options configured in the VirtualHost's `options` field will override all
-	//delegated options. If multiple VirtualHostOption CRs are delegated to, configuration will
-	//be taken from prior VirtualHostOption CRs over later ones.
-	//For example if `headerManipulation` is specified on the VirtualHost options, a delegated
-	//`VirtualHostOption` vhost-opt-1, and a second delegated `VirtualHostOption` vhost-opt-2, the `headerManipulation`
-	//config from only the VirtualHost-level `options` will be applied. If the config is removed from the VirtualHost-level `options` field,
-	//then the config from the first delegated `VirtualHostOption`, vhost-opt-1, is applied.
+	// Any options configured in the VirtualHost's `options` field will override all
+	// delegated options. If multiple VirtualHostOption CRs are delegated to, configuration will
+	// be taken from prior VirtualHostOption CRs over later ones.
+	// For example if `headerManipulation` is specified on the VirtualHost options, a delegated
+	// `VirtualHostOption` vhost-opt-1, and a second delegated `VirtualHostOption` vhost-opt-2, the `headerManipulation`
+	// config from only the VirtualHost-level `options` will be applied. If the config is removed from the VirtualHost-level `options` field,
+	// then the config from the first delegated `VirtualHostOption`, vhost-opt-1, is applied.
 	OptionsConfigRefs *DelegateOptionsRefs `protobuf:"bytes,5,opt,name=options_config_refs,json=optionsConfigRefs,proto3,oneof"`
 }
 
 func (*VirtualHost_OptionsConfigRefs) isVirtualHost_ExternalOptionsConfig() {}
 
-//
 // A route specifies how to match a request and what action to take when the request is matched.
 //
 // When a request matches on a route, the route can perform one of the following actions:
@@ -435,6 +440,7 @@ type Route struct {
 	// The Route Action Defines what action the proxy should take when a request matches the route.
 	//
 	// Types that are assignable to Action:
+	//
 	//	*Route_RouteAction
 	//	*Route_RedirectAction
 	//	*Route_DirectResponseAction
@@ -448,6 +454,7 @@ type Route struct {
 	// The name provides a convenience for users to be able to refer to a route by name.
 	Name string `protobuf:"bytes,7,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to ExternalOptionsConfig:
+	//
 	//	*Route_OptionsConfigRefs
 	ExternalOptionsConfig isRoute_ExternalOptionsConfig `protobuf_oneof:"external_options_config"`
 }
@@ -625,13 +632,13 @@ type isRoute_ExternalOptionsConfig interface {
 
 type Route_OptionsConfigRefs struct {
 	// Delegate the Route options to an external RouteOption Resource.
-	//Any options configured in the Route's `options` field will override all
-	//delegated options. If multiple RouteOption CRs are delegated to, configuration will
-	//be taken from prior RouteOption CRs over later ones.
-	//For example if `headerManipulation` is specified on the route options, a delegated
-	//`RouteOption` route-opt-1, and a second delegated `RouteOption` route-opt-2, the `headerManipulation`
-	//config from only the Route-level `options` will be applied. If the config is removed from the Route-level `options` field,
-	//then the config from the first delegated `RouteOption`, route-opt-1, is applied.
+	// Any options configured in the Route's `options` field will override all
+	// delegated options. If multiple RouteOption CRs are delegated to, configuration will
+	// be taken from prior RouteOption CRs over later ones.
+	// For example if `headerManipulation` is specified on the route options, a delegated
+	// `RouteOption` route-opt-1, and a second delegated `RouteOption` route-opt-2, the `headerManipulation`
+	// config from only the Route-level `options` will be applied. If the config is removed from the Route-level `options` field,
+	// then the config from the first delegated `RouteOption`, route-opt-1, is applied.
 	OptionsConfigRefs *DelegateOptionsRefs `protobuf:"bytes,10,opt,name=options_config_refs,json=optionsConfigRefs,proto3,oneof"`
 }
 
@@ -642,8 +649,7 @@ type DelegateOptionsRefs struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//List of resource refs to Option CRs
+	// List of resource refs to Option CRs
 	DelegateOptions []*core.ResourceRef `protobuf:"bytes,1,rep,name=delegate_options,json=delegateOptions,proto3" json:"delegate_options,omitempty"`
 }
 
@@ -705,6 +711,7 @@ type DelegateAction struct {
 	// Deprecated: Do not use.
 	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
 	// Types that are assignable to DelegationType:
+	//
 	//	*DelegateAction_Ref
 	//	*DelegateAction_Selector
 	DelegationType isDelegateAction_DelegationType `protobuf_oneof:"delegation_type"`

--- a/projects/gloo/pkg/api/external/envoy/api/v2/core/health_check.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/api/v2/core/health_check.pb.go
@@ -135,6 +135,7 @@ type HealthCheck struct {
 	// Reuse health check connection between health checks. Default is true.
 	ReuseConnection *wrappers.BoolValue `protobuf:"bytes,7,opt,name=reuse_connection,json=reuseConnection,proto3" json:"reuse_connection,omitempty"`
 	// Types that are assignable to HealthChecker:
+	//
 	//	*HealthCheck_HttpHealthCheck_
 	//	*HealthCheck_TcpHealthCheck_
 	//	*HealthCheck_GrpcHealthCheck_
@@ -381,6 +382,7 @@ type HealthCheck_Payload struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Payload:
+	//
 	//	*HealthCheck_Payload_Text
 	Payload isHealthCheck_Payload_Payload `protobuf_oneof:"payload"`
 }
@@ -630,7 +632,7 @@ type HealthCheck_RedisHealthCheck struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value
+	// If set, optionally perform “EXISTS <key>“ instead of “PING“. A return value
 	// from Redis of 0 (does not exist) is considered a passing healthcheck. A return value other
 	// than 0 is considered a failure. This allows the user to mark a Redis instance for maintenance
 	// by setting the specified key to any value and waiting for traffic to drain.
@@ -755,6 +757,7 @@ type HealthCheck_CustomHealthCheck struct {
 	// being instantiated. See :api:`envoy/config/health_checker` for reference.
 	//
 	// Types that are assignable to ConfigType:
+	//
 	//	*HealthCheck_CustomHealthCheck_Config
 	//	*HealthCheck_CustomHealthCheck_TypedConfig
 	ConfigType isHealthCheck_CustomHealthCheck_ConfigType `protobuf_oneof:"config_type"`

--- a/projects/gloo/pkg/api/external/envoy/api/v2/route/route.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/api/v2/route/route.pb.go
@@ -256,17 +256,20 @@ type VirtualHost struct {
 	// virtual host. Wildcard hosts are supported in the suffix or prefix form.
 	//
 	// Domain search order:
-	//  1. Exact domain names: ``www.foo.com``.
-	//  2. Suffix domain wildcards: ``*.foo.com`` or ``*-bar.foo.com``.
-	//  3. Prefix domain wildcards: ``foo.*`` or ``foo-*``.
-	//  4. Special wildcard ``*`` matching any domain.
 	//
+	//  1. Exact domain names: “www.foo.com“.
 	//
-	//   The wildcard will not match the empty string.
-	//   e.g. ``*-bar.foo.com`` will match ``baz-bar.foo.com`` but not ``-bar.foo.com``.
-	//   The longest wildcards match first.
-	//   Only a single virtual host in the entire route configuration can match on ``*``. A domain
-	//   must be unique across all virtual hosts or the config will fail to load.
+	//  2. Suffix domain wildcards: “*.foo.com“ or “*-bar.foo.com“.
+	//
+	//  3. Prefix domain wildcards: “foo.*“ or “foo-*“.
+	//
+	//  4. Special wildcard “*“ matching any domain.
+	//
+	//     The wildcard will not match the empty string.
+	//     e.g. “*-bar.foo.com“ will match “baz-bar.foo.com“ but not “-bar.foo.com“.
+	//     The longest wildcards match first.
+	//     Only a single virtual host in the entire route configuration can match on “*“. A domain
+	//     must be unique across all virtual hosts or the config will fail to load.
 	Domains []string `protobuf:"bytes,2,rep,name=domains,proto3" json:"domains,omitempty"`
 	// The list of routes that will be matched, in order, for incoming requests.
 	// The first route that matches will be used.
@@ -480,9 +483,8 @@ func (x *VirtualHost) GetHedgePolicy() *HedgePolicy {
 // A route is both a specification of how to match a request as well as an indication of what to do
 // next (e.g., redirect, forward, rewrite, etc.).
 //
-//
-//   Envoy supports routing on HTTP method via `header matching
-//   (envoy_api_msg_route.HeaderMatcher)`.
+//	Envoy supports routing on HTTP method via `header matching
+//	(envoy_api_msg_route.HeaderMatcher)`.
 type Route struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -493,6 +495,7 @@ type Route struct {
 	// Route matching parameters.
 	Match *RouteMatch `protobuf:"bytes,1,opt,name=match,proto3" json:"match,omitempty"`
 	// Types that are assignable to Action:
+	//
 	//	*Route_Route
 	//	*Route_Redirect
 	//	*Route_DirectResponse
@@ -790,6 +793,7 @@ type RouteMatch struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to PathSpecifier:
+	//
 	//	*RouteMatch_Prefix
 	//	*RouteMatch_Path
 	//	*RouteMatch_Regex
@@ -806,12 +810,11 @@ type RouteMatch struct {
 	// code/config deploys. Refer to the `traffic shifting
 	// (config_http_conn_man_route_table_traffic_splitting_shift)` docs for additional documentation.
 	//
-	//
-	//    Parsing this field is implemented such that the runtime key's data may be represented
-	//    as a FractionalPercent proto represented as JSON/YAML and may also be represented as an
-	//    integer with the assumption that the value is an integral percentage out of 100. For
-	//    instance, a runtime key lookup returning the value "42" would parse as a FractionalPercent
-	//    whose numerator is 42 and denominator is HUNDRED. This preserves legacy semantics.
+	//	Parsing this field is implemented such that the runtime key's data may be represented
+	//	as a FractionalPercent proto represented as JSON/YAML and may also be represented as an
+	//	integer with the assumption that the value is an integral percentage out of 100. For
+	//	instance, a runtime key lookup returning the value "42" would parse as a FractionalPercent
+	//	whose numerator is 42 and denominator is HUNDRED. This preserves legacy semantics.
 	RuntimeFraction *core.RuntimeFractionalPercent `protobuf:"bytes,9,opt,name=runtime_fraction,json=runtimeFraction,proto3" json:"runtime_fraction,omitempty"`
 	// Specifies a set of headers that the route should match on. The router will
 	// check the request’s headers against all the specified headers in the route
@@ -988,6 +991,7 @@ type CorsPolicy struct {
 	// Specifies whether the resource allows credentials.
 	AllowCredentials *wrappers.BoolValue `protobuf:"bytes,6,opt,name=allow_credentials,json=allowCredentials,proto3" json:"allow_credentials,omitempty"`
 	// Types that are assignable to EnabledSpecifier:
+	//
 	//	*CorsPolicy_Enabled
 	//	*CorsPolicy_FilterEnabled
 	EnabledSpecifier isCorsPolicy_EnabledSpecifier `protobuf_oneof:"enabled_specifier"`
@@ -997,9 +1001,8 @@ type CorsPolicy struct {
 	// More information on how this can be controlled via runtime can be found
 	// `here (cors-runtime)`.
 	//
-	//
-	//   This field defaults to 100/`HUNDRED
-	//   (envoy_api_enum_type.FractionalPercent.DenominatorType)`.
+	//	This field defaults to 100/`HUNDRED
+	//	(envoy_api_enum_type.FractionalPercent.DenominatorType)`.
 	ShadowEnabled *core.RuntimeFractionalPercent `protobuf:"bytes,10,opt,name=shadow_enabled,json=shadowEnabled,proto3" json:"shadow_enabled,omitempty"`
 }
 
@@ -1120,8 +1123,8 @@ type isCorsPolicy_EnabledSpecifier interface {
 type CorsPolicy_Enabled struct {
 	// Specifies if CORS is enabled. Defaults to true. Only effective on route.
 	//
-	//   **This field is deprecated**. Set the
-	//   `filter_enabled (envoy_api_field_route.CorsPolicy.filter_enabled)` field instead.
+	//	**This field is deprecated**. Set the
+	//	`filter_enabled (envoy_api_field_route.CorsPolicy.filter_enabled)` field instead.
 	//
 	// Deprecated: Do not use.
 	Enabled *wrappers.BoolValue `protobuf:"bytes,7,opt,name=enabled,proto3,oneof"`
@@ -1133,9 +1136,8 @@ type CorsPolicy_FilterEnabled struct {
 	// More information on how this can be controlled via runtime can be found
 	// `here (cors-runtime)`.
 	//
-	//
-	//   This field defaults to 100/`HUNDRED
-	//   (envoy_api_enum_type.FractionalPercent.DenominatorType)`.
+	//	This field defaults to 100/`HUNDRED
+	//	(envoy_api_enum_type.FractionalPercent.DenominatorType)`.
 	FilterEnabled *core.RuntimeFractionalPercent `protobuf:"bytes,9,opt,name=filter_enabled,json=filterEnabled,proto3,oneof"`
 }
 
@@ -1149,6 +1151,7 @@ type RouteAction struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ClusterSpecifier:
+	//
 	//	*RouteAction_Cluster
 	//	*RouteAction_ClusterHeader
 	//	*RouteAction_WeightedClusters
@@ -1168,26 +1171,27 @@ type RouteAction struct {
 	// place the original path before rewrite into the `x-envoy-original-path
 	// (config_http_filters_router_x-envoy-original-path)` header.
 	//
-	//   Pay careful attention to the use of trailing slashes in the
-	//   `route's match (envoy_api_field_route.Route.match)` prefix value.
-	//   Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
-	//   rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
-	//   `Route (envoy_api_msg_route.Route)`, as shown by the below config entries:
+	//	Pay careful attention to the use of trailing slashes in the
+	//	`route's match (envoy_api_field_route.Route.match)` prefix value.
+	//	Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
+	//	rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
+	//	`Route (envoy_api_msg_route.Route)`, as shown by the below config entries:
 	//
-	//   ```
-	//     - match:
-	//         prefix: "/prefix/"
-	//       route:
-	//         prefix_rewrite: "/"
-	//     - match:
-	//         prefix: "/prefix"
-	//       route:
-	//         prefix_rewrite: "/"
-	//   ```
-	//   Having above entries in the config, requests to */prefix* will be stripped to */*, while
-	//   requests to */prefix/etc* will be stripped to */etc*.
+	//	```
+	//	  - match:
+	//	      prefix: "/prefix/"
+	//	    route:
+	//	      prefix_rewrite: "/"
+	//	  - match:
+	//	      prefix: "/prefix"
+	//	    route:
+	//	      prefix_rewrite: "/"
+	//	```
+	//	Having above entries in the config, requests to */prefix* will be stripped to */*, while
+	//	requests to */prefix/etc* will be stripped to */etc*.
 	PrefixRewrite string `protobuf:"bytes,5,opt,name=prefix_rewrite,json=prefixRewrite,proto3" json:"prefix_rewrite,omitempty"`
 	// Types that are assignable to HostRewriteSpecifier:
+	//
 	//	*RouteAction_HostRewrite
 	//	*RouteAction_AutoHostRewrite
 	//	*RouteAction_AutoHostRewriteHeader
@@ -1196,11 +1200,10 @@ type RouteAction struct {
 	// spans between the point at which the entire downstream request (i.e. end-of-stream) has been
 	// processed and when the upstream response has been completely processed.
 	//
-	//
-	//   This timeout includes all retries. See also
-	//   `config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
-	//   `config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
-	//   `retry overview (arch_overview_http_routing_retry)`.
+	//	This timeout includes all retries. See also
+	//	`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
+	//	`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
+	//	`retry overview (arch_overview_http_routing_retry)`.
 	Timeout *duration.Duration `protobuf:"bytes,8,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	// Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
 	// although the connection manager wide `stream_idle_timeout
@@ -1503,9 +1506,8 @@ type RouteAction_ClusterHeader struct {
 	// header is not found or the referenced cluster does not exist, Envoy will
 	// return a 404 response.
 	//
-	//
-	//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
-	//   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+	//	Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+	//	*Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
 	ClusterHeader string `protobuf:"bytes,2,opt,name=cluster_header,json=clusterHeader,proto3,oneof"`
 }
 
@@ -1548,9 +1550,8 @@ type RouteAction_AutoHostRewriteHeader struct {
 	// downstream or `custom (config_http_conn_man_headers_custom_request_headers)` header.
 	// If header value is empty, host header is left intact.
 	//
-	//
-	//   Pay attention to the potential security implications of using this option. Provided header
-	//   must come from trusted source.
+	//	Pay attention to the potential security implications of using this option. Provided header
+	//	must come from trusted source.
 	AutoHostRewriteHeader string `protobuf:"bytes,29,opt,name=auto_host_rewrite_header,json=autoHostRewriteHeader,proto3,oneof"`
 }
 
@@ -1578,12 +1579,11 @@ type RetryPolicy struct {
 	// same conditions documented for
 	// `config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms` apply.
 	//
-	//
-	//   If left unspecified, Envoy will use the global
-	//   `route timeout (envoy_api_field_route.RouteAction.timeout)` for the request.
-	//   Consequently, when using a `5xx (config_http_filters_router_x-envoy-retry-on)` based
-	//   retry policy, a request that times out will not be retried as the total timeout budget
-	//   would have been exhausted.
+	//	If left unspecified, Envoy will use the global
+	//	`route timeout (envoy_api_field_route.RouteAction.timeout)` for the request.
+	//	Consequently, when using a `5xx (config_http_filters_router_x-envoy-retry-on)` based
+	//	retry policy, a request that times out will not be retried as the total timeout budget
+	//	would have been exhausted.
 	PerTryTimeout *duration.Duration `protobuf:"bytes,3,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`
 	// Specifies an implementation of a RetryPriority which is used to determine the
 	// distribution of load across priorities used for retries. Refer to
@@ -1788,6 +1788,7 @@ type RedirectAction struct {
 	//     set to `:443`, the port will be removed after the redirection
 	//
 	// Types that are assignable to SchemeRewriteSpecifier:
+	//
 	//	*RedirectAction_HttpsRedirect
 	//	*RedirectAction_SchemeRedirect
 	SchemeRewriteSpecifier isRedirectAction_SchemeRewriteSpecifier `protobuf_oneof:"scheme_rewrite_specifier"`
@@ -1796,6 +1797,7 @@ type RedirectAction struct {
 	// The port value of the URL will be swapped with this value.
 	PortRedirect uint32 `protobuf:"varint,8,opt,name=port_redirect,json=portRedirect,proto3" json:"port_redirect,omitempty"`
 	// Types that are assignable to PathRewriteSpecifier:
+	//
 	//	*RedirectAction_PathRedirect
 	//	*RedirectAction_PrefixRewrite
 	PathRewriteSpecifier isRedirectAction_PathRewriteSpecifier `protobuf_oneof:"path_rewrite_specifier"`
@@ -1941,9 +1943,8 @@ type RedirectAction_PrefixRewrite struct {
 	// should be swapped with this value. This option allows redirect URLs be dynamically created
 	// based on the request.
 	//
-	//
-	//   Pay attention to the use of trailing slashes as mentioned in
-	//   `RouteAction's prefix_rewrite (envoy_api_field_route.RouteAction.prefix_rewrite)`.
+	//	Pay attention to the use of trailing slashes as mentioned in
+	//	`RouteAction's prefix_rewrite (envoy_api_field_route.RouteAction.prefix_rewrite)`.
 	PrefixRewrite string `protobuf:"bytes,5,opt,name=prefix_rewrite,json=prefixRewrite,proto3,oneof"`
 }
 
@@ -1961,10 +1962,9 @@ type DirectResponseAction struct {
 	// Specifies the content of the response body. If this setting is omitted,
 	// no body is included in the generated response.
 	//
-	//
-	//   Headers can be specified using *response_headers_to_add* in the enclosing
-	//   `envoy_api_msg_route.Route`, `envoy_api_msg_RouteConfiguration` or
-	//   `envoy_api_msg_route.VirtualHost`.
+	//	Headers can be specified using *response_headers_to_add* in the enclosing
+	//	`envoy_api_msg_route.Route`, `envoy_api_msg_RouteConfiguration` or
+	//	`envoy_api_msg_route.VirtualHost`.
 	Body *core.DataSource `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
 }
 
@@ -2022,10 +2022,9 @@ type Decorator struct {
 	// The operation name associated with the request matched to this route. If tracing is
 	// enabled, this information will be used as the span name reported for this request.
 	//
-	//
-	//   For ingress (inbound) requests, or egress (outbound) responses, this value may be overridden
-	//   by the `x-envoy-decorator-operation
-	//   (config_http_filters_router_x-envoy-decorator-operation)` header.
+	//	For ingress (inbound) requests, or egress (outbound) responses, this value may be overridden
+	//	by the `x-envoy-decorator-operation
+	//	(config_http_filters_router_x-envoy-decorator-operation)` header.
 	Operation string `protobuf:"bytes,1,opt,name=operation,proto3" json:"operation,omitempty"`
 }
 
@@ -2162,10 +2161,9 @@ func (x *Tracing) GetOverallSampling() *_type.FractionalPercent {
 //
 // Documentation for `virtual cluster statistics (config_http_filters_router_stats)`.
 //
-//
-//    Virtual clusters are a useful tool, but we do not recommend setting up a virtual cluster for
-//    every application endpoint. This is both not easily maintainable and as well the matching and
-//    statistics output are not free.
+//	Virtual clusters are a useful tool, but we do not recommend setting up a virtual cluster for
+//	every application endpoint. This is both not easily maintainable and as well the matching and
+//	statistics output are not free.
 type VirtualCluster struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2181,7 +2179,8 @@ type VirtualCluster struct {
 	// * The regex */rides/\d+* matches the path */rides/123*
 	// * The regex */rides/\d+* does not match the path */rides/123/456*
 	Pattern string `protobuf:"bytes,1,opt,name=pattern,proto3" json:"pattern,omitempty"`
-	//  Specifies the name of the virtual cluster. The virtual cluster name as well
+	//	Specifies the name of the virtual cluster. The virtual cluster name as well
+	//
 	// as the virtual host name are used when emitting statistics. The statistics are emitted by the
 	// router filter and are documented `here (config_http_filters_router_stats)`.
 	Name string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
@@ -2254,8 +2253,7 @@ type RateLimit struct {
 	// applies to filters with the same stage number. The default stage number is
 	// 0.
 	//
-	//
-	//   The filter supports a range of 0 - 10 inclusively for stage numbers.
+	//	The filter supports a range of 0 - 10 inclusively for stage numbers.
 	Stage *wrappers.UInt32Value `protobuf:"bytes,1,opt,name=stage,proto3" json:"stage,omitempty"`
 	// The key to be set in runtime to disable this rate limit configuration.
 	DisableKey string `protobuf:"bytes,2,opt,name=disable_key,json=disableKey,proto3" json:"disable_key,omitempty"`
@@ -2321,26 +2319,25 @@ func (x *RateLimit) GetActions() []*RateLimit_Action {
 	return nil
 }
 
+// Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
+// header. Thus, if attempting to match on *Host*, match on *:authority* instead.
 //
-//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
-//   header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+// To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
+// HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
 //
+// ```
 //
-//   To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
-//   HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
+//	{
+//	  "name": ":method",
+//	  "exact_match": "POST"
+//	}
 //
-//   ```
-//     {
-//       "name": ":method",
-//       "exact_match": "POST"
-//     }
-//   ```
+// ```
 //
-//   In the absence of any header match specifier, match will default to `present_match
-//   (envoy_api_field_route.HeaderMatcher.present_match)`. i.e, a request that has the `name
-//   (envoy_api_field_route.HeaderMatcher.name)` header will match, regardless of the header's
-//   value.
-//
+// In the absence of any header match specifier, match will default to `present_match
+// (envoy_api_field_route.HeaderMatcher.present_match)`. i.e, a request that has the `name
+// (envoy_api_field_route.HeaderMatcher.name)` header will match, regardless of the header's
+// value.
 type HeaderMatcher struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2351,6 +2348,7 @@ type HeaderMatcher struct {
 	// Specifies how the header match will be performed to route the request.
 	//
 	// Types that are assignable to HeaderMatchSpecifier:
+	//
 	//	*HeaderMatcher_ExactMatch
 	//	*HeaderMatcher_RegexMatch
 	//	*HeaderMatcher_RangeMatch
@@ -2495,8 +2493,8 @@ type HeaderMatcher_RangeMatch struct {
 	//
 	// Examples:
 	//
-	// * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
-	//   "-1somestring"
+	//   - For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+	//     "-1somestring"
 	RangeMatch *_type1.Int64Range `protobuf:"bytes,6,opt,name=range_match,json=rangeMatch,proto3,oneof"`
 }
 
@@ -2822,10 +2820,9 @@ type RouteAction_RequestMirrorPolicy struct {
 	// configuration but not present in runtime, 0 is the default and thus 0% of
 	// requests will be mirrored.
 	//
-	//
-	//   **This field is deprecated**. Set the
-	//   `runtime_fraction
-	//   (envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_fraction)` field instead.
+	//	**This field is deprecated**. Set the
+	//	`runtime_fraction
+	//	(envoy_api_field_route.RouteAction.RequestMirrorPolicy.runtime_fraction)` field instead.
 	//
 	// Deprecated: Do not use.
 	RuntimeKey string `protobuf:"bytes,2,opt,name=runtime_key,json=runtimeKey,proto3" json:"runtime_key,omitempty"`
@@ -2840,14 +2837,13 @@ type RouteAction_RequestMirrorPolicy struct {
 	// number is <= the value of the numerator N, or if the key is not present, the default
 	// value, the request will be mirrored.
 	//
-	//
-	//   Parsing this field is implemented such that the runtime key's data may be represented
-	//   as a `FractionalPercent (envoy_api_msg_type.FractionalPercent)` proto represented
-	//   as JSON/YAML and may also be represented as an integer with the assumption that the value
-	//   is an integral percentage out of 100. For instance, a runtime key lookup returning the
-	//   value "42" would parse as a `FractionalPercent` whose numerator is 42 and denominator is
-	//   HUNDRED. This is behaviour is different to that of the deprecated `runtime_key` field,
-	//   where the implicit denominator is 10000.
+	//	Parsing this field is implemented such that the runtime key's data may be represented
+	//	as a `FractionalPercent (envoy_api_msg_type.FractionalPercent)` proto represented
+	//	as JSON/YAML and may also be represented as an integer with the assumption that the value
+	//	is an integral percentage out of 100. For instance, a runtime key lookup returning the
+	//	value "42" would parse as a `FractionalPercent` whose numerator is 42 and denominator is
+	//	HUNDRED. This is behaviour is different to that of the deprecated `runtime_key` field,
+	//	where the implicit denominator is 10000.
 	RuntimeFraction *core.RuntimeFractionalPercent `protobuf:"bytes,3,opt,name=runtime_fraction,json=runtimeFraction,proto3" json:"runtime_fraction,omitempty"`
 }
 
@@ -2913,6 +2909,7 @@ type RouteAction_HashPolicy struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to PolicySpecifier:
+	//
 	//	*RouteAction_HashPolicy_Header_
 	//	*RouteAction_HashPolicy_Cookie_
 	//	*RouteAction_HashPolicy_ConnectionProperties_
@@ -2926,13 +2923,13 @@ type RouteAction_HashPolicy struct {
 	// list of hash polices.
 	// For example, if the following hash methods are configured:
 	//
-	//  ========= ========
-	//  specifier terminal
-	//  ========= ========
-	//  Header A  true
-	//  Header B  false
-	//  Header C  false
-	//  ========= ========
+	//	========= ========
+	//	specifier terminal
+	//	========= ========
+	//	Header A  true
+	//	Header B  false
+	//	Header C  false
+	//	========= ========
 	//
 	// The generateHash process ends if policy "header A" generates a hash, as
 	// it's a terminal policy.
@@ -3147,18 +3144,18 @@ func (x *RouteAction_HashPolicy_Header) GetHeaderName() string {
 
 // Envoy supports two types of cookie affinity:
 //
-// 1. Passive. Envoy takes a cookie that's present in the cookies header and
-//    hashes on its value.
+//  1. Passive. Envoy takes a cookie that's present in the cookies header and
+//     hashes on its value.
 //
-// 2. Generated. Envoy generates and sets a cookie with an expiration (TTL)
-//    on the first request from the client in its response to the client,
-//    based on the endpoint the request gets sent to. The client then
-//    presents this on the next and all subsequent requests. The hash of
-//    this is sufficient to ensure these requests get sent to the same
-//    endpoint. The cookie is generated by hashing the source and
-//    destination ports and addresses so that multiple independent HTTP2
-//    streams on the same connection will independently receive the same
-//    cookie, even if they arrive at the Envoy simultaneously.
+//  2. Generated. Envoy generates and sets a cookie with an expiration (TTL)
+//     on the first request from the client in its response to the client,
+//     based on the endpoint the request gets sent to. The client then
+//     presents this on the next and all subsequent requests. The hash of
+//     this is sufficient to ensure these requests get sent to the same
+//     endpoint. The cookie is generated by hashing the source and
+//     destination ports and addresses so that multiple independent HTTP2
+//     streams on the same connection will independently receive the same
+//     cookie, even if they arrive at the Envoy simultaneously.
 type RouteAction_HashPolicy_Cookie struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3285,6 +3282,7 @@ type RetryPolicy_RetryPriority struct {
 
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to ConfigType:
+	//
 	//	*RetryPolicy_RetryPriority_Config
 	//	*RetryPolicy_RetryPriority_TypedConfig
 	ConfigType isRetryPolicy_RetryPriority_ConfigType `protobuf_oneof:"config_type"`
@@ -3373,6 +3371,7 @@ type RetryPolicy_RetryHostPredicate struct {
 
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to ConfigType:
+	//
 	//	*RetryPolicy_RetryHostPredicate_Config
 	//	*RetryPolicy_RetryHostPredicate_TypedConfig
 	ConfigType isRetryPolicy_RetryHostPredicate_ConfigType `protobuf_oneof:"config_type"`
@@ -3523,6 +3522,7 @@ type RateLimit_Action struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ActionSpecifier:
+	//
 	//	*RateLimit_Action_SourceCluster_
 	//	*RateLimit_Action_DestinationCluster_
 	//	*RateLimit_Action_RequestHeaders_
@@ -3662,7 +3662,9 @@ func (*RateLimit_Action_HeaderValueMatch_) isRateLimit_Action_ActionSpecifier() 
 // The following descriptor entry is appended to the descriptor:
 //
 // ```
-//   ("source_cluster", "<local service cluster>")
+//
+//	("source_cluster", "<local service cluster>")
+//
 // ```
 //
 // <local service cluster> is derived from the :option:`--service-cluster` option.
@@ -3707,19 +3709,21 @@ func (*RateLimit_Action_SourceCluster) Descriptor() ([]byte, []int) {
 // The following descriptor entry is appended to the descriptor:
 //
 // ```
-//   ("destination_cluster", "<routed target cluster>")
+//
+//	("destination_cluster", "<routed target cluster>")
+//
 // ```
 //
 // Once a request matches against a route table rule, a routed cluster is determined by one of
 // the following `route table configuration (envoy_api_msg_RouteConfiguration)`
 // settings:
 //
-// * `cluster (envoy_api_field_route.RouteAction.cluster)` indicates the upstream cluster
-//   to route to.
-// * `weighted_clusters (envoy_api_field_route.RouteAction.weighted_clusters)`
-//   chooses a cluster randomly from a set of clusters with attributed weight.
-// * `cluster_header (envoy_api_field_route.RouteAction.cluster_header)` indicates which
-//   header in the request contains the target cluster.
+//   - `cluster (envoy_api_field_route.RouteAction.cluster)` indicates the upstream cluster
+//     to route to.
+//   - `weighted_clusters (envoy_api_field_route.RouteAction.weighted_clusters)`
+//     chooses a cluster randomly from a set of clusters with attributed weight.
+//   - `cluster_header (envoy_api_field_route.RouteAction.cluster_header)` indicates which
+//     header in the request contains the target cluster.
 type RateLimit_Action_DestinationCluster struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3762,7 +3766,9 @@ func (*RateLimit_Action_DestinationCluster) Descriptor() ([]byte, []int) {
 // *header_name*:
 //
 // ```
-//   ("<descriptor_key>", "<header_value_queried_from_header>")
+//
+//	("<descriptor_key>", "<header_value_queried_from_header>")
+//
 // ```
 type RateLimit_Action_RequestHeaders struct {
 	state         protoimpl.MessageState
@@ -3827,7 +3833,9 @@ func (x *RateLimit_Action_RequestHeaders) GetDescriptorKey() string {
 // trusted address from `x-forwarded-for (config_http_conn_man_headers_x-forwarded-for)`:
 //
 // ```
-//   ("remote_address", "<trusted address from x-forwarded-for>")
+//
+//	("remote_address", "<trusted address from x-forwarded-for>")
+//
 // ```
 type RateLimit_Action_RemoteAddress struct {
 	state         protoimpl.MessageState
@@ -3870,7 +3878,9 @@ func (*RateLimit_Action_RemoteAddress) Descriptor() ([]byte, []int) {
 // The following descriptor entry is appended to the descriptor:
 //
 // ```
-//   ("generic_key", "<descriptor_value>")
+//
+//	("generic_key", "<descriptor_value>")
+//
 // ```
 type RateLimit_Action_GenericKey struct {
 	state         protoimpl.MessageState
@@ -3923,7 +3933,9 @@ func (x *RateLimit_Action_GenericKey) GetDescriptorValue() string {
 // The following descriptor entry is appended to the descriptor:
 //
 // ```
-//   ("header_match", "<descriptor_value>")
+//
+//	("header_match", "<descriptor_value>")
+//
 // ```
 type RateLimit_Action_HeaderValueMatch struct {
 	state         protoimpl.MessageState

--- a/projects/gloo/pkg/api/external/envoy/config/core/v3/address.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/core/v3/address.pb.go
@@ -139,7 +139,7 @@ type SocketAddress struct {
 
 	Protocol SocketAddress_Protocol `protobuf:"varint,1,opt,name=protocol,proto3,enum=solo.io.envoy.config.core.v3.SocketAddress_Protocol" json:"protocol,omitempty"`
 	// The address for this socket. :ref:`Listeners <config_listeners>` will bind
-	// to the address. An empty address is not allowed. Specify ``0.0.0.0`` or ``::``
+	// to the address. An empty address is not allowed. Specify “0.0.0.0“ or “::“
 	// to bind to any address. [#comment:TODO(zuercher) reinstate when implemented:
 	// It is possible to distinguish a Listener address via the prefix/suffix matching
 	// in :ref:`FilterChainMatch <envoy_api_msg_config.listener.v3.FilterChainMatch>`.] When used
@@ -151,6 +151,7 @@ type SocketAddress struct {
 	// via :ref:`resolver_name <envoy_api_field_config.core.v3.SocketAddress.resolver_name>`.
 	Address string `protobuf:"bytes,2,opt,name=address,proto3" json:"address,omitempty"`
 	// Types that are assignable to PortSpecifier:
+	//
 	//	*SocketAddress_PortValue
 	//	*SocketAddress_NamedPort
 	PortSpecifier isSocketAddress_PortSpecifier `protobuf_oneof:"port_specifier"`
@@ -161,9 +162,9 @@ type SocketAddress struct {
 	// *STRICT_DNS* or *LOGICAL_DNS* will generate an error at runtime.
 	ResolverName string `protobuf:"bytes,5,opt,name=resolver_name,json=resolverName,proto3" json:"resolver_name,omitempty"`
 	// When binding to an IPv6 address above, this enables `IPv4 compatibility
-	// <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to ``::`` will
+	// <https://tools.ietf.org/html/rfc3493#page-11>`_. Binding to “::“ will
 	// allow both IPv4 and IPv6 connections, with peer IPv4 addresses mapped into
-	// IPv6 space as ``::FFFF:<IPv4-address>``.
+	// IPv6 space as “::FFFF:<IPv4-address>“.
 	Ipv4Compat bool `protobuf:"varint,6,opt,name=ipv4_compat,json=ipv4Compat,proto3" json:"ipv4_compat,omitempty"`
 }
 
@@ -420,6 +421,7 @@ type Address struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Address:
+	//
 	//	*Address_SocketAddress
 	//	*Address_Pipe
 	Address isAddress_Address `protobuf_oneof:"address"`
@@ -501,7 +503,7 @@ type CidrRange struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// IPv4 or IPv6 address, e.g. ``192.0.0.0`` or ``2001:db8::``.
+	// IPv4 or IPv6 address, e.g. “192.0.0.0“ or “2001:db8::“.
 	AddressPrefix string `protobuf:"bytes,1,opt,name=address_prefix,json=addressPrefix,proto3" json:"address_prefix,omitempty"`
 	// Length of prefix, e.g. 0, 32.
 	PrefixLen *wrappers.UInt32Value `protobuf:"bytes,2,opt,name=prefix_len,json=prefixLen,proto3" json:"prefix_len,omitempty"`

--- a/projects/gloo/pkg/api/external/envoy/config/core/v3/base.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/core/v3/base.pb.go
@@ -475,6 +475,7 @@ type Node struct {
 	// E.g. "envoy" or "grpc"
 	UserAgentName string `protobuf:"bytes,6,opt,name=user_agent_name,json=userAgentName,proto3" json:"user_agent_name,omitempty"`
 	// Types that are assignable to UserAgentVersionType:
+	//
 	//	*Node_UserAgentVersion
 	//	*Node_UserAgentBuildVersion
 	UserAgentVersionType isNode_UserAgentVersionType `protobuf_oneof:"user_agent_version_type"`
@@ -639,9 +640,10 @@ func (*Node_UserAgentBuildVersion) isNode_UserAgentVersionType() {}
 // object to match against. There are some well defined metadata used today for
 // this purpose:
 //
-// * ``{"envoy.lb": {"canary": <bool> }}`` This indicates the canary status of an
-//   endpoint and is also used during header processing
-//   (x-envoy-upstream-canary) and for stats purposes.
+//   - “{"envoy.lb": {"canary": <bool> }}“ This indicates the canary status of an
+//     endpoint and is also used during header processing
+//     (x-envoy-upstream-canary) and for stats purposes.
+//
 // [#next-major-version: move to type/metadata/v2]
 type Metadata struct {
 	state         protoimpl.MessageState
@@ -1044,6 +1046,7 @@ type DataSource struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Specifier:
+	//
 	//	*DataSource_Filename
 	//	*DataSource_InlineBytes
 	//	*DataSource_InlineString
@@ -1270,6 +1273,7 @@ type AsyncDataSource struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Specifier:
+	//
 	//	*AsyncDataSource_Local
 	//	*AsyncDataSource_Remote
 	Specifier isAsyncDataSource_Specifier `protobuf_oneof:"specifier"`
@@ -1362,6 +1366,7 @@ type TransportSocket struct {
 	// See the supported transport socket implementations for further documentation.
 	//
 	// Types that are assignable to ConfigType:
+	//
 	//	*TransportSocket_TypedConfig
 	ConfigType isTransportSocket_ConfigType `protobuf_oneof:"config_type"`
 }
@@ -1434,11 +1439,11 @@ func (*TransportSocket_TypedConfig) isTransportSocket_ConfigType() {}
 //
 // .. note::
 //
-//   Parsing of the runtime key's data is implemented such that it may be represented as a
-//   :ref:`FractionalPercent <envoy_api_msg_type.v3.FractionalPercent>` proto represented as JSON/YAML
-//   and may also be represented as an integer with the assumption that the value is an integral
-//   percentage out of 100. For instance, a runtime key lookup returning the value "42" would parse
-//   as a `FractionalPercent` whose numerator is 42 and denominator is HUNDRED.
+//	Parsing of the runtime key's data is implemented such that it may be represented as a
+//	:ref:`FractionalPercent <envoy_api_msg_type.v3.FractionalPercent>` proto represented as JSON/YAML
+//	and may also be represented as an integer with the assumption that the value is an integral
+//	percentage out of 100. For instance, a runtime key lookup returning the value "42" would parse
+//	as a `FractionalPercent` whose numerator is 42 and denominator is HUNDRED.
 type RuntimeFractionalPercent struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/external/envoy/config/core/v3/event_service_config.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/core/v3/event_service_config.pb.go
@@ -32,6 +32,7 @@ type EventServiceConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ConfigSourceSpecifier:
+	//
 	//	*EventServiceConfig_GrpcService
 	ConfigSourceSpecifier isEventServiceConfig_ConfigSourceSpecifier `protobuf_oneof:"config_source_specifier"`
 }

--- a/projects/gloo/pkg/api/external/envoy/config/core/v3/grpc_service.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/core/v3/grpc_service.pb.go
@@ -38,6 +38,7 @@ type GrpcService struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to TargetSpecifier:
+	//
 	//	*GrpcService_EnvoyGrpc_
 	//	*GrpcService_GoogleGrpc_
 	TargetSpecifier isGrpcService_TargetSpecifier `protobuf_oneof:"target_specifier"`
@@ -46,7 +47,7 @@ type GrpcService struct {
 	Timeout *duration.Duration `protobuf:"bytes,3,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	// Additional metadata to include in streams initiated to the GrpcService.
 	// This can be used for scenarios in which additional ad hoc authorization
-	// headers (e.g. ``x-foo-bar: baz-key``) are to be injected.
+	// headers (e.g. “x-foo-bar: baz-key“) are to be injected.
 	InitialMetadata []*HeaderValue `protobuf:"bytes,5,rep,name=initial_metadata,json=initialMetadata,proto3" json:"initial_metadata,omitempty"`
 }
 
@@ -207,11 +208,12 @@ type GrpcService_GoogleGrpc struct {
 	// service.
 	//
 	// .. csv-table::
-	//    :header: Name, Type, Description
-	//    :widths: 1, 1, 2
 	//
-	//    streams_total, Counter, Total number of streams opened
-	//    streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
+	//	:header: Name, Type, Description
+	//	:widths: 1, 1, 2
+	//
+	//	streams_total, Counter, Total number of streams opened
+	//	streams_closed_<gRPC status code>, Counter, Total streams closed with <gRPC status code>
 	StatPrefix string `protobuf:"bytes,4,opt,name=stat_prefix,json=statPrefix,proto3" json:"stat_prefix,omitempty"`
 	// The name of the Google gRPC credentials factory to use. This must have been registered with
 	// Envoy. If this is empty, a default credentials factory will be used that sets up channel
@@ -430,6 +432,7 @@ type GrpcService_GoogleGrpc_ChannelCredentials struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to CredentialSpecifier:
+	//
 	//	*GrpcService_GoogleGrpc_ChannelCredentials_SslCredentials
 	//	*GrpcService_GoogleGrpc_ChannelCredentials_GoogleDefault
 	//	*GrpcService_GoogleGrpc_ChannelCredentials_LocalCredentials
@@ -529,6 +532,7 @@ type GrpcService_GoogleGrpc_CallCredentials struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to CredentialSpecifier:
+	//
 	//	*GrpcService_GoogleGrpc_CallCredentials_AccessToken
 	//	*GrpcService_GoogleGrpc_CallCredentials_GoogleComputeEngine
 	//	*GrpcService_GoogleGrpc_CallCredentials_GoogleRefreshToken
@@ -862,6 +866,7 @@ type GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin struct
 
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to ConfigType:
+	//
 	//	*GrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_TypedConfig
 	ConfigType isGrpcService_GoogleGrpc_CallCredentials_MetadataCredentialsFromPlugin_ConfigType `protobuf_oneof:"config_type"`
 }
@@ -1072,6 +1077,7 @@ type GrpcService_GoogleGrpc_ChannelArgs_Value struct {
 	// delivered via the API.
 	//
 	// Types that are assignable to ValueSpecifier:
+	//
 	//	*GrpcService_GoogleGrpc_ChannelArgs_Value_StringValue
 	//	*GrpcService_GoogleGrpc_ChannelArgs_Value_IntValue
 	ValueSpecifier isGrpcService_GoogleGrpc_ChannelArgs_Value_ValueSpecifier `protobuf_oneof:"value_specifier"`

--- a/projects/gloo/pkg/api/external/envoy/config/core/v3/health_check.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/core/v3/health_check.pb.go
@@ -139,6 +139,7 @@ type HealthCheck struct {
 	// Reuse health check connection between health checks. Default is true.
 	ReuseConnection *wrappers.BoolValue `protobuf:"bytes,7,opt,name=reuse_connection,json=reuseConnection,proto3" json:"reuse_connection,omitempty"`
 	// Types that are assignable to HealthChecker:
+	//
 	//	*HealthCheck_HttpHealthCheck_
 	//	*HealthCheck_TcpHealthCheck_
 	//	*HealthCheck_GrpcHealthCheck_
@@ -191,20 +192,20 @@ type HealthCheck struct {
 	//
 	// .. code-block:: yaml
 	//
-	//  transport_socket_match_criteria:
-	//    useMTLS: true
+	//	transport_socket_match_criteria:
+	//	  useMTLS: true
 	//
 	// Will match the following :ref:`cluster socket match <envoy_api_msg_config.cluster.v3.Cluster.TransportSocketMatch>`
 	//
 	// .. code-block:: yaml
 	//
-	//  transport_socket_matches:
-	//  - name: "useMTLS"
-	//    match:
-	//      useMTLS: true
-	//    transport_socket:
-	//      name: envoy.transport_sockets.tls
-	//      config: { ... } # tls socket configuration
+	//	transport_socket_matches:
+	//	- name: "useMTLS"
+	//	  match:
+	//	    useMTLS: true
+	//	  transport_socket:
+	//	    name: envoy.transport_sockets.tls
+	//	    config: { ... } # tls socket configuration
 	//
 	// If this field is set, then for health checks it will supersede an entry of *envoy.transport_socket* in the
 	// :ref:`LbEndpoint.Metadata <envoy_api_field_config.endpoint.v3.LbEndpoint.metadata>`.
@@ -450,6 +451,7 @@ type HealthCheck_Payload struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Payload:
+	//
 	//	*HealthCheck_Payload_Text
 	//	*HealthCheck_Payload_Binary
 	Payload isHealthCheck_Payload_Payload `protobuf_oneof:"payload"`
@@ -735,7 +737,7 @@ type HealthCheck_RedisHealthCheck struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// If set, optionally perform ``EXISTS <key>`` instead of ``PING``. A return value
+	// If set, optionally perform “EXISTS <key>“ instead of “PING“. A return value
 	// from Redis of 0 (does not exist) is considered a passing healthcheck. A return value other
 	// than 0 is considered a failure. This allows the user to mark a Redis instance for maintenance
 	// by setting the specified key to any value and waiting for traffic to drain.
@@ -861,6 +863,7 @@ type HealthCheck_CustomHealthCheck struct {
 	// being instantiated. See :api:`envoy/config/health_checker` for reference.
 	//
 	// Types that are assignable to ConfigType:
+	//
 	//	*HealthCheck_CustomHealthCheck_TypedConfig
 	ConfigType isHealthCheck_CustomHealthCheck_ConfigType `protobuf_oneof:"config_type"`
 }

--- a/projects/gloo/pkg/api/external/envoy/config/core/v3/http_uri.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/core/v3/http_uri.pb.go
@@ -37,8 +37,7 @@ type HttpUri struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    uri: https://www.googleapis.com/oauth2/v1/certs
-	//
+	//	uri: https://www.googleapis.com/oauth2/v1/certs
 	Uri string `protobuf:"bytes,1,opt,name=uri,proto3" json:"uri,omitempty"`
 	// Specify how `uri` is to be fetched. Today, this requires an explicit
 	// cluster, but in the future we may support dynamic cluster creation or
@@ -46,6 +45,7 @@ type HttpUri struct {
 	// <https://github.com/envoyproxy/envoy/issues/1606>`_.
 	//
 	// Types that are assignable to HttpUpstreamType:
+	//
 	//	*HttpUri_Cluster
 	HttpUpstreamType isHttpUri_HttpUpstreamType `protobuf_oneof:"http_upstream_type"`
 	// Sets the maximum duration in milliseconds that a response can take to arrive upon request.
@@ -124,8 +124,7 @@ type HttpUri_Cluster struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    cluster: jwks_cluster
-	//
+	//	cluster: jwks_cluster
 	Cluster string `protobuf:"bytes,2,opt,name=cluster,proto3,oneof"`
 }
 

--- a/projects/gloo/pkg/api/external/envoy/config/core/v3/socket_option.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/core/v3/socket_option.pb.go
@@ -92,6 +92,7 @@ type SocketOption struct {
 	// The numeric name as passed to setsockopt
 	Name int64 `protobuf:"varint,3,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to Value:
+	//
 	//	*SocketOption_IntValue
 	//	*SocketOption_BufValue
 	Value isSocketOption_Value `protobuf_oneof:"value"`

--- a/projects/gloo/pkg/api/external/envoy/config/route/v3/route_components.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/route/v3/route_components.pb.go
@@ -263,18 +263,18 @@ type VirtualHost struct {
 	// virtual host. Wildcard hosts are supported in the suffix or prefix form.
 	//
 	// Domain search order:
-	//  1. Exact domain names: ``www.foo.com``.
-	//  2. Suffix domain wildcards: ``*.foo.com`` or ``*-bar.foo.com``.
-	//  3. Prefix domain wildcards: ``foo.*`` or ``foo-*``.
-	//  4. Special wildcard ``*`` matching any domain.
+	//  1. Exact domain names: “www.foo.com“.
+	//  2. Suffix domain wildcards: “*.foo.com“ or “*-bar.foo.com“.
+	//  3. Prefix domain wildcards: “foo.*“ or “foo-*“.
+	//  4. Special wildcard “*“ matching any domain.
 	//
 	// .. note::
 	//
-	//   The wildcard will not match the empty string.
-	//   e.g. ``*-bar.foo.com`` will match ``baz-bar.foo.com`` but not ``-bar.foo.com``.
-	//   The longest wildcards match first.
-	//   Only a single virtual host in the entire route configuration can match on ``*``. A domain
-	//   must be unique across all virtual hosts or the config will fail to load.
+	//	The wildcard will not match the empty string.
+	//	e.g. ``*-bar.foo.com`` will match ``baz-bar.foo.com`` but not ``-bar.foo.com``.
+	//	The longest wildcards match first.
+	//	Only a single virtual host in the entire route configuration can match on ``*``. A domain
+	//	must be unique across all virtual hosts or the config will fail to load.
 	//
 	// Domains cannot contain control characters. This is validated by the well_known_regex HTTP_HEADER_VALUE.
 	Domains []string `protobuf:"bytes,2,rep,name=domains,proto3" json:"domains,omitempty"`
@@ -569,8 +569,9 @@ func (x *FilterAction) GetAction() *any1.Any {
 //
 // .. attention::
 //
-//   Envoy supports routing on HTTP method via :ref:`header matching
-//   <envoy_api_msg_config.route.v3.HeaderMatcher>`.
+//	Envoy supports routing on HTTP method via :ref:`header matching
+//	<envoy_api_msg_config.route.v3.HeaderMatcher>`.
+//
 // [#next-free-field: 18]
 type Route struct {
 	state         protoimpl.MessageState
@@ -582,6 +583,7 @@ type Route struct {
 	// Route matching parameters.
 	Match *RouteMatch `protobuf:"bytes,1,opt,name=match,proto3" json:"match,omitempty"`
 	// Types that are assignable to Action:
+	//
 	//	*Route_Route
 	//	*Route_Redirect
 	//	*Route_DirectResponse
@@ -897,6 +899,7 @@ type RouteMatch struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to PathSpecifier:
+	//
 	//	*RouteMatch_Prefix
 	//	*RouteMatch_Path
 	//	*RouteMatch_SafeRegex
@@ -916,11 +919,11 @@ type RouteMatch struct {
 	//
 	// .. note::
 	//
-	//    Parsing this field is implemented such that the runtime key's data may be represented
-	//    as a FractionalPercent proto represented as JSON/YAML and may also be represented as an
-	//    integer with the assumption that the value is an integral percentage out of 100. For
-	//    instance, a runtime key lookup returning the value "42" would parse as a FractionalPercent
-	//    whose numerator is 42 and denominator is HUNDRED. This preserves legacy semantics.
+	//	Parsing this field is implemented such that the runtime key's data may be represented
+	//	as a FractionalPercent proto represented as JSON/YAML and may also be represented as an
+	//	integer with the assumption that the value is an integral percentage out of 100. For
+	//	instance, a runtime key lookup returning the value "42" would parse as a FractionalPercent
+	//	whose numerator is 42 and denominator is HUNDRED. This preserves legacy semantics.
 	RuntimeFraction *v3.RuntimeFractionalPercent `protobuf:"bytes,9,opt,name=runtime_fraction,json=runtimeFraction,proto3" json:"runtime_fraction,omitempty"`
 	// Specifies a set of headers that the route should match on. The router will
 	// check the request’s headers against all the specified headers in the route
@@ -1127,12 +1130,13 @@ type CorsPolicy struct {
 	// Specifies whether the resource allows credentials.
 	AllowCredentials *wrappers.BoolValue `protobuf:"bytes,6,opt,name=allow_credentials,json=allowCredentials,proto3" json:"allow_credentials,omitempty"`
 	// Types that are assignable to EnabledSpecifier:
+	//
 	//	*CorsPolicy_FilterEnabled
 	EnabledSpecifier isCorsPolicy_EnabledSpecifier `protobuf_oneof:"enabled_specifier"`
 	// Specifies the % of requests for which the CORS policies will be evaluated and tracked, but not
 	// enforced.
 	//
-	// This field is intended to be used when ``filter_enabled`` and ``enabled`` are off. One of those
+	// This field is intended to be used when “filter_enabled“ and “enabled“ are off. One of those
 	// fields have to explicitly disable the filter in order for this setting to take effect.
 	//
 	// If :ref:`runtime_key <envoy_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is specified,
@@ -1243,7 +1247,7 @@ type isCorsPolicy_EnabledSpecifier interface {
 type CorsPolicy_FilterEnabled struct {
 	// Specifies the % of requests for which the CORS filter is enabled.
 	//
-	// If neither ``enabled``, ``filter_enabled``, nor ``shadow_enabled`` are specified, the CORS
+	// If neither “enabled“, “filter_enabled“, nor “shadow_enabled“ are specified, the CORS
 	// filter will be enabled for 100% of the requests.
 	//
 	// If :ref:`runtime_key <envoy_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is
@@ -1260,6 +1264,7 @@ type RouteAction struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ClusterSpecifier:
+	//
 	//	*RouteAction_Cluster
 	//	*RouteAction_ClusterHeader
 	//	*RouteAction_WeightedClusters
@@ -1285,25 +1290,25 @@ type RouteAction struct {
 	//
 	// .. attention::
 	//
-	//   Pay careful attention to the use of trailing slashes in the
-	//   :ref:`route's match <envoy_api_field_config.route.v3.Route.match>` prefix value.
-	//   Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
-	//   rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
-	//   :ref:`Route <envoy_api_msg_config.route.v3.Route>`, as shown by the below config entries:
+	//	Pay careful attention to the use of trailing slashes in the
+	//	:ref:`route's match <envoy_api_field_config.route.v3.Route.match>` prefix value.
+	//	Stripping a prefix from a path requires multiple Routes to handle all cases. For example,
+	//	rewriting */prefix* to */* and */prefix/etc* to */etc* cannot be done in a single
+	//	:ref:`Route <envoy_api_msg_config.route.v3.Route>`, as shown by the below config entries:
 	//
-	//   .. code-block:: yaml
+	//	.. code-block:: yaml
 	//
-	//     - match:
-	//         prefix: "/prefix/"
-	//       route:
-	//         prefix_rewrite: "/"
-	//     - match:
-	//         prefix: "/prefix"
-	//       route:
-	//         prefix_rewrite: "/"
+	//	  - match:
+	//	      prefix: "/prefix/"
+	//	    route:
+	//	      prefix_rewrite: "/"
+	//	  - match:
+	//	      prefix: "/prefix"
+	//	    route:
+	//	      prefix_rewrite: "/"
 	//
-	//   Having above entries in the config, requests to */prefix* will be stripped to */*, while
-	//   requests to */prefix/etc* will be stripped to */etc*.
+	//	Having above entries in the config, requests to */prefix* will be stripped to */*, while
+	//	requests to */prefix/etc* will be stripped to */etc*.
 	PrefixRewrite string `protobuf:"bytes,5,opt,name=prefix_rewrite,json=prefixRewrite,proto3" json:"prefix_rewrite,omitempty"`
 	// Indicates that during forwarding, portions of the path that match the
 	// pattern should be rewritten, even allowing the substitution of capture
@@ -1319,22 +1324,23 @@ type RouteAction struct {
 	//
 	// Examples using Google's `RE2 <https://github.com/google/re2>`_ engine:
 	//
-	// * The path pattern ``^/service/([^/]+)(/.*)$`` paired with a substitution
-	//   string of ``\2/instance/\1`` would transform ``/service/foo/v1/api``
-	//   into ``/v1/api/instance/foo``.
+	//   - The path pattern “^/service/([^/]+)(/.*)$“ paired with a substitution
+	//     string of “\2/instance/\1“ would transform “/service/foo/v1/api“
+	//     into “/v1/api/instance/foo“.
 	//
-	// * The pattern ``one`` paired with a substitution string of ``two`` would
-	//   transform ``/xxx/one/yyy/one/zzz`` into ``/xxx/two/yyy/two/zzz``.
+	//   - The pattern “one“ paired with a substitution string of “two“ would
+	//     transform “/xxx/one/yyy/one/zzz“ into “/xxx/two/yyy/two/zzz“.
 	//
-	// * The pattern ``^(.*?)one(.*)$`` paired with a substitution string of
-	//   ``\1two\2`` would replace only the first occurrence of ``one``,
-	//   transforming path ``/xxx/one/yyy/one/zzz`` into ``/xxx/two/yyy/one/zzz``.
+	//   - The pattern “^(.*?)one(.*)$“ paired with a substitution string of
+	//     “\1two\2“ would replace only the first occurrence of “one“,
+	//     transforming path “/xxx/one/yyy/one/zzz“ into “/xxx/two/yyy/one/zzz“.
 	//
-	// * The pattern ``(?i)/xxx/`` paired with a substitution string of ``/yyy/``
-	//   would do a case-insensitive match and transform path ``/aaa/XxX/bbb`` to
-	//   ``/aaa/yyy/bbb``.
+	//   - The pattern “(?i)/xxx/“ paired with a substitution string of “/yyy/“
+	//     would do a case-insensitive match and transform path “/aaa/XxX/bbb“ to
+	//     “/aaa/yyy/bbb“.
 	RegexRewrite *v31.RegexMatchAndSubstitute `protobuf:"bytes,32,opt,name=regex_rewrite,json=regexRewrite,proto3" json:"regex_rewrite,omitempty"`
 	// Types that are assignable to HostRewriteSpecifier:
+	//
 	//	*RouteAction_HostRewriteLiteral
 	//	*RouteAction_AutoHostRewrite
 	//	*RouteAction_HostRewriteHeader
@@ -1346,10 +1352,10 @@ type RouteAction struct {
 	//
 	// .. note::
 	//
-	//   This timeout includes all retries. See also
-	//   :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
-	//   :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
-	//   :ref:`retry overview <arch_overview_http_routing_retry>`.
+	//	This timeout includes all retries. See also
+	//	:ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
+	//	:ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
+	//	:ref:`retry overview <arch_overview_http_routing_retry>`.
 	Timeout *duration.Duration `protobuf:"bytes,8,opt,name=timeout,proto3" json:"timeout,omitempty"`
 	// Specifies the idle timeout for the route. If not specified, there is no per-route idle timeout,
 	// although the connection manager wide :ref:`stream_idle_timeout
@@ -1420,12 +1426,12 @@ type RouteAction struct {
 	//
 	// .. note::
 	//
-	//    If a timeout is specified using :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`, it takes
-	//    precedence over `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, when
-	//    both are present. See also
-	//    :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
-	//    :ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
-	//    :ref:`retry overview <arch_overview_http_routing_retry>`.
+	//	If a timeout is specified using :ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`, it takes
+	//	precedence over `grpc-timeout header <https://github.com/grpc/grpc/blob/master/doc/PROTOCOL-HTTP2.md>`_, when
+	//	both are present. See also
+	//	:ref:`config_http_filters_router_x-envoy-upstream-rq-timeout-ms`,
+	//	:ref:`config_http_filters_router_x-envoy-upstream-rq-per-try-timeout-ms`, and the
+	//	:ref:`retry overview <arch_overview_http_routing_retry>`.
 	MaxGrpcTimeout *duration.Duration `protobuf:"bytes,23,opt,name=max_grpc_timeout,json=maxGrpcTimeout,proto3" json:"max_grpc_timeout,omitempty"`
 	// If present, Envoy will adjust the timeout provided by the `grpc-timeout` header by subtracting
 	// the provided duration from the header. This is useful in allowing Envoy to set its global
@@ -1721,8 +1727,8 @@ type RouteAction_ClusterHeader struct {
 	//
 	// .. attention::
 	//
-	//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
-	//   *Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+	//	Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1
+	//	*Host* header. Thus, if attempting to match on *Host*, match on *:authority* instead.
 	ClusterHeader string `protobuf:"bytes,2,opt,name=cluster_header,json=clusterHeader,proto3,oneof"`
 }
 
@@ -1767,8 +1773,8 @@ type RouteAction_HostRewriteHeader struct {
 	//
 	// .. attention::
 	//
-	//   Pay attention to the potential security implications of using this option. Provided header
-	//   must come from trusted source.
+	//	Pay attention to the potential security implications of using this option. Provided header
+	//	must come from trusted source.
 	HostRewriteHeader string `protobuf:"bytes,29,opt,name=host_rewrite_header,json=hostRewriteHeader,proto3,oneof"`
 }
 
@@ -1799,11 +1805,11 @@ type RetryPolicy struct {
 	//
 	// .. note::
 	//
-	//   If left unspecified, Envoy will use the global
-	//   :ref:`route timeout <envoy_api_field_config.route.v3.RouteAction.timeout>` for the request.
-	//   Consequently, when using a :ref:`5xx <config_http_filters_router_x-envoy-retry-on>` based
-	//   retry policy, a request that times out will not be retried as the total timeout budget
-	//   would have been exhausted.
+	//	If left unspecified, Envoy will use the global
+	//	:ref:`route timeout <envoy_api_field_config.route.v3.RouteAction.timeout>` for the request.
+	//	Consequently, when using a :ref:`5xx <config_http_filters_router_x-envoy-retry-on>` based
+	//	retry policy, a request that times out will not be retried as the total timeout budget
+	//	would have been exhausted.
 	PerTryTimeout *duration.Duration `protobuf:"bytes,3,opt,name=per_try_timeout,json=perTryTimeout,proto3" json:"per_try_timeout,omitempty"`
 	// Specifies an implementation of a RetryPriority which is used to determine the
 	// distribution of load across priorities used for retries. Refer to
@@ -2029,6 +2035,7 @@ type RedirectAction struct {
 	//     set to `:443`, the port will be removed after the redirection
 	//
 	// Types that are assignable to SchemeRewriteSpecifier:
+	//
 	//	*RedirectAction_HttpsRedirect
 	//	*RedirectAction_SchemeRedirect
 	SchemeRewriteSpecifier isRedirectAction_SchemeRewriteSpecifier `protobuf_oneof:"scheme_rewrite_specifier"`
@@ -2037,6 +2044,7 @@ type RedirectAction struct {
 	// The port value of the URL will be swapped with this value.
 	PortRedirect uint32 `protobuf:"varint,8,opt,name=port_redirect,json=portRedirect,proto3" json:"port_redirect,omitempty"`
 	// Types that are assignable to PathRewriteSpecifier:
+	//
 	//	*RedirectAction_PathRedirect
 	//	*RedirectAction_PrefixRewrite
 	PathRewriteSpecifier isRedirectAction_PathRewriteSpecifier `protobuf_oneof:"path_rewrite_specifier"`
@@ -2179,12 +2187,12 @@ type RedirectAction_PathRedirect struct {
 	//
 	// For example, let's say we have the following routes:
 	//
-	// - match: { path: "/old-path-1" }
-	//   redirect: { path_redirect: "/new-path-1" }
-	// - match: { path: "/old-path-2" }
-	//   redirect: { path_redirect: "/new-path-2", strip-query: "true" }
-	// - match: { path: "/old-path-3" }
-	//   redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
+	//   - match: { path: "/old-path-1" }
+	//     redirect: { path_redirect: "/new-path-1" }
+	//   - match: { path: "/old-path-2" }
+	//     redirect: { path_redirect: "/new-path-2", strip-query: "true" }
+	//   - match: { path: "/old-path-3" }
+	//     redirect: { path_redirect: "/new-path-3?foo=1", strip_query: "true" }
 	//
 	// 1. if request uri is "/old-path-1?bar=1", users will be redirected to "/new-path-1?bar=1"
 	// 2. if request uri is "/old-path-2?bar=1", users will be redirected to "/new-path-2"
@@ -2199,8 +2207,8 @@ type RedirectAction_PrefixRewrite struct {
 	//
 	// .. attention::
 	//
-	//   Pay attention to the use of trailing slashes as mentioned in
-	//   :ref:`RouteAction's prefix_rewrite <envoy_api_field_config.route.v3.RouteAction.prefix_rewrite>`.
+	//	Pay attention to the use of trailing slashes as mentioned in
+	//	:ref:`RouteAction's prefix_rewrite <envoy_api_field_config.route.v3.RouteAction.prefix_rewrite>`.
 	PrefixRewrite string `protobuf:"bytes,5,opt,name=prefix_rewrite,json=prefixRewrite,proto3,oneof"`
 }
 
@@ -2220,9 +2228,9 @@ type DirectResponseAction struct {
 	//
 	// .. note::
 	//
-	//   Headers can be specified using *response_headers_to_add* in the enclosing
-	//   :ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
-	//   :ref:`envoy_api_msg_config.route.v3.VirtualHost`.
+	//	Headers can be specified using *response_headers_to_add* in the enclosing
+	//	:ref:`envoy_api_msg_config.route.v3.Route`, :ref:`envoy_api_msg_config.route.v3.RouteConfiguration` or
+	//	:ref:`envoy_api_msg_config.route.v3.VirtualHost`.
 	Body *v3.DataSource `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
 }
 
@@ -2282,9 +2290,9 @@ type Decorator struct {
 	//
 	// .. note::
 	//
-	//   For ingress (inbound) requests, or egress (outbound) responses, this value may be overridden
-	//   by the :ref:`x-envoy-decorator-operation
-	//   <config_http_filters_router_x-envoy-decorator-operation>` header.
+	//	For ingress (inbound) requests, or egress (outbound) responses, this value may be overridden
+	//	by the :ref:`x-envoy-decorator-operation
+	//	<config_http_filters_router_x-envoy-decorator-operation>` header.
 	Operation string `protobuf:"bytes,1,opt,name=operation,proto3" json:"operation,omitempty"`
 	// Whether the decorated details should be propagated to the other party. The default is true.
 	Propagate *wrappers.BoolValue `protobuf:"bytes,2,opt,name=propagate,proto3" json:"propagate,omitempty"`
@@ -2446,9 +2454,9 @@ func (x *Tracing) GetCustomTags() []*v33.CustomTag {
 //
 // .. note::
 //
-//    Virtual clusters are a useful tool, but we do not recommend setting up a virtual cluster for
-//    every application endpoint. This is both not easily maintainable and as well the matching and
-//    statistics output are not free.
+//	Virtual clusters are a useful tool, but we do not recommend setting up a virtual cluster for
+//	every application endpoint. This is both not easily maintainable and as well the matching and
+//	statistics output are not free.
 type VirtualCluster struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -2522,7 +2530,7 @@ type RateLimit struct {
 	//
 	// .. note::
 	//
-	//   The filter supports a range of 0 - 10 inclusively for stage numbers.
+	//	The filter supports a range of 0 - 10 inclusively for stage numbers.
 	Stage *wrappers.UInt32Value `protobuf:"bytes,1,opt,name=stage,proto3" json:"stage,omitempty"`
 	// The key to be set in runtime to disable this rate limit configuration.
 	DisableKey string `protobuf:"bytes,2,opt,name=disable_key,json=disableKey,proto3" json:"disable_key,omitempty"`
@@ -2602,28 +2610,30 @@ func (x *RateLimit) GetLimit() *RateLimit_Override {
 
 // .. attention::
 //
-//   Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
-//   header. Thus, if attempting to match on *Host*, match on *:authority* instead.
+//	Internally, Envoy always uses the HTTP/2 *:authority* header to represent the HTTP/1 *Host*
+//	header. Thus, if attempting to match on *Host*, match on *:authority* instead.
 //
 // .. attention::
 //
-//   To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
-//   HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
+//	To route on HTTP method, use the special HTTP/2 *:method* header. This works for both
+//	HTTP/1 and HTTP/2 as Envoy normalizes headers. E.g.,
 //
-//   .. code-block:: json
+//	.. code-block:: json
 //
-//     {
-//       "name": ":method",
-//       "exact_match": "POST"
-//     }
+//	  {
+//	    "name": ":method",
+//	    "exact_match": "POST"
+//	  }
 //
 // .. attention::
-//   In the absence of any header match specifier, match will default to :ref:`present_match
-//   <envoy_api_field_config.route.v3.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
-//   <envoy_api_field_config.route.v3.HeaderMatcher.name>` header will match, regardless of the header's
-//   value.
 //
-//  [#next-major-version: HeaderMatcher should be refactored to use StringMatcher.]
+//	 In the absence of any header match specifier, match will default to :ref:`present_match
+//	 <envoy_api_field_config.route.v3.HeaderMatcher.present_match>`. i.e, a request that has the :ref:`name
+//	 <envoy_api_field_config.route.v3.HeaderMatcher.name>` header will match, regardless of the header's
+//	 value.
+//
+//	[#next-major-version: HeaderMatcher should be refactored to use StringMatcher.]
+//
 // [#next-free-field: 12]
 type HeaderMatcher struct {
 	state         protoimpl.MessageState
@@ -2635,6 +2645,7 @@ type HeaderMatcher struct {
 	// Specifies how the header match will be performed to route the request.
 	//
 	// Types that are assignable to HeaderMatchSpecifier:
+	//
 	//	*HeaderMatcher_ExactMatch
 	//	*HeaderMatcher_SafeRegexMatch
 	//	*HeaderMatcher_RangeMatch
@@ -2646,7 +2657,7 @@ type HeaderMatcher struct {
 	//
 	// Examples:
 	//
-	// * The regex ``\d{3}`` does not match the value *1234*, so it will match when inverted.
+	// * The regex “\d{3}“ does not match the value *1234*, so it will match when inverted.
 	// * The range [-10,0) will match the value -1, so it will not match when inverted.
 	InvertMatch bool `protobuf:"varint,8,opt,name=invert_match,json=invertMatch,proto3" json:"invert_match,omitempty"`
 }
@@ -2772,8 +2783,8 @@ type HeaderMatcher_RangeMatch struct {
 	//
 	// Examples:
 	//
-	// * For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
-	//   "-1somestring"
+	//   - For range [-10,0), route will match for header value -1, but not for 0, "somestring", 10.9,
+	//     "-1somestring"
 	RangeMatch *v32.Int64Range `protobuf:"bytes,6,opt,name=range_match,json=rangeMatch,proto3,oneof"`
 }
 
@@ -2827,6 +2838,7 @@ type QueryParameterMatcher struct {
 	// *path*'s query string.
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to QueryParameterMatchSpecifier:
+	//
 	//	*QueryParameterMatcher_StringMatch
 	//	*QueryParameterMatcher_PresentMatch
 	QueryParameterMatchSpecifier isQueryParameterMatcher_QueryParameterMatchSpecifier `protobuf_oneof:"query_parameter_match_specifier"`
@@ -3282,7 +3294,7 @@ func (*RouteMatch_ConnectMatcher) Descriptor() ([]byte, []int) {
 //
 // .. note::
 //
-//   Shadowing will not be triggered if the primary cluster does not exist.
+//	Shadowing will not be triggered if the primary cluster does not exist.
 type RouteAction_RequestMirrorPolicy struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3366,6 +3378,7 @@ type RouteAction_HashPolicy struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to PolicySpecifier:
+	//
 	//	*RouteAction_HashPolicy_Header_
 	//	*RouteAction_HashPolicy_Cookie_
 	//	*RouteAction_HashPolicy_ConnectionProperties_
@@ -3381,13 +3394,13 @@ type RouteAction_HashPolicy struct {
 	// list of hash polices.
 	// For example, if the following hash methods are configured:
 	//
-	//  ========= ========
-	//  specifier terminal
-	//  ========= ========
-	//  Header A  true
-	//  Header B  false
-	//  Header C  false
-	//  ========= ========
+	//	========= ========
+	//	specifier terminal
+	//	========= ========
+	//	Header A  true
+	//	Header B  false
+	//	Header C  false
+	//	========= ========
 	//
 	// The generateHash process ends if policy "header A" generates a hash, as
 	// it's a terminal policy.
@@ -3652,18 +3665,18 @@ func (x *RouteAction_HashPolicy_Header) GetRegexRewrite() *v31.RegexMatchAndSubs
 
 // Envoy supports two types of cookie affinity:
 //
-// 1. Passive. Envoy takes a cookie that's present in the cookies header and
-//    hashes on its value.
+//  1. Passive. Envoy takes a cookie that's present in the cookies header and
+//     hashes on its value.
 //
-// 2. Generated. Envoy generates and sets a cookie with an expiration (TTL)
-//    on the first request from the client in its response to the client,
-//    based on the endpoint the request gets sent to. The client then
-//    presents this on the next and all subsequent requests. The hash of
-//    this is sufficient to ensure these requests get sent to the same
-//    endpoint. The cookie is generated by hashing the source and
-//    destination ports and addresses so that multiple independent HTTP2
-//    streams on the same connection will independently receive the same
-//    cookie, even if they arrive at the Envoy simultaneously.
+//  2. Generated. Envoy generates and sets a cookie with an expiration (TTL)
+//     on the first request from the client in its response to the client,
+//     based on the endpoint the request gets sent to. The client then
+//     presents this on the next and all subsequent requests. The hash of
+//     this is sufficient to ensure these requests get sent to the same
+//     endpoint. The cookie is generated by hashing the source and
+//     destination ports and addresses so that multiple independent HTTP2
+//     streams on the same connection will independently receive the same
+//     cookie, even if they arrive at the Envoy simultaneously.
 type RouteAction_HashPolicy_Cookie struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3940,6 +3953,7 @@ type RetryPolicy_RetryPriority struct {
 
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to ConfigType:
+	//
 	//	*RetryPolicy_RetryPriority_TypedConfig
 	ConfigType isRetryPolicy_RetryPriority_ConfigType `protobuf_oneof:"config_type"`
 }
@@ -4014,6 +4028,7 @@ type RetryPolicy_RetryHostPredicate struct {
 
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to ConfigType:
+	//
 	//	*RetryPolicy_RetryHostPredicate_TypedConfig
 	ConfigType isRetryPolicy_RetryHostPredicate_ConfigType `protobuf_oneof:"config_type"`
 }
@@ -4151,6 +4166,7 @@ type RateLimit_Action struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ActionSpecifier:
+	//
 	//	*RateLimit_Action_SourceCluster_
 	//	*RateLimit_Action_DestinationCluster_
 	//	*RateLimit_Action_RequestHeaders_
@@ -4308,6 +4324,7 @@ type RateLimit_Override struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to OverrideSpecifier:
+	//
 	//	*RateLimit_Override_DynamicMetadata_
 	OverrideSpecifier isRateLimit_Override_OverrideSpecifier `protobuf_oneof:"override_specifier"`
 }
@@ -4373,7 +4390,7 @@ func (*RateLimit_Override_DynamicMetadata_) isRateLimit_Override_OverrideSpecifi
 //
 // .. code-block:: cpp
 //
-//   ("source_cluster", "<local service cluster>")
+//	("source_cluster", "<local service cluster>")
 //
 // <local service cluster> is derived from the :option:`--service-cluster` option.
 type RateLimit_Action_SourceCluster struct {
@@ -4418,18 +4435,18 @@ func (*RateLimit_Action_SourceCluster) Descriptor() ([]byte, []int) {
 //
 // .. code-block:: cpp
 //
-//   ("destination_cluster", "<routed target cluster>")
+//	("destination_cluster", "<routed target cluster>")
 //
 // Once a request matches against a route table rule, a routed cluster is determined by one of
 // the following :ref:`route table configuration <envoy_api_msg_config.route.v3.RouteConfiguration>`
 // settings:
 //
-// * :ref:`cluster <envoy_api_field_config.route.v3.RouteAction.cluster>` indicates the upstream cluster
-//   to route to.
-// * :ref:`weighted_clusters <envoy_api_field_config.route.v3.RouteAction.weighted_clusters>`
-//   chooses a cluster randomly from a set of clusters with attributed weight.
-// * :ref:`cluster_header <envoy_api_field_config.route.v3.RouteAction.cluster_header>` indicates which
-//   header in the request contains the target cluster.
+//   - :ref:`cluster <envoy_api_field_config.route.v3.RouteAction.cluster>` indicates the upstream cluster
+//     to route to.
+//   - :ref:`weighted_clusters <envoy_api_field_config.route.v3.RouteAction.weighted_clusters>`
+//     chooses a cluster randomly from a set of clusters with attributed weight.
+//   - :ref:`cluster_header <envoy_api_field_config.route.v3.RouteAction.cluster_header>` indicates which
+//     header in the request contains the target cluster.
 type RateLimit_Action_DestinationCluster struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -4473,7 +4490,7 @@ func (*RateLimit_Action_DestinationCluster) Descriptor() ([]byte, []int) {
 //
 // .. code-block:: cpp
 //
-//   ("<descriptor_key>", "<header_value_queried_from_header>")
+//	("<descriptor_key>", "<header_value_queried_from_header>")
 type RateLimit_Action_RequestHeaders struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -4549,7 +4566,7 @@ func (x *RateLimit_Action_RequestHeaders) GetSkipIfAbsent() bool {
 //
 // .. code-block:: cpp
 //
-//   ("remote_address", "<trusted address from x-forwarded-for>")
+//	("remote_address", "<trusted address from x-forwarded-for>")
 type RateLimit_Action_RemoteAddress struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -4592,7 +4609,7 @@ func (*RateLimit_Action_RemoteAddress) Descriptor() ([]byte, []int) {
 //
 // .. code-block:: cpp
 //
-//   ("generic_key", "<descriptor_value>")
+//	("generic_key", "<descriptor_value>")
 type RateLimit_Action_GenericKey struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -4645,7 +4662,7 @@ func (x *RateLimit_Action_GenericKey) GetDescriptorValue() string {
 //
 // .. code-block:: cpp
 //
-//   ("header_match", "<descriptor_value>")
+//	("header_match", "<descriptor_value>")
 type RateLimit_Action_HeaderValueMatch struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -4723,7 +4740,7 @@ func (x *RateLimit_Action_HeaderValueMatch) GetHeaders() []*HeaderMatcher {
 //
 // .. code-block:: cpp
 //
-//   ("<descriptor_key>", "<value_queried_from_metadata>")
+//	("<descriptor_key>", "<value_queried_from_metadata>")
 type RateLimit_Action_DynamicMetaData struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/external/envoy/config/trace/v3/datadog.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/trace/v3/datadog.pb.go
@@ -36,6 +36,7 @@ type DatadogConfig struct {
 	// The cluster to use for submitting traces to the Datadog agent.
 	//
 	// Types that are assignable to CollectorCluster:
+	//
 	//	*DatadogConfig_CollectorUpstreamRef
 	//	*DatadogConfig_ClusterName
 	CollectorCluster isDatadogConfig_CollectorCluster `protobuf_oneof:"collector_cluster"`

--- a/projects/gloo/pkg/api/external/envoy/config/trace/v3/opencensus.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/trace/v3/opencensus.pb.go
@@ -155,6 +155,7 @@ type OpenCensusConfig struct {
 	// Upstream to which trace data should be sent
 	//
 	// Types that are assignable to OcagentAddress:
+	//
 	//	*OpenCensusConfig_HttpAddress
 	//	*OpenCensusConfig_GrpcAddress
 	OcagentAddress isOpenCensusConfig_OcagentAddress `protobuf_oneof:"ocagent_address"`
@@ -269,6 +270,7 @@ type TraceConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Sampler:
+	//
 	//	*TraceConfig_ProbabilitySampler
 	//	*TraceConfig_ConstantSampler
 	//	*TraceConfig_RateLimitingSampler

--- a/projects/gloo/pkg/api/external/envoy/config/trace/v3/opentelemetry.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/trace/v3/opentelemetry.pb.go
@@ -35,6 +35,7 @@ type OpenTelemetryConfig struct {
 	// The cluster to use for submitting traces to the OpenTelemetry agent.
 	//
 	// Types that are assignable to CollectorCluster:
+	//
 	//	*OpenTelemetryConfig_CollectorUpstreamRef
 	//	*OpenTelemetryConfig_ClusterName
 	CollectorCluster isOpenTelemetryConfig_CollectorCluster `protobuf_oneof:"collector_cluster"`

--- a/projects/gloo/pkg/api/external/envoy/config/trace/v3/zipkin.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/config/trace/v3/zipkin.pb.go
@@ -99,6 +99,7 @@ type ZipkinConfig struct {
 	// The cluster that hosts the Zipkin collectors.
 	//
 	// Types that are assignable to CollectorCluster:
+	//
 	//	*ZipkinConfig_CollectorUpstreamRef
 	//	*ZipkinConfig_ClusterName
 	CollectorCluster isZipkinConfig_CollectorCluster `protobuf_oneof:"collector_cluster"`
@@ -112,7 +113,7 @@ type ZipkinConfig struct {
 	// Determines whether client and server spans will share the same span context.
 	// The default value is true.
 	SharedSpanContext *wrappers.BoolValue `protobuf:"bytes,4,opt,name=shared_span_context,json=sharedSpanContext,proto3" json:"shared_span_context,omitempty"`
-	// Determines the selected collector endpoint version. By default, the ``HTTP_JSON_V1`` will be
+	// Determines the selected collector endpoint version. By default, the “HTTP_JSON_V1“ will be
 	// used.
 	CollectorEndpointVersion ZipkinConfig_CollectorEndpointVersion `protobuf:"varint,5,opt,name=collector_endpoint_version,json=collectorEndpointVersion,proto3,enum=solo.io.envoy.config.trace.v3.ZipkinConfig_CollectorEndpointVersion" json:"collector_endpoint_version,omitempty"`
 }

--- a/projects/gloo/pkg/api/external/envoy/extensions/advanced_http/advanced_http.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/advanced_http/advanced_http.pb.go
@@ -75,14 +75,14 @@ func (HealthCheckResult) EnumDescriptor() ([]byte, []int) {
 }
 
 // Same as envoy's default HTTP health checker, but with some additions:
-// - allows a custom path and method on the health check request per endpoint.
-//   The http path to use can be overridden using endpoint metadata. The endpoint-specific
-//   path should be in the "io.solo.health_checkers.advanced_http" namespace, under a string
-//   value named "path". The same can be done for the method by setting a string value
-//   named "method".
-// - allows for health check responses to leverage the response body rather than just
-//   the http status code returned. The response body can be parsed as json and complex
-//   assertions can be made on fields parsed from the json or plaintext response body.
+//   - allows a custom path and method on the health check request per endpoint.
+//     The http path to use can be overridden using endpoint metadata. The endpoint-specific
+//     path should be in the "io.solo.health_checkers.advanced_http" namespace, under a string
+//     value named "path". The same can be done for the method by setting a string value
+//     named "method".
+//   - allows for health check responses to leverage the response body rather than just
+//     the http status code returned. The response body can be parsed as json and complex
+//     assertions can be made on fields parsed from the json or plaintext response body.
 type AdvancedHttp struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -280,6 +280,7 @@ type ResponseMatch struct {
 	// The source of the extraction
 	//
 	// Types that are assignable to Source:
+	//
 	//	*ResponseMatch_Header
 	//	*ResponseMatch_Body
 	Source isResponseMatch_Source `protobuf_oneof:"source"`
@@ -436,6 +437,7 @@ type JsonKey_PathSegment struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Segment:
+	//
 	//	*JsonKey_PathSegment_Key
 	Segment isJsonKey_PathSegment_Segment `protobuf_oneof:"segment"`
 }

--- a/projects/gloo/pkg/api/external/envoy/extensions/aws/filter.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/aws/filter.pb.go
@@ -253,6 +253,7 @@ type AWSLambdaConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to CredentialsFetcher:
+	//
 	//	*AWSLambdaConfig_UseDefaultCredentials
 	//	*AWSLambdaConfig_ServiceAccountCredentials_
 	CredentialsFetcher isAWSLambdaConfig_CredentialsFetcher `protobuf_oneof:"credentials_fetcher"`
@@ -357,8 +358,8 @@ type AWSLambdaConfig_ServiceAccountCredentials_ struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 	//
 	// If the following environment values are not present, this option cannot be used.
-	//   1. AWS_WEB_IDENTITY_TOKEN_FILE
-	//   2. AWS_ROLE_ARN
+	//  1. AWS_WEB_IDENTITY_TOKEN_FILE
+	//  2. AWS_ROLE_ARN
 	//
 	// If they are not specified envoy will NACK the config update, which will show up in the logs when running OS Gloo.
 	// When running Gloo enterprise it will be reflected in the prometheus stat: "glooe.solo.io/xds/nack"

--- a/projects/gloo/pkg/api/external/envoy/extensions/filters/http/buffer/v3/buffer.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/filters/http/buffer/v3/buffer.pb.go
@@ -81,6 +81,7 @@ type BufferPerRoute struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Override:
+	//
 	//	*BufferPerRoute_Disabled
 	//	*BufferPerRoute_Buffer
 	Override isBufferPerRoute_Override `protobuf_oneof:"override"`

--- a/projects/gloo/pkg/api/external/envoy/extensions/filters/http/csrf/v3/csrf.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/filters/http/csrf/v3/csrf.pb.go
@@ -40,12 +40,12 @@ type CsrfPolicy struct {
 	//
 	// .. note::
 	//
-	//   This field defaults to 100/:ref:`HUNDRED
-	//   <envoy_api_enum_type.v3.FractionalPercent.DenominatorType>`.
+	//	This field defaults to 100/:ref:`HUNDRED
+	//	<envoy_api_enum_type.v3.FractionalPercent.DenominatorType>`.
 	FilterEnabled *v3.RuntimeFractionalPercent `protobuf:"bytes,1,opt,name=filter_enabled,json=filterEnabled,proto3" json:"filter_enabled,omitempty"`
 	// Specifies that CSRF policies will be evaluated and tracked, but not enforced.
 	//
-	// This is intended to be used when ``filter_enabled`` is off and will be ignored otherwise.
+	// This is intended to be used when “filter_enabled“ is off and will be ignored otherwise.
 	//
 	// If :ref:`runtime_key <envoy_api_field_config.core.v3.RuntimeFractionalPercent.runtime_key>` is specified,
 	// Envoy will lookup the runtime key to get the percentage of requests for which it will evaluate

--- a/projects/gloo/pkg/api/external/envoy/extensions/filters/http/graphql/v2/graphql.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/filters/http/graphql/v2/graphql.pb.go
@@ -149,6 +149,7 @@ type PathSegment struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Segment:
+	//
 	//	*PathSegment_Key
 	//	*PathSegment_Index
 	//	*PathSegment_All
@@ -292,15 +293,14 @@ type TemplatedPath struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//
-	//If non-empty, Inserts named paths into a template string.
-	//For example, if the template is '/api/{apiVersionPath}/pet/{petIdPath}'
-	//and we have two named paths defined in `named_paths`, apiVersionPath and petIdPath, with extracted values 'v2' and '123' respectively,
-	//the final resulting value will be '/api/v2/pet/123'
-	//Use {PATH_NAME} as the interpolation notation (even repeated) regardless of the type of the
-	//provided value.
-	//If an undefined PATH_NAME is used in the template, this will nack during configuration.
-	//If this is empty, only the value of the first provider will be used as the resulting value.
+	// If non-empty, Inserts named paths into a template string.
+	// For example, if the template is '/api/{apiVersionPath}/pet/{petIdPath}'
+	// and we have two named paths defined in `named_paths`, apiVersionPath and petIdPath, with extracted values 'v2' and '123' respectively,
+	// the final resulting value will be '/api/v2/pet/123'
+	// Use {PATH_NAME} as the interpolation notation (even repeated) regardless of the type of the
+	// provided value.
+	// If an undefined PATH_NAME is used in the template, this will nack during configuration.
+	// If this is empty, only the value of the first provider will be used as the resulting value.
 	PathTemplate string           `protobuf:"bytes,1,opt,name=path_template,json=pathTemplate,proto3" json:"path_template,omitempty"`
 	NamedPaths   map[string]*Path `protobuf:"bytes,2,rep,name=named_paths,json=namedPaths,proto3" json:"named_paths,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
@@ -360,15 +360,14 @@ type ValueProvider struct {
 	// Map of provider name to provider definition.
 	// The name will be used to insert the provider value in the provider_template.
 	Providers map[string]*ValueProvider_Provider `protobuf:"bytes,3,rep,name=providers,proto3" json:"providers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	//
-	//If non-empty, Inserts named providers into a template string.
-	//For example, if the provider_template is '/api/{apiVersionProvider}/pet/{petIdProvider}'
-	//and we have two named providers defined in `providers`, apiVersionProvider and petIdProvider, with extracted values 'v2' and '123' respectively,
-	//the final resulting value will be '/api/v2/pet/123'
-	//Use {PROVIDER_NAME} as the interpolation notation (even repeated) regardless of the type of the
-	//provided value.
-	//If an undefined PROVIDER_NAME is used in the provider_template, this will nack during configuration.
-	//If this is empty, only the value of the first provider will be used as the resulting value.
+	// If non-empty, Inserts named providers into a template string.
+	// For example, if the provider_template is '/api/{apiVersionProvider}/pet/{petIdProvider}'
+	// and we have two named providers defined in `providers`, apiVersionProvider and petIdProvider, with extracted values 'v2' and '123' respectively,
+	// the final resulting value will be '/api/v2/pet/123'
+	// Use {PROVIDER_NAME} as the interpolation notation (even repeated) regardless of the type of the
+	// provided value.
+	// If an undefined PROVIDER_NAME is used in the provider_template, this will nack during configuration.
+	// If this is empty, only the value of the first provider will be used as the resulting value.
 	ProviderTemplate string `protobuf:"bytes,4,opt,name=provider_template,json=providerTemplate,proto3" json:"provider_template,omitempty"`
 }
 
@@ -471,6 +470,7 @@ type JsonValue struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to JsonVal:
+	//
 	//	*JsonValue_Node
 	//	*JsonValue_ValueProvider
 	//	*JsonValue_List
@@ -764,45 +764,44 @@ type ResponseTemplate struct {
 	// If {"a": {"b": [1,2,3]}} is the response from the api, setting resultroot as `a.b`
 	// will pass on [1,2,3] to the execution engine rather than the whole api response
 	ResultRoot []*PathSegment `protobuf:"bytes,1,rep,name=result_root,json=resultRoot,proto3" json:"result_root,omitempty"`
+	// Example:
+	// ```
+	// type Query {
+	// getSimple: Simple
+	// }
 	//
-	//Example:
-	//```
-	//type Query {
-	//getSimple: Simple
-	//}
+	// type Simple {
+	// name String
+	// address String
+	// }```
 	//
-	//type Simple {
-	//name String
-	//address String
-	//}```
-	//
-	//if we do `getsimple` and the response we get back from the upstream is
-	//```
-	//{"data": {
-	//"people":
-	//{
-	//"name": "John Doe",
-	//"details": {
-	//"address": "123 Turnip Rd"
-	//}
-	//}
-	//}
-	//}
-	//```
-	//the following response transform would let the graphql execution engine correctly
-	//marshal the upstream resposne into the expected graphql response:
-	//`
-	//responseTransform:
-	//result_root:
-	//segments:
-	//- key: data
-	//- key: people
-	//setters:
-	//address:
-	//segments:
-	//- key: details
-	//- key: address
-	//`yaml
+	// if we do `getsimple` and the response we get back from the upstream is
+	// ```
+	// {"data": {
+	// "people":
+	// {
+	// "name": "John Doe",
+	// "details": {
+	// "address": "123 Turnip Rd"
+	// }
+	// }
+	// }
+	// }
+	// ```
+	// the following response transform would let the graphql execution engine correctly
+	// marshal the upstream resposne into the expected graphql response:
+	// `
+	// responseTransform:
+	// result_root:
+	// segments:
+	// - key: data
+	// - key: people
+	// setters:
+	// address:
+	// segments:
+	// - key: details
+	// - key: address
+	// `yaml
 	Setters map[string]*TemplatedPath `protobuf:"bytes,2,rep,name=setters,proto3" json:"setters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -865,7 +864,6 @@ type RESTResolver struct {
 	// Request flow: GraphQL request -> request_transform (instantiate REST request) ->
 	// REST API resp -> pre_execution_transform -> execution engine ->
 	// complete GraphQL field response
-	//
 	PreExecutionTransform *ResponseTemplate `protobuf:"bytes,3,opt,name=pre_execution_transform,json=preExecutionTransform,proto3" json:"pre_execution_transform,omitempty"`
 	SpanName              string            `protobuf:"bytes,4,opt,name=span_name,json=spanName,proto3" json:"span_name,omitempty"`
 }
@@ -1072,7 +1070,7 @@ type GrpcResolver struct {
 	// gRPC API resp -> pre_execution_transform -> execution engine ->
 	// complete GraphQL field response
 	//
-	//ResponseTemplate pre_execution_transform = 3;
+	// ResponseTemplate pre_execution_transform = 3;
 	SpanName string `protobuf:"bytes,4,opt,name=span_name,json=spanName,proto3" json:"span_name,omitempty"`
 }
 
@@ -1136,6 +1134,7 @@ type StaticResolver struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Response:
+	//
 	//	*StaticResolver_SyncResponse
 	//	*StaticResolver_AsyncResponse_
 	//	*StaticResolver_ErrorResponse
@@ -1273,6 +1272,7 @@ type QueryMatcher struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Match:
+	//
 	//	*QueryMatcher_FieldMatcher_
 	Match isQueryMatcher_Match `protobuf_oneof:"match"`
 }
@@ -1740,6 +1740,7 @@ type Executor struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Executor:
+	//
 	//	*Executor_Local_
 	//	*Executor_Remote_
 	Executor isExecutor_Executor `protobuf_oneof:"executor"`
@@ -1937,6 +1938,7 @@ type ValueProvider_TypedValueProvider struct {
 	// this value will be cast to an int type.
 	Type ValueProvider_TypedValueProvider_Type `protobuf:"varint,1,opt,name=type,proto3,enum=envoy.config.filter.http.graphql.v2.ValueProvider_TypedValueProvider_Type" json:"type,omitempty"`
 	// Types that are assignable to ValProvider:
+	//
 	//	*ValueProvider_TypedValueProvider_Header
 	//	*ValueProvider_TypedValueProvider_Value
 	ValProvider isValueProvider_TypedValueProvider_ValProvider `protobuf_oneof:"val_provider"`
@@ -2026,6 +2028,7 @@ type ValueProvider_Provider struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Provider:
+	//
 	//	*ValueProvider_Provider_GraphqlArg
 	//	*ValueProvider_Provider_TypedProvider
 	//	*ValueProvider_Provider_GraphqlParent
@@ -2242,12 +2245,14 @@ type Executor_Local struct {
 	// The max amount of nesting a query can be executed against this schema.
 	// e.g. the following query has these depths:
 	// query {         # Depth: 0
-	//   me {          # Depth: 1
-	//     friends {   # Depth: 2
-	//        friends  # Depth: 3
-	//     }
-	//   }
-	// }
+	//
+	//	  me {          # Depth: 1
+	//	    friends {   # Depth: 2
+	//	       friends  # Depth: 3
+	//	    }
+	//	  }
+	//	}
+	//
 	// If the max_depth is set to 2, then the query at depth 3 will receive an error as a response.
 	// The max_depth value of 0 (set by default) will allow an unbounded query depth.
 	MaxDepth uint32 `protobuf:"varint,3,opt,name=max_depth,json=maxDepth,proto3" json:"max_depth,omitempty"`
@@ -2377,6 +2382,7 @@ type Executor_Remote_Extraction struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ExtractionType:
+	//
 	//	*Executor_Remote_Extraction_Value
 	//	*Executor_Remote_Extraction_Header
 	//	*Executor_Remote_Extraction_DynamicMetadata

--- a/projects/gloo/pkg/api/external/envoy/extensions/filters/http/jwt_authn/v3/config.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/filters/http/jwt_authn/v3/config.pb.go
@@ -45,17 +45,17 @@ const (
 //
 // .. code-block:: yaml
 //
-//     issuer: https://example.com
-//     audiences:
-//     - bookstore_android.apps.googleusercontent.com
-//     - bookstore_web.apps.googleusercontent.com
-//     remote_jwks:
-//       http_uri:
-//         uri: https://example.com/.well-known/jwks.json
-//         cluster: example_jwks_cluster
-//         timeout: 1s
-//       cache_duration:
-//         seconds: 300
+//	issuer: https://example.com
+//	audiences:
+//	- bookstore_android.apps.googleusercontent.com
+//	- bookstore_web.apps.googleusercontent.com
+//	remote_jwks:
+//	  http_uri:
+//	    uri: https://example.com/.well-known/jwks.json
+//	    cluster: example_jwks_cluster
+//	    timeout: 1s
+//	  cache_duration:
+//	    seconds: 300
 //
 // [#next-free-field: 11]
 type JwtProvider struct {
@@ -82,7 +82,6 @@ type JwtProvider struct {
 	//
 	// Example: https://securetoken.google.com
 	// Example: 1234567-compute@developer.gserviceaccount.com
-	//
 	Issuer string `protobuf:"bytes,1,opt,name=issuer,proto3" json:"issuer,omitempty"`
 	// The list of JWT `audiences <https://tools.ietf.org/html/rfc7519#section-4.1.3>`_ are
 	// allowed to access. A JWT containing any of these audiences will be accepted. If not specified,
@@ -92,15 +91,15 @@ type JwtProvider struct {
 	//
 	// .. code-block:: yaml
 	//
-	//     audiences:
-	//     - bookstore_android.apps.googleusercontent.com
-	//     - bookstore_web.apps.googleusercontent.com
-	//
+	//	audiences:
+	//	- bookstore_android.apps.googleusercontent.com
+	//	- bookstore_web.apps.googleusercontent.com
 	Audiences []string `protobuf:"bytes,2,rep,name=audiences,proto3" json:"audiences,omitempty"`
 	// `JSON Web Key Set (JWKS) <https://tools.ietf.org/html/rfc7517#appendix-A>`_ is needed to
 	// validate signature of a JWT. This field specifies where to fetch JWKS.
 	//
 	// Types that are assignable to JwksSourceSpecifier:
+	//
 	//	*JwtProvider_RemoteJwks
 	//	*JwtProvider_LocalJwks
 	JwksSourceSpecifier isJwtProvider_JwksSourceSpecifier `protobuf_oneof:"jwks_source_specifier"`
@@ -114,7 +113,7 @@ type JwtProvider struct {
 	// 1. The Authorization header using the `Bearer schema
 	// <https://tools.ietf.org/html/rfc6750#section-2.1>`_. Example::
 	//
-	//    Authorization: Bearer <token>.
+	//	Authorization: Bearer <token>.
 	//
 	// 2. `access_token <https://tools.ietf.org/html/rfc6750#section-2.3>`_ query parameter.
 	//
@@ -125,13 +124,12 @@ type JwtProvider struct {
 	//
 	// .. code-block:: yaml
 	//
-	//   from_headers:
-	//   - name: x-goog-iap-jwt-assertion
+	//	from_headers:
+	//	- name: x-goog-iap-jwt-assertion
 	//
 	// can be used to extract token from header::
 	//
-	//   ``x-goog-iap-jwt-assertion: <JWT>``.
-	//
+	//	``x-goog-iap-jwt-assertion: <JWT>``.
 	FromHeaders []*JwtHeader `protobuf:"bytes,6,rep,name=from_headers,json=fromHeaders,proto3" json:"from_headers,omitempty"`
 	// JWT is sent in a query parameter. `jwt_params` represents the query parameter names.
 	//
@@ -139,18 +137,17 @@ type JwtProvider struct {
 	//
 	// .. code-block:: yaml
 	//
-	//   from_params:
-	//   - jwt_token
+	//	from_params:
+	//	- jwt_token
 	//
 	// The JWT format in query parameter is::
 	//
-	//    /path?jwt_token=<JWT>
-	//
+	//	/path?jwt_token=<JWT>
 	FromParams []string `protobuf:"bytes,7,rep,name=from_params,json=fromParams,proto3" json:"from_params,omitempty"`
 	// This field specifies the header name to forward a successfully verified JWT payload to the
 	// backend. The forwarded data is::
 	//
-	//    base64url_encoded(jwt_payload_in_JSON)
+	//	base64url_encoded(jwt_payload_in_JSON)
 	//
 	// If it is not specified, the payload will not be forwarded.
 	ForwardPayloadHeader string `protobuf:"bytes,8,opt,name=forward_payload_header,json=forwardPayloadHeader,proto3" json:"forward_payload_header,omitempty"`
@@ -163,13 +160,12 @@ type JwtProvider struct {
 	//
 	// .. code-block:: yaml
 	//
-	//   envoy.filters.http.jwt_authn:
-	//     my_payload:
-	//       iss: https://example.com
-	//       sub: test@example.com
-	//       aud: https://example.com
-	//       exp: 1501281058
-	//
+	//	envoy.filters.http.jwt_authn:
+	//	  my_payload:
+	//	    iss: https://example.com
+	//	    sub: test@example.com
+	//	    aud: https://example.com
+	//	    exp: 1501281058
 	PayloadInMetadata string `protobuf:"bytes,9,opt,name=payload_in_metadata,json=payloadInMetadata,proto3" json:"payload_in_metadata,omitempty"`
 	// Specify the clock skew in seconds when verifying JWT time constraint,
 	// such as `exp`, and `nbf`. If not specified, default is 60 seconds.
@@ -297,14 +293,13 @@ type JwtProvider_RemoteJwks struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    remote_jwks:
-	//      http_uri:
-	//        uri: https://www.googleapis.com/oauth2/v1/certs
-	//        cluster: jwt.www.googleapis.com|443
-	//        timeout: 1s
-	//      cache_duration:
-	//        seconds: 300
-	//
+	//	remote_jwks:
+	//	  http_uri:
+	//	    uri: https://www.googleapis.com/oauth2/v1/certs
+	//	    cluster: jwt.www.googleapis.com|443
+	//	    timeout: 1s
+	//	  cache_duration:
+	//	    seconds: 300
 	RemoteJwks *RemoteJwks `protobuf:"bytes,3,opt,name=remote_jwks,json=remoteJwks,proto3,oneof"`
 }
 
@@ -316,16 +311,15 @@ type JwtProvider_LocalJwks struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    local_jwks:
-	//      filename: /etc/envoy/jwks/jwks1.txt
+	//	local_jwks:
+	//	  filename: /etc/envoy/jwks/jwks1.txt
 	//
 	// Example: inline_string
 	//
 	// .. code-block:: yaml
 	//
-	//    local_jwks:
-	//      inline_string: ACADADADADA
-	//
+	//	local_jwks:
+	//	  inline_string: ACADADADADA
 	LocalJwks *v3.DataSource `protobuf:"bytes,4,opt,name=local_jwks,json=localJwks,proto3,oneof"`
 }
 
@@ -343,11 +337,10 @@ type RemoteJwks struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    http_uri:
-	//      uri: https://www.googleapis.com/oauth2/v1/certs
-	//      cluster: jwt.www.googleapis.com|443
-	//      timeout: 1s
-	//
+	//	http_uri:
+	//	  uri: https://www.googleapis.com/oauth2/v1/certs
+	//	  cluster: jwt.www.googleapis.com|443
+	//	  timeout: 1s
 	HttpUri *v3.HttpUri `protobuf:"bytes,1,opt,name=http_uri,json=httpUri,proto3" json:"http_uri,omitempty"`
 	// Duration after which the cached JWKS should be expired. If not specified, default cache
 	// duration is 5 minutes.
@@ -357,15 +350,15 @@ type RemoteJwks struct {
 	//
 	// If this feature is not enabled:
 	//
-	// * The Jwks is fetched on-demand when the requests come. During the fetching, first
-	//   few requests are paused until the Jwks is fetched.
-	// * Each worker thread fetches its own Jwks since Jwks cache is per worker thread.
+	//   - The Jwks is fetched on-demand when the requests come. During the fetching, first
+	//     few requests are paused until the Jwks is fetched.
+	//   - Each worker thread fetches its own Jwks since Jwks cache is per worker thread.
 	//
 	// If this feature is enabled:
 	//
-	// * Fetched Jwks is done in the main thread before the listener is activated. Its fetched
-	//   Jwks can be used by all worker threads. Each worker thread doesn't need to fetch its own.
-	// * Jwks is ready when the requests come, not need to wait for the Jwks fetching.
+	//   - Fetched Jwks is done in the main thread before the listener is activated. Its fetched
+	//     Jwks can be used by all worker threads. Each worker thread doesn't need to fetch its own.
+	//   - Jwks is ready when the requests come, not need to wait for the Jwks fetching.
 	AsyncFetch *JwksAsyncFetch `protobuf:"bytes,3,opt,name=async_fetch,json=asyncFetch,proto3" json:"async_fetch,omitempty"`
 }
 
@@ -600,56 +593,56 @@ func (x *ProviderWithAudiences) GetAudiences() []string {
 //
 // .. code-block:: yaml
 //
-//  # Example 1: not required with an empty message
+//	# Example 1: not required with an empty message
 //
-//  # Example 2: require A
-//  provider_name: provider-A
+//	# Example 2: require A
+//	provider_name: provider-A
 //
-//  # Example 3: require A or B
-//  requires_any:
-//    requirements:
-//      - provider_name: provider-A
-//      - provider_name: provider-B
+//	# Example 3: require A or B
+//	requires_any:
+//	  requirements:
+//	    - provider_name: provider-A
+//	    - provider_name: provider-B
 //
-//  # Example 4: require A and B
-//  requires_all:
-//    requirements:
-//      - provider_name: provider-A
-//      - provider_name: provider-B
+//	# Example 4: require A and B
+//	requires_all:
+//	  requirements:
+//	    - provider_name: provider-A
+//	    - provider_name: provider-B
 //
-//  # Example 5: require A and (B or C)
-//  requires_all:
-//    requirements:
-//      - provider_name: provider-A
-//      - requires_any:
-//        requirements:
-//          - provider_name: provider-B
-//          - provider_name: provider-C
+//	# Example 5: require A and (B or C)
+//	requires_all:
+//	  requirements:
+//	    - provider_name: provider-A
+//	    - requires_any:
+//	      requirements:
+//	        - provider_name: provider-B
+//	        - provider_name: provider-C
 //
-//  # Example 6: require A or (B and C)
-//  requires_any:
-//    requirements:
-//      - provider_name: provider-A
-//      - requires_all:
-//        requirements:
-//          - provider_name: provider-B
-//          - provider_name: provider-C
+//	# Example 6: require A or (B and C)
+//	requires_any:
+//	  requirements:
+//	    - provider_name: provider-A
+//	    - requires_all:
+//	      requirements:
+//	        - provider_name: provider-B
+//	        - provider_name: provider-C
 //
-//  # Example 7: A is optional (if token from A is provided, it must be valid, but also allows
-//  missing token.)
-//  requires_any:
-//    requirements:
-//    - provider_name: provider-A
-//    - allow_missing: {}
+//	# Example 7: A is optional (if token from A is provided, it must be valid, but also allows
+//	missing token.)
+//	requires_any:
+//	  requirements:
+//	  - provider_name: provider-A
+//	  - allow_missing: {}
 //
-//  # Example 8: A is optional and B is required.
-//  requires_all:
-//    requirements:
-//    - requires_any:
-//        requirements:
-//        - provider_name: provider-A
-//        - allow_missing: {}
-//    - provider_name: provider-B
+//	# Example 8: A is optional and B is required.
+//	requires_all:
+//	  requirements:
+//	  - requires_any:
+//	      requirements:
+//	      - provider_name: provider-A
+//	      - allow_missing: {}
+//	  - provider_name: provider-B
 //
 // [#next-free-field: 7]
 type JwtRequirement struct {
@@ -658,6 +651,7 @@ type JwtRequirement struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to RequiresType:
+	//
 	//	*JwtRequirement_ProviderName
 	//	*JwtRequirement_ProviderAndAudiences
 	//	*JwtRequirement_RequiresAny
@@ -907,8 +901,8 @@ func (x *JwtRequirementAndList) GetRequirements() []*JwtRequirement {
 //
 // .. code-block:: yaml
 //
-//    - match:
-//        prefix: /healthz
+//   - match:
+//     prefix: /healthz
 //
 // In above example, "requires" field is empty for /healthz prefix match,
 // it means that requests matching the path prefix don't require JWT authentication.
@@ -917,9 +911,9 @@ func (x *JwtRequirementAndList) GetRequirements() []*JwtRequirement {
 //
 // .. code-block:: yaml
 //
-//    - match:
-//        prefix: /
-//      requires: { provider_name: provider-A }
+//   - match:
+//     prefix: /
+//     requires: { provider_name: provider-A }
 //
 // In above example, all requests matched the path prefix require jwt authentication
 // from "provider-A".
@@ -935,14 +929,14 @@ type RequirementRule struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    match:
-	//      prefix: /
-	//
+	//	match:
+	//	  prefix: /
 	Match *v31.RouteMatch `protobuf:"bytes,1,opt,name=match,proto3" json:"match,omitempty"`
 	// Specify a Jwt requirement.
 	// If not specified, Jwt verification is disabled.
 	//
 	// Types that are assignable to RequirementType:
+	//
 	//	*RequirementRule_Requires
 	//	*RequirementRule_RequirementName
 	RequirementType isRequirementRule_RequirementType `protobuf_oneof:"requirement_type"`
@@ -1037,12 +1031,12 @@ func (*RequirementRule_RequirementName) isRequirementRule_RequirementType() {}
 //
 // .. code-block:: yaml
 //
-//    name: jwt_selector
-//    requires:
-//      issuer_1:
-//        provider_name: issuer1
-//      issuer_2:
-//        provider_name: issuer2
+//	name: jwt_selector
+//	requires:
+//	  issuer_1:
+//	    provider_name: issuer1
+//	  issuer_2:
+//	    provider_name: issuer2
 //
 // If a filter set "jwt_selector" with "issuer_1" to FilterState for a request,
 // jwt_authn filter will use JwtRequirement{"provider_name": "issuer1"} to verify.
@@ -1110,41 +1104,41 @@ func (x *FilterStateRule) GetRequires() map[string]*JwtRequirement {
 //
 // .. code-block:: yaml
 //
-//   providers:
-//      provider1:
-//        issuer: issuer1
-//        audiences:
-//        - audience1
-//        - audience2
-//        remote_jwks:
-//          http_uri:
-//            uri: https://example.com/.well-known/jwks.json
-//            cluster: example_jwks_cluster
-//            timeout: 1s
-//      provider2:
-//        issuer: issuer2
-//        local_jwks:
-//          inline_string: jwks_string
+//	providers:
+//	   provider1:
+//	     issuer: issuer1
+//	     audiences:
+//	     - audience1
+//	     - audience2
+//	     remote_jwks:
+//	       http_uri:
+//	         uri: https://example.com/.well-known/jwks.json
+//	         cluster: example_jwks_cluster
+//	         timeout: 1s
+//	   provider2:
+//	     issuer: issuer2
+//	     local_jwks:
+//	       inline_string: jwks_string
 //
-//   rules:
-//      # Not jwt verification is required for /health path
-//      - match:
-//          prefix: /health
+//	rules:
+//	   # Not jwt verification is required for /health path
+//	   - match:
+//	       prefix: /health
 //
-//      # Jwt verification for provider1 is required for path prefixed with "prefix"
-//      - match:
-//          prefix: /prefix
-//        requires:
-//          provider_name: provider1
+//	   # Jwt verification for provider1 is required for path prefixed with "prefix"
+//	   - match:
+//	       prefix: /prefix
+//	     requires:
+//	       provider_name: provider1
 //
-//      # Jwt verification for either provider1 or provider2 is required for all other requests.
-//      - match:
-//          prefix: /
-//        requires:
-//          requires_any:
-//            requirements:
-//              - provider_name: provider1
-//              - provider_name: provider2
+//	   # Jwt verification for either provider1 or provider2 is required for all other requests.
+//	   - match:
+//	       prefix: /
+//	     requires:
+//	       requires_any:
+//	         requirements:
+//	           - provider_name: provider1
+//	           - provider_name: provider2
 //
 // [#next-free-field: 6]
 type JwtAuthentication struct {
@@ -1156,52 +1150,50 @@ type JwtAuthentication struct {
 	//
 	// .. code-block:: yaml
 	//
-	//   providers:
-	//     provider1:
-	//        issuer: issuer1
-	//        audiences:
-	//        - audience1
-	//        - audience2
-	//        remote_jwks:
-	//          http_uri:
-	//            uri: https://example.com/.well-known/jwks.json
-	//            cluster: example_jwks_cluster
-	//            timeout: 1s
-	//      provider2:
-	//        issuer: provider2
-	//        local_jwks:
-	//          inline_string: jwks_string
-	//
+	//	providers:
+	//	  provider1:
+	//	     issuer: issuer1
+	//	     audiences:
+	//	     - audience1
+	//	     - audience2
+	//	     remote_jwks:
+	//	       http_uri:
+	//	         uri: https://example.com/.well-known/jwks.json
+	//	         cluster: example_jwks_cluster
+	//	         timeout: 1s
+	//	   provider2:
+	//	     issuer: provider2
+	//	     local_jwks:
+	//	       inline_string: jwks_string
 	Providers map[string]*JwtProvider `protobuf:"bytes,1,rep,name=providers,proto3" json:"providers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Specifies requirements based on the route matches. The first matched requirement will be
 	// applied. If there are overlapped match conditions, please put the most specific match first.
 	//
-	// Examples
+	// # Examples
 	//
 	// .. code-block:: yaml
 	//
-	//   rules:
-	//     - match:
-	//         prefix: /healthz
-	//     - match:
-	//         prefix: /baz
-	//       requires:
-	//         provider_name: provider1
-	//     - match:
-	//         prefix: /foo
-	//       requires:
-	//         requires_any:
-	//           requirements:
-	//             - provider_name: provider1
-	//             - provider_name: provider2
-	//     - match:
-	//         prefix: /bar
-	//       requires:
-	//         requires_all:
-	//           requirements:
-	//             - provider_name: provider1
-	//             - provider_name: provider2
-	//
+	//	rules:
+	//	  - match:
+	//	      prefix: /healthz
+	//	  - match:
+	//	      prefix: /baz
+	//	    requires:
+	//	      provider_name: provider1
+	//	  - match:
+	//	      prefix: /foo
+	//	    requires:
+	//	      requires_any:
+	//	        requirements:
+	//	          - provider_name: provider1
+	//	          - provider_name: provider2
+	//	  - match:
+	//	      prefix: /bar
+	//	    requires:
+	//	      requires_all:
+	//	        requirements:
+	//	          - provider_name: provider1
+	//	          - provider_name: provider2
 	Rules []*RequirementRule `protobuf:"bytes,2,rep,name=rules,proto3" json:"rules,omitempty"`
 	// This message specifies Jwt requirements based on stream_info.filterState.
 	// Other HTTP filters can use it to specify Jwt requirements dynamically.
@@ -1292,6 +1284,7 @@ type PerRouteConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to RequirementSpecifier:
+	//
 	//	*PerRouteConfig_Disabled
 	//	*PerRouteConfig_RequirementName
 	RequirementSpecifier isPerRouteConfig_RequirementSpecifier `protobuf_oneof:"requirement_specifier"`

--- a/projects/gloo/pkg/api/external/envoy/extensions/proxy_protocol/proxyprotocol.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/proxy_protocol/proxyprotocol.pb.go
@@ -34,11 +34,10 @@ type CustomProxyProtocol struct {
 	//
 	// .. attention::
 	//
-	//   This breaks conformance with the specification.
-	//   Only enable if ALL traffic to the listener comes from a trusted source.
-	//   For more information on the security implications of this feature, see
-	//   https://www.haproxy.org/download/2.1/doc/proxy-protocol.txt
-	//
+	//	This breaks conformance with the specification.
+	//	Only enable if ALL traffic to the listener comes from a trusted source.
+	//	For more information on the security implications of this feature, see
+	//	https://www.haproxy.org/download/2.1/doc/proxy-protocol.txt
 	AllowRequestsWithoutProxyProtocol bool `protobuf:"varint,2,opt,name=allow_requests_without_proxy_protocol,json=allowRequestsWithoutProxyProtocol,proto3" json:"allow_requests_without_proxy_protocol,omitempty"`
 }
 

--- a/projects/gloo/pkg/api/external/envoy/extensions/transformation/transformation.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/transformation/transformation.pb.go
@@ -148,9 +148,8 @@ type TransformationRule struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    match:
-	//      prefix: /
-	//
+	//	match:
+	//	  prefix: /
 	Match *v3.RouteMatch `protobuf:"bytes,1,opt,name=match,proto3" json:"match,omitempty"`
 	// transformation to perform
 	RouteTransformations *TransformationRule_Transformations `protobuf:"bytes,2,opt,name=route_transformations,json=routeTransformations,proto3" json:"route_transformations,omitempty"`
@@ -415,6 +414,7 @@ type Transformation struct {
 	// The type of transformation to apply.
 	//
 	// Types that are assignable to TransformationType:
+	//
 	//	*Transformation_TransformationTemplate
 	//	*Transformation_HeaderBodyTransform
 	//	*Transformation_TransformerConfig
@@ -520,6 +520,7 @@ type Extraction struct {
 	// The source of the extraction
 	//
 	// Types that are assignable to Source:
+	//
 	//	*Extraction_Header
 	//	*Extraction_Body
 	Source isExtraction_Source `protobuf_oneof:"source"`
@@ -652,14 +653,16 @@ type TransformationTemplate struct {
 	// For example, the following header transformation configuration:
 	//
 	// ```yaml
-	//    headers:
-	//      x-header-one: {"text": "first {{inja}} template"}
-	//      x-header-one: {"text": "second {{inja}} template"}
-	//    headersToAppend:
-	//      - key: x-header-one
-	//        value: {"text": "first appended {{inja}} template"}
-	//      - key: x-header-one
-	//        value: {"text": "second appended {{inja}} template"}
+	//
+	//	headers:
+	//	  x-header-one: {"text": "first {{inja}} template"}
+	//	  x-header-one: {"text": "second {{inja}} template"}
+	//	headersToAppend:
+	//	  - key: x-header-one
+	//	    value: {"text": "first appended {{inja}} template"}
+	//	  - key: x-header-one
+	//	    value: {"text": "second appended {{inja}} template"}
+	//
 	// ```
 	// will result in the following headers on the HTTP message:
 	//
@@ -681,6 +684,7 @@ type TransformationTemplate struct {
 	// Determines the type of transformation to apply to the request/response body
 	//
 	// Types that are assignable to BodyTransformation:
+	//
 	//	*TransformationTemplate_Body
 	//	*TransformationTemplate_Passthrough
 	//	*TransformationTemplate_MergeExtractorsToBody
@@ -1115,6 +1119,7 @@ type RouteTransformations_RouteTransformation struct {
 	// the same stage number.
 	Stage uint32 `protobuf:"varint,1,opt,name=stage,proto3" json:"stage,omitempty"`
 	// Types that are assignable to Match:
+	//
 	//	*RouteTransformations_RouteTransformation_RequestMatch_
 	//	*RouteTransformations_RouteTransformation_ResponseMatch_
 	Match isRouteTransformations_RouteTransformation_Match `protobuf_oneof:"match"`

--- a/projects/gloo/pkg/api/external/envoy/extensions/transformation_ee/transformation.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/transformation_ee/transformation.pb.go
@@ -86,9 +86,8 @@ type TransformationRule struct {
 	//
 	// .. code-block:: yaml
 	//
-	//    match:
-	//      prefix: /
-	//
+	//	match:
+	//	  prefix: /
 	Match   *route.RouteMatch `protobuf:"bytes,1,opt,name=match,proto3" json:"match,omitempty"`
 	MatchV3 *v3.RouteMatch    `protobuf:"bytes,3,opt,name=match_v3,json=matchV3,proto3" json:"match_v3,omitempty"`
 	// transformation to perform
@@ -230,6 +229,7 @@ type Transformation struct {
 	// Template is in the transformed request language domain
 	//
 	// Types that are assignable to TransformationType:
+	//
 	//	*Transformation_DlpTransformation
 	TransformationType isTransformation_TransformationType `protobuf_oneof:"transformation_type"`
 }
@@ -640,6 +640,7 @@ type Action_DlpMatcher struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Matcher:
+	//
 	//	*Action_DlpMatcher_RegexMatcher
 	//	*Action_DlpMatcher_KeyValueMatcher
 	Matcher isAction_DlpMatcher_Matcher `protobuf_oneof:"matcher"`

--- a/projects/gloo/pkg/api/external/envoy/extensions/wasm/v3/wasm.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/extensions/wasm/v3/wasm.pb.go
@@ -151,6 +151,7 @@ type PluginConfig struct {
 	// Configuration for finding or starting VM.
 	//
 	// Types that are assignable to Vm:
+	//
 	//	*PluginConfig_VmConfig
 	Vm isPluginConfig_Vm `protobuf_oneof:"vm"`
 	// Filter/service configuration used to configure or reconfigure a plugin

--- a/projects/gloo/pkg/api/external/envoy/type/matcher/v3/regex.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/type/matcher/v3/regex.pb.go
@@ -32,6 +32,7 @@ type RegexMatcher struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to EngineType:
+	//
 	//	*RegexMatcher_GoogleRe2
 	EngineType isRegexMatcher_EngineType `protobuf_oneof:"engine_type"`
 	// The regex match string. The string must be supported by the configured engine.
@@ -126,7 +127,7 @@ type RegexMatchAndSubstitute struct {
 	// defined by the chosen regular expression engine. Google's `RE2
 	// <https://github.com/google/re2>`_ regular expression engine uses a
 	// backslash followed by the capture group number to denote a numbered
-	// capture group. E.g., ``\1`` refers to capture group 1, and ``\2`` refers
+	// capture group. E.g., “\1“ refers to capture group 1, and “\2“ refers
 	// to capture group 2.
 	Substitution string `protobuf:"bytes,2,opt,name=substitution,proto3" json:"substitution,omitempty"`
 }

--- a/projects/gloo/pkg/api/external/envoy/type/matcher/v3/string.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/type/matcher/v3/string.pb.go
@@ -33,6 +33,7 @@ type StringMatcher struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to MatchPattern:
+	//
 	//	*StringMatcher_Exact
 	//	*StringMatcher_Prefix
 	//	*StringMatcher_Suffix

--- a/projects/gloo/pkg/api/external/envoy/type/metadata/v3/metadata.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/type/metadata/v3/metadata.pb.go
@@ -31,22 +31,21 @@ const (
 //
 // .. code-block:: yaml
 //
-//    filter_metadata:
-//      envoy.xxx:
-//        prop:
-//          foo: bar
-//          xyz:
-//            hello: envoy
+//	filter_metadata:
+//	  envoy.xxx:
+//	    prop:
+//	      foo: bar
+//	      xyz:
+//	        hello: envoy
 //
 // The following MetadataKey will retrieve a string value "bar" from the Metadata.
 //
 // .. code-block:: yaml
 //
-//    key: envoy.xxx
-//    path:
-//    - key: prop
-//    - key: foo
-//
+//	key: envoy.xxx
+//	path:
+//	- key: prop
+//	- key: foo
 type MetadataKey struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -56,7 +55,7 @@ type MetadataKey struct {
 	// Typically, it represents a builtin subsystem or custom extension.
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// The path to retrieve the Value from the Struct. It can be a prefix or a full path,
-	// e.g. ``[prop, xyz]`` for a struct or ``[prop, foo]`` for a string in the example,
+	// e.g. “[prop, xyz]“ for a struct or “[prop, foo]“ for a string in the example,
 	// which depends on the particular scenario.
 	//
 	// Note: Due to that only the key type segment is supported, the path can not specify a list
@@ -117,6 +116,7 @@ type MetadataKind struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Kind:
+	//
 	//	*MetadataKind_Request_
 	//	*MetadataKind_Route_
 	//	*MetadataKind_Cluster_
@@ -231,6 +231,7 @@ type MetadataKey_PathSegment struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Segment:
+	//
 	//	*MetadataKey_PathSegment_Key
 	Segment isMetadataKey_PathSegment_Segment `protobuf_oneof:"segment"`
 }

--- a/projects/gloo/pkg/api/external/envoy/type/tracing/v3/custom_tag.pb.go
+++ b/projects/gloo/pkg/api/external/envoy/type/tracing/v3/custom_tag.pb.go
@@ -37,6 +37,7 @@ type CustomTag struct {
 	// Used to specify what kind of custom tag.
 	//
 	// Types that are assignable to Type:
+	//
 	//	*CustomTag_Literal_
 	//	*CustomTag_Environment_
 	//	*CustomTag_RequestHeader

--- a/projects/gloo/pkg/api/grpc/validation/gloo_validation.pb.go
+++ b/projects/gloo/pkg/api/grpc/validation/gloo_validation.pb.go
@@ -377,6 +377,7 @@ type GlooValidationServiceRequest struct {
 	// For deletions, we pass in the resource refs rather than the full resources.
 	//
 	// Types that are assignable to Resources:
+	//
 	//	*GlooValidationServiceRequest_ModifiedResources
 	//	*GlooValidationServiceRequest_DeletedResources
 	Resources isGlooValidationServiceRequest_Resources `protobuf_oneof:"resources"`
@@ -828,7 +829,6 @@ func (*NotifyOnResyncResponse) Descriptor() ([]byte, []int) {
 	return file_github_com_solo_io_gloo_projects_gloo_api_grpc_validation_gloo_validation_proto_rawDescGZIP(), []int{7}
 }
 
-//
 // The Proxy Report should contain one report for each sub-resource of the Proxy
 // E.g., each listener will have a corresponding report. Within each listener report is
 // a route report corresponding to each route on the listener.
@@ -889,6 +889,7 @@ type ListenerReport struct {
 	// errors on top-level config of the listener
 	Errors []*ListenerReport_Error `protobuf:"bytes,2,rep,name=errors,proto3" json:"errors,omitempty"`
 	// Types that are assignable to ListenerTypeReport:
+	//
 	//	*ListenerReport_HttpListenerReport
 	//	*ListenerReport_TcpListenerReport
 	//	*ListenerReport_HybridListenerReport
@@ -1329,6 +1330,7 @@ type MatchedListenerReport struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ListenerReportType:
+	//
 	//	*MatchedListenerReport_HttpListenerReport
 	//	*MatchedListenerReport_TcpListenerReport
 	ListenerReportType isMatchedListenerReport_ListenerReportType `protobuf_oneof:"ListenerReportType"`

--- a/projects/gloo/pkg/api/grpc/version/version.pb.go
+++ b/projects/gloo/pkg/api/grpc/version/version.pb.go
@@ -91,6 +91,7 @@ type ServerVersion struct {
 	// Currently only kubernetes is supported
 	//
 	// Types that are assignable to VersionType:
+	//
 	//	*ServerVersion_Kubernetes
 	VersionType isServerVersion_VersionType `protobuf_oneof:"version_type"`
 }

--- a/projects/gloo/pkg/api/v1/artifact.pb.go
+++ b/projects/gloo/pkg/api/v1/artifact.pb.go
@@ -23,18 +23,17 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// @solo-kit:resource.short_name=art
+// @solo-kit:resource.plural_name=artifacts
 //
-//@solo-kit:resource.short_name=art
-//@solo-kit:resource.plural_name=artifacts
+// Gloo Artifacts are used by Gloo to store small bits of binary or file data.
 //
-//Gloo Artifacts are used by Gloo to store small bits of binary or file data.
+// Certain options such as the gRPC option read and write artifacts to one of Gloo's configured
+// storage layer.
 //
-//Certain options such as the gRPC option read and write artifacts to one of Gloo's configured
-//storage layer.
+// Artifacts can be backed by files on disk, Kubernetes ConfigMaps, and Consul Key/Value pairs.
 //
-//Artifacts can be backed by files on disk, Kubernetes ConfigMaps, and Consul Key/Value pairs.
-//
-//Supported artifact backends can be selected in Gloo's boostrap options.
+// Supported artifact backends can be selected in Gloo's boostrap options.
 type Artifact struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/v1/core/matchers/matchers.pb.go
+++ b/projects/gloo/pkg/api/v1/core/matchers/matchers.pb.go
@@ -30,6 +30,7 @@ type Matcher struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to PathSpecifier:
+	//
 	//	*Matcher_Prefix
 	//	*Matcher_Exact
 	//	*Matcher_Regex
@@ -201,7 +202,7 @@ type HeaderMatcher struct {
 	// Examples:
 	// * name=foo, invert_match=true: matches if no header named `foo` is present
 	// * name=foo, value=bar, invert_match=true: matches if no header named `foo` with value `bar` is present
-	// * name=foo, value=``\d{3}``, regex=true, invert_match=true: matches if no header named `foo` with a value consisting of three integers is present
+	// * name=foo, value=“\d{3}“, regex=true, invert_match=true: matches if no header named `foo` with a value consisting of three integers is present
 	InvertMatch bool `protobuf:"varint,4,opt,name=invert_match,json=invertMatch,proto3" json:"invert_match,omitempty"`
 }
 

--- a/projects/gloo/pkg/api/v1/endpoint.pb.go
+++ b/projects/gloo/pkg/api/v1/endpoint.pb.go
@@ -23,9 +23,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//
-//
-//Endpoints represent dynamically discovered address/ports where an upstream service is listening
+// Endpoints represent dynamically discovered address/ports where an upstream service is listening
 type Endpoint struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/v1/enterprise/options/dlp/dlp.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/dlp/dlp.pb.go
@@ -130,45 +130,43 @@ func (Config_EnableFor) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_dlp_dlp_proto_rawDescGZIP(), []int{2, 0}
 }
 
+// The following pre-made action types map to subgroup 1 of the listed regex patterns:
 //
-//The following pre-made action types map to subgroup 1 of the listed regex patterns:
+// SSN:
+// - '(?:^|\D)([0-9]{9})(?:\D|$)'
+// - '(?:^|\D)([0-9]{3}\-[0-9]{2}\-[0-9]{4})(?:\D|$)'
+// - '(?:^|\D)([0-9]{3}\ [0-9]{2}\ [0-9]{4})(?:\D|$)'
 //
-//SSN:
-//- '(?:^|\D)([0-9]{9})(?:\D|$)'
-//- '(?:^|\D)([0-9]{3}\-[0-9]{2}\-[0-9]{4})(?:\D|$)'
-//- '(?:^|\D)([0-9]{3}\ [0-9]{2}\ [0-9]{4})(?:\D|$)'
+// MASTERCARD:
+// - '(?:^|\D)(5[1-5][0-9]{2}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
 //
-//MASTERCARD:
-//- '(?:^|\D)(5[1-5][0-9]{2}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
+// VISA:
+// - '(?:^|\D)(4[0-9]{3}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
 //
-//VISA:
-//- '(?:^|\D)(4[0-9]{3}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
+// AMEX:
+// - '(?:^|\D)((?:34|37)[0-9]{2}(?:\ |\-|)[0-9]{6}(?:\ |\-|)[0-9]{5})(?:\D|$)'
 //
-//AMEX:
-//- '(?:^|\D)((?:34|37)[0-9]{2}(?:\ |\-|)[0-9]{6}(?:\ |\-|)[0-9]{5})(?:\D|$)'
+// DISCOVER:
+// - '(?:^|\D)(6011(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
 //
-//DISCOVER:
-//- '(?:^|\D)(6011(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
+// JCB:
+// - '(?:^|\D)(3[0-9]{3}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
+// - '(?:^|\D)((?:2131|1800)[0-9]{11})(?:\D|$)'
 //
-//JCB:
-//- '(?:^|\D)(3[0-9]{3}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4}(?:\ |\-|)[0-9]{4})(?:\D|$)'
-//- '(?:^|\D)((?:2131|1800)[0-9]{11})(?:\D|$)'
+// DINERS_CLUB:
+// - '(?:^|\D)(30[0-5][0-9](?:\ |\-|)[0-9]{6}(?:\ |\-|)[0-9]{4})(?:\D|$)'
+// - '(?:^|\D)((?:36|38)[0-9]{2}(?:\ |\-|)[0-9]{6}(?:\ |\-|)[0-9]{4})(?:\D|$)'
 //
-//DINERS_CLUB:
-//- '(?:^|\D)(30[0-5][0-9](?:\ |\-|)[0-9]{6}(?:\ |\-|)[0-9]{4})(?:\D|$)'
-//- '(?:^|\D)((?:36|38)[0-9]{2}(?:\ |\-|)[0-9]{6}(?:\ |\-|)[0-9]{4})(?:\D|$)'
+// CREDIT_CARD_TRACKERS:
+// - '([1-9][0-9]{2}\-[0-9]{2}\-[0-9]{4}\^\d)'
+// - '(?:^|\D)(\%?[Bb]\d{13,19}\^[\-\/\.\w\s]{2,26}\^[0-9][0-9][01][0-9][0-9]{3})'
+// - '(?:^|\D)(\;\d{13,19}\=(?:\d{3}|)(?:\d{4}|\=))'
 //
-//CREDIT_CARD_TRACKERS:
-//- '([1-9][0-9]{2}\-[0-9]{2}\-[0-9]{4}\^\d)'
-//- '(?:^|\D)(\%?[Bb]\d{13,19}\^[\-\/\.\w\s]{2,26}\^[0-9][0-9][01][0-9][0-9]{3})'
-//- '(?:^|\D)(\;\d{13,19}\=(?:\d{3}|)(?:\d{4}|\=))'
+// ALL_CREDIT_CARDS:
+// - (All credit card related regexes from above)
 //
-//ALL_CREDIT_CARDS:
-//- (All credit card related regexes from above)
-//
-//ALL_CREDIT_CARDS_COMBINED:
-//- Same as ALL_CREDIT_CARDS but using a single action instead of multiple which should be marginally faster
-//
+// ALL_CREDIT_CARDS_COMBINED:
+// - Same as ALL_CREDIT_CARDS but using a single action instead of multiple which should be marginally faster
 type Action_ActionType int32
 
 const (
@@ -366,11 +364,10 @@ func (x *DlpRule) GetActions() []*Action {
 	return nil
 }
 
+// Route/Vhost level config for dlp filter
 //
-//Route/Vhost level config for dlp filter
-//
-//If a config is present on the route or vhost level it will completely overwrite the
-//listener level config.
+// If a config is present on the route or vhost level it will completely overwrite the
+// listener level config.
 type Config struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -430,33 +427,30 @@ func (x *Config) GetEnabledFor() Config_EnableFor {
 	return Config_RESPONSE_BODY
 }
 
+// A single action meant to mask sensitive data.
+// The action type represents a set of pre configured actions,
+// as well as the ability to create custom actions.
+// These actions can also be shadowed, a shadowed action will be recorded
+// in the statistics, and debug logs, but not actually committed in the response body.
 //
-//A single action meant to mask sensitive data.
-//The action type represents a set of pre configured actions,
-//as well as the ability to create custom actions.
-//These actions can also be shadowed, a shadowed action will be recorded
-//in the statistics, and debug logs, but not actually committed in the response body.
+// To use a pre-made action simply set the action type to anything other than `CUSTOM`
 //
-//To use a pre-made action simply set the action type to anything other than `CUSTOM`
+// ``` yaml
+// actionType: VISA
+// ```
 //
-//``` yaml
-//actionType: VISA
-//```
+// To create a custom action set the custom action field. The default enum value
+// is custom, so that can be left empty.
 //
-//To create a custom action set the custom action field. The default enum value
-//is custom, so that can be left empty.
-//
-//``` yaml
-//customAction:
-//name: test
-//regex:
-//- "hello"
-//- "world"
-//maskChar: Y
-//percent: 60
-//```
-//
-//
+// ``` yaml
+// customAction:
+// name: test
+// regex:
+// - "hello"
+// - "world"
+// maskChar: Y
+// percent: 60
+// ```
 type Action struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -535,29 +529,27 @@ func (x *Action) GetShadow() bool {
 	return false
 }
 
+// A user defined custom action to carry out on the response body.
 //
-//A user defined custom action to carry out on the response body.
+// The list of regex strings are applied in order. So for instance, if there is a response body with the content:
+// `hello world`
 //
-//The list of regex strings are applied in order. So for instance, if there is a response body with the content:
-//`hello world`
+// And there is a custom action
+// ``` yaml
+// customAction:
+// name: test
+// regex:
+// - "hello"
+// - "world"
+// maskChar: Y
+// percent: 60
+// ```
 //
-//And there is a custom action
-//``` yaml
-//customAction:
-//name: test
-//regex:
-//- "hello"
-//- "world"
-//maskChar: Y
-//percent: 60
-//```
+// the result would be:
+// `YYYlo YYYld`
 //
-//the result would be:
-//`YYYlo YYYld`
-//
-//If the mask_char, and percent were left to default, the result would be:
-//`XXXXo XXXXd`
-//
+// If the mask_char, and percent were left to default, the result would be:
+// `XXXXo XXXXd`
 type CustomAction struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
@@ -340,6 +340,7 @@ type ExtAuthExtension struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Spec:
+	//
 	//	*ExtAuthExtension_Disable
 	//	*ExtAuthExtension_ConfigRef
 	//	*ExtAuthExtension_CustomAuth
@@ -411,7 +412,7 @@ type isExtAuthExtension_Spec interface {
 }
 
 type ExtAuthExtension_Disable struct {
-	//  Set to true to disable auth on the virtual host/route.
+	// Set to true to disable auth on the virtual host/route.
 	Disable bool `protobuf:"varint,1,opt,name=disable,proto3,oneof"`
 }
 
@@ -440,6 +441,7 @@ type Settings struct {
 	// The upstream to ask about auth decisions
 	ExtauthzServerRef *core.ResourceRef `protobuf:"bytes,1,opt,name=extauthz_server_ref,json=extauthzServerRef,proto3" json:"extauthz_server_ref,omitempty"`
 	// Types that are assignable to ServiceType:
+	//
 	//	*Settings_HttpService
 	//	*Settings_GrpcService
 	ServiceType isSettings_ServiceType `protobuf_oneof:"service_type"`
@@ -462,7 +464,6 @@ type Settings struct {
 	//
 	// 3. At least one *authorization response header* is added to the client request, or is used for
 	// altering another client request header.
-	//
 	ClearRouteCache bool `protobuf:"varint,7,opt,name=clear_route_cache,json=clearRouteCache,proto3" json:"clear_route_cache,omitempty"`
 	// Sets the HTTP status that is returned to the client when there is a network error between the
 	// filter and the authorization server. The default status is HTTP 403 Forbidden.
@@ -1130,6 +1131,7 @@ type OAuth2 struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to OauthType:
+	//
 	//	*OAuth2_OidcAuthorizationCode
 	//	*OAuth2_AccessTokenValidation
 	//	*OAuth2_Oauth2
@@ -1332,6 +1334,7 @@ type UserSession struct {
 	// Set-Cookie options
 	CookieOptions *UserSession_CookieOptions `protobuf:"bytes,2,opt,name=cookie_options,json=cookieOptions,proto3" json:"cookie_options,omitempty"`
 	// Types that are assignable to Session:
+	//
 	//	*UserSession_Cookie
 	//	*UserSession_Redis
 	Session isUserSession_Session `protobuf_oneof:"session"`
@@ -1643,6 +1646,7 @@ type JwksOnDemandCacheRefreshPolicy struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Policy:
+	//
 	//	*JwksOnDemandCacheRefreshPolicy_Never
 	//	*JwksOnDemandCacheRefreshPolicy_Always
 	//	*JwksOnDemandCacheRefreshPolicy_MaxIdpReqPerPollingInterval
@@ -1880,25 +1884,26 @@ type OidcAuthorizationCode struct {
 	// OIDC configuration is discovered at <issuerUrl>/.well-known/openid-configuration
 	// The discovery override defines any properties that should override this discovery configuration
 	// For example, the following AuthConfig CRD could be defined as:
-	//    ```yaml
-	//    apiVersion: enterprise.gloo.solo.io/v1
-	//    kind: AuthConfig
-	//    metadata:
-	//      name: google-oidc
-	//      namespace: gloo-system
-	//    spec:
-	//      configs:
-	//      - oauth:
-	//          app_url: http://localhost:8080
-	//          callback_path: /callback
-	//          client_id: $CLIENT_ID
-	//          client_secret_ref:
-	//            name: google
-	//            namespace: gloo-system
-	//          issuer_url: https://accounts.google.com
-	//          discovery_override:
-	//            token_endpoint: "https://token.url/gettoken"
-	//    ```
+	//
+	//	```yaml
+	//	apiVersion: enterprise.gloo.solo.io/v1
+	//	kind: AuthConfig
+	//	metadata:
+	//	  name: google-oidc
+	//	  namespace: gloo-system
+	//	spec:
+	//	  configs:
+	//	  - oauth:
+	//	      app_url: http://localhost:8080
+	//	      callback_path: /callback
+	//	      client_id: $CLIENT_ID
+	//	      client_secret_ref:
+	//	        name: google
+	//	        namespace: gloo-system
+	//	      issuer_url: https://accounts.google.com
+	//	      discovery_override:
+	//	        token_endpoint: "https://token.url/gettoken"
+	//	```
 	//
 	// And this will ensure that regardless of what value is discovered at
 	// <issuerUrl>/.well-known/openid-configuration, "https://token.url/gettoken" will be used as the token endpoint
@@ -2285,6 +2290,7 @@ type JwtValidation struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to JwksSourceSpecifier:
+	//
 	//	*JwtValidation_RemoteJwks_
 	//	*JwtValidation_LocalJwks_
 	JwksSourceSpecifier isJwtValidation_JwksSourceSpecifier `protobuf_oneof:"jwks_source_specifier"`
@@ -2467,6 +2473,7 @@ type AccessTokenValidation struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ValidationType:
+	//
 	//	*AccessTokenValidation_IntrospectionUrl
 	//	*AccessTokenValidation_Jwt
 	//	*AccessTokenValidation_Introspection
@@ -2484,6 +2491,7 @@ type AccessTokenValidation struct {
 	// Optional criteria for validating the scopes of a token.
 	//
 	// Types that are assignable to ScopeValidation:
+	//
 	//	*AccessTokenValidation_RequiredScopes
 	ScopeValidation isAccessTokenValidation_ScopeValidation `protobuf_oneof:"scope_validation"`
 }
@@ -2706,6 +2714,7 @@ type ApiKeyAuth struct {
 	// in the API key metadata structure that will be inspected to determine the value for the header.
 	HeadersFromMetadataEntry map[string]*ApiKeyAuth_MetadataEntry `protobuf:"bytes,5,rep,name=headers_from_metadata_entry,json=headersFromMetadataEntry,proto3" json:"headers_from_metadata_entry,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Types that are assignable to StorageBackend:
+	//
 	//	*ApiKeyAuth_K8SSecretApikeyStorage
 	//	*ApiKeyAuth_AerospikeApikeyStorage
 	StorageBackend isApiKeyAuth_StorageBackend `protobuf_oneof:"storage_backend"`
@@ -2897,6 +2906,7 @@ type AerospikeApiKeyStorage struct {
 	// Defaults to "commit_all".
 	//
 	// Types that are assignable to CommitLevel:
+	//
 	//	*AerospikeApiKeyStorage_CommitAll
 	//	*AerospikeApiKeyStorage_CommitMaster
 	CommitLevel isAerospikeApiKeyStorage_CommitLevel `protobuf_oneof:"commit_level"`
@@ -3347,10 +3357,10 @@ func (x *OpaAuthOptions) GetFastInputConversion() bool {
 }
 
 // Authenticates and authorizes requests by querying an LDAP server. Gloo makes the following assumptions:
-//  * Requests provide credentials via the basic HTTP authentication header. Gloo will BIND to the LDAP server using the
-//    credentials extracted from the header.
-//  * Your LDAP server is configured so that each entry you want to authorize has an attribute that indicates its group
-//    memberships. A common way of achieving this is by using the [*memberof* overlay](http://www.openldap.org/software/man.cgi?query=slapo-memberof).
+//   - Requests provide credentials via the basic HTTP authentication header. Gloo will BIND to the LDAP server using the
+//     credentials extracted from the header.
+//   - Your LDAP server is configured so that each entry you want to authorize has an attribute that indicates its group
+//     memberships. A common way of achieving this is by using the [*memberof* overlay](http://www.openldap.org/software/man.cgi?query=slapo-memberof).
 type Ldap struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -3535,13 +3545,16 @@ type PassThroughAuth struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Protocol:
+	//
 	//	*PassThroughAuth_Grpc
 	//	*PassThroughAuth_Http
 	Protocol isPassThroughAuth_Protocol `protobuf_oneof:"protocol"`
 	// Custom config to be passed per request to the passthrough auth service.
 	Config *_struct.Struct `protobuf:"bytes,4,opt,name=config,proto3" json:"config,omitempty"`
 	// If set to true, the service will accept client request even if the communication with
-	//  the authorization service has failed, or if the authorization service has returned a server error.
+	//
+	//	the authorization service has failed, or if the authorization service has returned a server error.
+	//
 	// Defaults to false.
 	FailureModeAllow bool `protobuf:"varint,5,opt,name=failure_mode_allow,json=failureModeAllow,proto3" json:"failure_mode_allow,omitempty"`
 }
@@ -3816,12 +3829,11 @@ func (x *PassThroughHttp) GetConnectionTimeout() *duration.Duration {
 	return nil
 }
 
+// @solo-kit:xds-service=ExtAuthDiscoveryService
+// @solo-kit:resource.no_references
 //
-//@solo-kit:xds-service=ExtAuthDiscoveryService
-//@solo-kit:resource.no_references
-//
-//This is an internal API used to share configuration between gloo-ee and extauth. Although this API is only used in gloo-ee,
-//rules about breaking changes still apply to ensure we do not get errors during upgrade and downgrade.
+// This is an internal API used to share configuration between gloo-ee and extauth. Although this API is only used in gloo-ee,
+// rules about breaking changes still apply to ensure we do not get errors during upgrade and downgrade.
 type ExtAuthConfig struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -4329,6 +4341,7 @@ type AuthConfig_Config struct {
 	// the name assigned on the plugin config itself.
 	Name *wrappers.StringValue `protobuf:"bytes,9,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to AuthConfig:
+	//
 	//	*AuthConfig_Config_BasicAuth
 	//	*AuthConfig_Config_Oauth
 	//	*AuthConfig_Config_Oauth2
@@ -5321,6 +5334,7 @@ type AerospikeApiKeyStorageReadModeSc struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ReadModeSc:
+	//
 	//	*AerospikeApiKeyStorageReadModeSc_ReadModeScSession
 	//	*AerospikeApiKeyStorageReadModeSc_ReadModeScLinearize
 	//	*AerospikeApiKeyStorageReadModeSc_ReadModeScReplica
@@ -5441,6 +5455,7 @@ type AerospikeApiKeyStorageReadModeAp struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ReadModeAp:
+	//
 	//	*AerospikeApiKeyStorageReadModeAp_ReadModeApOne
 	//	*AerospikeApiKeyStorageReadModeAp_ReadModeApAll
 	ReadModeAp isAerospikeApiKeyStorageReadModeAp_ReadModeAp `protobuf_oneof:"read_mode_ap"`
@@ -5526,6 +5541,7 @@ type AerospikeApiKeyStorageTlsCurveID struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to CurveId:
+	//
 	//	*AerospikeApiKeyStorageTlsCurveID_CurveP256
 	//	*AerospikeApiKeyStorageTlsCurveID_CurveP384
 	//	*AerospikeApiKeyStorageTlsCurveID_CurveP521
@@ -5688,20 +5704,19 @@ func (x *Ldap_ConnectionPool) GetInitialSize() *wrappers.UInt32Value {
 }
 
 // The passthrough http request can be configured to pass through the incoming request body,
-//the ext-auth state (which is shared between different auth methods within one ext-auth instance), and
-//the [filterMetadata](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/data_sharing_between_filters#metadata)
-//The body of the passthrough auth request will be a JSON as follows:
-//{
-//"body" : string,
-//"state": object (map[string]interface{}),
-//"filterMetadata": object (map[string]protobuf.Struct),
-//"config": object (protobuf.Struct),
-//}
-//`config` is the struct block specified under the passthrough auth configuration.
-//If `passthrough_body`, `passthrough_state`, `passthrough_filter_metadata`, and `config` are all false/nil,
-//the body of the auth request will remain empty. Setting any of these will increase latency slightly due to
-//JSON marshalling.
-//
+// the ext-auth state (which is shared between different auth methods within one ext-auth instance), and
+// the [filterMetadata](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/advanced/data_sharing_between_filters#metadata)
+// The body of the passthrough auth request will be a JSON as follows:
+// {
+// "body" : string,
+// "state": object (map[string]interface{}),
+// "filterMetadata": object (map[string]protobuf.Struct),
+// "config": object (protobuf.Struct),
+// }
+// `config` is the struct block specified under the passthrough auth configuration.
+// If `passthrough_body`, `passthrough_state`, `passthrough_filter_metadata`, and `config` are all false/nil,
+// the body of the auth request will remain empty. Setting any of these will increase latency slightly due to
+// JSON marshalling.
 type PassThroughHttp_Request struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -5821,9 +5836,11 @@ type PassThroughHttp_Response struct {
 	// If this is empty, by default, no authorization response headers will be added to the client response.
 	AllowedClientHeadersOnDenied []string `protobuf:"bytes,2,rep,name=allowed_client_headers_on_denied,json=allowedClientHeadersOnDenied,proto3" json:"allowed_client_headers_on_denied,omitempty"`
 	// If this is set to true, the body of the response from the http passthrough auth server is expected to have shape
-	// {
-	//   "state": object (map[string]interface{})
-	// }
+	//
+	//	{
+	//	  "state": object (map[string]interface{})
+	//	}
+	//
 	// The state will be marshalled from the response body and this is the state that will be passed on to other auth configs.
 	// Because of the marshalling from JSON to Go map, this will add some latency to the request.
 	// If the marshalling fails, the authorization check will fail and the request will be unauthorized after the ext-auth-service pod
@@ -6052,25 +6069,26 @@ type ExtAuthConfig_OidcAuthorizationCodeConfig struct {
 	// OIDC configuration is discovered at <issuerUrl>/.well-known/openid-configuration
 	// The configuration override defines any properties that should override this discovery configuration
 	// For example, the following AuthConfig CRD could be defined as:
-	//    ```yaml
-	//    apiVersion: enterprise.gloo.solo.io/v1
-	//    kind: AuthConfig
-	//    metadata:
-	//      name: google-oidc
-	//      namespace: gloo-system
-	//    spec:
-	//      configs:
-	//      - oauth:
-	//          app_url: http://localhost:8080
-	//          callback_path: /callback
-	//          client_id: $CLIENT_ID
-	//          client_secret_ref:
-	//            name: google
-	//            namespace: gloo-system
-	//          issuer_url: https://accounts.google.com
-	//          discovery_override:
-	//            token_endpoint: "https://token.url/gettoken"
-	//    ```
+	//
+	//	```yaml
+	//	apiVersion: enterprise.gloo.solo.io/v1
+	//	kind: AuthConfig
+	//	metadata:
+	//	  name: google-oidc
+	//	  namespace: gloo-system
+	//	spec:
+	//	  configs:
+	//	  - oauth:
+	//	      app_url: http://localhost:8080
+	//	      callback_path: /callback
+	//	      client_id: $CLIENT_ID
+	//	      client_secret_ref:
+	//	        name: google
+	//	        namespace: gloo-system
+	//	      issuer_url: https://accounts.google.com
+	//	      discovery_override:
+	//	        token_endpoint: "https://token.url/gettoken"
+	//	```
 	//
 	// And this will ensure that regardless of what value is discovered at
 	// <issuerUrl>/.well-known/openid-configuration, "https://token.url/gettoken" will be used as the token endpoint
@@ -6269,6 +6287,7 @@ type ExtAuthConfig_AccessTokenValidationConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to ValidationType:
+	//
 	//	*ExtAuthConfig_AccessTokenValidationConfig_IntrospectionUrl
 	//	*ExtAuthConfig_AccessTokenValidationConfig_Jwt
 	//	*ExtAuthConfig_AccessTokenValidationConfig_Introspection
@@ -6286,6 +6305,7 @@ type ExtAuthConfig_AccessTokenValidationConfig struct {
 	// Optional criteria for validating the scopes of a token.
 	//
 	// Types that are assignable to ScopeValidation:
+	//
 	//	*ExtAuthConfig_AccessTokenValidationConfig_RequiredScopes
 	ScopeValidation isExtAuthConfig_AccessTokenValidationConfig_ScopeValidation `protobuf_oneof:"scope_validation"`
 }
@@ -6604,6 +6624,7 @@ type ExtAuthConfig_OAuth2Config struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to OauthType:
+	//
 	//	*ExtAuthConfig_OAuth2Config_OidcAuthorizationCode
 	//	*ExtAuthConfig_OAuth2Config_AccessTokenValidationConfig
 	//	*ExtAuthConfig_OAuth2Config_Oauth2Config
@@ -6723,6 +6744,7 @@ type ExtAuthConfig_ApiKeyAuthConfig struct {
 	// value is the key that will be used to look up the data entry in the key metadata.
 	HeadersFromKeyMetadata map[string]string `protobuf:"bytes,3,rep,name=headers_from_key_metadata,json=headersFromKeyMetadata,proto3" json:"headers_from_key_metadata,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Types that are assignable to StorageBackend:
+	//
 	//	*ExtAuthConfig_ApiKeyAuthConfig_K8SSecretApikeyStorage
 	//	*ExtAuthConfig_ApiKeyAuthConfig_AerospikeApikeyStorage
 	StorageBackend isExtAuthConfig_ApiKeyAuthConfig_StorageBackend `protobuf_oneof:"storage_backend"`
@@ -7084,6 +7106,7 @@ type ExtAuthConfig_Config struct {
 	// the name assigned on the plugin config itself.
 	Name *wrappers.StringValue `protobuf:"bytes,11,opt,name=name,proto3" json:"name,omitempty"`
 	// Types that are assignable to AuthConfig:
+	//
 	//	*ExtAuthConfig_Config_Oauth
 	//	*ExtAuthConfig_Config_Oauth2
 	//	*ExtAuthConfig_Config_BasicAuth
@@ -7309,6 +7332,7 @@ type ExtAuthConfig_AccessTokenValidationConfig_JwtValidation struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to JwksSourceSpecifier:
+	//
 	//	*ExtAuthConfig_AccessTokenValidationConfig_JwtValidation_RemoteJwks_
 	//	*ExtAuthConfig_AccessTokenValidationConfig_JwtValidation_LocalJwks_
 	JwksSourceSpecifier isExtAuthConfig_AccessTokenValidationConfig_JwtValidation_JwksSourceSpecifier `protobuf_oneof:"jwks_source_specifier"`

--- a/projects/gloo/pkg/api/v1/enterprise/options/graphql/v1beta1/graphql.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/graphql/v1beta1/graphql.pb.go
@@ -42,7 +42,8 @@ type RequestTemplate struct {
 	// for example, if a header is an authorization token, taken from the graphql args,
 	// we can use the following configuration:
 	// headers:
-	//   Authorization: "Bearer {$args.token}"
+	//
+	//	Authorization: "Bearer {$args.token}"
 	Headers map[string]string `protobuf:"bytes,1,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Use this attribute to set query parameters to your REST service. It consists of a
 	// map of strings to templated value strings. The string key determines the name of the
@@ -52,7 +53,8 @@ type RequestTemplate struct {
 	// for example, if a query parameter is an id, taken from the graphql parent object,
 	// we can use the following configuration:
 	// queryParams:
-	//   id: "{$parent.id}"
+	//
+	//	id: "{$parent.id}"
 	QueryParams map[string]string `protobuf:"bytes,2,rep,name=query_params,json=queryParams,proto3" json:"query_params,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Used to construct the outgoing body to the upstream from the
 	// graphql value providers.
@@ -118,42 +120,40 @@ type ResponseTemplate struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
+	// Sets the "root" of the upstream response to be turned into a graphql type by the graphql server.
+	// For example, if the graphql type is:
 	//
-	//Sets the "root" of the upstream response to be turned into a graphql type by the graphql server.
-	//For example, if the graphql type is:
+	// type Simple {
+	// name String
+	// }
 	//
-	//type Simple {
-	//name String
-	//}
-	//
-	//and the upstream response is `{"data": {"simple": {"name": "simple name"}}}`,
-	//the graphql server will not be able to marshal the upstream response into the Simple graphql type
-	//because it does not know where the relevant data is. If we set result_root to "data.simple", we can give the
-	//graphql server a hint of where to look in the upstream response for the relevant data that graphql type wants.
+	// and the upstream response is `{"data": {"simple": {"name": "simple name"}}}`,
+	// the graphql server will not be able to marshal the upstream response into the Simple graphql type
+	// because it does not know where the relevant data is. If we set result_root to "data.simple", we can give the
+	// graphql server a hint of where to look in the upstream response for the relevant data that graphql type wants.
 	ResultRoot string `protobuf:"bytes,1,opt,name=result_root,json=resultRoot,proto3" json:"result_root,omitempty"`
+	// Field-specific mapping for a graphql field to a JSON path in the upstream response.
+	// For example, if the graphql type is:
 	//
-	//Field-specific mapping for a graphql field to a JSON path in the upstream response.
-	//For example, if the graphql type is:
+	// type Person {
+	// firstname String
+	// lastname String
+	// fullname String
+	// }
 	//
-	//type Person {
-	//firstname String
-	//lastname String
-	//fullname String
-	//}
+	// and the upstream response is `{"firstname": "Joe", "details": {"lastname": "Smith"}}`,
+	// the graphql server will not be able to marshal the upstream response into the Person graphql type because of the
+	// nested `lastname` field. We can use a simple setter here:
 	//
-	//and the upstream response is `{"firstname": "Joe", "details": {"lastname": "Smith"}}`,
-	//the graphql server will not be able to marshal the upstream response into the Person graphql type because of the
-	//nested `lastname` field. We can use a simple setter here:
+	// setters:
+	// lastname: '{$body.details.lastname}'
+	// fullname: '{$body.details.firstname} {$body.details.lastname}'
 	//
-	//setters:
-	//lastname: '{$body.details.lastname}'
-	//fullname: '{$body.details.firstname} {$body.details.lastname}'
+	// and the graphql server will be able to extract data for a field given the path to the relevant data
+	// in the upstream JSON response. We do not need to have a setter for the `firstname` field because the
+	// JSON response has that field in a position the graphql server can understand automatically.
 	//
-	//and the graphql server will be able to extract data for a field given the path to the relevant data
-	//in the upstream JSON response. We do not need to have a setter for the `firstname` field because the
-	//JSON response has that field in a position the graphql server can understand automatically.
-	//
-	//So far only the $body keyword is supported, but in the future we may add support for others such as $headers.
+	// So far only the $body keyword is supported, but in the future we may add support for others such as $headers.
 	Setters map[string]string `protobuf:"bytes,2,rep,name=setters,proto3" json:"setters,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -375,6 +375,7 @@ type GrpcDescriptorRegistry struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to DescriptorSet:
+	//
 	//	*GrpcDescriptorRegistry_ProtoDescriptor
 	//	*GrpcDescriptorRegistry_ProtoDescriptorBin
 	//	*GrpcDescriptorRegistry_ProtoRefsList
@@ -603,6 +604,7 @@ type MockResolver struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Response:
+	//
 	//	*MockResolver_SyncResponse
 	//	*MockResolver_AsyncResponse_
 	//	*MockResolver_ErrorResponse
@@ -707,6 +709,7 @@ type Resolution struct {
 	// The resolver to use.
 	//
 	// Types that are assignable to Resolver:
+	//
 	//	*Resolution_RestResolver
 	//	*Resolution_GrpcResolver
 	//	*Resolution_MockResolver
@@ -831,6 +834,7 @@ type GraphQLApi struct {
 	// Metadata contains the object metadata for this resource
 	Metadata *core.Metadata `protobuf:"bytes,2,opt,name=metadata,proto3" json:"metadata,omitempty"`
 	// Types that are assignable to Schema:
+	//
 	//	*GraphQLApi_ExecutableSchema
 	//	*GraphQLApi_StitchedSchema
 	Schema isGraphQLApi_Schema `protobuf_oneof:"schema"`
@@ -1015,25 +1019,25 @@ type ExecutableSchema struct {
 	unknownFields protoimpl.UnknownFields
 
 	// The following directives are supported:
-	//- @resolve(name: string)
-	//- @cacheControl(maxAge: uint32, inheritMaxAge: bool, scope: unset/public/private)
+	// - @resolve(name: string)
+	// - @cacheControl(maxAge: uint32, inheritMaxAge: bool, scope: unset/public/private)
 	//
-	//Define named resolvers on the `Executor.Local.resolutions` message, and reference them here using @resolve:
-	//```gql
-	//type Query {
-	//author: String @resolve(name: "authorResolver")
-	//}
+	// Define named resolvers on the `Executor.Local.resolutions` message, and reference them here using @resolve:
+	// ```gql
+	// type Query {
+	// author: String @resolve(name: "authorResolver")
+	// }
 	//
-	//Further, fields/types can be annotated with the @cacheControl directive, e.g.
-	//```gql
-	//type Query @cacheControl(maxAge: 60) {
-	//author: String @resolve(name: "authorResolver") @cacheControl(maxAge: 90, scope: private)
-	//}
-	//```
-	//Any type-level cache control defaults are overridden by field settings, if provided.
-	//The most restrictive cache control setting (smallest maxAge and scope) across all fields in
-	//an entire query will be returned to the client in the `Cache-Control` header with appropriate
-	//`max-age` and  scope (unset, `public`, or `private`) directives.
+	// Further, fields/types can be annotated with the @cacheControl directive, e.g.
+	// ```gql
+	// type Query @cacheControl(maxAge: 60) {
+	// author: String @resolve(name: "authorResolver") @cacheControl(maxAge: 90, scope: private)
+	// }
+	// ```
+	// Any type-level cache control defaults are overridden by field settings, if provided.
+	// The most restrictive cache control setting (smallest maxAge and scope) across all fields in
+	// an entire query will be returned to the client in the `Cache-Control` header with appropriate
+	// `max-age` and  scope (unset, `public`, or `private`) directives.
 	SchemaDefinition string `protobuf:"bytes,1,opt,name=schema_definition,json=schemaDefinition,proto3" json:"schema_definition,omitempty"`
 	// how to execute the schema
 	Executor *Executor `protobuf:"bytes,2,opt,name=executor,proto3" json:"executor,omitempty"`
@@ -1100,6 +1104,7 @@ type Executor struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Executor:
+	//
 	//	*Executor_Local_
 	//	*Executor_Remote_
 	Executor isExecutor_Executor `protobuf_oneof:"executor"`
@@ -1234,46 +1239,45 @@ type StitchedSchema_SubschemaConfig struct {
 	Name string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	// namespace of the GraphQLApi subschema
 	Namespace string `protobuf:"bytes,2,opt,name=namespace,proto3" json:"namespace,omitempty"`
+	// Type merge configuration for this subschema. Let's say this subschema is a Users service schema
+	// and provides the User type (with a query to fetch a user given the username)
 	//
-	//Type merge configuration for this subschema. Let's say this subschema is a Users service schema
-	//and provides the User type (with a query to fetch a user given the username)
+	// ```gql
+	// type Query {
+	// GetUser(username: String): User
+	// }
+	// type User {
+	// username: String
+	// firstName: String
+	// lastName: String
+	// }
+	// ```
 	//
-	//```gql
-	//type Query {
-	//GetUser(username: String): User
-	//}
-	//type User {
-	//username: String
-	//firstName: String
-	//lastName: String
-	//}
-	//```
+	// and another subschema, e.g. Reviews schema, may have a partial User type:
+	// ```gql
+	// type Review {
+	// author: User
+	// }
 	//
-	//and another subschema, e.g. Reviews schema, may have a partial User type:
-	//```gql
-	//type Review {
-	//author: User
-	//}
+	// type User {
+	// username: String
+	// }
+	// ```
+	// We want to provide the relevant information from this Users service schema,
+	// so that another API that can give us a partial User type (with the username) will then
+	// be able to have access to the full user type. With the correct type merging config under the Users subschema, e.g.:
 	//
-	//type User {
-	//username: String
-	//}
-	//```
-	//We want to provide the relevant information from this Users service schema,
-	//so that another API that can give us a partial User type (with the username) will then
-	//be able to have access to the full user type. With the correct type merging config under the Users subschema, e.g.:
-	//
-	//```yaml
-	//type_merge:
-	//User:
-	//selection_set: '{ username }'
-	//query_name: 'GetUser'
-	//args:
-	//username: username
-	//```
-	//the stitched schema will now be able to provide the full user type to all types that require it. In this case,
-	//we can now get the first name of an author from the Review.author field even though the Reviews schema does not
-	//provide the full User type.
+	// ```yaml
+	// type_merge:
+	// User:
+	// selection_set: '{ username }'
+	// query_name: 'GetUser'
+	// args:
+	// username: username
+	// ```
+	// the stitched schema will now be able to provide the full user type to all types that require it. In this case,
+	// we can now get the first name of an author from the Review.author field even though the Reviews schema does not
+	// provide the full User type.
 	TypeMerge map[string]*StitchedSchema_SubschemaConfig_TypeMergeConfig `protobuf:"bytes,3,rep,name=type_merge,json=typeMerge,proto3" json:"type_merge,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }
 
@@ -1513,23 +1517,23 @@ type Executor_Local struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Mapping of resolver name to resolver definition.
-	//The names are used to reference the resolver in the graphql schema.
-	//For example, a resolver with name "authorResolver" can be defined as
-	//```yaml
-	//authorResolver:
-	//restResolver:
-	//upstreamRef: ...
-	//request:
-	//...
-	//response:
-	//...
-	//```
-	//and referenced in the graphql schema as
-	//```gql
-	//type Query {
-	//author: String @resolve(name: "authorResolver")
-	//}
-	//```
+	// The names are used to reference the resolver in the graphql schema.
+	// For example, a resolver with name "authorResolver" can be defined as
+	// ```yaml
+	// authorResolver:
+	// restResolver:
+	// upstreamRef: ...
+	// request:
+	// ...
+	// response:
+	// ...
+	// ```
+	// and referenced in the graphql schema as
+	// ```gql
+	// type Query {
+	// author: String @resolve(name: "authorResolver")
+	// }
+	// ```
 	Resolutions map[string]*Resolution `protobuf:"bytes,1,rep,name=resolutions,proto3" json:"resolutions,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// Do we enable introspection for the schema? general recommendation is to
 	// disable this for production and hence it defaults to false.
@@ -1601,7 +1605,8 @@ type Executor_Remote struct {
 	// e.g.
 	// ':path':   '/hard/coded/path'
 	// ':method': '{$headers.method}'
-	//  ':key':    '{$metadata.io.solo.transformation:endpoint_url}'
+	//
+	//	':key':    '{$metadata.io.solo.transformation:endpoint_url}'
 	Headers map[string]string `protobuf:"bytes,2,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// map of query parameter name to extraction type:
 	// e.g.
@@ -1680,41 +1685,47 @@ type Executor_Local_LocalExecutorOptions struct {
 	// any GraphQL operation that runs past the `max_depth` will add an error message to the response and will return as `null`.
 	// As as simple example, if the schema is
 	// ```gql
-	// type Query {
-	//   employee: Employee
-	// }
 	//
-	// type Employee {
-	//   manager: Employee
-	//   name: String
-	// }
+	//	type Query {
+	//	  employee: Employee
+	//	}
+	//
+	//	type Employee {
+	//	  manager: Employee
+	//	  name: String
+	//	}
+	//
 	// ```
 	// and we set a `max_depth` of `3` and we run a query
 	// ```gql
 	// query {             # query depth : 0
-	//   employee {        # query depth : 1
-	//     manager {       # query depth : 2
-	//       name          # query depth : 3
-	//       manager {     # query depth : 3
-	//         name        # query depth : 4
-	//       }
-	//     }
-	//   }
-	// }
+	//
+	//	  employee {        # query depth : 1
+	//	    manager {       # query depth : 2
+	//	      name          # query depth : 3
+	//	      manager {     # query depth : 3
+	//	        name        # query depth : 4
+	//	      }
+	//	    }
+	//	  }
+	//	}
+	//
 	// ```
 	// the graphql server will respond with a response:
 	// ```json
-	// { "data" : {
-	//     "employee" : {
-	//       "manager" : {
-	//         "name" : "Manager 1",
-	//         "manager"  : {
-	//           "name" : null
-	//   }}}},
-	//   "errors": [
-	//      {"message": "field 'name' exceeds the max operation depth of 3 for this schema"}
-	//    ]
-	// }
+	//
+	//	{ "data" : {
+	//	    "employee" : {
+	//	      "manager" : {
+	//	        "name" : "Manager 1",
+	//	        "manager"  : {
+	//	          "name" : null
+	//	  }}}},
+	//	  "errors": [
+	//	     {"message": "field 'name' exceeds the max operation depth of 3 for this schema"}
+	//	   ]
+	//	}
+	//
 	// If not configured, or the value is 0, the query depth will be unbounded.
 	MaxDepth *wrappers.UInt32Value `protobuf:"bytes,1,opt,name=max_depth,json=maxDepth,proto3" json:"max_depth,omitempty"`
 }

--- a/projects/gloo/pkg/api/v1/enterprise/options/jwt/jwt.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/jwt/jwt.pb.go
@@ -346,6 +346,7 @@ type Jwks struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Jwks:
+	//
 	//	*Jwks_Remote
 	//	*Jwks_Local
 	Jwks isJwks_Jwks `protobuf_oneof:"jwks"`
@@ -440,15 +441,15 @@ type RemoteJwks struct {
 	//
 	// If this feature is not enabled:
 	//
-	// * The Jwks is fetched on-demand when the requests come. During the fetching, first
-	//   few requests are paused until the Jwks is fetched.
-	// * Each worker thread fetches its own Jwks since Jwks cache is per worker thread.
+	//   - The Jwks is fetched on-demand when the requests come. During the fetching, first
+	//     few requests are paused until the Jwks is fetched.
+	//   - Each worker thread fetches its own Jwks since Jwks cache is per worker thread.
 	//
 	// If this feature is enabled:
 	//
-	// * Fetched Jwks is done in the main thread before the listener is activated. Its fetched
-	//   Jwks can be used by all worker threads. Each worker thread doesn't need to fetch its own.
-	// * Jwks is ready when the requests come, not need to wait for the Jwks fetching.
+	//   - Fetched Jwks is done in the main thread before the listener is activated. Its fetched
+	//     Jwks can be used by all worker threads. Each worker thread doesn't need to fetch its own.
+	//   - Jwks is ready when the requests come, not need to wait for the Jwks fetching.
 	AsyncFetch *v3.JwksAsyncFetch `protobuf:"bytes,3,opt,name=async_fetch,json=asyncFetch,proto3" json:"async_fetch,omitempty"`
 }
 

--- a/projects/gloo/pkg/api/v1/enterprise/options/ratelimit/ratelimit.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/ratelimit/ratelimit.pb.go
@@ -169,18 +169,18 @@ func (x *Settings) GetRateLimitBeforeAuth() bool {
 // Sample configuration below:
 //
 // descriptors:
-//- key: account_id
-//  descriptors:
-//  - key: plan
-//    value: BASIC
-//    rateLimit:
-//      requestsPerUnit: 1
-//      unit: MINUTE
-//  - key: plan
-//    value: PLUS
-//    rateLimit:
-//      requestsPerUnit: 20
-//      unit: MINUTE
+//   - key: account_id
+//     descriptors:
+//   - key: plan
+//     value: BASIC
+//     rateLimit:
+//     requestsPerUnit: 1
+//     unit: MINUTE
+//   - key: plan
+//     value: PLUS
+//     rateLimit:
+//     requestsPerUnit: 20
+//     unit: MINUTE
 type ServiceSettings struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/v1/enterprise/options/waf/waf.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/waf/waf.pb.go
@@ -211,6 +211,7 @@ type CoreRuleSet struct {
 	// The same rules apply to these options as do to the `RuleSet`s. The file option is better if possible.
 	//
 	// Types that are assignable to CustomSettingsType:
+	//
 	//	*CoreRuleSet_CustomSettingsString
 	//	*CoreRuleSet_CustomSettingsFile
 	CustomSettingsType isCoreRuleSet_CustomSettingsType `protobuf_oneof:"CustomSettingsType"`

--- a/projects/gloo/pkg/api/v1/enterprise/ratelimit.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/ratelimit.pb.go
@@ -29,9 +29,8 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//
-//@solo-kit:xds-service=RateLimitDiscoveryService
-//@solo-kit:resource.no_references
+// @solo-kit:xds-service=RateLimitDiscoveryService
+// @solo-kit:resource.no_references
 type RateLimitConfig struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/v1/failover.pb.go
+++ b/projects/gloo/pkg/api/v1/failover.pb.go
@@ -25,21 +25,18 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Failover configuration for an upstream.
 //
+// Failover allows for optional fallback endpoints in the case that the primary set of endpoints is deemed
+// unhealthy. As failover requires knowledge of the health of each set of endpoints, active or passive
+// health checks must be configured on an upstream using failover in order for it to work properly.
 //
-//Failover configuration for an upstream.
-//
-//Failover allows for optional fallback endpoints in the case that the primary set of endpoints is deemed
-//unhealthy. As failover requires knowledge of the health of each set of endpoints, active or passive
-//health checks must be configured on an upstream using failover in order for it to work properly.
-//
-//Failover closely resembles the Envoy config which this is translated to, with one notable exception.
-//The priorities are not defined on the `LocalityLbEndpoints` but rather inferred from the list of
-//`PrioritizedLocality`. More information on envoy prioritization can be found
-//[here](https://www.envoyproxy.io/docs/envoy/v1.14.1/intro/arch_overview/upstream/load_balancing/priority#arch-overview-load-balancing-priority-levels).
-//In practice this means that the priority of a given set of `LocalityLbEndpoints` is determined by its index in
-//the list, first being `0` through `n-1`.
-//
+// Failover closely resembles the Envoy config which this is translated to, with one notable exception.
+// The priorities are not defined on the `LocalityLbEndpoints` but rather inferred from the list of
+// `PrioritizedLocality`. More information on envoy prioritization can be found
+// [here](https://www.envoyproxy.io/docs/envoy/v1.14.1/intro/arch_overview/upstream/load_balancing/priority#arch-overview-load-balancing-priority-levels).
+// In practice this means that the priority of a given set of `LocalityLbEndpoints` is determined by its index in
+// the list, first being `0` through `n-1`.
 type Failover struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -402,7 +399,7 @@ type Failover_Policy struct {
 	//
 	// .. code-block:: json
 	//
-	//  { "overprovisioning_factor": 100 }
+	//	{ "overprovisioning_factor": 100 }
 	//
 	// Read more at :ref:`priority levels <arch_overview_load_balancing_priority_levels>` and
 	// :ref:`localities <arch_overview_load_balancing_locality_weighted_lb>`.

--- a/projects/gloo/pkg/api/v1/load_balancer.pb.go
+++ b/projects/gloo/pkg/api/v1/load_balancer.pb.go
@@ -40,6 +40,7 @@ type LoadBalancerConfig struct {
 	// Set to 0 to disable and have changes applied immediately.
 	UpdateMergeWindow *duration.Duration `protobuf:"bytes,2,opt,name=update_merge_window,json=updateMergeWindow,proto3" json:"update_merge_window,omitempty"`
 	// Types that are assignable to Type:
+	//
 	//	*LoadBalancerConfig_RoundRobin_
 	//	*LoadBalancerConfig_LeastRequest_
 	//	*LoadBalancerConfig_Random_
@@ -47,6 +48,7 @@ type LoadBalancerConfig struct {
 	//	*LoadBalancerConfig_Maglev_
 	Type isLoadBalancerConfig_Type `protobuf_oneof:"type"`
 	// Types that are assignable to LocalityConfig:
+	//
 	//	*LoadBalancerConfig_LocalityWeightedLbConfig
 	LocalityConfig isLoadBalancerConfig_LocalityConfig `protobuf_oneof:"locality_config"`
 }
@@ -512,8 +514,8 @@ type LoadBalancerConfig_SlowStartConfig struct {
 	// By tuning the parameter, is possible to achieve polynomial or exponential shape of ramp-up curve.
 	//
 	// During slow start window, effective weight of an endpoint would be scaled with time factor and aggression:
-	// ``new_weight = weight * max(min_weight_percent, time_factor ^ (1 / aggression))``,
-	// where ``time_factor=(time_since_start_seconds / slow_start_time_seconds)``.
+	// “new_weight = weight * max(min_weight_percent, time_factor ^ (1 / aggression))“,
+	// where “time_factor=(time_since_start_seconds / slow_start_time_seconds)“.
 	//
 	// As time progresses, more and more traffic would be sent to endpoint, which is in slow start window.
 	// Once host exits slow start, time_factor and aggression no longer affect its weight.

--- a/projects/gloo/pkg/api/v1/options.pb.go
+++ b/projects/gloo/pkg/api/v1/options.pb.go
@@ -243,9 +243,11 @@ type HttpListenerOptions struct {
 	// Example:
 	// ```
 	// gzip:
-	//  contentType:
-	//  - "application/json"
-	//  compressionLevel: BEST
+	//
+	//	contentType:
+	//	- "application/json"
+	//	compressionLevel: BEST
+	//
 	// ```
 	Gzip *v2.Gzip `protobuf:"bytes,8,opt,name=gzip,proto3" json:"gzip,omitempty"`
 	// Enterprise-only: Proxy latency
@@ -513,14 +515,17 @@ type VirtualHostOptions struct {
 	// Enterprise-only: Config for GlooE rate-limiting using simplified (gloo-specific) API
 	RatelimitBasic *ratelimit.IngressRateLimit `protobuf:"bytes,6,opt,name=ratelimit_basic,json=ratelimitBasic,proto3" json:"ratelimit_basic,omitempty"`
 	// Types that are assignable to RateLimitEarlyConfigType:
+	//
 	//	*VirtualHostOptions_RatelimitEarly
 	//	*VirtualHostOptions_RateLimitEarlyConfigs
 	RateLimitEarlyConfigType isVirtualHostOptions_RateLimitEarlyConfigType `protobuf_oneof:"rate_limit_early_config_type"`
 	// Types that are assignable to RateLimitConfigType:
+	//
 	//	*VirtualHostOptions_Ratelimit
 	//	*VirtualHostOptions_RateLimitConfigs
 	RateLimitConfigType isVirtualHostOptions_RateLimitConfigType `protobuf_oneof:"rate_limit_config_type"`
 	// Types that are assignable to RateLimitRegularConfigType:
+	//
 	//	*VirtualHostOptions_RatelimitRegular
 	//	*VirtualHostOptions_RateLimitRegularConfigs
 	RateLimitRegularConfigType isVirtualHostOptions_RateLimitRegularConfigType `protobuf_oneof:"rate_limit_regular_config_type"`
@@ -528,6 +533,7 @@ type VirtualHostOptions struct {
 	// the popular ModSecurity 3.0 ruleset
 	Waf *waf.Settings `protobuf:"bytes,8,opt,name=waf,proto3" json:"waf,omitempty"`
 	// Types that are assignable to JwtConfig:
+	//
 	//	*VirtualHostOptions_Jwt
 	//	*VirtualHostOptions_JwtStaged
 	JwtConfig isVirtualHostOptions_JwtConfig `protobuf_oneof:"jwt_config"`
@@ -941,6 +947,7 @@ type RouteOptions struct {
 	// For requests matched on this route, rewrite the Host header before forwarding upstream
 	//
 	// Types that are assignable to HostRewriteType:
+	//
 	//	*RouteOptions_HostRewrite
 	//	*RouteOptions_AutoHostRewrite
 	HostRewriteType isRouteOptions_HostRewriteType `protobuf_oneof:"host_rewrite_type"`
@@ -956,14 +963,17 @@ type RouteOptions struct {
 	// Enterprise-only: Config for GlooE rate-limiting using simplified (gloo-specific) API
 	RatelimitBasic *ratelimit.IngressRateLimit `protobuf:"bytes,13,opt,name=ratelimit_basic,json=ratelimitBasic,proto3" json:"ratelimit_basic,omitempty"`
 	// Types that are assignable to RateLimitEarlyConfigType:
+	//
 	//	*RouteOptions_RatelimitEarly
 	//	*RouteOptions_RateLimitEarlyConfigs
 	RateLimitEarlyConfigType isRouteOptions_RateLimitEarlyConfigType `protobuf_oneof:"rate_limit_early_config_type"`
 	// Types that are assignable to RateLimitConfigType:
+	//
 	//	*RouteOptions_Ratelimit
 	//	*RouteOptions_RateLimitConfigs
 	RateLimitConfigType isRouteOptions_RateLimitConfigType `protobuf_oneof:"rate_limit_config_type"`
 	// Types that are assignable to RateLimitRegularConfigType:
+	//
 	//	*RouteOptions_RatelimitRegular
 	//	*RouteOptions_RateLimitRegularConfigs
 	RateLimitRegularConfigType isRouteOptions_RateLimitRegularConfigType `protobuf_oneof:"rate_limit_regular_config_type"`
@@ -971,6 +981,7 @@ type RouteOptions struct {
 	// the popular ModSecurity 3.0 ruleset
 	Waf *waf.Settings `protobuf:"bytes,15,opt,name=waf,proto3" json:"waf,omitempty"`
 	// Types that are assignable to JwtConfig:
+	//
 	//	*RouteOptions_Jwt
 	//	*RouteOptions_JwtStaged
 	JwtConfig isRouteOptions_JwtConfig `protobuf_oneof:"jwt_config"`
@@ -1443,6 +1454,7 @@ type DestinationSpec struct {
 	// to be usable by Gloo.
 	//
 	// Types that are assignable to DestinationType:
+	//
 	//	*DestinationSpec_Aws
 	//	*DestinationSpec_Azure
 	//	*DestinationSpec_Rest

--- a/projects/gloo/pkg/api/v1/options/advanced_http/advanced_http.pb.go
+++ b/projects/gloo/pkg/api/v1/options/advanced_http/advanced_http.pb.go
@@ -208,6 +208,7 @@ type ResponseMatch struct {
 	// The source of the extraction
 	//
 	// Types that are assignable to Source:
+	//
 	//	*ResponseMatch_Header
 	//	*ResponseMatch_Body
 	Source isResponseMatch_Source `protobuf_oneof:"source"`
@@ -364,6 +365,7 @@ type JsonKey_PathSegment struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Segment:
+	//
 	//	*JsonKey_PathSegment_Key
 	Segment isJsonKey_PathSegment_Segment `protobuf_oneof:"segment"`
 }

--- a/projects/gloo/pkg/api/v1/options/als/als.pb.go
+++ b/projects/gloo/pkg/api/v1/options/als/als.pb.go
@@ -231,6 +231,7 @@ type AccessLog struct {
 	// type of Access Logging service to implement
 	//
 	// Types that are assignable to OutputDestination:
+	//
 	//	*AccessLog_FileSink
 	//	*AccessLog_GrpcService
 	OutputDestination isAccessLog_OutputDestination `protobuf_oneof:"OutputDestination"`
@@ -325,6 +326,7 @@ type FileSink struct {
 	// the format which the logs should be outputted by
 	//
 	// Types that are assignable to OutputFormat:
+	//
 	//	*FileSink_StringFormat
 	//	*FileSink_JsonFormat
 	OutputFormat isFileSink_OutputFormat `protobuf_oneof:"output_format"`
@@ -420,6 +422,7 @@ type GrpcService struct {
 	// The static cluster defined in bootstrap config to route to
 	//
 	// Types that are assignable to ServiceRef:
+	//
 	//	*GrpcService_StaticClusterName
 	ServiceRef                      isGrpcService_ServiceRef `protobuf_oneof:"service_ref"`
 	AdditionalRequestHeadersToLog   []string                 `protobuf:"bytes,4,rep,name=additional_request_headers_to_log,json=additionalRequestHeadersToLog,proto3" json:"additional_request_headers_to_log,omitempty"`
@@ -517,6 +520,7 @@ type AccessLogFilter struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to FilterSpecifier:
+	//
 	//	*AccessLogFilter_StatusCodeFilter
 	//	*AccessLogFilter_DurationFilter
 	//	*AccessLogFilter_NotHealthCheckFilter
@@ -956,7 +960,7 @@ type RuntimeFilter struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Runtime key to get an optional overridden numerator for use in the
-	// ``percent_sampled`` field. If found in runtime, this value will replace the
+	// “percent_sampled“ field. If found in runtime, this value will replace the
 	// default numerator.
 	RuntimeKey string `protobuf:"bytes,1,opt,name=runtime_key,json=runtimeKey,proto3" json:"runtime_key,omitempty"`
 	// The default sampling percentage. If not specified, defaults to 0% with
@@ -968,9 +972,9 @@ type RuntimeFilter struct {
 	// is present, the filter will consistently sample across multiple hosts based
 	// on the runtime key value and the value extracted from
 	// :ref:`x-request-id<config_http_conn_man_headers_x-request-id>`. If it is
-	// missing, or ``use_independent_randomness`` is set to true, the filter will
+	// missing, or “use_independent_randomness“ is set to true, the filter will
 	// randomly sample based on the runtime key value alone.
-	// ``use_independent_randomness`` can be used for logging kill switches within
+	// “use_independent_randomness“ can be used for logging kill switches within
 	// complex nested :ref:`AndFilter
 	// <envoy_v3_api_msg_config.accesslog.v3.AndFilter>` and :ref:`OrFilter
 	// <envoy_v3_api_msg_config.accesslog.v3.OrFilter>` blocks that are easier to

--- a/projects/gloo/pkg/api/v1/options/aws/aws.pb.go
+++ b/projects/gloo/pkg/api/v1/options/aws/aws.pb.go
@@ -82,11 +82,12 @@ type UpstreamSpec struct {
 	// A [Gloo Secret Ref](https://docs.solo.io/gloo-edge/latest/reference/cli/glooctl_create_secret_aws/) to an AWS Secret
 	// AWS Secrets can be created with `glooctl secret create aws ...`
 	// If the secret is created manually, it must conform to the following structure:
-	//  ```
-	//  access_key: <aws access key>
-	//  secret_key: <aws secret key>
-	//  session_token: <(optional) aws session token>
-	//  ```
+	//
+	//	```
+	//	access_key: <aws access key>
+	//	secret_key: <aws secret key>
+	//	session_token: <(optional) aws session token>
+	//	```
 	SecretRef *core.ResourceRef `protobuf:"bytes,2,opt,name=secret_ref,json=secretRef,proto3" json:"secret_ref,omitempty"`
 	// The list of Lambda Functions contained within this region.
 	// This list will be automatically populated by Gloo if discovery is enabled for AWS Lambda Functions

--- a/projects/gloo/pkg/api/v1/options/aws/ec2/aws_ec2.pb.go
+++ b/projects/gloo/pkg/api/v1/options/aws/ec2/aws_ec2.pb.go
@@ -41,10 +41,12 @@ type UpstreamSpec struct {
 	// If set, a [Gloo Secret Ref](https://docs.solo.io/gloo-edge/latest/reference/cli/glooctl_create_secret_aws/) to an AWS Secret
 	// AWS Secrets can be created with `glooctl secret create aws ...`
 	// If the secret is created manually, it must conform to the following structure:
-	//  ```
-	//  access_key: <aws access key>
-	//  secret_key: <aws secret key>
-	//  ```
+	//
+	//	```
+	//	access_key: <aws access key>
+	//	secret_key: <aws secret key>
+	//	```
+	//
 	// Gloo will create an EC2 API client with this credential. You may choose to use a credential with limited access
 	// in conjunction with a list of Roles, specified by their Amazon Resource Number (ARN).
 	SecretRef *core.ResourceRef `protobuf:"bytes,2,opt,name=secret_ref,json=secretRef,proto3" json:"secret_ref,omitempty"`
@@ -143,6 +145,7 @@ type TagFilter struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Spec:
+	//
 	//	*TagFilter_Key
 	//	*TagFilter_KvPair_
 	Spec isTagFilter_Spec `protobuf_oneof:"spec"`

--- a/projects/gloo/pkg/api/v1/options/dynamic_forward_proxy/dynamic_forward_proxy.pb.go
+++ b/projects/gloo/pkg/api/v1/options/dynamic_forward_proxy/dynamic_forward_proxy.pb.go
@@ -254,21 +254,21 @@ type DnsCacheConfig struct {
 	//
 	// .. note:
 	//
-	//   The TTL is only checked at the time of DNS refresh, as specified by *dns_refresh_rate*. This
-	//   means that if the configured TTL is shorter than the refresh rate the host may not be removed
-	//   immediately.
+	//	 The TTL is only checked at the time of DNS refresh, as specified by *dns_refresh_rate*. This
+	//	 means that if the configured TTL is shorter than the refresh rate the host may not be removed
+	//	 immediately.
 	//
-	//  .. note:
+	//	.. note:
 	//
-	//   The TTL has no relation to DNS TTL and is only used to control Envoy's resource usage.
+	//	 The TTL has no relation to DNS TTL and is only used to control Envoy's resource usage.
 	HostTtl *duration.Duration `protobuf:"bytes,4,opt,name=host_ttl,json=hostTtl,proto3" json:"host_ttl,omitempty"`
 	// The maximum number of hosts that the cache will hold. If not specified defaults to 1024.
 	//
 	// .. note:
 	//
-	//   The implementation is approximate and enforced independently on each worker thread, thus
-	//   it is possible for the maximum hosts in the cache to go slightly above the configured
-	//   value depending on timing. This is similar to how other circuit breakers work.
+	//	The implementation is approximate and enforced independently on each worker thread, thus
+	//	it is possible for the maximum hosts in the cache to go slightly above the configured
+	//	value depending on timing. This is similar to how other circuit breakers work.
 	MaxHosts *wrappers.UInt32Value `protobuf:"bytes,5,opt,name=max_hosts,json=maxHosts,proto3" json:"max_hosts,omitempty"`
 	// If the DNS failure refresh rate is specified,
 	// this is used as the cache's DNS refresh rate when DNS requests are failing. If this setting is
@@ -278,6 +278,7 @@ type DnsCacheConfig struct {
 	// Envoy will use dns cache circuit breakers with default settings even if this value is not set.
 	DnsCacheCircuitBreaker *DnsCacheCircuitBreakers `protobuf:"bytes,7,opt,name=dns_cache_circuit_breaker,json=dnsCacheCircuitBreaker,proto3" json:"dns_cache_circuit_breaker,omitempty"`
 	// Types that are assignable to DnsCacheType:
+	//
 	//	*DnsCacheConfig_CaresDns
 	//	*DnsCacheConfig_AppleDns
 	DnsCacheType isDnsCacheConfig_DnsCacheType `protobuf_oneof:"DnsCacheType"`
@@ -486,6 +487,7 @@ type PerRouteConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to HostRewriteSpecifier:
+	//
 	//	*PerRouteConfig_HostRewrite
 	//	*PerRouteConfig_AutoHostRewriteHeader
 	HostRewriteSpecifier isPerRouteConfig_HostRewriteSpecifier `protobuf_oneof:"host_rewrite_specifier"`
@@ -574,7 +576,7 @@ type PerRouteConfig_AutoHostRewriteHeader struct {
 	//
 	// .. note::
 	//
-	//   If the header appears multiple times only the first value is used.
+	//	If the header appears multiple times only the first value is used.
 	AutoHostRewriteHeader string `protobuf:"bytes,2,opt,name=auto_host_rewrite_header,json=autoHostRewriteHeader,proto3,oneof"`
 }
 

--- a/projects/gloo/pkg/api/v1/options/grpc_json/grpc_json.pb.go
+++ b/projects/gloo/pkg/api/v1/options/grpc_json/grpc_json.pb.go
@@ -33,14 +33,15 @@ type GrpcJsonTranscoder struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to DescriptorSet:
+	//
 	//	*GrpcJsonTranscoder_ProtoDescriptor
 	//	*GrpcJsonTranscoder_ProtoDescriptorBin
 	//	*GrpcJsonTranscoder_ProtoDescriptorConfigMap
 	DescriptorSet isGrpcJsonTranscoder_DescriptorSet `protobuf_oneof:"descriptor_set"`
 	// A list of strings that
 	// supplies the fully qualified service names (i.e. "package_name.service_name") that
-	// the transcoder will translate. If the service name doesn't exist in ``proto_descriptor``,
-	// Envoy will fail at startup. The ``proto_descriptor`` may contain more services than
+	// the transcoder will translate. If the service name doesn't exist in “proto_descriptor“,
+	// Envoy will fail at startup. The “proto_descriptor“ may contain more services than
 	// the service names specified here, but they won't be translated.
 	Services []string `protobuf:"bytes,2,rep,name=services,proto3" json:"services,omitempty"`
 	// Control options for response JSON. These options are passed directly to
@@ -60,78 +61,78 @@ type GrpcJsonTranscoder struct {
 	//
 	// .. code-block:: proto
 	//
-	//     service Bookstore {
-	//       rpc GetShelf(GetShelfRequest) returns (Shelf) {
-	//         option (google.api.http) = {
-	//           get: "/shelves/{shelf}"
-	//         };
-	//       }
-	//     }
+	//	service Bookstore {
+	//	  rpc GetShelf(GetShelfRequest) returns (Shelf) {
+	//	    option (google.api.http) = {
+	//	      get: "/shelves/{shelf}"
+	//	    };
+	//	  }
+	//	}
 	//
-	//     message GetShelfRequest {
-	//       int64 shelf = 1;
-	//     }
+	//	message GetShelfRequest {
+	//	  int64 shelf = 1;
+	//	}
 	//
-	//     message Shelf {}
+	//	message Shelf {}
 	//
-	// The request ``/shelves/100?foo=bar`` will not be mapped to ``GetShelf``` because variable
-	// binding for ``foo`` is not defined. Adding ``foo`` to ``ignored_query_parameters`` will allow
-	// the same request to be mapped to ``GetShelf``.
+	// The request “/shelves/100?foo=bar“ will not be mapped to “GetShelf``` because variable
+	// binding for “foo“ is not defined. Adding “foo“ to “ignored_query_parameters“ will allow
+	// the same request to be mapped to “GetShelf“.
 	IgnoredQueryParameters []string `protobuf:"bytes,6,rep,name=ignored_query_parameters,json=ignoredQueryParameters,proto3" json:"ignored_query_parameters,omitempty"`
-	// Whether to route methods without the ``google.api.http`` option.
+	// Whether to route methods without the “google.api.http“ option.
 	//
 	// Example :
 	//
 	// .. code-block:: proto
 	//
-	//     package bookstore;
+	//	package bookstore;
 	//
-	//     service Bookstore {
-	//       rpc GetShelf(GetShelfRequest) returns (Shelf) {}
-	//     }
+	//	service Bookstore {
+	//	  rpc GetShelf(GetShelfRequest) returns (Shelf) {}
+	//	}
 	//
-	//     message GetShelfRequest {
-	//       int64 shelf = 1;
-	//     }
+	//	message GetShelfRequest {
+	//	  int64 shelf = 1;
+	//	}
 	//
-	//     message Shelf {}
+	//	message Shelf {}
 	//
-	// The client could ``post`` a json body ``{"shelf": 1234}`` with the path of
-	// ``/bookstore.Bookstore/GetShelfRequest`` to call ``GetShelfRequest``.
+	// The client could “post“ a json body “{"shelf": 1234}“ with the path of
+	// “/bookstore.Bookstore/GetShelfRequest“ to call “GetShelfRequest“.
 	AutoMapping bool `protobuf:"varint,7,opt,name=auto_mapping,json=autoMapping,proto3" json:"auto_mapping,omitempty"`
 	// Whether to ignore query parameters that cannot be mapped to a corresponding
 	// protobuf field. Use this if you cannot control the query parameters and do
-	// not know them beforehand. Otherwise use ``ignored_query_parameters``.
+	// not know them beforehand. Otherwise use “ignored_query_parameters“.
 	// Defaults to false.
 	IgnoreUnknownQueryParameters bool `protobuf:"varint,8,opt,name=ignore_unknown_query_parameters,json=ignoreUnknownQueryParameters,proto3" json:"ignore_unknown_query_parameters,omitempty"`
 	// Whether to convert gRPC status headers to JSON.
-	// When trailer indicates a gRPC error and there was no HTTP body, take ``google.rpc.Status``
-	// from the ``grpc-status-details-bin`` header and use it as JSON body.
-	// If there was no such header, make ``google.rpc.Status`` out of the ``grpc-status`` and
-	// ``grpc-message`` headers.
-	// The error details types must be present in the ``proto_descriptor``.
+	// When trailer indicates a gRPC error and there was no HTTP body, take “google.rpc.Status“
+	// from the “grpc-status-details-bin“ header and use it as JSON body.
+	// If there was no such header, make “google.rpc.Status“ out of the “grpc-status“ and
+	// “grpc-message“ headers.
+	// The error details types must be present in the “proto_descriptor“.
 	//
 	// For example, if an upstream server replies with headers:
 	//
 	// .. code-block:: none
 	//
-	//     grpc-status: 5
-	//     grpc-status-details-bin:
-	//         CAUaMwoqdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUucnBjLlJlcXVlc3RJbmZvEgUKA3ItMQ
+	//	grpc-status: 5
+	//	grpc-status-details-bin:
+	//	    CAUaMwoqdHlwZS5nb29nbGVhcGlzLmNvbS9nb29nbGUucnBjLlJlcXVlc3RJbmZvEgUKA3ItMQ
 	//
-	// The ``grpc-status-details-bin`` header contains a base64-encoded protobuf message
-	// ``google.rpc.Status``. It will be transcoded into:
+	// The “grpc-status-details-bin“ header contains a base64-encoded protobuf message
+	// “google.rpc.Status“. It will be transcoded into:
 	//
 	// .. code-block:: none
 	//
-	//     HTTP/1.1 404 Not Found
-	//     content-type: application/json
+	//	   HTTP/1.1 404 Not Found
+	//	   content-type: application/json
 	//
-	//     {"code":5,"details":[{"@type":"type.googleapis.com/google.rpc.RequestInfo","requestId":"r-1"}]}
+	//	   {"code":5,"details":[{"@type":"type.googleapis.com/google.rpc.RequestInfo","requestId":"r-1"}]}
 	//
-	//  In order to transcode the message, the ``google.rpc.RequestInfo`` type from
-	//  the ``google/rpc/error_details.proto`` should be included in the configured
-	//  :ref:`proto descriptor set <config_grpc_json_generate_proto_descriptor_set>`.
+	//	In order to transcode the message, the ``google.rpc.RequestInfo`` type from
+	//	the ``google/rpc/error_details.proto`` should be included in the configured
+	//	:ref:`proto descriptor set <config_grpc_json_generate_proto_descriptor_set>`.
 	ConvertGrpcStatus bool `protobuf:"varint,9,opt,name=convert_grpc_status,json=convertGrpcStatus,proto3" json:"convert_grpc_status,omitempty"`
 }
 
@@ -291,7 +292,7 @@ type GrpcJsonTranscoder_PrintOptions struct {
 	// as strings. Defaults to false.
 	AlwaysPrintEnumsAsInts bool `protobuf:"varint,3,opt,name=always_print_enums_as_ints,json=alwaysPrintEnumsAsInts,proto3" json:"always_print_enums_as_ints,omitempty"`
 	// Whether to preserve proto field names. By default protobuf will
-	// generate JSON field names using the ``json_name`` option, or lower camel case,
+	// generate JSON field names using the “json_name“ option, or lower camel case,
 	// in that order. Setting this flag will preserve the original field names. Defaults to false.
 	PreserveProtoFieldNames bool `protobuf:"varint,4,opt,name=preserve_proto_field_names,json=preserveProtoFieldNames,proto3" json:"preserve_proto_field_names,omitempty"`
 }

--- a/projects/gloo/pkg/api/v1/options/hcm/hcm.pb.go
+++ b/projects/gloo/pkg/api/v1/options/hcm/hcm.pb.go
@@ -357,6 +357,7 @@ type HttpConnectionManagerSettings struct {
 	AllowChunkedLength *wrappers.BoolValue `protobuf:"bytes,34,opt,name=allow_chunked_length,json=allowChunkedLength,proto3" json:"allow_chunked_length,omitempty"`
 	EnableTrailers     *wrappers.BoolValue `protobuf:"bytes,35,opt,name=enable_trailers,json=enableTrailers,proto3" json:"enable_trailers,omitempty"`
 	// Types that are assignable to HeaderFormat:
+	//
 	//	*HttpConnectionManagerSettings_ProperCaseHeaderKeyFormat
 	//	*HttpConnectionManagerSettings_PreserveCaseHeaderKeyFormat
 	HeaderFormat                isHttpConnectionManagerSettings_HeaderFormat               `protobuf_oneof:"header_format"`

--- a/projects/gloo/pkg/api/v1/options/lbhash/lbhash.pb.go
+++ b/projects/gloo/pkg/api/v1/options/lbhash/lbhash.pb.go
@@ -151,6 +151,7 @@ type HashPolicy struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to KeyType:
+	//
 	//	*HashPolicy_Header
 	//	*HashPolicy_Cookie
 	//	*HashPolicy_SourceIp

--- a/projects/gloo/pkg/api/v1/options/protocol/protocol.pb.go
+++ b/projects/gloo/pkg/api/v1/options/protocol/protocol.pb.go
@@ -100,8 +100,9 @@ type HttpProtocolOptions struct {
 	// If not specified, this defaults to 1 hour. To disable idle timeouts explicitly set this to 0.
 	//
 	// .. warning::
-	//   Disabling this timeout has a highly likelihood of yielding connection leaks due to lost TCP
-	//   FIN packets, etc.
+	//
+	//	Disabling this timeout has a highly likelihood of yielding connection leaks due to lost TCP
+	//	FIN packets, etc.
 	IdleTimeout *duration.Duration `protobuf:"bytes,1,opt,name=idle_timeout,json=idleTimeout,proto3" json:"idle_timeout,omitempty"`
 	// The maximum number of headers. If unconfigured, the default
 	// maximum number of request headers allowed is 100. Requests that exceed this limit will receive
@@ -185,6 +186,7 @@ type Http1ProtocolOptions struct {
 	// Note: Trailers must also be enabled at the gateway level in order for this option to take effect.
 	EnableTrailers bool `protobuf:"varint,1,opt,name=enable_trailers,json=enableTrailers,proto3" json:"enable_trailers,omitempty"`
 	// Types that are assignable to HeaderFormat:
+	//
 	//	*Http1ProtocolOptions_ProperCaseHeaderKeyFormat
 	//	*Http1ProtocolOptions_PreserveCaseHeaderKeyFormat
 	HeaderFormat isHttp1ProtocolOptions_HeaderFormat `protobuf_oneof:"header_format"`

--- a/projects/gloo/pkg/api/v1/options/protocol_upgrade/protocol_upgrade.pb.go
+++ b/projects/gloo/pkg/api/v1/options/protocol_upgrade/protocol_upgrade.pb.go
@@ -29,6 +29,7 @@ type ProtocolUpgradeConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to UpgradeType:
+	//
 	//	*ProtocolUpgradeConfig_Websocket
 	UpgradeType isProtocolUpgradeConfig_UpgradeType `protobuf_oneof:"upgrade_type"`
 }

--- a/projects/gloo/pkg/api/v1/options/proxy_protocol/proxy_protocol.pb.go
+++ b/projects/gloo/pkg/api/v1/options/proxy_protocol/proxy_protocol.pb.go
@@ -34,12 +34,11 @@ type ProxyProtocol struct {
 	//
 	// .. attention::
 	//
-	//   The true setting is only honored in Gloo Edge Enterprise.
-	//   This breaks conformance with the specification.
-	//   Only enable if ALL traffic to the listener comes from a trusted source.
-	//   For more information on the security implications of this feature, see
-	//   https://www.haproxy.org/download/2.1/doc/proxy-protocol.txt
-	//
+	//	The true setting is only honored in Gloo Edge Enterprise.
+	//	This breaks conformance with the specification.
+	//	Only enable if ALL traffic to the listener comes from a trusted source.
+	//	For more information on the security implications of this feature, see
+	//	https://www.haproxy.org/download/2.1/doc/proxy-protocol.txt
 	AllowRequestsWithoutProxyProtocol bool `protobuf:"varint,2,opt,name=allow_requests_without_proxy_protocol,json=allowRequestsWithoutProxyProtocol,proto3" json:"allow_requests_without_proxy_protocol,omitempty"`
 }
 

--- a/projects/gloo/pkg/api/v1/options/rest/rest.pb.go
+++ b/projects/gloo/pkg/api/v1/options/rest/rest.pb.go
@@ -149,6 +149,7 @@ type ServiceSpec_SwaggerInfo struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to SwaggerSpec:
+	//
 	//	*ServiceSpec_SwaggerInfo_Url
 	//	*ServiceSpec_SwaggerInfo_Inline
 	SwaggerSpec isServiceSpec_SwaggerInfo_SwaggerSpec `protobuf_oneof:"swagger_spec"`

--- a/projects/gloo/pkg/api/v1/options/service_spec.pb.go
+++ b/projects/gloo/pkg/api/v1/options/service_spec.pb.go
@@ -37,6 +37,7 @@ type ServiceSpec struct {
 	// to be usable by Gloo. (plugins currently need to be compiled into Gloo)
 	//
 	// Types that are assignable to PluginType:
+	//
 	//	*ServiceSpec_Rest
 	//	*ServiceSpec_Grpc
 	PluginType isServiceSpec_PluginType `protobuf_oneof:"plugin_type"`

--- a/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.go
+++ b/projects/gloo/pkg/api/v1/options/tracing/tracing.pb.go
@@ -45,6 +45,7 @@ type ListenerTracingSettings struct {
 	// ProviderConfig defines the configuration for an external tracing provider.
 	//
 	// Types that are assignable to ProviderConfig:
+	//
 	//	*ListenerTracingSettings_ZipkinConfig
 	//	*ListenerTracingSettings_DatadogConfig
 	//	*ListenerTracingSettings_OpenTelemetryConfig

--- a/projects/gloo/pkg/api/v1/options/transformation/parameters.pb.go
+++ b/projects/gloo/pkg/api/v1/options/transformation/parameters.pb.go
@@ -32,18 +32,20 @@ type Parameters struct {
 	// Gloo will search for parameters by their name in header value strings, enclosed in single
 	// curly braces
 	// Example:
-	//   extensions:
-	//     parameters:
-	//         headers:
-	//           x-user-id: '{userId}'
+	//
+	//	extensions:
+	//	  parameters:
+	//	      headers:
+	//	        x-user-id: '{userId}'
 	Headers map[string]string `protobuf:"bytes,1,rep,name=headers,proto3" json:"headers,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	// part of the (or the entire) path that will be used extract data for processing output templates
 	// Gloo will search for parameters by their name in header value strings, enclosed in single
 	// curly braces
 	// Example:
-	//   extensions:
-	//     parameters:
-	//         path: /users/{ userId }
+	//
+	//	extensions:
+	//	  parameters:
+	//	      path: /users/{ userId }
 	Path *wrappers.StringValue `protobuf:"bytes,2,opt,name=path,proto3" json:"path,omitempty"`
 }
 

--- a/projects/gloo/pkg/api/v1/options/transformation/transformation.pb.go
+++ b/projects/gloo/pkg/api/v1/options/transformation/transformation.pb.go
@@ -375,6 +375,7 @@ type Transformation struct {
 	// The type of transformation to apply.
 	//
 	// Types that are assignable to TransformationType:
+	//
 	//	*Transformation_TransformationTemplate
 	//	*Transformation_HeaderBodyTransform
 	//	*Transformation_XsltTransformation

--- a/projects/gloo/pkg/api/v1/options/wasm/wasm.pb.go
+++ b/projects/gloo/pkg/api/v1/options/wasm/wasm.pb.go
@@ -190,8 +190,7 @@ func (FilterStage_Predicate) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_solo_io_gloo_projects_gloo_api_v1_options_wasm_wasm_proto_rawDescGZIP(), []int{2, 1}
 }
 
-//
-//Options config for WASM filters
+// Options config for WASM filters
 type PluginSource struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -240,14 +239,14 @@ func (x *PluginSource) GetFilters() []*WasmFilter {
 	return nil
 }
 
-//
-//This message defines a single Envoy WASM filter to be placed into the filter chain
+// This message defines a single Envoy WASM filter to be placed into the filter chain
 type WasmFilter struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Src:
+	//
 	//	*WasmFilter_Image
 	//	*WasmFilter_FilePath
 	Src isWasmFilter_Src `protobuf_oneof:"src"`

--- a/projects/gloo/pkg/api/v1/proxy.pb.go
+++ b/projects/gloo/pkg/api/v1/proxy.pb.go
@@ -91,16 +91,15 @@ func (RedirectAction_RedirectResponseCode) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_solo_io_gloo_projects_gloo_api_v1_proxy_proto_rawDescGZIP(), []int{18, 0}
 }
 
+// A Proxy is a container for the entire set of configuration that will to be applied to one or more Proxy instances.
+// Proxies can be understood as a set of listeners, represents a different bind address/port where the proxy will listen
+// for connections. Each listener has its own set of configuration.
 //
-//A Proxy is a container for the entire set of configuration that will to be applied to one or more Proxy instances.
-//Proxies can be understood as a set of listeners, represents a different bind address/port where the proxy will listen
-//for connections. Each listener has its own set of configuration.
+// If any of the sub-resources within a listener is declared invalid (e.g. due to invalid user configuration), the
+// proxy will be marked invalid by Gloo.
 //
-//If any of the sub-resources within a listener is declared invalid (e.g. due to invalid user configuration), the
-//proxy will be marked invalid by Gloo.
-//
-//Proxy instances that register with Gloo are assigned the proxy configuration corresponding with
-//a proxy-specific identifier.
+// Proxy instances that register with Gloo are assigned the proxy configuration corresponding with
+// a proxy-specific identifier.
 // In the case of Envoy, proxy instances are identified by their Node ID. Node IDs must match a existing Proxy
 // Node ID can be specified in Envoy with the `--service-node` flag, or in the Envoy instance's bootstrap config.
 type Proxy struct {
@@ -200,6 +199,7 @@ type Listener struct {
 	// Listeners can listen for HTTP, TCP (unsupported), and UDP (unsupported) connections
 	//
 	// Types that are assignable to ListenerType:
+	//
 	//	*Listener_HttpListener
 	//	*Listener_TcpListener
 	//	*Listener_HybridListener
@@ -218,6 +218,7 @@ type Listener struct {
 	// top level options
 	Options *ListenerOptions `protobuf:"bytes,8,opt,name=options,proto3" json:"options,omitempty"`
 	// Types that are assignable to OpaqueMetadata:
+	//
 	//	*Listener_Metadata
 	//	*Listener_MetadataStatic
 	OpaqueMetadata isListener_OpaqueMetadata `protobuf_oneof:"opaque_metadata"`
@@ -684,6 +685,7 @@ type MatchedListener struct {
 	// Empty Matchers are effectively catch-alls, and there can be no more than one empty Matcher per HybridListener
 	Matcher *Matcher `protobuf:"bytes,1,opt,name=matcher,proto3" json:"matcher,omitempty"`
 	// Types that are assignable to ListenerType:
+	//
 	//	*MatchedListener_HttpListener
 	//	*MatchedListener_TcpListener
 	ListenerType isMatchedListener_ListenerType `protobuf_oneof:"ListenerType"`
@@ -889,7 +891,6 @@ func (x *AggregateListener) GetHttpFilterChains() []*AggregateListener_HttpFilte
 	return nil
 }
 
-//
 // Virtual Hosts group an ordered list of routes under one or more domains.
 // Each Virtual Host has a logical name, which must be unique for the http listener.
 // An HTTP request is first matched to a virtual host based on its host header, then to a route within the virtual host.
@@ -916,6 +917,7 @@ type VirtualHost struct {
 	// Some configuration here can be overridden by Route Options.
 	Options *VirtualHostOptions `protobuf:"bytes,4,opt,name=options,proto3" json:"options,omitempty"`
 	// Types that are assignable to OpaqueMetadata:
+	//
 	//	*VirtualHost_Metadata
 	//	*VirtualHost_MetadataStatic
 	OpaqueMetadata isVirtualHost_OpaqueMetadata `protobuf_oneof:"opaque_metadata"`
@@ -1024,7 +1026,7 @@ func (*VirtualHost_Metadata) isVirtualHost_OpaqueMetadata() {}
 
 func (*VirtualHost_MetadataStatic) isVirtualHost_OpaqueMetadata() {}
 
-//*
+// *
 // Routes declare the entry points on virtual hosts and the action to take for matched requests.
 type Route struct {
 	state         protoimpl.MessageState
@@ -1037,6 +1039,7 @@ type Route struct {
 	// The Route Action Defines what action the proxy should take when a request matches the route.
 	//
 	// Types that are assignable to Action:
+	//
 	//	*Route_RouteAction
 	//	*Route_RedirectAction
 	//	*Route_DirectResponseAction
@@ -1046,6 +1049,7 @@ type Route struct {
 	// Route options include configuration such as retries, rate limiting, and request/response transformation.
 	Options *RouteOptions `protobuf:"bytes,5,opt,name=options,proto3" json:"options,omitempty"`
 	// Types that are assignable to OpaqueMetadata:
+	//
 	//	*Route_Metadata
 	//	*Route_MetadataStatic
 	OpaqueMetadata isRoute_OpaqueMetadata `protobuf_oneof:"opaque_metadata"`
@@ -1233,6 +1237,7 @@ type RouteAction struct {
 	// to be specified).
 	//
 	// Types that are assignable to Destination:
+	//
 	//	*RouteAction_Single
 	//	*RouteAction_Multi
 	//	*RouteAction_UpstreamGroup
@@ -1366,9 +1371,10 @@ type Destination struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	//  The type of the destination
+	//	The type of the destination
 	//
 	// Types that are assignable to DestinationType:
+	//
 	//	*Destination_Upstream
 	//	*Destination_Kube
 	//	*Destination_Consul
@@ -1809,6 +1815,7 @@ type RedirectAction struct {
 	// The host portion of the URL will be swapped with this value.
 	HostRedirect string `protobuf:"bytes,1,opt,name=host_redirect,json=hostRedirect,proto3" json:"host_redirect,omitempty"`
 	// Types that are assignable to PathRewriteSpecifier:
+	//
 	//	*RedirectAction_PathRedirect
 	//	*RedirectAction_PrefixRewrite
 	//	*RedirectAction_RegexRewrite
@@ -1925,8 +1932,8 @@ type RedirectAction_PrefixRewrite struct {
 	// should be swapped with this value. This option allows redirect URLs be dynamically created
 	// based on the request.
 	//
-	//   Pay attention to the use of trailing slashes as mentioned in
-	//   `RouteAction`'s `prefix_rewrite`.
+	//	Pay attention to the use of trailing slashes as mentioned in
+	//	`RouteAction`'s `prefix_rewrite`.
 	PrefixRewrite string `protobuf:"bytes,5,opt,name=prefix_rewrite,json=prefixRewrite,proto3,oneof"`
 }
 
@@ -1945,20 +1952,20 @@ type RedirectAction_RegexRewrite struct {
 	//
 	// Examples using Google's `RE2 <https://github.com/google/re2>`_ engine:
 	//
-	// * The path pattern ``^/service/([^/]+)(/.*)$`` paired with a substitution
-	//   string of ``\2/instance/\1`` would transform ``/service/foo/v1/api``
-	//   into ``/v1/api/instance/foo``.
+	//   - The path pattern “^/service/([^/]+)(/.*)$“ paired with a substitution
+	//     string of “\2/instance/\1“ would transform “/service/foo/v1/api“
+	//     into “/v1/api/instance/foo“.
 	//
-	// * The pattern ``one`` paired with a substitution string of ``two`` would
-	//   transform ``/xxx/one/yyy/one/zzz`` into ``/xxx/two/yyy/two/zzz``.
+	//   - The pattern “one“ paired with a substitution string of “two“ would
+	//     transform “/xxx/one/yyy/one/zzz“ into “/xxx/two/yyy/two/zzz“.
 	//
-	// * The pattern ``^(.*?)one(.*)$`` paired with a substitution string of
-	//   ``\1two\2`` would replace only the first occurrence of ``one``,
-	//   transforming path ``/xxx/one/yyy/one/zzz`` into ``/xxx/two/yyy/one/zzz``.
+	//   - The pattern “^(.*?)one(.*)$“ paired with a substitution string of
+	//     “\1two\2“ would replace only the first occurrence of “one“,
+	//     transforming path “/xxx/one/yyy/one/zzz“ into “/xxx/two/yyy/one/zzz“.
 	//
-	// * The pattern ``(?i)/xxx/`` paired with a substitution string of ``/yyy/``
-	//   would do a case-insensitive match and transform path ``/aaa/XxX/bbb`` to
-	//   ``/aaa/yyy/bbb``.
+	//   - The pattern “(?i)/xxx/“ paired with a substitution string of “/yyy/“
+	//     would do a case-insensitive match and transform path “/aaa/XxX/bbb“ to
+	//     “/aaa/yyy/bbb“.
 	RegexRewrite *v31.RegexMatchAndSubstitute `protobuf:"bytes,32,opt,name=regex_rewrite,json=regexRewrite,proto3,oneof"`
 }
 
@@ -1979,8 +1986,8 @@ type DirectResponseAction struct {
 	// Specifies the content of the response body. If this setting is omitted,
 	// no body is included in the generated response.
 	//
-	//   Note: Headers can be specified using the Header Modification feature in the enclosing
-	//   Route, Virtual Host, or Listener options.
+	//	Note: Headers can be specified using the Header Modification feature in the enclosing
+	//	Route, Virtual Host, or Listener options.
 	Body string `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
 }
 
@@ -2090,6 +2097,7 @@ type TcpHost_TcpAction struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Destination:
+	//
 	//	*TcpHost_TcpAction_Single
 	//	*TcpHost_TcpAction_Multi
 	//	*TcpHost_TcpAction_UpstreamGroup

--- a/projects/gloo/pkg/api/v1/secret.pb.go
+++ b/projects/gloo/pkg/api/v1/secret.pb.go
@@ -24,23 +24,23 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Certain features such as the AWS Lambda option require the use of secrets for authentication, configuration of SSL Certificates, and other data that should not be stored in plaintext configuration.
 //
-//Certain features such as the AWS Lambda option require the use of secrets for authentication, configuration of SSL Certificates, and other data that should not be stored in plaintext configuration.
+// Gloo runs an independent (goroutine) controller to monitor secrets. Secrets are stored in their own secret storage layer. Gloo can monitor secrets stored in the following secret storage services:
 //
-//Gloo runs an independent (goroutine) controller to monitor secrets. Secrets are stored in their own secret storage layer. Gloo can monitor secrets stored in the following secret storage services:
+// - Kubernetes Secrets
+// - Hashicorp Vault
+// - Plaintext files (recommended only for testing)
+// - Secrets must adhere to a structure, specified by the option that requires them.
 //
-//- Kubernetes Secrets
-//- Hashicorp Vault
-//- Plaintext files (recommended only for testing)
-//- Secrets must adhere to a structure, specified by the option that requires them.
-//
-//Gloo's secret backend can be configured in Gloo's bootstrap options
+// Gloo's secret backend can be configured in Gloo's bootstrap options
 type Secret struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to Kind:
+	//
 	//	*Secret_Aws
 	//	*Secret_Azure
 	//	*Secret_Tls
@@ -222,56 +222,63 @@ func (*Secret_Credentials) isSecret_Kind() {}
 
 func (*Secret_Extensions) isSecret_Kind() {}
 
+// There are two ways of providing AWS secrets:
 //
-//
-//There are two ways of providing AWS secrets:
-//
-//- Method 1: `glooctl create secret aws`
+// - Method 1: `glooctl create secret aws`
 //
 // ```
-// glooctl create secret aws --name aws-secret-from-glooctl \
-//     --namespace default \
-//     --access-key $ACC \
-//     --secret-key $SEC
+//
+//	glooctl create secret aws --name aws-secret-from-glooctl \
+//	    --namespace default \
+//	    --access-key $ACC \
+//	    --secret-key $SEC
+//
 // ```
 //
-//will produce a Kubernetes resource similar to this (note the `aws` field and `resource_kind` annotation):
+// will produce a Kubernetes resource similar to this (note the `aws` field and `resource_kind` annotation):
 //
 // ```
 // apiVersion: v1
 // data:
-//   aws: base64EncodedStringForMachineConsumption
+//
+//	aws: base64EncodedStringForMachineConsumption
+//
 // kind: Secret
 // metadata:
-//   annotations:
-//     resource_kind: '*v1.Secret'
-//   creationTimestamp: "2019-08-23T15:10:20Z"
-//   name: aws-secret-from-glooctl
-//   namespace: default
-//   resourceVersion: "592637"
-//   selfLink: /api/v1/namespaces/default/secrets/secret-e2e
-//   uid: 1f8c147f-c5b8-11e9-bbf3-42010a8001bc
+//
+//	annotations:
+//	  resource_kind: '*v1.Secret'
+//	creationTimestamp: "2019-08-23T15:10:20Z"
+//	name: aws-secret-from-glooctl
+//	namespace: default
+//	resourceVersion: "592637"
+//	selfLink: /api/v1/namespaces/default/secrets/secret-e2e
+//	uid: 1f8c147f-c5b8-11e9-bbf3-42010a8001bc
+//
 // type: Opaque
 // ```
 //
 // - Method 2: `kubectl apply -f resource-file.yaml`
 //   - If using a git-ops flow, or otherwise creating secrets from yaml files, you may prefer to provide AWS credentials
-//   using the format below, with `aws_access_key_id` and `aws_secret_access_key` fields.
+//     using the format below, with `aws_access_key_id` and `aws_secret_access_key` fields.
 //   - This circumvents the need for the annotation, which are not supported by some tools such as
-//   [godaddy/kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets)
+//     [godaddy/kubernetes-external-secrets](https://github.com/godaddy/kubernetes-external-secrets)
 //
 // ```yaml
 // # a sample aws secret resource-file.yaml
 // apiVersion: v1
 // data:
-//   aws_access_key_id: some-id
-//   aws_secret_access_key: some-secret
+//
+//	aws_access_key_id: some-id
+//	aws_secret_access_key: some-secret
+//
 // kind: Secret
 // metadata:
-//   name: aws-secret-abcd
-//   namespace: default
-// ```
 //
+//	name: aws-secret-abcd
+//	namespace: default
+//
+// ```
 type AwsSecret struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/gloo/pkg/api/v1/settings.pb.go
+++ b/projects/gloo/pkg/api/v1/settings.pb.go
@@ -170,6 +170,7 @@ type Settings struct {
 	// This setting determines where Gloo controllers will store its resources
 	//
 	// Types that are assignable to ConfigSource:
+	//
 	//	*Settings_KubernetesConfigSource
 	//	*Settings_DirectoryConfigSource
 	//	*Settings_ConsulKvSource
@@ -177,6 +178,7 @@ type Settings struct {
 	// Determines where Gloo will read/write secrets from/to.
 	//
 	// Types that are assignable to SecretSource:
+	//
 	//	*Settings_KubernetesSecretSource
 	//	*Settings_VaultSecretSource
 	//	*Settings_DirectorySecretSource
@@ -184,6 +186,7 @@ type Settings struct {
 	// Where to read artifacts from.
 	//
 	// Types that are assignable to ArtifactSource:
+	//
 	//	*Settings_KubernetesArtifactSource
 	//	*Settings_DirectoryArtifactSource
 	//	*Settings_ConsulKvArtifactSource
@@ -2437,6 +2440,7 @@ type GlooOptions_AWSOptions struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to CredentialsFetcher:
+	//
 	//	*GlooOptions_AWSOptions_EnableCredentialsDiscovey
 	//	*GlooOptions_AWSOptions_ServiceAccountCredentials
 	CredentialsFetcher isGlooOptions_AWSOptions_CredentialsFetcher `protobuf_oneof:"credentials_fetcher"`
@@ -2552,8 +2556,8 @@ type GlooOptions_AWSOptions_ServiceAccountCredentials struct {
 	// https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
 	//
 	// If the following environment values are not present in the gateway-proxy, this option cannot be used.
-	//   1. AWS_WEB_IDENTITY_TOKEN_FILE
-	//   2. AWS_ROLE_ARN
+	//  1. AWS_WEB_IDENTITY_TOKEN_FILE
+	//  2. AWS_ROLE_ARN
 	//
 	// The role which will be assumed by the credentials will be the one specified by AWS_ROLE_ARN, however, this
 	// can also be overwritten in the AWS Upstream spec via the role_arn field

--- a/projects/gloo/pkg/api/v1/ssl/ssl.pb.go
+++ b/projects/gloo/pkg/api/v1/ssl/ssl.pb.go
@@ -92,6 +92,7 @@ type SslConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to SslSecrets:
+	//
 	//	*SslConfig_SecretRef
 	//	*SslConfig_SslFiles
 	//	*SslConfig_Sds
@@ -325,6 +326,7 @@ type UpstreamSslConfig struct {
 	unknownFields protoimpl.UnknownFields
 
 	// Types that are assignable to SslSecrets:
+	//
 	//	*UpstreamSslConfig_SecretRef
 	//	*UpstreamSslConfig_SslFiles
 	//	*UpstreamSslConfig_Sds
@@ -449,7 +451,7 @@ type UpstreamSslConfig_SecretRef struct {
 }
 
 type UpstreamSslConfig_SslFiles struct {
-	//  SSLFiles reference paths to certificates which are local to the proxy
+	// SSLFiles reference paths to certificates which are local to the proxy
 	SslFiles *SSLFiles `protobuf:"bytes,2,opt,name=ssl_files,json=sslFiles,proto3,oneof"`
 }
 
@@ -472,6 +474,7 @@ type SDSConfig struct {
 	// Target uri for the sds channel. currently only a unix domain socket is supported.
 	TargetUri string `protobuf:"bytes,1,opt,name=target_uri,json=targetUri,proto3" json:"target_uri,omitempty"`
 	// Types that are assignable to SdsBuilder:
+	//
 	//	*SDSConfig_CallCredentials
 	//	*SDSConfig_ClusterName
 	SdsBuilder isSDSConfig_SdsBuilder `protobuf_oneof:"sds_builder"`

--- a/projects/gloo/pkg/api/v1/upstream.pb.go
+++ b/projects/gloo/pkg/api/v1/upstream.pb.go
@@ -84,7 +84,6 @@ func (Upstream_ClusterProtocolSelection) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_solo_io_gloo_projects_gloo_api_v1_upstream_proto_rawDescGZIP(), []int{0, 0}
 }
 
-//
 // Upstreams represent destination for routing HTTP requests. Upstreams can be compared to
 // [clusters](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto) in Envoy terminology.
 // Each upstream in Gloo has a type. Supported types include `static`, `kubernetes`, `aws`, `consul`, and more.
@@ -116,6 +115,7 @@ type Upstream struct {
 	// to be usable by Gloo. (plugins currently need to be compiled into Gloo)
 	//
 	// Types that are assignable to UpstreamType:
+	//
 	//	*Upstream_Kube
 	//	*Upstream_Static
 	//	*Upstream_Pipe
@@ -126,7 +126,7 @@ type Upstream struct {
 	UpstreamType isUpstream_UpstreamType `protobuf_oneof:"upstream_type"`
 	// Failover endpoints for this upstream. If omitted (the default) no failovers will be applied.
 	Failover *Failover `protobuf:"bytes,18,opt,name=failover,proto3" json:"failover,omitempty"`
-	//HTTP/1 connection configurations
+	// HTTP/1 connection configurations
 	ConnectionConfig *ConnectionConfig `protobuf:"bytes,7,opt,name=connection_config,json=connectionConfig,proto3" json:"connection_config,omitempty"`
 	// Determines how Envoy selects the protocol used to speak to upstream hosts.
 	ProtocolSelection Upstream_ClusterProtocolSelection `protobuf:"varint,25,opt,name=protocol_selection,json=protocolSelection,proto3,enum=gloo.solo.io.Upstream_ClusterProtocolSelection" json:"protocol_selection,omitempty"`
@@ -166,13 +166,13 @@ type Upstream struct {
 	// For example, setting to: host.com:443 and making a request routed to the upstream such as `curl <envoy>:<port>/v1`
 	// would result in the following request:
 	//
-	//    CONNECT host.com:443 HTTP/1.1
-	//    host: host.com:443
+	//	CONNECT host.com:443 HTTP/1.1
+	//	host: host.com:443
 	//
-	//    GET /v1 HTTP/1.1
-	//    host: <envoy>:<port>
-	//    user-agent: curl/7.64.1
-	//    accept: */*
+	//	GET /v1 HTTP/1.1
+	//	host: <envoy>:<port>
+	//	user-agent: curl/7.64.1
+	//	accept: */*
 	//
 	// Note: if setting this field to a hostname rather than IP:PORT, you may want to also set `host_rewrite` on the route
 	HttpProxyHostname *wrappers.StringValue `protobuf:"bytes,21,opt,name=http_proxy_hostname,json=httpProxyHostname,proto3" json:"http_proxy_hostname,omitempty"`

--- a/projects/gloo/pkg/validation/server_test.go
+++ b/projects/gloo/pkg/validation/server_test.go
@@ -500,22 +500,32 @@ var _ = Describe("Validation Server", func() {
 
 			var notifications []*validationgrpc.NotifyOnResyncResponse
 			var l sync.Mutex
-			var desiredErrCode codes.Code
+
+			terminalState := make(chan codes.Code, 1)
 
 			// watch notifications
 			go func() {
 				defer GinkgoRecover()
+				var state codes.Code // ENUM value 0
 				for {
 					notification, err := stream.Recv()
-					if desiredErrCode == 0 {
-						Expect(err).To(BeNil())
-					} else {
+
+					select {
+					case someCode := <-terminalState:
+						state = someCode
+					default:
+
+					}
+					if state != 0 {
 						Expect(err).NotTo(BeNil())
 						st, ok := status.FromError(err)
 						Expect(ok).To(BeTrue())
-						Expect(st.Code()).To(Equal(desiredErrCode))
+						Expect(st.Code()).To(Equal(state))
 						continue
+					} else {
+						Expect(err).To(BeNil())
 					}
+
 					l.Lock()
 					notifications = append(notifications, notification)
 					l.Unlock()
@@ -560,7 +570,7 @@ var _ = Describe("Validation Server", func() {
 			Eventually(getNotifications, time.Second).Should(HaveLen(5))
 
 			// test close
-			desiredErrCode = codes.Unavailable
+			terminalState <- codes.Unavailable
 			srv.Stop()
 
 			// create jitter by changing upstreams

--- a/projects/ingress/pkg/api/v1/ingress.pb.go
+++ b/projects/ingress/pkg/api/v1/ingress.pb.go
@@ -24,8 +24,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//
-//A simple wrapper for a Kubernetes Ingress Object.
+// A simple wrapper for a Kubernetes Ingress Object.
 type Ingress struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache

--- a/projects/ingress/pkg/api/v1/service.pb.go
+++ b/projects/ingress/pkg/api/v1/service.pb.go
@@ -24,8 +24,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
-//
-//A simple wrapper for a Kubernetes Service Object.
+// A simple wrapper for a Kubernetes Service Object.
 type KubeService struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache


### PR DESCRIPTION
# Description

Bump  go version to 1.20. This forces plugins to be rebuilt and ctl extensions to be reloaded. 

Biggest changes include the formatting updates.

This should improve translation speed somewhat but we will benchmark off of the next enterprise release that contains this changeset.

Helm changes as this now uses helm 3 for tests in cloud build which deprecates the way we used to push helm charts to registeries

ee wip: https://github.com/solo-io/solo-projects/pull/5251