### PR TITLE
Fix solo-apis action and small addition to rlc translation fix.

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -66,7 +66,7 @@ jobs:
           path: gloo
           ref: ${{ env.SOURCE_COMMIT }}
       - name: Prep Go Runner
-        uses: ./.github/workflows/composite-actions/prep-go-runner
+        uses: ./gloo/.github/workflows/composite-actions/prep-go-runner
         with:
           working-directory: gloo
       - name: Install Protoc

--- a/changelog/v1.16.0-beta2/gha-fix.yaml
+++ b/changelog/v1.16.0-beta2/gha-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Provide correct path for sub-actions in the action to create solo-apis PRs.
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8573
+    resolvesIssue: false
+    description: Add a default case when converting Solo ratelimit actions to Enovy actions.

--- a/projects/gloo/pkg/plugins/ratelimit/raw_util.go
+++ b/projects/gloo/pkg/plugins/ratelimit/raw_util.go
@@ -166,6 +166,8 @@ func convertAction(ctx context.Context, action *solo_rl.Action) (*envoy_config_r
 				Source:       envoy_config_route_v3.RateLimit_Action_MetaData_Source(specificAction.Metadata.GetSource()),
 			},
 		}
+	default:
+		return nil, eris.Errorf("Unknown action type")
 	}
 
 	return &retAction, nil


### PR DESCRIPTION
# Description
Use the correct path for the composite actions when actions have a different working directory.
Add a default case when translating ratelimit actions. In addition to missing fields, it's also possible to define config for an action that can't be cast. Without a default case, we give Envoy an empty action that makes it unhappy.
# Context

Failed solo-apis run: https://github.com/solo-io/gloo/actions/runs/5860985506