### PR TITLE
[1.15] Add Vault + AWS IRSA Integration Docs

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         # upgrade tests are run on LTS but not on main branch, for main they are run nightly
         # this is the github action version of ternary op
-        kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade']
+        kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'istio', 'upgrade' ]
         kube-version: [ { node: 'v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72', kubectl: 'v1.27.3', kind: 'v0.20.0', helm: 'v3.12.2' } ]
         merge-to-main:
           - ${{ github.event.pull_request.base.ref == 'main' }}

--- a/changelog/v1.15.6/docs-for-vault-aws-irsa-integration.yaml
+++ b/changelog/v1.15.6/docs-for-vault-aws-irsa-integration.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/8645
+    resolvesIssue: false
+    description: >-
+      Add user-facing docs for Vault + AWS IRSA integration. 
+      skipCI-kube-tests:true

--- a/docs/content/guides/integrations/vault/_index.md
+++ b/docs/content/guides/integrations/vault/_index.md
@@ -1,0 +1,16 @@
+---
+title: Vault Integration
+description: Managing secrets using HashiCorp Vault
+weight: 7
+---
+
+# Overview
+
+Gloo Edge can integrate with HashiCorp Vault to provide an alternative way to manage secrets.
+
+Managing secrets using HashiCorp Vault has many benefits such as:
+- **Centralized Secret Management**: Vault provides a centralized solution for managing secrets which can be accessed across different environments. When you only store secrets in Kubernetes, secret access is limited to a single cluster, which might not be sufficient for complex or multi-cloud architectures.
+- **Advanced Access Control**: Vault offers fine-grained access control and authentication mechanisms, allowing you to define policies which determine who can access and manage secrets.
+- **Security Integrations**: Vault provides multiple methods of securing access to secrets through identity provider integration (IAM, LDAP, OAuth, etc.)
+- **Secret Rotation**: Vault supports secret rotation and TTL (time-to-live) for secrets, which reduces the window or opportunity for attackers to use stolen credentials.
+- **Secret Auditing**: Vault provides a detailed audit log of all secret access and management, which can be used for compliance and security purposes.

