### PR TITLE
Removing redundant checks in configmaps

### DIFF
--- a/changelog/v1.16.0-beta14/configmap-checks.yaml
+++ b/changelog/v1.16.0-beta14/configmap-checks.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Removes redundant checks in configmaps to keep them consistent across versions. This fix was applied in 1.13.x - 1.15.x but not in main
+

--- a/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/11-ingress-proxy-deployment.yaml
@@ -31,13 +31,11 @@ spec:
         {{- end }}
       annotations:
         checksum/ingress-envoy-config: {{ include (print .Template.BasePath "/12-ingress-proxy-configmap.yaml") . | sha256sum }}
-        {{- if or .Values.ingressProxy.deployment.extraAnnotations .Values.global.istioIntegration.disableAutoinjection }}
         {{- if .Values.ingressProxy.deployment.extraAnnotations }}
         {{- range $key, $value := .Values.ingressProxy.deployment.extraAnnotations }}
         {{ $key }}: {{ $value | quote }}
         {{- end }}
         {{- end }}
-      {{- end }}
     spec:
       {{- include "gloo.pullSecret" $image | nindent 6 -}}
       containers:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -74,7 +74,6 @@ spec:
         # This annotation was introduced to resolve https://github.com/solo-io/gloo/issues/8392
         # It triggers a new rollout of the gateway proxy if the values in this config map changes.
         checksum/{{ $name | kebabcase }}-envoy-config: {{ $gatewaySpec.checksum }}
-        {{- if or ($spec.podTemplate.extraAnnotations) (.Values.global.glooStats.setDatadogAnnotations) }}
       {{- range $key, $value := $spec.podTemplate.extraAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
@@ -84,7 +83,6 @@ spec:
         ad.datadoghq.com/gateway-proxy.instances: '[{"stats_url": "http://%%host%%:8081/stats"}]'
         ad.datadoghq.com/gateway-proxy.logs: '[{"source": "envoy", "service": "gloo","log_processing_rules":[{"type": "multi_line", "name": "log_start_with_date","pattern" : "^\\[[0-9]{4}-[0-9]{2}-[0-9]{2}"}]}]'
       {{- end }}
-{{- end }}
 {{- if $statsConfig.enabled }}
         prometheus.io/path: /metrics
         prometheus.io/port: "8081"


### PR DESCRIPTION
# Description

Forward port of https://github.com/solo-io/gloo/pull/8745/commits/be1bff6a6a641dbfc7d46261e7d0439cc06e53e9
This ensures that the config maps are consistent across branches

In the [previous PR](https://github.com/solo-io/gloo/pull/8733) the redundant checks were not removed but addressed in the backports

# Context

https://github.com/solo-io/gloo/pull/8745#discussion_r1347355063
https://github.com/solo-io/gloo/pull/8745#pullrequestreview-1659752500

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->