### PR TITLE
Move to ubuntu based envoy dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.26.4-patch3
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:4a183dc7005c4637be320418831d90e18fa91d32
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:4a183dc7005c4637be320418831d90e18fa91d32
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.26.4-patch4
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/changelog/v1.16.0-beta12/envoy-change.yaml
+++ b/changelog/v1.16.0-beta12/envoy-change.yaml
@@ -1,0 +1,18 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/5344
+    resolvesIssue: false
+    description: > 
+      Migrate from alpine to ubuntu for released version. 
+      Backlogged an issue to move fully to distroless on beta branch.
+      Can be found here https://github.com/solo-io/solo-projects/issues/5388
+      Not migrating prior as this may impact some debugging steps.
+      Forced to migrate per glibc being unable to update.
+      https://nvd.nist.gov/vuln/detail/CVE-2022-23218
+      https://nvd.nist.gov/vuln/detail/CVE-2022-23219
+      https://nvd.nist.gov/vuln/detail/CVE-2021-38604
+      https://nvd.nist.gov/vuln/detail/CVE-2021-3998
+      See here for glibc on alpine maintainers
+      https://gitlab.alpinelinux.org/alpine/tsc/-/issues/43#note_306270
+      https://github.com/sgerrand/alpine-pkg-glibc/issues/207#issuecomment-1707209887
+      https://github.com/sgerrand/alpine-pkg-glibc/issues/176

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -30,7 +30,7 @@ steps:
   args:
   - '-c'
   - |
-    ENVOY_VERSION=$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
+    ENVOY_VERSION=v$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
     gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy.stripped /workspace/envoy
     chmod +x /workspace/envoy
   waitFor:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -30,9 +30,15 @@ steps:
   args:
   - '-c'
   - |
-    ENVOY_VERSION=v$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
-    gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy.stripped /workspace/envoy
-    chmod +x /workspace/envoy
+    { # try to pull release assets first
+      ENVOY_VERSION=v$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
+      gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy.stripped /workspace/envoy
+      chmod +x /workspace/envoy
+    } || { # if that fails, pull from CI
+      ENVOY_VERSION=$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
+      gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy /workspace/envoy
+      chmod +x /workspace/envoy
+    }
   waitFor:
   - 'prepare-workspace'
 

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -30,7 +30,7 @@ steps:
   args:
   - '-c'
   - |
-    ENVOY_VERSION=v$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
+    ENVOY_VERSION=$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
     gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy.stripped /workspace/envoy
     chmod +x /workspace/envoy
   waitFor:

--- a/projects/envoyinit/cmd/Dockerfile.envoyinit
+++ b/projects/envoyinit/cmd/Dockerfile.envoyinit
@@ -3,8 +3,11 @@ ARG ENVOY_IMAGE
 FROM $ENVOY_IMAGE
 
 ARG GOARCH=amd64
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apk -U upgrade
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
 
 COPY envoyinit-linux-$GOARCH /usr/local/bin/envoyinit
 
@@ -13,5 +16,5 @@ COPY docker-entrypoint.sh /
 
 USER 10101
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--", "/docker-entrypoint.sh"]
+ENTRYPOINT [ "/docker-entrypoint.sh"]
 CMD []

--- a/projects/envoyinit/cmd/Dockerfile.envoyinit
+++ b/projects/envoyinit/cmd/Dockerfile.envoyinit
@@ -3,6 +3,8 @@ ARG ENVOY_IMAGE
 FROM $ENVOY_IMAGE
 
 ARG GOARCH=amd64
+# eventually may matter for now https://unix.stackexchange.com/a/701288
+# means its not too useful
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \

--- a/projects/gloo/cmd/Dockerfile
+++ b/projects/gloo/cmd/Dockerfile
@@ -3,10 +3,13 @@ ARG ENVOY_IMAGE
 FROM $ENVOY_IMAGE
 
 ARG GOARCH=amd64
+ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apk upgrade --update-cache \
-    && apk add ca-certificates \
-    && rm -rf /var/cache/apk/*
+RUN apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install --no-install-recommends -y  ca-certificates \
+    && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
+
 
 COPY gloo-linux-$GOARCH /usr/local/bin/gloo
 

--- a/projects/gloo/cmd/Dockerfile
+++ b/projects/gloo/cmd/Dockerfile
@@ -3,6 +3,8 @@ ARG ENVOY_IMAGE
 FROM $ENVOY_IMAGE
 
 ARG GOARCH=amd64
+# eventually may matter for now https://unix.stackexchange.com/a/701288
+# means its not too useful
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \


### PR DESCRIPTION
# Description
Move to an ubuntu based envoy image with plans to introduce distroless in 1.16. 
This is done to avoid cves in glibc that cannot be fixed with our current alpine setup

https://gitlab.alpinelinux.org/alpine/tsc/-/issues/43#note_306270
https://github.com/sgerrand/alpine-pkg-glibc/issues/207#issuecomment-1707209887
https://github.com/sgerrand/alpine-pkg-glibc/issues/176


## Code changes
update docker images for all things with 

# Context

glibc is sort of eol for alpine. or at least looks like it

## Interesting decisions
 
We chose to do it this way to make normal gateway-proxy -> gateway-proxy-debug be a smaller change.
As we intend to backport this to lts branches we wanted the least potential problems and so opted not to go with only distroless to start.

## Testing steps
Gateway-proxy comes up and can handle requests on http and https ports
Gloo pod comes up


# Checklist:

- [ /] I have performed a self-review of my own code
- [ /] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

