### PR TITLE
Fix push to solo-apis syntax

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -83,10 +83,10 @@ jobs:
           path: gloo
           ref: ${{ env.RELEASE_TAG_NAME }}
       - name: Set up Go
-          uses: actions/setup-go@v4
-          with:
-            go-version-file: gloo/go.mod
-          id: go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: gloo/go.mod
+        id: go
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/changelog/v1.13.26/indentation-fix.yaml
+++ b/changelog/v1.13.26/indentation-fix.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix indentation in github action to push to solo-apis.


### PR DESCRIPTION
# Description

I accidentally introduced extra indentation when backporting the change to stop using the prep-go-runner action. I handled the solo-apis change for the last 1.13 release by running the action manually with the action defined on 1.14. This PR fixes the action so it will work on releases.