### PR TITLE
Advise using HttpClientBuilder when testing network (L4) filters

### DIFF
--- a/changelog/v1.16.0-beta6/update-testclient-docs.yaml
+++ b/changelog/v1.16.0-beta6/update-testclient-docs.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Adding comments to testutils.DefaultClient detailing the consequences of it caching TCP connections and to instead create a new client everytime when testing network (L4) filters
+    skipCI-kube-tests:true
+    skipCI-docs-build:true
+

--- a/test/testutils/http_client.go
+++ b/test/testutils/http_client.go
@@ -20,6 +20,8 @@ import (
 //
 // The solution would be to increase the client timeout defined below. We chose 2 seconds as a reasonable
 // default which allows tests to pass consistently.
+// Since http.Client caches TCP connections, it is advised to create a new client via DefaultClientBuilder().Build()
+// each time while testing any feature that operates at L4 to avoid TCP connection caching issues.
 var DefaultHttpClient = &http.Client{
 	Timeout: time.Second * 2,
 }
@@ -34,6 +36,8 @@ type HttpClientBuilder struct {
 }
 
 // DefaultClientBuilder returns an HttpClientBuilder with some default values
+// Since http.Client caches TCP connections, it is advised to create a new client each time
+// while testing any feature that operates at L4.
 func DefaultClientBuilder() *HttpClientBuilder {
 	return &HttpClientBuilder{
 		timeout:    DefaultHttpClient.Timeout,


### PR DESCRIPTION
# Description

Add comments to testutils.DefaultHttpClient && testutils.DefaultClientBuilder detailing the consequences of it caching TCP connections and to instead create a new client everytime when testing network (L4) filters

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->