### PR TITLE
[1.12.x] Bump envoy-gloo to fix CVE-2023-44487

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ else
   endif
 endif
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.12-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.23.12-patch3
 
 # The full SHA of the currently checked out commit
 CHECKED_OUT_SHA := $(shell git rev-parse HEAD)

--- a/changelog/v1.12.59/bump-envoy-gloo.yaml
+++ b/changelog/v1.12.59/bump-envoy-gloo.yaml
@@ -1,0 +1,8 @@
+
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: envoy-gloo
+    dependencyRepo: solo-io
+    dependencyTag: v1.23.12-patch3
+    description: >-
+      Upgrade envoy-gloo version to handle CVE-2023-44487


### PR DESCRIPTION
# Description
 - Bump envoy-gloo to 1.23.12-patch3
 - This pulls in fixes for CVE-2023-44487