### PR TITLE
[1.14] helm: Adding a longer timeout for the resource rollout job to complete

### DIFF
--- a/changelog/v1.14.23/add-timeout-resource-rollout-job.yaml
+++ b/changelog/v1.14.23/add-timeout-resource-rollout-job.yaml
@@ -1,4 +1,5 @@
 changelog:
-  - type: NON_USER_FACING
-    description: Adding a longer timeout while waiting for the resource rollout job to complete.
+  - type: HELM
+    issue_link: https://github.com/solo-io/gloo/issues/8782
+    description: Adds the helm value `gateway.rolloutJob.timeout` to specifiy the timeout while waiting for the resource rollout job to complete.
 

--- a/changelog/v1.14.23/add-timeout-resource-rollout-job.yaml
+++ b/changelog/v1.14.23/add-timeout-resource-rollout-job.yaml
@@ -1,5 +1,6 @@
 changelog:
   - type: HELM
-    issue_link: https://github.com/solo-io/gloo/issues/8782
-    description: Adds the helm value `gateway.rolloutJob.timeout` to specifiy the timeout while waiting for the resource rollout job to complete.
+    issueLink: https://github.com/solo-io/gloo/issues/8782
+    resolvesIssue: true
+    description: Adds the helm value `gateway.rolloutJob.timeout` to specifiy the timeout to wait for the resource rollout job to complete.
 

--- a/changelog/v1.14.23/add-timeout-resource-rollout-job.yaml
+++ b/changelog/v1.14.23/add-timeout-resource-rollout-job.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Adding a longer timeout while waiting for the resource rollout job to complete.
+

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -395,6 +395,7 @@
 |gateway.rolloutJob.resources.requests.cpu|string||amount of CPUs|
 |gateway.rolloutJob.floatingUserId|bool||If true, allows the cluster to dynamically assign a user ID for the processes running in the container.|
 |gateway.rolloutJob.runAsUser|float64||Explicitly set the user ID for the processes in the container to run as. Default is 10101.|
+|gateway.rolloutJob.timeout|int|600|Time to wait in seconds until the job has completed. If it exceeds this limit, it is deemed to have failed. Defaults to 600|
 |gateway.cleanupJob.restartPolicy|string|OnFailure|restart policy to use when the pod exits|
 |gateway.cleanupJob.priorityClassName|string||name of a defined priority class|
 |gateway.cleanupJob.nodeName|string||name of node to run on|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -381,6 +381,7 @@ type RolloutJob struct {
 	Resources      *ResourceRequirements `json:"resources,omitempty"`
 	FloatingUserId *bool                 `json:"floatingUserId,omitempty" desc:"If true, allows the cluster to dynamically assign a user ID for the processes running in the container."`
 	RunAsUser      *float64              `json:"runAsUser,omitempty" desc:"Explicitly set the user ID for the processes in the container to run as. Default is 10101."`
+	Timeout        *int                  `json:"timeout,omitempty" desc:"Time to wait in seconds until the job has completed. If it exceeds this limit, it is deemed to have failed. Defaults to 600"`
 }
 
 type CleanupJob struct {

--- a/install/helm/gloo/templates/5-resource-rollout-job-check.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-check.yaml
@@ -80,7 +80,7 @@ spec:
               if [ $? -eq 0 ]
               then
                 echo "Waiting for the resource rollout job to complete"
-                kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-resource-rollout --timeout=600s || exit 1
+                kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-resource-rollout --timeout={{ .Values.gateway.rolloutJob.timeout }}s || exit 1
               fi
               # Delete the resource rollout job as it can linger around and not be re-created durig an upgrade
               kubectl -n {{ .Release.Namespace }} delete job gloo-resource-rollout

--- a/install/helm/gloo/templates/5-resource-rollout-job-check.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-check.yaml
@@ -80,7 +80,7 @@ spec:
               if [ $? -eq 0 ]
               then
                 echo "Waiting for the resource rollout job to complete"
-                kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-resource-rollout
+                kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-resource-rollout --timeout=600s || exit 1
               fi
               # Delete the resource rollout job as it can linger around and not be re-created durig an upgrade
               kubectl -n {{ .Release.Namespace }} delete job gloo-resource-rollout

--- a/install/helm/gloo/templates/5-resource-rollout-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job.yaml
@@ -78,7 +78,7 @@ spec:
             if [ $? -eq 0 ]
             then
               echo "Waiting for the enterprise resource rollout job to complete"
-              kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-ee-resource-rollout --timeout=600s || exit 1
+              kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-ee-resource-rollout --timeout={{ .Values.gateway.rolloutJob.timeout }}s || exit 1
             fi
 
             # apply Gloo Edge custom resources

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -101,6 +101,7 @@ gateway:
     # When adding the --wait && --wait-for-jobs flag in helm, sometimes the job can complete and be deleted before helm can check if it has finished (for instance, while helm is waiting on a deployment).
     # So set this to a higher value where it should still be around after all the other resources are ready
     ttlSecondsAfterFinished: 300
+    timeout: 600
   cleanupJob:
     enabled: true
     image:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4377,6 +4377,30 @@ metadata:
 							Expect(cleanupJob.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal("350Mi"))
 							Expect(cleanupJob.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String()).To(Equal("450m"))
 						})
+
+						Context("Timeout waiting for the resource rollout job", func() {
+							It("sets the default value when none specified", func() {
+								prepareMakefile(namespace, helmValues{valuesArgs: []string{}})
+
+								rolloutJob := getJob(testManifest, namespace, "gloo-resource-rollout")
+								Expect(rolloutJob.Spec.Template.Spec.Containers[0].Command[2]).To(ContainSubstring("--timeout=600s || exit 1"))
+
+								rolloutCheckJob := getJob(testManifest, namespace, "gloo-resource-rollout-check")
+								Expect(rolloutCheckJob.Spec.Template.Spec.Containers[0].Command[2]).To(ContainSubstring("--timeout=600s || exit 1"))
+							})
+
+							It("sets the custom values specified", func() {
+								prepareMakefile(namespace, helmValues{valuesArgs: []string{
+									"gateway.rolloutJob.timeout=800",
+								}})
+
+								rolloutJob := getJob(testManifest, namespace, "gloo-resource-rollout")
+								Expect(rolloutJob.Spec.Template.Spec.Containers[0].Command[2]).To(ContainSubstring("--timeout=800s || exit 1"))
+
+								rolloutCheckJob := getJob(testManifest, namespace, "gloo-resource-rollout-check")
+								Expect(rolloutCheckJob.Spec.Template.Spec.Containers[0].Command[2]).To(ContainSubstring("--timeout=800s || exit 1"))
+							})
+						})
 					})
 
 					It("creates the certgen job, rbac, and service account", func() {


### PR DESCRIPTION
# Description

Adds a longer timeout (600s vs the default is 30s) for the resource rollout job to complete. This can handle cases of slow gloo installs

# Context

If the gloo installation is slow, the wait on the resource rollout && rollout check jobs can timeout and execute before the prior jobs have been completed

## Interesting decisions
 
N/A

## Testing steps

N/A

## Notes for reviewers

N/A

Please proofread comments on ...

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/8782