### PR TITLE
[1.15] fix: Skip directives script failing on no changelog

### DIFF
--- a/changelog/v1.15.9/fix-check-skip-directives-again.yaml
+++ b/changelog/v1.15.9/fix-check-skip-directives-again.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix process-skip-directive script that breaks when there is no changelog.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true
+

--- a/ci/github-actions/process-skip-directives/script.sh
+++ b/ci/github-actions/process-skip-directives/script.sh
@@ -22,19 +22,25 @@ skipDocsBuildDirective="skipCI-docs-build:true"
 shouldSkipDocsBuild=false
 
 githubBaseRef=$1
-
-changelog=$(git diff origin/$githubBaseRef HEAD --name-only | grep "changelog/")
-if [[ $(echo $changelog | wc -l | tr -d ' ') = "1" ]]; then
-    echo "exactly one changelog added since main"
-    echo "changelog file name == $changelog"
-    if [[ $(cat $changelog | grep $skipKubeTestsDirective) ]]; then
-        shouldSkipKubeTests=true
+# If `githubBaseRef` is not present, it means that this script is not running as part of a PR (probably running on a push to main or an LTS branch).
+# In that case we ignore the skip directives since we need to run CI
+if [ ! -z "$githubBaseRef" ]; then
+    # If there is no changelog found, the grep command fails and in turn the entire script exits since the error on exit flag has been set
+    # To avoid that, we are using `|| true` to ensure that even if there is no changelog, it doesn't exit
+    changelog=$(git diff origin/$githubBaseRef HEAD --name-only | grep "changelog/" || true)
+    # An empty string is also one line in bash. Hence adding the first check
+    if [ ! -z "$changelog" ] && [[ $(echo $changelog | wc -l | tr -d ' ') = "1" ]]; then
+        echo "exactly one changelog added since main"
+        echo "changelog file name == $changelog"
+        if [[ $(cat $changelog | grep $skipKubeTestsDirective) ]]; then
+            shouldSkipKubeTests=true
+        fi
+        if [[ $(cat $changelog | grep $skipDocsBuildDirective) ]]; then
+            shouldSkipDocsBuild=true
+        fi
+    else
+        echo "no changelog found (or more than one changelog found) - not skipping CI"
     fi
-    if [[ $(cat $changelog | grep $skipDocsBuildDirective) ]]; then
-        shouldSkipDocsBuild=true
-    fi
-else
-    echo "no changelog found (or more than one changelog found) - not skipping CI"
 fi
 
 echo "skip-kube-tests=${shouldSkipKubeTests}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
# Description

Fixes the failing https://github.com/solo-io/gloo/blob/1.15.x/ci/github-actions/process-skip-directives/script.sh when it runs if there is no changelog

## CI changes
- Fixed process-skip-directives/script.sh

# Context

Contributors ran into this issue when there is no changelog present in their PR and tests do not run

## Testing steps

https://github.com/solo-io/gloo/actions/runs/6420660619/job/17433245951?pr=8751
https://github.com/solo-io/gloo/actions/runs/6420694824/job/17433357462?pr=8751

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->