### PR TITLE
remove 1.11 from scans, docs, issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/DOCS-ISSUE.yml
+++ b/.github/ISSUE_TEMPLATE/DOCS-ISSUE.yml
@@ -12,11 +12,11 @@ body:
       label: Version
       description: Which version of the Gloo Edge docs does this affect?
       options:
-        - main (1.15.x beta)
-        - 1.14.x (latest)
+        - main (1.16.x beta)
+        - 1.15.x (latest)
+        - 1.14.x
         - 1.13.x 
         - 1.12.x
-        - 1.11.x
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
     - 'main'
+    - 'v1.15.x'
     - 'v1.14.x'
     - 'v1.13.x'
     - 'v1.12.x'
-    - 'v1.11.x'
   pull_request:
     branches:
     - 'main'

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -37,7 +37,7 @@ jobs:
         env:
           SCAN_DIR: _output/scans
           IMAGE_REGISTRY: quay.io/solo-io
-          MIN_SCANNED_VERSION: 'v1.11.0' # ⚠️ you should also change docs-gen.yaml ⚠️
+          MIN_SCANNED_VERSION: 'v1.12.0' # ⚠️ you should also change docs-gen.yaml ⚠️
         run: |
           mkdir -p $SCAN_DIR
           make run-security-scan

--- a/Makefile
+++ b/Makefile
@@ -801,7 +801,7 @@ build-test-chart: ## Build the Helm chart and place it in the _test directory
 SCAN_DIR ?= $(OUTPUT_DIR)/scans
 SCAN_BUCKET ?= solo-gloo-security-scans
 # The minimum version to scan with trivy
-MIN_SCANNED_VERSION ?= v1.11.0
+MIN_SCANNED_VERSION ?= v1.12.0
 
 .PHONY: run-security-scans
 run-security-scan:

--- a/changelog/v1.16.0-beta10/remove-1.11-scans.yaml
+++ b/changelog/v1.16.0-beta10/remove-1.11-scans.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Remove 1.11 as supported version from security scans, docs, and issue template 
+      skipCI-kube-tests:true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ HUGO_VERSION := 0.81.0
 SOLO_HUGO_THEME_REVISION := v0.0.25
 
 # The minimum version to maintain in our public docs
-MIN_SCANNED_VERSION ?= v1.11.0
+MIN_SCANNED_VERSION ?= v1.12.0
 
 #----------------------------------------------------------------------------------
 # Docs


### PR DESCRIPTION
# Description

Stop doing security scans for 1.11 and make other cosmetic changes to reflect dropping of support for 1.11

_Fill out any of the following sections that are relevant and remove the others_

## Issue template changes:
- Add 1.15.x as an option for docs issue, remove 1.11.x

## Workflow changes
- Docs gen no longer runs on pushes to 1.11.x and does run on pushes to 1.15.x
- Trivy scans have a minimum version of 1.12.0

## Makefile changes
- Change default value for `MIN_SCANNED_VERSION`, used by `run-security-scans` target, to `v1.12.0`

## Docs changes
- Bump minimum scanned version presented in docs to 1.12.0

# Context

A couple of issues were recently opened regarding a [CVE in 1.11](https://github.com/solo-io/solo-projects/issues/5361) and requesting a [release of 1.11](https://github.com/solo-io/solo-projects/issues/5362)

We no longer support 1.11, as of the release of 1.15.0, and therefore need to update parts our project which hard-code minimum versions

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works