### PR TITLE
ci: Update builders to match enterprise

### DIFF
--- a/changelog/v1.14.15/cloud-builders-bump.yaml
+++ b/changelog/v1.14.15/cloud-builders-bump.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: cloud-builders
+  dependencyTag: v0.6.4
+  issueLink: https://github.com/solo-io/solo-projects/issues/5215
+  resolvesIssue: false
+  description: >-
+    Use the latest cloud builders to match go version of builder to that of enterprise

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.4'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -44,7 +44,7 @@ steps:
   - 'us-central1-a'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   id: 'docker-push-extended'
   args:
   - 'docker-push-extended'
@@ -65,7 +65,7 @@ steps:
   waitFor:
   - 'docker-push-extended'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   id: 'release-chart'
   dir: *dir
   args:
@@ -82,7 +82,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.4'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -23,7 +23,7 @@ steps:
     cd /go/pkg
     gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   id: 'prepare-envoy'
   dir: *dir
   entrypoint: 'bash'
@@ -68,7 +68,7 @@ steps:
   waitFor:
   - 'prepare-gcr-zone'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
   id: 'prepare-test-tools'
   dir: *dir
   args:
@@ -79,7 +79,7 @@ steps:
   - 'prepare-gcr-zone'
   - 'prepare-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
   id: 'run-tests'
   dir: *dir
   entrypoint: 'make'
@@ -90,7 +90,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.2'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
   id: 'run-e2e-tests'
   dir: *dir
   entrypoint: 'make'


### PR DESCRIPTION
https://github.com/solo-io/gloo/pull/8557

Update builders for releases to match enterprise to have the newest 1.20 go patch release used in builds.

This should update all 0.6.2 references to solo cloud builder assets to 0.6.4

This can be tested by release and sanity checked by looking at ee code base.