--- a/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
+++ b/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
@@ -1,0 +1,234 @@
+---
+title: Securing secrets in Hashicorp Vault using AWS IAM Roles for Service Accounts (IRSA)
+description: Secure your secrets using AWS IAM Roles for Service Accounts (IRSA)
+weight: 1
+---
+
+Vault supports AWS IAM roles for authentication, offering a choice between hard-coded long-lived credentials and automated AWS IAM Roles for Service Accounts (IRSA).
+
+AWS IAM Roles for Service Accounts (IRSA) enable you to associate IAM roles with Kubernetes Service Accounts, allowing automatic retrieval and use of temporary AWS credentials.
+This integration enhances security and operational efficiency, ensuring Kubernetes applications securely access Vault secrets while following AWS IAM best practices.
+
+## AWS
+
+Start by creating the necessary permissions in AWS.
+
+### Step 1: Create a cluster with OIDC
+
+To configure IRSA, create or use an EKS cluster with an associated OpenID Provider (OIDC). For setup instructions, follow [Creating an IAM OIDC provider for your cluster](https://docs.aws.amazon.com/eks/latest/userguide/enable-iam-roles-for-service-accounts.html) in the AWS docs.
+
+Next, export the following environment variables to use throughout your configuration.
+
+```shell
+export NAMESPACE=gloo-system
+# use the cluster name created above
+export CLUSTER_NAME="gloo-ee-vault-integration"
+export AWS_REGION="us-east-1"
+export ACCOUNT_ID=$(aws sts get-caller-identity --query "Account" --output text)
+export OIDC_PROVIDER=$(aws eks describe-cluster --name $CLUSTER_NAME --region $AWS_REGION --query "cluster.identity.oidc.issuer" --output text | sed -e "s/^https:\/\///")
+```
+
+### Step 2: Set up a Role
+
+Create an AWS Role with a trust relationship to your OIDC provider. This allows the provider to assume the AWS IAM role, specifically for the service accounts in `gloo` and `discovery`.
+
+```shell
+cat <<EOF > trust-relationship.json
+{
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Federated": "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+			},
+			"Action": "sts:AssumeRoleWithWebIdentity",
+			"Condition": {
+				"StringEqualsIfExists": {
+					"${OIDC_PROVIDER}:aud": "sts.amazonaws.com",
+					"${OIDC_PROVIDER}:sub": [
+						"system:serviceaccount:${NAMESPACE}:gloo",
+						"system:serviceaccount:${NAMESPACE}:discovery"
+					]
+				}
+			}
+		}
+	]
+}
+EOF
+
+export VAULT_AUTH_ROLE_NAME="dev-role-iam"
+export VAULT_AUTH_ROLE_ARN=$([[ $(aws iam list-roles --query "Roles[?RoleName=='${VAULT_AUTH_ROLE_NAME}'].Arn" --output text) == "" ]] \
+	&& aws iam create-role \
+		--role-name $VAULT_AUTH_ROLE_NAME \
+		--assume-role-policy-document file://trust-relationship.json \
+		--description "Vault auth role" | jq -r .Role.Arn || aws iam list-roles --query "Roles[?RoleName=='${VAULT_AUTH_ROLE_NAME}'].Arn" --output text)
+
+# remove the created file
+rm -f trust-relationship.json
+```
+
+### Step 3: Set a Policy
+
+Create an AWS Policy to grant the necessary permissions for Vault to perform actions, such as assuming the IAM role and getting instance and user information. This is a lighter version of Vault's [Recommended Vault IAM Policy](https://developer.hashicorp.com/vault/docs/auth/aws#recommended-vault-iam-policy).
+
+```shell
+export VAULT_AUTH_POLICY_NAME=gloo-vault-auth-policy
+cat <<EOF > gloo-vault-auth-policy.json
+{
+	"Version": "2012-10-17"
+	"Statement": [
+        {
+			"Sid": "",
+			"Effect": "Allow",
+			"Action": [
+				"iam:GetInstanceProfile",
+				"ec2:DescribeInstances"
+				"iam:GetUser",
+				"iam:GetRole",
+			],
+			"Resource": "*"
+		},
+		{
+			"Effect": "Allow",
+			"Action": ["sts:AssumeRole"],
+			"Resource": ["${VAULT_AUTH_ROLE_ARN}"]
+		}
+	]
+}
+EOF
+
+export VAULT_AUTH_POLICY_ARN=$([[ $(aws iam list-policies --query "Policies[?PolicyName=='${VAULT_AUTH_POLICY_NAME}'].Arn" --output text) == "" ]] \
+    && aws iam create-policy \
+        --region=${AWS_REGION} \
+        --policy-name="${VAULT_AUTH_POLICY_NAME}" \
+        --description="Policy used by the Vault user to check instance identity" \
+        --policy-document file://gloo-vault-auth-policy.json | jq -r .Policy.Arn || aws iam list-policies --query "Policies[?PolicyName=='${VAULT_AUTH_POLICY_NAME}'].Arn" --output text)
+
+rm -f gloo-vault-auth-policy.json
+```
+
+Finally, attach the newly-created policy to the role that you created earlier.
+```shell
+aws iam attach-role-policy --role-name $VAULT_AUTH_ROLE_NAME --policy-arn=${VAULT_AUTH_POLICY_ARN}
+```
+
+## Vault
+
+After you set up your AWS resources, you can configure Vault with AWS authentication.
+
+### Step 1: Set up Vault
+
+Install Vault by choosing one of the installation methods in Vault's [Installing Vault](https://developer.hashicorp.com/vault/docs/install) documentation.
+
+### Step 2: Enable AWS authentication on Vault
+
+```shell
+vault auth enable aws
+```
+
+### Step 3: Enable a secrets engine
+
+```shell
+vault secrets enable -path="dev" -version=2 kv
+```
+
+### Step 4: Create a Vault Policy
+
+```shell
+cat <<EOF > policy.hcl
+# Access to dev path
+path "dev/*" {
+	capabilities = ["create", "read", "update", "delete", "list"]
+} 
+
+# Additional access for UI
+path "dev/" {
+	capabilities = ["list"]
+}
+
+path "sys/mounts" {
+	capabilities = ["read", "list"]
+}
+EOF
+
+vault policy write dev policy.hcl
+rm -f policy.hcl
+```
+
+### Step 5: Configure the AWS authentication method
+
+Next, configure Vault's AWS authentication method to point to the Security Token Service (STS) endpoint for your provider.
+
+In later steps, you add an `iam_server_id_header_value` to secure the authN/authZ process and ensure that it matches with your configuration in Gloo For more information on the IAM Server ID header, see the Vault [API docs](https://developer.hashicorp.com/vault/api-docs/auth/aws#iam_server_id_header_value).
+
+```shell
+export IAM_SERVER_ID_HEADER_VALUE=vault.gloo.example.com
+vault write auth/aws/config/client \
+	iam_server_id_header_value=${IAM_SERVER_ID_HEADER_VALUE} \
+	sts_endpoint=https://sts.${AWS_REGION}.amazonaws.com \
+	sts_region=${AWS_REGION}
+```
+
+### Step 6: Associate the Vault Policy with AWS Role
+
+Finally, bind the Vault authentication and policy to your role in AWS. To use IAM roles, the following command sets the `auth_type` to `iam`.
+
+```shell
+vault write auth/aws/role/dev-role-iam \
+	auth_type=iam \
+    bound_iam_principal_arn="${VAULT_AUTH_ROLE_ARN}" \
+    policies=dev \
+    max_ttl=24h
+```
+
+## Gloo Edge
+
+Lastly, install Gloo Edge by using a configuration that allows Vault and IRSA credential fetching.
+### Step 1: Prepare Helm overrides
+
+Override the default settings to use Vault as a source for managing secrets. To allow for IRSA, add the `eks.amazonaws.com/role-arn` annotations, which reference the roles to assume, to the `gloo` and `discovery` service accounts.
+
+```shell
+cat <<EOF > helm-overrides.yaml
+settings:
+	secretOptions:
+		sources:
+		- vault:
+			# set to address for the Vault instance
+			address: http://vault-internal.vault:8200
+			aws:
+				iamServerIdHeader: ${IAM_SERVER_ID_HEADER_VALUE}
+				mountPath: aws
+				region: ${AWS_REGION}
+			pathPrefix: dev
+gloo:
+	serviceAccount:
+		extraAnnotations: 
+			eks.amazonaws.com/role-arn: ${VAULT_AUTH_ROLE_ARN}
+discovery:
+	serviceAccount:
+		extraAnnotations:
+			eks.amazonaws.com/role-arn: ${VAULT_AUTH_ROLE_ARN}
+EOF
+```
+
+{{% notice note %}}
+If you use Gloo Edge Enterprise, nest these Helm settings within the `gloo` section.
+{{% /notice %}}
+
+
+### Step 2: Install Gloo using Helm
+
+```shell
+export EDGE_VERSION=v1.15.2
+
+helm repo add gloo https://storage.googleapis.com/solo-public-helm
+helm repo update
+helm install gloo gloo/gloo --namespace gloo-system --create-namespace --version $EDGE_VERSION --values helm-overrides.yaml
+```
+
+## Summary
+
+Now, Gloo Edge securely accesses Vault secrets using temporary credentials obtained through AWS IAM Roles for Service Accounts (IRSA).
+This enhances security, streamlines access control, and simplifies authorization within your Kubernetes environment.

--- a/test/e2e/vault_aws_test.go
+++ b/test/e2e/vault_aws_test.go
@@ -23,10 +23,6 @@ const (
 	vaultAwsRegion = "us-east-1"
 
 	vaultRole = "vault-role"
-
-	// The x-vault-awsiam-server-id is used to validate between Vault and AWS.
-	// The value used in our Vault AWS auth settings and in Vault's client config must match.
-	iamServerIdHeader = "vault.gloo.example.com"
 )
 
 var _ = Describe("Vault Secret Store (AWS Auth)", decorators.Vault, func() {
@@ -35,7 +31,6 @@ var _ = Describe("Vault Secret Store (AWS Auth)", decorators.Vault, func() {
 		testContext         *e2e.TestContextWithVault
 		vaultSecretSettings *gloov1.Settings_VaultSecrets
 		oauthSecret         *gloov1.Secret
-		useCredentials      bool
 	)
 
 	BeforeEach(func() {
@@ -72,12 +67,7 @@ var _ = Describe("Vault Secret Store (AWS Auth)", decorators.Vault, func() {
 		testContext.RunVault()
 
 		// We need to turn on Vault AWS Auth after it has started running
-		var err error
-		if useCredentials {
-			err = testContext.VaultInstance().EnableAWSCredentialsAuthMethod(vaultSecretSettings, vaultAwsRole)
-		} else {
-			err = testContext.VaultInstance().EnableAWSSTSAuthMethod(vaultAwsRole, iamServerIdHeader, vaultAwsRegion)
-		}
+		err := testContext.VaultInstance().EnableAWSCredentialsAuthMethod(vaultSecretSettings, vaultAwsRole)
 		Expect(err).NotTo(HaveOccurred())
 
 		testContext.JustBeforeEach()
@@ -89,7 +79,6 @@ var _ = Describe("Vault Secret Store (AWS Auth)", decorators.Vault, func() {
 
 	Context("Vault Credentials", func() {
 		BeforeEach(func() {
-			useCredentials = true
 			localAwsCredentials := credentials.NewSharedCredentials("", "")
 			v, err := localAwsCredentials.Get()
 			Expect(err).NotTo(HaveOccurred(), "can load AWS shared credentials")
@@ -150,77 +139,6 @@ var _ = Describe("Vault Secret Store (AWS Auth)", decorators.Vault, func() {
 			}, "5s", ".5s").Should(Succeed())
 		})
 
-	})
-
-	// TODO(fabiangonz98): Fix these tests
-	Context("STS", func() {
-		BeforeEach(func() {
-			useCredentials = false
-			vaultSecretSettings = &gloov1.Settings_VaultSecrets{
-				Address: testContext.VaultInstance().Address(),
-				AuthMethod: &gloov1.Settings_VaultSecrets_Aws{
-					Aws: &gloov1.Settings_VaultAwsAuth{
-						IamServerIdHeader: iamServerIdHeader,
-						// TODO(fabiangonz98): Example didn't have this set
-						VaultRole: vaultRole,
-						Region:    vaultAwsRegion,
-						MountPath: "aws",
-					},
-				},
-				PathPrefix: bootstrap.DefaultPathPrefix,
-				RootKey:    bootstrap.DefaultRootKey,
-			}
-		})
-
-		// add the extra annotation
-		JustBeforeEach(func() {
-			// can't find helm settings on test start...
-			// need to patch deployment(?) to add the annotation and restart?
-			// gloo.gloo.serviceAccount.extraAnnotations: eks.amazonaws.com/role-arn: arn:aws:iam::802411188784:role/vault-role
-		})
-
-		It("can read secret using resource client", func() {
-			Skip("Need to fix permissions and complete setup")
-			Eventually(func(g Gomega) {
-				secret, err := testContext.TestClients().SecretClient.Read(
-					oauthSecret.GetMetadata().GetNamespace(),
-					oauthSecret.GetMetadata().GetName(),
-					clients.ReadOpts{
-						Ctx: testContext.Ctx(),
-					})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(secret.GetOauth().GetClientSecret()).To(Equal("test"))
-			}, "5s", ".5s").Should(Succeed())
-		})
-
-		It("can pick up new secrets created by vault client ", func() {
-			Skip("Need to fix permissions and complete setup")
-			newSecret := &gloov1.Secret{
-				Metadata: &core.Metadata{
-					Name:      "new-secret",
-					Namespace: writeNamespace,
-				},
-				Kind: &gloov1.Secret_Oauth{
-					Oauth: &v1.OauthSecret{
-						ClientSecret: "new-secret",
-					},
-				},
-			}
-
-			err := testContext.VaultInstance().WriteSecret(newSecret)
-			Expect(err).NotTo(HaveOccurred())
-
-			Eventually(func(g Gomega) {
-				secret, err := testContext.TestClients().SecretClient.Read(
-					newSecret.GetMetadata().GetNamespace(),
-					newSecret.GetMetadata().GetName(),
-					clients.ReadOpts{
-						Ctx: testContext.Ctx(),
-					})
-				g.Expect(err).NotTo(HaveOccurred())
-				g.Expect(secret.GetOauth().GetClientSecret()).To(Equal("new-secret"))
-			}, "5s", ".5s").Should(Succeed())
-		})
 	})
 
 })


### PR DESCRIPTION
_backport of #8647_

# Description

Adds user-facing documentation for Vault as a secret storage using AWS IRSA to handle credential fetching and secret access.

## Code changes
- Removed "STS" test in `test/e2e/vault_aws_test.go`.
    - I originally added it when creating the first ticket, but was minsunderstanding, since we were working with IRSA and required kubernetes cluster(s).

## Docs changes
- Added guide about feature vault integration with AWS IRSA

# Context

We recently removed the need to hard-code credentials when setting aws credentials for vault-as-secret-storage (#8622). This opened up the possibility for customers to make use of AWS IRSA which handles credential fetching. These are docs for said possibility.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works