### PR TITLE
Version Assets Properly from Forked Repositories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -601,7 +601,7 @@ ifneq (,$(TEST_ASSET_ID))
 PUBLISH_CONTEXT := PULL_REQUEST
 ifeq ($(shell echo $(git_tag) | egrep "$(tag_regex)"),)
 # Forked repos don't have tags by default, so we create a standard tag for them
-# This only impacts the version of the assets in the PR, so it is ok that it is not a real tag
+# This only impacts the version of the assets used in CI for this PR, so it is ok that it is not a real tag
 VERSION = 1.0.0-$(TEST_ASSET_ID)
 else
 VERSION = $(shell echo $(git_tag) | cut -c 2-)-$(TEST_ASSET_ID) # example: 1.16.0-beta4-{TEST_ASSET_ID}

--- a/Makefile
+++ b/Makefile
@@ -592,7 +592,13 @@ package-chart: generate-helm-files
 # TODO: delete this logic block when we have a github actions-managed release
 ifneq (,$(TEST_ASSET_ID))
 PUBLISH_CONTEXT := PULL_REQUEST
-VERSION := $(shell git describe --tags --abbrev=0 | cut -c 2-)-$(TEST_ASSET_ID)
+MOST_RECENT_TAG := $(shell git describe --tags --abbrev=0 | cut -c 2-) # example: 1.16.0-beta4
+ifeq (,$(MOST_RECENT_TAG))
+# Forked repos don't have tags by default, so we create a standard tag for them
+# This only impacts the version of the assets in the PR, so it is ok that it is not a real tag
+MOST_RECENT_TAG := 1.0.0
+endif
+VERSION := $(MOST_RECENT_TAG)-$(TEST_ASSET_ID)
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -590,12 +590,22 @@ package-chart: generate-helm-files
 #	- Pull Request (we publish unreleased artifacts to be consumed by our Enterprise project)
 #----------------------------------------------------------------------------------
 # TODO: delete this logic block when we have a github actions-managed release
+
+# git_tag is evaluated when is used (recursively expanded variable)
+# https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html#SEC59
+git_tag = $(shell git describe --abbrev=0 --tags)
+# Semantic versioning format https://semver.org/
+tag_regex := ^v([0-9]{1,}\.){2}[0-9]{1,}$
+
 ifneq (,$(TEST_ASSET_ID))
 PUBLISH_CONTEXT := PULL_REQUEST
+ifeq ($(shell echo $(git_tag) | egrep "$(tag_regex)"),)
 # Forked repos don't have tags by default, so we create a standard tag for them
 # This only impacts the version of the assets in the PR, so it is ok that it is not a real tag
-MOST_RECENT_TAG := $(shell git describe --tags --abbrev=0) || v1.0.0 # example: v1.16.0-beta4
-VERSION := $(MOST_RECENT_TAG | cut -c 2-)-$(TEST_ASSET_ID)
+VERSION = 1.0.0-$(TEST_ASSET_ID)
+else
+VERSION = $(git_tag | cut -c 2-)-$(TEST_ASSET_ID) # example: 1.16.0-beta4-{TEST_ASSET_ID}
+endif
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -604,7 +604,7 @@ ifeq ($(shell echo $(git_tag) | egrep "$(tag_regex)"),)
 # This only impacts the version of the assets in the PR, so it is ok that it is not a real tag
 VERSION = 1.0.0-$(TEST_ASSET_ID)
 else
-VERSION = $(git_tag | cut -c 2-)-$(TEST_ASSET_ID) # example: 1.16.0-beta4-{TEST_ASSET_ID}
+VERSION = $(shell echo $(git_tag) | cut -c 2-)-$(TEST_ASSET_ID) # example: 1.16.0-beta4-{TEST_ASSET_ID}
 endif
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 endif

--- a/Makefile
+++ b/Makefile
@@ -592,13 +592,10 @@ package-chart: generate-helm-files
 # TODO: delete this logic block when we have a github actions-managed release
 ifneq (,$(TEST_ASSET_ID))
 PUBLISH_CONTEXT := PULL_REQUEST
-MOST_RECENT_TAG := $(shell git describe --tags --abbrev=0 | cut -c 2-) # example: 1.16.0-beta4
-ifeq (,$(MOST_RECENT_TAG))
 # Forked repos don't have tags by default, so we create a standard tag for them
 # This only impacts the version of the assets in the PR, so it is ok that it is not a real tag
