### PR TITLE
GHA timeouts 1.15

### DIFF
--- a/.github/workflows/add-pr-label.yaml
+++ b/.github/workflows/add-pr-label.yaml
@@ -7,6 +7,7 @@ jobs:
   add-label:
     name: Add `keep pr updated` Label
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Detect Community PR
         id: community-pr-check

--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -1,4 +1,4 @@
-name: Cache
+name: Cache Setup
 
 on:
   # We utilize this job to seed the GitHub action cache(s) for the LTS branch
@@ -11,6 +11,7 @@ jobs:
   setup-mod-cache:
     name: Setup Go Modules Cache
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,4 +1,4 @@
-name: Codegen
+name: Static Code Analysis
 
 on: pull_request
 
@@ -6,6 +6,7 @@ jobs:
   codegen:
     name: codegen check
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -22,6 +22,7 @@ jobs:
   prepare_env:
     name: Prepare Environment
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       should-build-docs: ${{ steps.build-strategy.outputs.build_value }}
       version: ${{ steps.version.outputs.value }}}
@@ -88,6 +89,7 @@ jobs:
     env:
       VERSION: ${{ needs.prepare_env.outputs.version }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/issue_board.yaml
+++ b/.github/workflows/issue_board.yaml
@@ -9,6 +9,7 @@ jobs:
   add-to-project:
     name: Add Gloo OSS issue to Gloo Edge or Docs project board
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/add-to-project@main
         with:

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -22,6 +22,7 @@ jobs:
     name: latest main regression tests
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression) || github.event.schedule == '0 5 * * 1-5' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     # Previously, there was an environment variable, RELEASED_VERSION="LATEST" set.  This made use of some internal code:
     #       https://github.com/solo-io/gloo/blob/main/test/kube2e/util.go#L229-L241
     # which modified our testing process to pull the latest beta release.
@@ -41,6 +42,7 @@ jobs:
     name: latest performance tests
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance) || github.event.schedule == '0 5 * * 1-5' }}
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/composite-actions/prep-go-runner
@@ -50,6 +52,7 @@ jobs:
     name: v1.14.x regression tests
     if: github.event.schedule == '10 10 * * 1'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +69,7 @@ jobs:
     name: v1.13.x regression tests
     if: github.event.schedule == '6 6 * * 1'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +84,7 @@ jobs:
 
   publish_results:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     if: ${{ always() }}
     needs: [ regression_tests_latest_main, performance_tests_latest_main, regression_tests_14, regression_tests_13 ]
     steps:

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -20,6 +20,7 @@ jobs:
   prepare-env:
     name: Prepare Environment Variables
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       # The Gloo Commit ID that contains the changes we are attempting to mirror
       # On a manual trigger, this is branch name with your changes
@@ -54,6 +55,7 @@ jobs:
       SOLO_APIS_PREFIX: ${{ needs.prepare-env.outputs.solo-apis-prefix }}
     name: Publish Gloo APIs
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - name: Install SSH Deploy key
         uses: webfactory/ssh-agent@v0.4.1

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -1,4 +1,4 @@
-name: CI
+name: Regression Tests
 on: pull_request
 
 env:
@@ -9,6 +9,7 @@ jobs:
   prepare_env:
     name: Prepare Environment
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       should-auto-succeed-regression-tests: ${{ steps.run-strategy.outputs.auto_succeed }}
     steps:
@@ -38,6 +39,7 @@ jobs:
     name: k8s regression tests (${{matrix.kube-e2e-test-type}})
     needs: prepare_env
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     if: ${{ !github.event.pull_request.draft }}
     strategy:
       fail-fast: false

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -1,4 +1,4 @@
-name: security-scan-scheduled
+name: Scheduled Security Scan
 
 on:
   # allow for version to be manually specified under actions page

--- a/changelog/v1.15.3/gha-timeouts.yaml
+++ b/changelog/v1.15.3/gha-timeouts.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Add timeout-minutes to GHA, overriding the default 6 hour timeout with more reasonable values.
+      Also update some action names to be more accurate/legible.
+      
+      skipCI-storybook-tests:true


### PR DESCRIPTION
# Description

Backport #8637

## CI changes
- Set `timeout-minutes` for most GHA jobs
- Update names for certain GHAs to align with EE and/or be more presentable

# Context

## Interesting decisions
 
Removed cache-eviction action, as it is run on main and does not need backporting.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works