### PR TITLE
GHA timeouts 1.13

### DIFF
--- a/.github/workflows/add-pr-label.yaml
+++ b/.github/workflows/add-pr-label.yaml
@@ -7,6 +7,7 @@ jobs:
   add-label:
     name: Add `keep pr updated` Label
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Detect Community PR
         id: community-pr-check

--- a/.github/workflows/cache-setup.yaml
+++ b/.github/workflows/cache-setup.yaml
@@ -1,4 +1,4 @@
-name: Cache
+name: Cache Setup
 
 on:
   # We utilize this job to seed the GitHub action cache(s) for the LTS branch
@@ -11,6 +11,7 @@ jobs:
   setup-mod-cache:
     name: Setup Go Modules Cache
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v3

--- a/.github/workflows/codegen.yaml
+++ b/.github/workflows/codegen.yaml
@@ -1,9 +1,10 @@
-name: CI
+name: Static Code Analysis
 on: pull_request
 jobs:
   codegen:
     name: codegen check
     runs-on: ubuntu-22.04
+    timeout-minutes: 30
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3

--- a/.github/workflows/do-not-submit.yaml
+++ b/.github/workflows/do-not-submit.yaml
@@ -3,6 +3,7 @@ on: pull_request
 jobs:
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     name: Test changed-files
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/push-solo-apis-branch.yaml
+++ b/.github/workflows/push-solo-apis-branch.yaml
@@ -18,6 +18,7 @@ jobs:
   prepare-env:
     name: Prepare Environment Variables
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       # The tag for the release commit (ie v1.8.0)
       release-tag-name: ${{ steps.release-tag-name.outputs.value }}
@@ -50,6 +51,7 @@ jobs:
       SOLO_APIS_PREFIX: ${{ needs.prepare-env.outputs.solo-apis-prefix }}
     name: Publish Gloo APIs
     runs-on: ubuntu-22.04
+    timeout-minutes: 15
     steps:
       - name: Cancel Previous Actions
         uses: styfle/cancel-workflow-action@0.11.0

--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -1,9 +1,10 @@
-name: CI
+name: Regression Tests
 on: pull_request
 jobs:
   prepare_env:
     name: Prepare Environment
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     outputs:
       should-run-regression-tests: ${{ steps.regression-tests.outputs.run_value }}
     steps:
@@ -52,6 +53,7 @@ jobs:
     needs: prepare_env
     if: needs.prepare_env.outputs.should-run-regression-tests == 'true'
     runs-on: ubuntu-22.04
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -63,6 +65,7 @@ jobs:
 
   notify_slack:
     runs-on: ubuntu-22.04
+    timeout-minutes: 5
     if: ${{ github.event_name == 'pull_request' && failure() }}
     needs: [ regression_tests ]
     steps:

--- a/changelog/v1.13.26/gha-timeouts.yaml
+++ b/changelog/v1.13.26/gha-timeouts.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Add timeout-minutes to GHA, overriding the default 6 hour timeout with more reasonable values.
+      Also update some action names to be more accurate/legible.
+      
+      skipCI-storybook-tests:true


### PR DESCRIPTION
# Description

Backport #8637

## CI changes
- Set `timeout-minutes` for most GHA jobs
- Update names for certain GHAs to align with EE and/or be more presentable

# Context

## Interesting decisions
 
Removed cache-eviction action, as it is run on main and does not need backporting.
Also omitted docs-gen, issue_board, nightly-tests, and trivy-analysis-scheduled actions which were not previously present on this LTS branch

Added timeouts to jobs that are not present in more recent versions

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works