-MOST_RECENT_TAG := 1.0.0
-endif
-VERSION := $(MOST_RECENT_TAG)-$(TEST_ASSET_ID)
+MOST_RECENT_TAG := v1.0.0 || $(shell git describe --tags --abbrev=0) # example: v1.16.0-beta4
+VERSION := $(MOST_RECENT_TAG | cut -c 2-)-$(TEST_ASSET_ID)
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -594,7 +594,7 @@ ifneq (,$(TEST_ASSET_ID))
 PUBLISH_CONTEXT := PULL_REQUEST
 # Forked repos don't have tags by default, so we create a standard tag for them
 # This only impacts the version of the assets in the PR, so it is ok that it is not a real tag
-MOST_RECENT_TAG := v1.0.0 || $(shell git describe --tags --abbrev=0) # example: v1.16.0-beta4
+MOST_RECENT_TAG := $(shell git describe --tags --abbrev=0) || v1.0.0 # example: v1.16.0-beta4
 VERSION := $(MOST_RECENT_TAG | cut -c 2-)-$(TEST_ASSET_ID)
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 endif

--- a/changelog/v1.16.0-beta6/version-no-tags.yaml
+++ b/changelog/v1.16.0-beta6/version-no-tags.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Ensure that PRs from forked repositories can properly version assets. Previously the version depended on
+      tags (which may not exist in a forked repo) and that caused the value of the tag that we send to docker
+      to be invalid.


### PR DESCRIPTION
# Description

Ensure that a PR from a forked repository, can correctly version resources generated in the PR


## CI changes
- Provide a default VERSION, in case `git describe` returns nothing


# Context

## Problem
The `VERSION` variable in the Makefile is used as the source of truth for identifying asset (docker images, helm charts) tags. On releases, this tag is supplied by the manual version that is supplied, but on PRs, we must determine the version dynamically. To do so, and to ensure that each PR has a unique version, we determine the value by the following:
- Use git describe to gather the latest tag
- Append a unique suffix that is provided by cloudbuild

And this ensures that versions on PRs tend to look like: `1.16.0-beta4-12345`, where 12345 is the `TEST_ASSET_ID`.

_This doesn't work however, when `git describe` returns no tags, because the resulting version is `-12345` which is not a valid tag for docker images_

Example logs: https://storage.googleapis.com/solo-public-build-logs/logs.html?buildid=1abb81c6-0985-4012-856d-d338c1936ccb
```
docker buildx build --load  /workspace/gloo/_output/projects/gloo -f /workspace/gloo/_output/projects/gloo/Dockerfile.gloo \
Step #0 - "publish-artifacts": Step #4 - "publish-docker": 	--build-arg GOARCH=amd64 \
Step #0 - "publish-artifacts": Step #4 - "publish-docker": 	--build-arg ENVOY_IMAGE=quay.io/solo-io/envoy-gloo:1.26.4-patch1 \
Step #0 - "publish-artifacts": Step #4 - "publish-docker": 	-t quay.io/solo-io/gloo:-8617 --label quay.expires-after=3w
Step #0 - "publish-artifacts": Step #4 - "publish-docker": ERROR: invalid tag "quay.io/solo-io/gloo:-8617": invalid reference format
```

## Manual Workaround
You just need to pull down the tags from the Gloo project:
```
git remote add gloo https://github.com/solo-io/gloo
git fetch gloo --tags
```

## Solution
Add logic to evalute the tags, and if the resulting value does not match semver regex, default to 1.0.0

## Interesting decisions
-

## Testing steps
### From a Repo Without Tags
I created this PR from a newly forked repo, that does not contain any tags. So by nature of this passing CI, this proves the change works

Logs: https://storage.googleapis.com/solo-public-build-logs/logs.html?buildid=54f85a03-7942-48e5-aab2-72707ac84f0b
```
GO111MODULE=on CGO_ENABLED=0 GOARCH=amd64 GOOS=linux go build -ldflags="-X github.com/solo-io/gloo/pkg/version.Version=1.0.0-8631" -gcflags=all="-N -l" -o /workspace/gloo/_output/projects/gloo/gloo-linux-amd64 projects/gloo/cmd/main.go
```

Alternatively, you can use the following Make commands to validate this behavior:
```
TEST_ASSET_ID=1 make print-VERSION
```

```
fatal: No names found, cannot describe anything.
1.0.0-1
```
_Note: That fatal is the result of evaluating git describe, but the VERSION is just 1.0.0-1_

### From a Repo With Tags
After the above validation was complete, I updated my fork to pull down the tags in the upstream gloo repo:
```
git remote add gloo https://github.com/solo-io/gloo
git fetch gloo --tags
```

Now printing the value of the version returns:
```
TEST_ASSET_ID=1 make print-VERSION
```

```
1.16.0-beta5-1
```


## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works