### PR TITLE
Add --wait to helm tests and other improvements to support CD tools

### DIFF
--- a/changelog/v1.16.0-beta12/helm-wait.yaml
+++ b/changelog/v1.16.0-beta12/helm-wait.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Most CI tools wait until resources are ready to mark a release as successful such as ArgoCD and Flux. We can emulate this by passing the --wait flag to helm rather than individually adding support for every CD tool out there.
+

--- a/changelog/v1.16.0-beta12/helm-wait.yaml
+++ b/changelog/v1.16.0-beta12/helm-wait.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: Most CI tools wait until resources are ready to mark a release as successful such as ArgoCD and Flux. We can emulate this by passing the --wait flag to helm rather than individually adding support for every CD tool out there.
-

--- a/changelog/v1.16.0-beta13/helm-wait.yaml
+++ b/changelog/v1.16.0-beta13/helm-wait.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Most CI tools wait until resources are ready to mark a release as successful such as ArgoCD and Flux. We can emulate this by passing the --wait flag to helm rather than individually adding support for every CD tool out there.
+

--- a/install/helm/gloo/templates/0-namespace.yaml
+++ b/install/helm/gloo/templates/0-namespace.yaml
@@ -14,4 +14,5 @@ metadata:
     {{- end}}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "-1" # Ensure that this is always the first hook triggered
 {{- end}}

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -4,12 +4,6 @@
 {{- $image = merge .Values.gateway.certGenJob.image .Values.global.image }}
 {{- end }}
 {{- if .Values.global.glooMtls.enabled }}
