### PR TITLE
[1.15] Helm support for FIPS Discovery image

### DIFF
--- a/changelog/v1.15.7/discovery-fips.yaml
+++ b/changelog/v1.15.7/discovery-fips.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/5367
+    resolvesIssue: false
+    description: >-
+      Update the helm option for enabling FIPS in Enterprise installations, to also apply to the discovery image.
+
+      skipCI-docs-build=true

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -27,7 +27,7 @@ rather than falling back (incorrectly) onto the digests of non-fips images
 */ -}}
 {{ .registry }}/{{ .repository }}-fips:{{ .tag }}@{{ .fipsDigest }}
 {{- else -}}
-{{ .registry }}/{{ .repository }}{{ ternary "-fips" "" ( and (has .repository (list "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" )) (default false .fips)) }}:{{ .tag }}{{ ternary "-extended" "" (default false .extended) }}{{- if .digest -}}@{{ .digest }}{{- end -}}
+{{ .registry }}/{{ .repository }}{{ ternary "-fips" "" ( and (has .repository (list "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" )) (default false .fips)) }}:{{ .tag }}{{ ternary "-extended" "" (default false .extended) }}{{- if .digest -}}@{{ .digest }}{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4928,6 +4928,18 @@ metadata:
 
 					})
 
+					It("supports deploying the fips envoy image", func() {
+						discoveryDeployment.Spec.Template.Spec.Containers[0].Image = "quay.io/solo-io/discovery-ee-fips:" + version
+						prepareMakefile(namespace, helmValues{
+							valuesArgs: []string{
+								"global.image.fips=true",
+								"discovery.deployment.image.repository=discovery-ee",
+							},
+						})
+
+						testManifest.ExpectDeploymentAppsV1(discoveryDeployment)
+					})
+
 					It("can set log level env var", func() {
 						discoveryDeployment.Spec.Template.Spec.Containers[0].Env = append(
 							discoveryDeployment.Spec.Template.Spec.Containers[0].Env,


### PR DESCRIPTION
Backport of: https://github.com/solo-io/gloo/pull/8708

# Description

When enabling FIPS images via Helm, include the discovery image in the list of images which will use the FIPS variant.

# Context

- Listed as non-user facing, since this only applies to Enterprise installs
- Includes a unit test to demonstrate the functionality
- Based off of https://github.com/solo-io/gloo/pull/5158, which is when this Helm API was initially introduced

## Enterprise Work
This Helm adjustment will be backed by enterprise code. https://github.com/solo-io/solo-projects/pull/5368 is an example of what this looked like for another LTS branch.


## Testing steps
- Run helm unit tests
```
TEST_PKG=./install/test/ make test
```

## Notes for reviewers
-

# Checklist:
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works