### PR TITLE
Fix Version Tagging on PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,7 +595,8 @@ package-chart: generate-helm-files
 # https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html#SEC59
 git_tag = $(shell git describe --abbrev=0 --tags)
 # Semantic versioning format https://semver.org/
-tag_regex := ^v([0-9]{1,}\.){2}[0-9]{1,}$
+# Regex copied from: https://github.com/solo-io/go-utils/blob/16d4d94e4e5f182ca8c10c5823df303087879dea/versionutils/version.go#L338
+tag_regex := v[0-9]+[.][0-9]+[.][0-9]+(-[a-z]+)*(-[a-z]+[0-9]*)?$
 
 ifneq (,$(TEST_ASSET_ID))
 PUBLISH_CONTEXT := PULL_REQUEST

--- a/Makefile
+++ b/Makefile
@@ -602,7 +602,7 @@ PUBLISH_CONTEXT := PULL_REQUEST
 ifeq ($(shell echo $(git_tag) | egrep "$(tag_regex)"),)
 # Forked repos don't have tags by default, so we create a standard tag for them
 # This only impacts the version of the assets used in CI for this PR, so it is ok that it is not a real tag
-VERSION = 1.0.0-$(TEST_ASSET_ID)
+VERSION = 1.0.0-$(TEST_ASSET_ID); echo "WARNING: $(git_tag) not valid semver, using version 1.0.0-$(TEST_ASSET_ID)"
 else
 VERSION = $(shell echo $(git_tag) | cut -c 2-)-$(TEST_ASSET_ID) # example: 1.16.0-beta4-{TEST_ASSET_ID}
 endif

--- a/changelog/v1.16.0-beta8/fix-version-on-prs.yaml
+++ b/changelog/v1.16.0-beta8/fix-version-on-prs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Ensure VERSION includes the most recent git tag, if one is available


### PR DESCRIPTION
# Description

Ensure that the VERSION variable, which corresponds to the tag for docker images that are built on the PR, includes the latest git tag, if one exists

# Context
This is follow up to https://github.com/solo-io/gloo/pull/8631. In that PR, we identified that forked repos, which do not contain git tags, were failing, because we did not properly identify when `git describe` returned an empty string. The testing steps included there worked on a local machine (mac) but did not verify the tag that our CI uses (linux). 

In a slack conversation (https://solo-io-corp.slack.com/archives/C03MFATU265/p1693594894391679?thread_ts=1693492511.156679&cid=C03MFATU265) the behavior of tagging in CI was identified. It did not break the behavior but was a confusing change.

This PR updates the logic to ensure that we abide by the following cases:
- If there are no tags available, we fallback to our `1.0.0-{TEST_ID}` tag. This will be unique per PR since the TEST_ID is unique to a PR, but should only occur on PRs from forked repos without all the tags pulled down
- If there are tags available (regardless of OS), the tag will fit the format `{GIT_TAG}-{TEST_ID}`

## Interesting decisions
I updated the semver we use in the regex (which I believe was failing on linux machines) to match what we use in our go-utils (leveraged by changelog-bot).

## Testing steps

## Mac
```
TEST_ASSET_ID=123 make print-VERSION
```
returns
```
1.16.0-beta6-123
```

## Linux
In CI, you can see that the logs indicate what version is being used to tag assets:
```
-ldflags="-X github.com/solo-io/gloo/pkg/version.Version=1.16.0-beta7-8653"
```

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works