### PR TITLE
Better support for unreleased envoy-gloo assets

### DIFF
--- a/changelog/v1.16.0-beta12/unreleased-envoy-gloo-support.yaml
+++ b/changelog/v1.16.0-beta12/unreleased-envoy-gloo-support.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >- 
+      Update CI to better support unreleased assets from envoy-gloo-ee CI builds
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -30,9 +30,15 @@ steps:
   args:
   - '-c'
   - |
-    ENVOY_VERSION=v$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
-    gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy.stripped /workspace/envoy
-    chmod +x /workspace/envoy
+    { # try to pull release assets first
+      ENVOY_VERSION=v$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
+      gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy.stripped /workspace/envoy
+      chmod +x /workspace/envoy
+    } || { # if that fails, pull from CI
+      ENVOY_VERSION=$$(make print-ENVOY_GLOO_IMAGE | cut -d: -f2)
+      gsutil cp gs://solo-public-artifacts.solo.io/envoy/$$ENVOY_VERSION/envoy /workspace/envoy
+      chmod +x /workspace/envoy
+    }
   waitFor:
   - 'prepare-workspace'
 


### PR DESCRIPTION
# Description
 - Update CI to better support unreleased assets from envoy-gloo CI builds
 - envoy-gloo CI builds and tags assets with a commit SHA. This leads to issues when we test unreleased assets in gloo CI, as gloo CI assumes that envoy-gloo assets are tagged in major.minor.patch-label format.
 - This PR introduces a try/except structure to the portion of CI that pulls envoy-gloo assets. First, we try to pull the asset using the major.minor.patch-label format. If that fails, we try to pull the asset using the commit SHA format.

# Context
 - essentially a port of this PR from the closed-source repo: https://github.com/solo-io/solo-projects/pull/5257