### PR TITLE
[1.14] Introduce GHA Go Cache on LTS

### DIFF
--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -2,7 +2,10 @@ name: Cache
 
 on:
   # We utilize this job to seed the GitHub action cache(s) for the LTS branch
-  push: {}
+  push:
+    branches:
+      - 'main'
+      - 'v1.**.x'
 
 jobs:
   go-modules:

--- a/.github/workflows/cache.yaml
+++ b/.github/workflows/cache.yaml
@@ -1,0 +1,27 @@
+name: Cache
+
+on:
+  # We utilize this job to seed the GitHub action cache(s) for the LTS branch
+  push: {}
+
+jobs:
+  go-modules:
+    name: Cache Go Modules
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Cancel Previous Actions
+        uses: styfle/cancel-workflow-action@0.11.0
+        with:
+          access_token: ${{ github.token }}
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      # This is the crucial step
+      # The setup-go action has caching built-in,
+      # so when this runs, a cache entry will be created, if it does not already exist
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+        id: go

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,14 +1,5 @@
 name: CI
-
-on:
-  # We want to run this check on PRs to ensure that the codegen is up to date
-  pull_request: {}
-  # We utilize this job to seed the GitHub action go cache for the LTS branch
-  # We don't really need this job to run, just that the setup-go action runs
-  # However, since this job exists on all branches, it will be easier to maintain, since
-  # we will not need to update the definition when cutting a new LTS branch
-  push: {}
-
+on: pull_request
 jobs:
   codegen:
     name: codegen check

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,5 +1,14 @@
 name: CI
-on: pull_request
+
+on:
+  # We want to run this check on PRs to ensure that the codegen is up to date
+  pull_request: {}
+  # We utilize this job to seed the GitHub action go cache for the LTS branch
+  # We don't really need this job to run, just that the setup-go action runs
+  # However, since this job exists on all branches, it will be easier to maintain, since
+  # we will not need to update the definition when cutting a new LTS branch
+  push: {}
+
 jobs:
   codegen:
     name: codegen check

--- a/changelog/v1.14.15/gha-cache.yaml
+++ b/changelog/v1.14.15/gha-cache.yaml
@@ -3,5 +3,5 @@ changelog:
   issueLink: https://github.com/solo-io/solo-projects/issues/4903
   resolvesIssue: false
   description: >-
-    Enable the codegen job to run on merge to v1.14.x.
+    Introduce a job to run on merge to v1.14.x that will cache the go modules for the v1.14.x branch.
     This will ensure that there exists a go cache entry for the v1.14.x branch, which future PRs can utilize.

--- a/changelog/v1.14.15/gha-cache.yaml
+++ b/changelog/v1.14.15/gha-cache.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/4903
+  resolvesIssue: false
+  description: >-
+    Enable the codegen job to run on merge to v1.14.x.
+    This will ensure that there exists a go cache entry for the v1.14.x branch, which future PRs can utilize.


### PR DESCRIPTION
# Description

Run a job on push to branch, to ensure a go cache entry exists for the LTS branch

## CI changes
- Create a new cache job to run on pushes to LTS branches


# Context
https://github.com/solo-io/solo-apis/pull/847#issuecomment-1552915687

We need to introduce this "on push" trigger on the branch that is performing the action, not just on the main branch

I specified the branch regex, because otherwise, if you just use "on push", all pushes to all branches will re-run this. We only want to run this on a push to an LTS branch

## Interesting decisions
 
There are 2 ways (as I see it) that we can have a job run on push to the branch:
1. Introduce a new job, that only runs on push
2. Re-use an existing job, and have it run on push

When deciding, I wanted to really focus on:
- Efficiency (let's avoid running jobs unnecessarily when we can)
- Maintainability (let's avoid introducing a maintenance burden every time we cut an LTS branch)

At first I went with Option 2. I modified the codegen job to run on pushes to main. This has the benefit of re-using an existing job, and a low maintenance burden, because we can add this to the main branch, and leave it as is, when we cut LTS branches. The downside is it runs a 5 minute job that is unnecessary. Also, if we need other caches reset/seeded, the codegen job might not provide that. As a result, I opted for Option 1. 

The value I see is:
- We control what runs, so we can run the minimal code (just setup-go for now)
- If we need to expand what we cache, we can easily update the new job, since it's sole responsibility is maintaining the caches
- We can add this to the main branch and don't need to modify it when we cut new branches so it's maintainable

## Testing steps

It's not really possible to test this without merging this code.

I did however, introduce this without a filter on the branches it should run on, and you can see that it correctly created the cache: 
<img width="1298" alt="Screen Shot 2023-08-03 at 9 26 42 AM" src="https://github.com/solo-io/gloo/assets/5279627/b31b8050-2abc-443c-b72c-7a4156b17897">

## Follow-Up
After this merges, we can then test this, and ensure PRs against this LTS branch benefit from caching. For a list of next steps, see https://github.com/solo-io/solo-projects/issues/4903#issuecomment-1664194821

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works