### PR TITLE
[1.16] Introduce GHA Cache on Main

### DIFF
--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -1,0 +1,18 @@
+name: Cache
+
+on:
+  # We utilize this job to seed the GitHub action cache(s) for the LTS branch
+  push:
+    branches:
+      - 'main'
+      - 'v1.**.x'
+
+jobs:
+  setup-mod-cache:
+    name: Setup Go Modules Cache
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+    - name: Prep Go Runner
+      uses: ./.github/workflows/composite-actions/prep-go-runner

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -7,8 +7,10 @@ jobs:
     name: codegen check
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: ./.github/workflows/composite-actions/prep-go-runner
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+      - name: Prep Go Runner
+        uses: ./.github/workflows/composite-actions/prep-go-runner
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/composite-actions/prep-go-runner/action.yaml
+++ b/.github/workflows/composite-actions/prep-go-runner/action.yaml
@@ -1,37 +1,62 @@
 name: Prep Go Runner
-description: common setup steps for gloo actions
+
+description: Common setup steps for Gloo actions
+
 inputs:
   working-directory:
     description: 'directory to run setup steps in'
     required: false
     default: '.'
+
 runs:
   using: "composite"
   steps:
-  - name: Cancel Previous Actions
-    uses: styfle/cancel-workflow-action@0.11.0
-    with:
-      access_token: ${{ github.token }}
-  - name: Free disk space
-    shell: bash
-    run: |
-      echo "Before clearing disk space:"
-      df -h
-
-      # https://github.com/actions/virtual-environments/issues/709
-      sudo apt-get clean
-
-      # Clean up pre-installed tools
-      # https://github.com/actions/virtual-environments/issues/1918
-      sudo rm -rf /usr/share/dotnet
-      sudo rm -rf /opt/ghc
-      sudo rm -rf /usr/local/share/boost
-      sudo rm -rf $AGENT_TOOLSDIRECTORY
-
-      echo "After clearing disk space:"
-      df -h
-  - name: Set up Go
-    uses: actions/setup-go@v4
-    with:
-      go-version-file: ${{ inputs.working-directory }}/go.mod
-    id: go
+    - name: Cancel Previous Actions
+      uses: styfle/cancel-workflow-action@0.11.0
+      with:
+        access_token: ${{ github.token }}
+    - name: Free disk space
+      shell: bash
+      run: |
+        echo "Before clearing disk space:"
+        df -h
+        
+        # https://github.com/actions/virtual-environments/issues/709
+        sudo apt-get clean
+        
+        # Clean up pre-installed tools
+        # https://github.com/actions/virtual-environments/issues/1918
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /opt/ghc
+        sudo rm -rf /usr/local/share/boost
+        sudo rm -rf $AGENT_TOOLSDIRECTORY
+        
+        echo "After clearing disk space:"
+        df -h
+    - name: Set up Go
+      id: setup-go
+      uses: actions/setup-go@v4
+      with:
+        # https://github.com/actions/setup-go/blob/main/action.yml
+        go-version-file: ${{ inputs.working-directory }}/go.mod
+        # Using the go-version-file, we will build with the latest go patch version
+        check-latest: true
+        # Caching in setup-go is limited, so we opt to use the more configurable https://github.com/actions/cache
+        cache: false
+    - name: Go Cache Paths
+      id: go-cache-paths
+      shell: bash
+      run: |
+        echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+    - name: Cache
+      uses: actions/cache@v3
+      id: cache
+      with:
+        # https://github.com/actions/cache/blob/main/examples.md#go---modules
+        path: |
+          ${{ steps.go-cache-paths.outputs.go-mod }}
+        key: ${{ runner.os }}-go-${{ steps.setup-go.outputs.go-version }}-${{ hashFiles('**/go.sum') }}
+    - name: Install Dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: make mod-download

--- a/.github/workflows/composite-actions/regression-tests/action.yaml
+++ b/.github/workflows/composite-actions/regression-tests/action.yaml
@@ -5,33 +5,8 @@ description: Tests which run Gloo Edge in a Kubernetes cluster
 runs:
   using: "composite"
   steps:
