### PR TITLE
Do not print full cluster information on cluster validation errors

### DIFF
--- a/changelog/v1.16.0-beta15/do-not-log-envoy-cluster-on-computeCluster.yaml
+++ b/changelog/v1.16.0-beta15/do-not-log-envoy-cluster-on-computeCluster.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8592
+    resolvesIssue: false
+    description: Remove the Envoy cluster from the error log when validating clusters, avoiding the exposure of sensitive data (secrets).

--- a/projects/gloo/pkg/translator/clusters.go
+++ b/projects/gloo/pkg/translator/clusters.go
@@ -71,8 +71,7 @@ func (t *translatorInstance) computeCluster(
 		}
 	}
 	if err := validateCluster(out); err != nil {
-		reports.AddError(upstream, eris.Wrapf(err, "cluster was configured improperly "+
-			"by one or more plugins: %v", out))
+		reports.AddError(upstream, eris.Wrap(err, "cluster was configured improperly by one or more plugins"))
 	}
 	return out
 }


### PR DESCRIPTION
# Description

Updated our error report during cluster computing + validation to not print the Envoy cluster.

This was added in [Gloo 0.5.0](https://github.com/solo-io/gloo/commit/68f091e58125110221cbfe8a2009a6a4c5f83b23), where it was imported from solo-projects. While it's hard to trace the historical _decisions_ for printing the cluster, it should be safe to remove because:
1. Users can view cluster information in config dumps 
2. The the error itself already prints the issue.

As part of a quick-follow, will be looking into other areas we log reports to see if they leak data.

## Code changes

- Removed the cluster (`out`) from being printed during validation error.

# Context

Users ran into this bug when misconfiguring an Upstream with validation on, where the secret inline data was printed in the error. 

## Testing steps

### 1. Install Gloo
**validation-webhook.yaml**
```yaml
gateway:
  enabled: true
  validation:
    enabled: true
    alwaysAcceptResources: false
    allowWarnings: false
    webhook:
      enabled: true
```
#### Without Fix
```shell
helm install gloo gloo/gloo --namespace default --create-namespace --version 1.16.0-beta1 --values validation-webhook.yaml
```

#### With Fix
```shell
make clean install-go-tools && ./ci/kind/setup-kind.sh
```
```shell
helm install gloo _test/gloo-1.0.0-ci.tgz --values validation-webhook.yaml
```

### 2. Create Secret
Generate a TLS secret we can use. It's data is not important, as we don't need to actually test connections.
```shell
openssl req -new -newkey rsa:4096 -x509 -sha256 -days 365 -nodes -out tls.crt -keyout tls.key
```

```bash
k create secret tls upstream-tls --key tls.key --cert tls.crt
```

### 3. Create Upstream
We create an upstream referencing the secret. This is where the issue will *stem* from, where we log the Secret's data. We won't see the validation error / log just yet, until we create a Virtual Service to reference this.
```bash
cat << EOF | kubectl apply -f -
apiVersion: gloo.solo.io/v1
kind: Upstream
metadata:
  name: upstream
  namespace: default
spec:
  discoveryMetadata: {}
  sslConfig:
    secretRef:
      name: upstream-tls
      namespace: default
EOF
```

### 4. Create Virtual Service
By creating a Virtual Service with a reference to the Upstream, validation will occur. We {will/wont} see the issue, depending on if we're testing pre-fix or post-fix.
```bash
cat << EOF | kubectl apply -f -
apiVersion: gateway.solo.io/v1           
kind: VirtualService
metadata:
  name: direct-response
  namespace: default
spec:
  virtualHost:
    domains:
    - '*'
    routes:
    - matchers:
      - prefix: /
      routeAction:
        single:
          upstream:
            name: upstream
            namespace: default
EOF
```

### 5. Results
#### Without Fix
We'll see an admission webhook error which contains information on the TLS certificate used.
```Error
[...]
cluster was configured improperly by one or more plugins: name:"upstream_default"  connect_timeout:{seconds:5}  transport_socket:{name:"envoy.transport_sockets.tls"  typed_config:{[type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext]:{common_tls_context:{tls_certificates:{certificate_chain:{inline_string:"-----BEGIN CERTIFICATE-----\nMIIDHzCCAgegAwIBAgIUJbcUksu0WhBz6pUQElgl8E0bJFowDQYJKoZIhvcNAQEL\nBQAwHzEdMBsGA1UEAwwUcGV0c3RvcmUuZXhhbXBsZS5jb20wHhcNMjMwOTIyMTgy\nODIyWhcNMjQwOTIxMTgyODIyWjAfMR0wGwYDVQQDDBRwZXRzdG9yZS5leGFtcGxl\nLmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAMSglkGoJkAXT4Q/\nGCCv88jXlKHWayKnouPjyabTNS6DCErJY+EFOvXjWjG53TaCZpkBWdjqJA6gu55P\ntzEdLJLRWXc8Qo/AEFEtkSdiK7BJ325zAa93HtbM8spac60M7oyuWjRjmfGUiyH+\n+SNtck3rLKM5+ppWv+1RV33vwYwWT6BMNP2q0I1qNUq1eapx6gCbf0Ufuf0Stri2\nMlvIKRndRHBuEc4+TTMg63exXfObtyU9YRnmQslTQc7hupB37U84ME6JEt5DMxFO\nomNRjdL/nw1w54fXv4ZENGg7J5hceVPoikWs078XsUMXJsZlmBSzTX/ME9Nx+f15\nvkAI09MCAwEAAaNTMFEwHQYDVR0OBBYEFPnMeNH/p+C1ujjvcuVmvrzhwYEqMB8G\nA1UdIwQYMBaAFPnMeNH/p+C1ujjvcuVmvrzhwYEqMA8GA1UdEwEB/wQFMAMBAf8w\nDQYJKoZIhvcNAQELBQADggEBAL873gfatpqnk463o0UA8RqPS2LKJ77UOqRPEF/z\nezzhbDj93vQPDPiTC7LnSfNB1WCxzGbj8W7c/209yqarR4TNayPp2Ev3JVFy4Owx\ntudxZELflHiKdBpy6qz1vW1Mw968vjRIToo8sF7eN2i5FrrzBmugWHYMAsgONAr3\ncTD+Jx/yvMMgJX0AK1IRqZl0t+kSsiqpYmNJ+0Ps470qrvsUmtTERguoGRWU8Mgk\n6G1oXhY4XnnCIxjVfZhHZXWyJfqbL4iSMJtAsvFXVeT7zHHlIi7XEw4MwVLM3UdL\nciJwCZybWQkbOE8jH2S2ftH+Gph4dT/WhiIOrJGsHkOfhwQ=\n-----END CERTIFICATE-----\n"}  private_key:{inline_string:"-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDEoJZBqCZAF0+E\nPxggr/PI15Sh1msip6Lj48mm0zUugwhKyWPhBTr141oxud02gmaZAVnY6iQOoLue\nT7cxHSyS0Vl3PEKPwBBRLZEnYiuwSd9ucwGvdx7WzPLKWnOtDO6Mrlo0Y5nxlIsh\n/vkjbXJN6yyjOfqaVr/tUVd978GMFk+gTDT9qtCNajVKtXmqceoAm39FH7n9Era4\ntjJbyCkZ3URwbhHOPk0zIOt3sV3zm7clPWEZ5kLJU0HO4bqQd+1PODBOiRLeQzMR\nTqJjUY3S/58NcOeH17+GRDRoOyeYXHlT6IpFrNO/F7FDFybGZZgUs01/zBPTcfn9\neb5ACNPTAgMBAAECggEABeAmddNW3LzTc8P7kFuOdFSHO7jNlcTA08TVWBNYgLh5\nMYbqNvrLqjYUkjGgaLk2wj62MJNHXydUXYbc4xj+tsDSrSUoq1yI3ifd2/mE6wbE\nOVrdbjHjwtvExSWKMsQuqRcyrqfjJe2tCxJjaBaCZZqrrrODIURosKyo4SRrMY8J\nK85WbMZqdxUDmbYtpx+ZQpteLapJqbJSjQION1z1H/P7H5goh28UAkW4c2NFRLMA\nA2UsnzUboE2Cu5IMWw5hIwclNqbINvqzwsLrxwgSi+mjMgiF9RcL42vfCjtUCmIh\nyp+zxHAaaA1friMw2bvFFzM9NutXqcvrS3SCWeCrJQKBgQDmXnP9P1kkitGczo0t\nfFPwm9pTIkKakiuAJyORFW0B/eNqBATS6XYlGlIiwh401g6+usNHj6bzOmosS5wG\nwD69A6T2U/ZrhFUC6qV+I1rOBkS7TicEf0yhCCUfhR85p3kRtwyWv5BqRx0IbnlQ\nbe6Vh/DFe9T04Sj0c0y1Ctxy/QKBgQDagRPhE/dxYcf/V34ugrRSuA88ldZkKnj9\n2EC9G3csGNr4oulCA7s5A6uvzSvtVzCUUaizGt1W7fUXuXRPTj4juSXeUmaQ3ROP\nddGx59D/828u/55RB3ZZr/q5cEZSVDa+Js0lZKMcKWELd4eIkVE04995tPsBbcjB\nOm1BDbOjDwKBgGgv/7VhmSd1wSdyI1eXCz+evTcsH4NY6GOlT+imEA7+jIO+HZBm\nFhDhvpQJxy+OQEzymq8awR7wJGS0LXTALZ++rjTZ9HDcALa4+O/7fW4AV8V+qxbV\nnAqYbHG8+0pP++mPKBpluSLX1sGhdSxzC5yFRteKEd5Olv83xlF7AAjhAoGAYMY+\nabeQJjVqgNrdVfgpqWE/zlOGqsJs5/C5a4gYlf1ELk7pBIXmi+/mQGycgffV2jr4\nfqrtUSz/GkzXCLDcsLG15euU5aAko6tI/oRveoz0t1obYkPt1PcuEqd5XclSnZFN\n1rvlyflBs/RyoLfLwaMTPTI84XsgKQSZkvBgmV0CgYEAq81AWpWTqniODvo1cSmg\ndF9/Kd1e8Y15aIst197+1YryjVlJms9H7R8xEq+IevDmlRB7CZrIXwCLUmcckHIx\nxJcmPEzYHMx693PDNGMzvYG/EcOIJDEgmBxkIetCPq+FlMuspoHvhNe2B/3Cafw9\nqVfCF0hkP4v/Ux9Km//HQ9k=\n-----END PRIVATE KEY-----\n"}}}}}}  metadata:{}: cluster type STATIC specified but LoadAssignment was empty
[...]
```

#### With Fix
The cluster (including the secret) is not logged on error.
```Error
cluster was configured improperly by one or more plugins: cluster type STATIC specified but LoadAssignment was empty
```

The upstream information is printed in the full error message
```
[...]
	* Validating *v1.VirtualService failed: validating *v1.VirtualService name:"direct-response"  namespace:"default": failed gloo validation resource reports: 2 errors occurred:
	* invalid resource default.upstream
[...]
```

## Notes for reviewers

This is a small PR for this specific fix to ensure it gets out on latest release.

# Checklist:

- [X] I have performed a self-review of my own code
- [-] I have commented my code, particularly in hard-to-understand areas
- [-] I have made corresponding changes to the documentation
- [-] I have added tests that prove my fix is effective or that my feature works