-{{- /* With ArgoCD, there is no concept or installs or upgrades. Everything is a sync. */}}
-{{- /* This causes an issue when a hook must run on an install but not an upgrade based on a flag. */}}
-{{- /* We address this by creating the job definition for an upgrade only if the flag says so */}}
-{{- /* This is done in the next two lines */}}
-{{- $shouldJobRunOnUpgrade := and .Release.IsUpgrade .Values.gateway.certGenJob.runOnUpdate }}
-{{- if or .Release.IsInstall $shouldJobRunOnUpgrade }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -19,6 +13,8 @@ metadata:
   name: gloo-mtls-certgen
   namespace: {{ .Release.Namespace }}
   annotations:
+    {{- /* With ArgoCD, there is no concept or installs or upgrades. Everything is a sync. */}}
+    {{- /* Due to this behavour of ArgoCD, the value of `gateway.certGenJob.runOnUpdate` can not be respected and will run on every sync. */}}
     {{- if .Values.gateway.certGenJob.runOnUpdate }}
     "helm.sh/hook": pre-install, pre-upgrade
     {{- include "gloo.jobHelmDeletePolicySucceededAndBeforeCreation" .Values.gateway.certGenJob | nindent 4 }}
@@ -75,7 +71,6 @@ spec:
             {{- if .Values.gateway.certGenJob.forceRotation }}
             - "--force-rotation=true"
             {{- end }} {{/* if .Values.gateway.certGenJob.forceRotation */}}
-{{- end }} {{/* if or .Release.IsInstall $shouldCreateOnUpgrade */}}
 {{- end }} {{/* if .Values.global.glooMtls.enabled */}}
 {{- end }} {{/* define gateway.certGenJob.JobSpec*/}}
 

--- a/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
+++ b/install/helm/gloo/templates/19-gloo-mtls-certgen-job.yaml
@@ -4,6 +4,12 @@
 {{- $image = merge .Values.gateway.certGenJob.image .Values.global.image }}
 {{- end }}
 {{- if .Values.global.glooMtls.enabled }}
+{{- /* With ArgoCD, there is no concept or installs or upgrades. Everything is a sync. */}}
+{{- /* This causes an issue when a hook must run on an install but not an upgrade based on a flag. */}}
+{{- /* We address this by creating the job definition for an upgrade only if the flag says so */}}
+{{- /* This is done in the next two lines */}}
+{{- $shouldJobRunOnUpgrade := and .Release.IsUpgrade .Values.gateway.certGenJob.runOnUpdate }}
+{{- if or .Release.IsInstall $shouldJobRunOnUpgrade }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -69,6 +75,7 @@ spec:
             {{- if .Values.gateway.certGenJob.forceRotation }}
             - "--force-rotation=true"
             {{- end }} {{/* if .Values.gateway.certGenJob.forceRotation */}}
+{{- end }} {{/* if or .Release.IsInstall $shouldCreateOnUpgrade */}}
 {{- end }} {{/* if .Values.global.glooMtls.enabled */}}
 {{- end }} {{/* define gateway.certGenJob.JobSpec*/}}
 

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -529,6 +529,17 @@ func installGloo(testHelper *helper.SoloTestHelper, chartUri string, fromRelease
 		args = append(args, chartUri)
 	}
 	args = append(args, "-n", testHelper.InstallNamespace,
+		// As most CD tools wait for resources to be ready before marking the release as successful,
+		// we're emulating that here by passing these two flags.
+		// This way we ensure that we indirectly add support for CD tools
+		"--wait",
+		"--wait-for-jobs",
+		// We run our e2e tests on a kind cluster, but kind hasn’t implemented LoadBalancer support.
+		// This leads to the service being in a pending state.
+		// Since the --wait flag is set, this can cause the upgrade to fail
+		// as helm waits until the service is ready and eventually times out.
+		// So instead we use the service type as ClusterIP to work around this limitation.
+		"--set", "gatewayProxies.gatewayProxy.service.type=ClusterIP",
 		"--create-namespace",
 		"--values", helmValuesFile)
 	if strictValidation {
@@ -566,6 +577,17 @@ func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, crdDir stri
 	defer cleanupFunc()
 
 	var args = []string{"upgrade", testHelper.HelmChartName,
+		// As most CD tools wait for resources to be ready before marking the release as successful,
+		// we're emulating that here by passing these two flags.
+		// This way we ensure that we indirectly add support for CD tools
+		"--wait",
+		"--wait-for-jobs",
+		// We run our e2e tests on a kind cluster, but kind hasn’t implemented LoadBalancer support.
+		// This leads to the service being in a pending state.
+		// Since the --wait flag is set, this can cause the upgrade to fail
+		// as helm waits until the service is ready and eventually times out.
+		// So instead we use the service type as ClusterIP to work around this limitation.
+		"--set", "gatewayProxies.gatewayProxy.service.type=ClusterIP",
 		"-n", testHelper.InstallNamespace,
 		"--values", valueOverrideFile}
 	if targetRelease != "" {

--- a/test/kube2e/upgrade/upgrade_test.go
+++ b/test/kube2e/upgrade/upgrade_test.go
@@ -275,6 +275,17 @@ func installGloo(testHelper *helper.SoloTestHelper, fromRelease string, strictVa
 		"--version", fromRelease)
 
 	args = append(args, "-n", testHelper.InstallNamespace,
+		// As most CD tools wait for resources to be ready before marking the release as successful,
+		// we're emulating that here by passing these two flags.
+		// This way we ensure that we indirectly add support for CD tools
+		"--wait",
+		"--wait-for-jobs",
+		// We run our e2e tests on a kind cluster, but kind hasn’t implemented LoadBalancer support.
+		// This leads to the service being in a pending state.
+		// Since the --wait flag is set, this can cause the upgrade to fail
+		// as helm waits until the service is ready and eventually times out.
+		// So instead we use the service type as ClusterIP to work around this limitation.
+		"--set", "gatewayProxies.gatewayProxy.service.type=ClusterIP",
 		"--create-namespace",
 		"--values", helmValuesFile)
 	if strictValidation {
@@ -306,6 +317,17 @@ func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, targetRelea
 	defer cleanupFunc()
 
 	var args = []string{"upgrade", testHelper.HelmChartName, chartUri,
+		// As most CD tools wait for resources to be ready before marking the release as successful,
+		// we're emulating that here by passing these two flags.
+		// This way we ensure that we indirectly add support for CD tools
+		"--wait",
+		"--wait-for-jobs",
+		// We run our e2e tests on a kind cluster, but kind hasn’t implemented LoadBalancer support.
+		// This leads to the service being in a pending state.
+		// Since the --wait flag is set, this can cause the upgrade to fail
+		// as helm waits until the service is ready and eventually times out.
+		// So instead we use the service type as ClusterIP to work around this limitation.
+		"--set", "gatewayProxies.gatewayProxy.service.type=ClusterIP",
 		"-n", testHelper.InstallNamespace,
 		"--values", valueOverrideFile}
 	if targetReleasedVersion != "" {


### PR DESCRIPTION
# Description

Most CI tools wait until resources are ready to mark a release as successful. Eg. [ArgoCD](https://argo-cd.readthedocs.io/en/stable/operator-manual/health/) and [Flux](https://fluxcd.io/flux/components/helm/helmreleases/#disabling-resource-waiting)
We can emulate this by passing the `--wait` flag to helm rather than individually adding support for every CD tool out there.
This PR adds this flag to the helm tests as well as some tweaks to support ArgoCD

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

I manually verified behavior by ...

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->