### PR TITLE
ci: Fix check skip directives script

### DIFF
--- a/changelog/v1.16.0-beta3/fix-check-skip-directives.yaml
+++ b/changelog/v1.16.0-beta3/fix-check-skip-directives.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix process-skip-directive script that checks against main instead of the base branch.
+

--- a/changelog/v1.16.0-beta3/fix-check-skip-directives.yaml
+++ b/changelog/v1.16.0-beta3/fix-check-skip-directives.yaml
@@ -1,4 +1,7 @@
 changelog:
   - type: NON_USER_FACING
-    description: Fix process-skip-directive script that checks against main instead of the base branch.
+    description: >-
+      Fix process-skip-directive script that checks against main instead of the base branch.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true
 

--- a/ci/github-actions/process-skip-directives/script.sh
+++ b/ci/github-actions/process-skip-directives/script.sh
@@ -23,14 +23,14 @@ shouldSkipDocsBuild=false
 
 githubBaseRef=$1
 
-if [[ $(git diff origin/$githubBaseRef HEAD --name-only | grep "changelog/" | wc -l) = "1" ]]; then
+changelog=$(git diff origin/$githubBaseRef HEAD --name-only | grep "changelog/")
+if [[ $(echo $changelog | wc -l | tr -d ' ') = "1" ]]; then
     echo "exactly one changelog added since main"
-    changelogFileName=$(git diff origin/main HEAD --name-only | grep "changelog/")
-    echo "changelog file name == $changelogFileName"
-    if [[ $(cat $changelogFileName | grep $skipKubeTestsDirective) ]]; then
+    echo "changelog file name == $changelog"
+    if [[ $(cat $changelog | grep $skipKubeTestsDirective) ]]; then
         shouldSkipKubeTests=true
     fi
-    if [[ $(cat $changelogFileName | grep $skipDocsBuildDirective) ]]; then
+    if [[ $(cat $changelog | grep $skipDocsBuildDirective) ]]; then
         shouldSkipDocsBuild=true
     fi
 else


### PR DESCRIPTION
# Description

This fixes a bug in [process-skip-directives script](https://github.com/solo-io/gloo/blob/main/ci/github-actions/process-skip-directives/script.sh#L28) that checks the changelog from main instead of the base branch

# Context

This causes issues when raising PRs against older branches as this can result in including changelogs from main which may contain the skip directives that can lead to kube tests being skipped

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->