### PR TITLE
Restore tag_regex in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -595,7 +595,8 @@ package-chart: generate-helm-files
 # https://ftp.gnu.org/old-gnu/Manuals/make-3.79.1/html_chapter/make_6.html#SEC59
 git_tag = $(shell git describe --abbrev=0 --tags)
 # Semantic versioning format https://semver.org/
-tag_regex := ^v([0-9]{1,}\.){2}[0-9]{1,}$
+# Regex copied from: https://github.com/solo-io/go-utils/blob/16d4d94e4e5f182ca8c10c5823df303087879dea/versionutils/version.go#L338
+tag_regex := v[0-9]+[.][0-9]+[.][0-9]+(-[a-z]+)*(-[a-z]+[0-9]*)?$
 
 ifneq (,$(TEST_ASSET_ID))
 PUBLISH_CONTEXT := PULL_REQUEST

--- a/changelog/v1.16.0-beta10/restore-tag-regex.yaml
+++ b/changelog/v1.16.0-beta10/restore-tag-regex.yaml
@@ -1,4 +1,4 @@
 changelog:
   - type: NON_USER_FACING
-    issueLink: https://github.com/solo-io/gloo/issues/4675
+    issueLink: https://github.com/solo-io/gloo/issues/8578
     description: Restore tag_regex in Makefile, which was accidentally removed in #8605

--- a/changelog/v1.16.0-beta10/restore-tag-regex.yaml
+++ b/changelog/v1.16.0-beta10/restore-tag-regex.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/4675
+    description: Restore tag_regex in Makefile, which was accidentally removed in #8605


### PR DESCRIPTION
# Description
 - Restore `tag_regex` variable in the top-level Makefile, which was accidentally removed in #8605
 - That PR inadvertenly reverted some changes introduced in https://github.com/solo-io/gloo/pull/8653
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/8578