### PR TITLE
1.15: Add tests for non custom probes and add wget back

### DIFF
--- a/changelog/v1.15.9/reenable-probes.yaml
+++ b/changelog/v1.15.9/reenable-probes.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8749
+    resolvesIssue: false
+    description: > 
+      Re-enable wget in our gloo and gateway-proxy pods.
+      Wget is currently used in our non-custom probes which are currently not well covered in tests.
+      Caused by https://github.com/solo-io/solo-projects/issues/5344 shift to ubuntu.

--- a/projects/envoyinit/cmd/Dockerfile.envoyinit
+++ b/projects/envoyinit/cmd/Dockerfile.envoyinit
@@ -7,8 +7,11 @@ ARG GOARCH=amd64
 # means its not too useful
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Update our deps to make cve toil lower
+#install wget for our default probes
 RUN apt-get update \
     && apt-get upgrade -y \
+    && apt-get install wget -y \  
     && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
 
 COPY envoyinit-linux-$GOARCH /usr/local/bin/envoyinit

--- a/projects/gloo/cmd/Dockerfile
+++ b/projects/gloo/cmd/Dockerfile
@@ -7,9 +7,12 @@ ARG GOARCH=amd64
 # means its not too useful
 ENV DEBIAN_FRONTEND=noninteractive
 
+# Update our deps to make cve toil lower
+#install wget for our default probes
 RUN apt-get update \
     && apt-get upgrade -y \
     && apt-get install --no-install-recommends -y  ca-certificates \
+    && apt-get install wget -y \ 
     && rm -rf  /var/log/*log /var/lib/apt/lists/* /var/log/apt/* /var/lib/dpkg/*-old /var/cache/debconf/*-old
 
 

--- a/test/kube2e/helm/artifacts/helm.yaml
+++ b/test/kube2e/helm/artifacts/helm.yaml
@@ -35,3 +35,5 @@ gloo:
 gatewayProxies:
   gatewayProxy:
     healthyPanicThreshold: 0
+    podTemplate:
+      probes: true


### PR DESCRIPTION
# Description

Add a failing test for noncustom readiness probes.
Add wget back to ourgloo and gateway-proxy pods


## Code changes
- New Test option
- Docker files get wget



# Context

We do not currently test our default probes. We should.
Ubuntu update broke non-custom probes. This is a quick fix.

Not needed for any alpine setups as it comes with wget by default https://pkgs.alpinelinux.org/package/edge/main/x86/wget 
We probably should consider if we want to update our probes to use curl in the future though.

## Interesting decisions
 
We chose to do things this way because we dont test all of our helm install options fully.

## Testing steps

I manually verified behavior by  checking for wget + sleep in our new docker files.
Added failing test as first commit  and then had it run here with changelog https://github.com/solo-io/gloo/actions/runs/6419883299/job/17430709129

