### PR TITLE
[v1.15.x] Bump envoy-gloo and cloud-builders

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.26.4-patch4
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.26.5-patch1
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/changelog/v1.15.11/bump_envoy_gloo.yaml
+++ b/changelog/v1.15.11/bump_envoy_gloo.yaml
@@ -1,0 +1,13 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: cloud-builders
+  dependencyTag: v0.6.5
+  description: >-
+    Use the latest cloud builders to match go version of builder to that of enterprise
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-gloo
+  dependencyTag: v1.26.5-patch1
+  description: >-
+    Use the latest cloud builders to match go version of builder to that of enterprise

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.5'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -44,7 +44,7 @@ steps:
   - 'us-central1-a'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   id: 'publish-docker'
   args:
   - 'publish-docker'
@@ -65,7 +65,7 @@ steps:
   waitFor:
   - 'publish-docker'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   id: 'release-chart'
   dir: *dir
   args:
@@ -80,7 +80,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.5'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -23,7 +23,7 @@ steps:
     cd /go/pkg
     gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   id: 'prepare-envoy'
   dir: *dir
   entrypoint: 'bash'
@@ -68,7 +68,7 @@ steps:
   waitFor:
   - 'prepare-gcr-zone'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   id: 'prepare-test-tools'
   dir: *dir
   args:
@@ -79,7 +79,7 @@ steps:
   - 'prepare-gcr-zone'
   - 'prepare-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.5'
   id: 'run-tests'
   dir: *dir
   entrypoint: 'make'
@@ -90,7 +90,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.5'
   id: 'run-e2e-tests'
   dir: *dir
   entrypoint: 'make'

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -101,7 +101,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.5'
   id: 'run-hashicorp-e2e-tests'
   dir: *dir
   entrypoint: 'make'


### PR DESCRIPTION
# Description
 - Bump envoy-gloo to v1.26.5-patch1
    - This pulls in fixes for recently disclosed CVEs in Envoy
 - Bump cloud builders to v0.6.5
   - This pulls in a go version bump that fixes recently disclosed CVEs in Go