### PR TITLE
[1.15] fp: Remove caching from action to push to solo-apis

### DIFF
--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -65,10 +65,12 @@ jobs:
           repository: solo-io/gloo
           path: gloo
           ref: ${{ env.SOURCE_COMMIT }}
-      - name: Prep Go Runner
-        uses: ./gloo/.github/workflows/composite-actions/prep-go-runner
+      - name: Set up Go
+        uses: actions/setup-go@v4
         with:
-          working-directory: gloo
+          cache: false
+          go-version-file: gloo/go.mod
+        id: go
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/changelog/v1.15.0-rc5/push-solo-apis.yaml
+++ b/changelog/v1.15.0-rc5/push-solo-apis.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Remove caching from the push-solo-apis-branch action.

--- a/changelog/v1.15.0-rc5/push-solo-apis.yaml
+++ b/changelog/v1.15.0-rc5/push-solo-apis.yaml
@@ -1,3 +1,6 @@
 changelog:
   - type: NON_USER_FACING
-    description: Remove caching from the push-solo-apis-branch action.
+    description: >
+      Remove caching from the push-solo-apis-branch action.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

Forward port of https://github.com/solo-io/gloo/pull/8585

Our cache action caches the results of gloo's `go mod download` but this action uses the go.mod from the solo-apis repo. The caching wasn't working and isn't useful.


# Context

https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1692130274771609

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

https://github.com/solo-io/gloo/actions/runs/5880803055

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
