### PR TITLE
ci: Fix skip directives script failing on merge

### DIFF
--- a/changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml
+++ b/changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix process-skip-directive script that breaks when run after  merge.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true
+


### PR DESCRIPTION
# Description

Fixes the failing https://github.com/solo-io/gloo/blob/main/ci/github-actions/process-skip-directives/script.sh when it runs on merge - caused when githubBaseRef` is not defined
```
Prepare all required actions
Run ./.github/workflows/composite-actions/process-skip-directives
Run ./ci/github-actions/process-skip-directives/script.sh 
+ skipKubeTestsDirective=skipCI-kube-tests:true
+ shouldSkipKubeTests=false
+ skipDocsBuildDirective=skipCI-docs-build:true
+ shouldSkipDocsBuild=false
+ githubBaseRef=
++ git diff origin/ HEAD --name-only
++ grep changelog/
fatal: ambiguous argument 'origin/': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
+ changelog=
Error: Process completed with exit code 1.
```

## CI changes

Fixed the script to not error out when `githubBaseRef` is not defined

# Tests

When the base branch is passed
```
./ci/github-actions/process-skip-directives/script.sh main

+ skipKubeTestsDirective=skipCI-kube-tests:true
+ shouldSkipKubeTests=false
+ skipDocsBuildDirective=skipCI-docs-build:true
+ shouldSkipDocsBuild=false
+ githubBaseRef=main
+ '[' '!' -z main ']'
++ git diff origin/main HEAD --name-only
++ grep changelog/
+ changelog=changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml
+ '[' '!' -z changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml ']'
++ echo changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml
++ wc -l
++ tr -d ' '
+ [[ 1 = \1 ]]
+ echo 'exactly one changelog added since main'
exactly one changelog added since main
+ echo 'changelog file name == changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml'
changelog file name == changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml
++ cat changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml
++ grep skipCI-kube-tests:true
+ [[ -n       skipCI-kube-tests:true ]]
+ shouldSkipKubeTests=true
++ cat changelog/v1.16.0-beta3/fix-check-skip-directives-again.yaml
++ grep skipCI-docs-build:true
+ [[ -n       skipCI-docs-build:true ]]
+ shouldSkipDocsBuild=true
+ echo skip-kube-tests=true
```

When no branch is passed
```
./ci/github-actions/process-skip-directives/script.sh 

+ skipKubeTestsDirective=skipCI-kube-tests:true
+ shouldSkipKubeTests=false
+ skipDocsBuildDirective=skipCI-docs-build:true
+ shouldSkipDocsBuild=false
+ githubBaseRef=
+ '[' '!' -z '' ']'
+ echo skip-kube-tests=false
```

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
