### PR TITLE
helm: Adding a longer timeout for the resource rollout job to complete

### DIFF
--- a/changelog/v1.15.11/add-timeout-resource-rollout-job.yaml
+++ b/changelog/v1.15.11/add-timeout-resource-rollout-job.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Adding a longer timeout while waiting for the resource rollout job to complete.
+

--- a/install/helm/gloo/templates/5-resource-rollout-job-check.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-check.yaml
@@ -80,7 +80,7 @@ spec:
               if [ $? -eq 0 ]
               then
                 echo "Waiting for the resource rollout job to complete"
-                kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-resource-rollout
+                kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-resource-rollout --timeout=600s || exit 1
               fi
               # Delete the resource rollout job as it can linger around and not be re-created durig an upgrade
               kubectl -n {{ .Release.Namespace }} delete job gloo-resource-rollout


### PR DESCRIPTION
# Description

Adds a longer timeout (600s vs the default is 30s) for the resource rollout job to complete. This can handle cases of slow gloo installs

# Context

If the gloo installation is slow, the wait on the resource rollout check job can timeout and execute before the prior job has been completed

## Interesting decisions
 
N/A

## Testing steps

N/A

## Notes for reviewers

N/A

Please proofread comments on ...

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->