-  - name: Cancel Previous Actions
-    uses: styfle/cancel-workflow-action@0.11.0
-    with:
-      access_token: ${{ github.token }}
-  - name: Free disk space
-    shell: bash
-    run: |
-      echo "Before clearing disk space:"
-      df -h
-
-      # https://github.com/actions/virtual-environments/issues/709
-      sudo apt-get clean
-
-      # Clean up pre-installed tools
-      # https://github.com/actions/virtual-environments/issues/1918
-      sudo rm -rf /usr/share/dotnet
-      sudo rm -rf /opt/ghc
-      sudo rm -rf /usr/local/share/boost
-      sudo rm -rf $AGENT_TOOLSDIRECTORY
-
-      echo "After clearing disk space:"
-      df -h
-  - name: Set up Go
-    uses: actions/setup-go@v4
-    with:
-      go-version-file: go.mod
-    id: go
+  - name: Prep Go Runner
+    uses: ./.github/workflows/composite-actions/prep-go-runner
   - name: Install kind
     uses: helm/kind-action@v1.5.0
     with:

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -65,7 +65,8 @@ jobs:
           repository: solo-io/gloo
           path: gloo
           ref: ${{ env.SOURCE_COMMIT }}
-      - uses: ./gloo/.github/workflows/composite-actions/prep-go-runner
+      - name: Prep Go Runner
+        uses: ./.github/workflows/composite-actions/prep-go-runner
         with:
           working-directory: gloo
       - name: Install Protoc

--- a/Makefile
+++ b/Makefile
@@ -110,11 +110,15 @@ fmt:
 fmt-changed:
 	git diff --name-only | grep '.*.go$$' | xargs -- goimports -w
 
-# must be a seperate target so that make waits for it to complete before moving on
+# must be a separate target so that make waits for it to complete before moving on
 .PHONY: mod-download
 mod-download: check-go-version
 	go mod download all
 
+
+.PHONY: mod-tidy
+mod-tidy:
+	go mod tidy
 
 # https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md
 .PHONY: install-go-tools

--- a/Makefile
+++ b/Makefile
@@ -115,11 +115,6 @@ fmt-changed:
 mod-download: check-go-version
 	go mod download all
 
-
-.PHONY: mod-tidy
-mod-tidy:
-	go mod tidy
-
 # https://github.com/go-modules-by-example/index/blob/master/010_tools/README.md
 .PHONY: install-go-tools
 install-go-tools: mod-download ## Download and install Go dependencies

--- a/changelog/v1.15.0-rc4/gha-cache.yaml
+++ b/changelog/v1.15.0-rc4/gha-cache.yaml
@@ -1,0 +1,21 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/4903
+  resolvesIssue: false
+  description: >-
+    Introduce a job to run on merge to v1.13.x that will cache the go modules for the v1.13.x branch.
+    This will ensure that there exists a go cache entry for the v1.13.x branch, which future PRs can utilize.
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/4903
+  resolvesIssue: false
+  description: >-
+    Update the cache to only track the mod cache and use the go.sum to determine if the cache is valid.
+    Remove the existing build cache. It wasn't clear if this cache was functioning properly, and it's
+    more important that we have clear cache behaviors, than CI that runs quickly but caches improperly.
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/4903
+  resolvesIssue: false
+  description: >-
+    Validate that a cache hit occurs when opening a PR with no dependency changes.
+    Cleanup the prep-go-runner action to not call `mod-download` on a cache hit. The impact is minimal,
+    since there is nothing to download, but the syntax was wrong and needed to be fixed.

--- a/changelog/v1.16.0-beta1/gha-cache.yaml
+++ b/changelog/v1.16.0-beta1/gha-cache.yaml
@@ -3,8 +3,8 @@ changelog:
   issueLink: https://github.com/solo-io/solo-projects/issues/4903
   resolvesIssue: false
   description: >-
-    Introduce a job to run on merge to v1.13.x that will cache the go modules for the v1.13.x branch.
-    This will ensure that there exists a go cache entry for the v1.13.x branch, which future PRs can utilize.
+    Introduce a job to run on merge to main that will cache the go modules for the main branch.
+    This will ensure that there exists a go cache entry for the main branch, which future PRs can utilize.
 - type: NON_USER_FACING
   issueLink: https://github.com/solo-io/solo-projects/issues/4903
   resolvesIssue: false


### PR DESCRIPTION
# Description

Run a job on push to branch, to ensure a go cache entry exists for the main branch

**This is a forwardport of work introduced into 1.14**

## CI changes
- Create a new cache job to run on pushes to LTS branches
- Update existing jobs to use a composite-action

# Context
https://github.com/solo-io/solo-apis/pull/847#issuecomment-1552915687

## 1.14 Changes
The work that merged into 1.14 was introduced in the following segments:
- https://github.com/solo-io/gloo/pull/8535
- https://github.com/solo-io/gloo/pull/8538
- https://github.com/solo-io/gloo/pull/8545

## Interesting decisions
I followed the same patterns/decisions as the changes in the 1.14 branch
 
## Testing steps
Since this was tested for 1.14, we assume this will work, but it is good to verify. This can be done after this PR merges.

## Follow-Up
After this merges, we can then test this, and ensure PRs against this LTS branch benefit from caching.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works