### PR TITLE
[1.13.x] Bump envoy-gloo to fix CVE-2023-44487

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.12-patch2
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.12-patch3
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.13.29/bump-envoy-gloo.yaml
+++ b/changelog/v1.13.29/bump-envoy-gloo.yaml
@@ -6,3 +6,11 @@ changelog:
     dependencyTag: v1.23.12-patch3
     description: >-
       Upgrade envoy-gloo version to handle CVE-2023-44487
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: cloud-builders
+    dependencyTag: v0.6.5
+    description: >-
+      Use the latest cloud builders to match go version of builder to that of enterprise
+      This pulls in fixes for CVE-2023-39325, as announced in
+      https://groups.google.com/g/golang-announce/c/iNNxDTCjZvo

--- a/changelog/v1.13.29/bump-envoy-gloo.yaml
+++ b/changelog/v1.13.29/bump-envoy-gloo.yaml
@@ -1,0 +1,8 @@
+
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: envoy-gloo
+    dependencyRepo: solo-io
+    dependencyTag: v1.23.12-patch3
+    description: >-
+      Upgrade envoy-gloo version to handle CVE-2023-44487

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
 # gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo,_PR_NUM=<<insert PR Number here>> --project solo-public
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.5'
   args:
     - "--repo-name"
     - "$REPO_NAME"
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['prepare-workspace']
   id: 'get-envoy'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   entrypoint: 'bash'
   args: ['-c', 'make proxycontroller']
   dir: '/workspace/gloo/example/proxycontroller'
@@ -68,7 +68,7 @@ steps:
 
 # Docker related setup
 # grab this container immediately in parallel
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.5'
   entrypoint: ls
   waitFor: ['-']
   id: 'grab-ginkgo-container'
@@ -82,12 +82,12 @@ steps:
   waitFor: ['set-gcr-zone']
   id: 'get-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   args: ['install-go-tools']
   dir: *dir
   id: 'install-go-tools'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.5'
   entrypoint: make
   env:
   - 'ACK_GINKGO_RC=true'
@@ -117,7 +117,7 @@ steps:
   id: 'docker-login'
 
   # 1) Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   args: ['docker-push-extended']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -138,7 +138,7 @@ steps:
   waitFor: ['docker-push-extended']
   id: 'gcr-auth'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   args: ['fetch-package-and-save-helm', 'render-manifests', 'upload-github-release-assets', 'push-chart-to-registry', '-B']
   env:
     - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -152,7 +152,7 @@ steps:
   id: 'release-chart'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.4'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.5'
   args: ['docker-push-retag']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'


### PR DESCRIPTION
# Description
 - Bump envoy-gloo to 1.23.12-patch3
   - This pulls in fixes for CVE-2023-44487
 - Bump cloudbuilders to 0.6.5 to pull in go CVE fixes