### PR TITLE
[1.15] Fix kube2e gateway_test flakes due to recent secret deletion validation

### DIFF
--- a/changelog/v1.15.13/fix-secret-deletion-validation-flake-gw-kube2e.yaml
+++ b/changelog/v1.15.13/fix-secret-deletion-validation-flake-gw-kube2e.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix flakes seen in gateway_test after the addition of secret deletion validation.

--- a/test/helpers/certs.go
+++ b/test/helpers/certs.go
@@ -19,6 +19,9 @@ import (
 	"sync"
 	"time"
 
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+
 	"golang.org/x/crypto/ocsp"
 
 	kubev1 "k8s.io/api/core/v1"
@@ -228,6 +231,21 @@ func GetKubeSecret(name, namespace string) *kubev1.Secret {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+		},
+	}
+}
+
+func GetTlsSecret(name, namespace string) *v1.Secret {
+	return &v1.Secret{
+		Metadata: &core.Metadata{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Kind: &v1.Secret_Tls{
+			Tls: &v1.TlsSecret{
+				PrivateKey: PrivateKey(),
+				CertChain:  Certificate(),
+			},
 		},
 	}
 }

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -3,14 +3,12 @@ package gateway_test
 import (
 	"context"
 	"fmt"
+	matchers2 "github.com/solo-io/gloo/test/gomega/matchers"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
-
-	"k8s.io/apimachinery/pkg/api/errors"
-
-	matchers2 "github.com/solo-io/gloo/test/gomega/matchers"
 
 	"github.com/google/uuid"
 
@@ -339,23 +337,18 @@ var _ = Describe("Kube2e: gateway", func() {
 				// get the certificate so it is generated in the background
 				go helpers.Certificate()
 
-				createdSecret, err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Create(ctx, helpers.GetKubeSecret(secretName, testHelper.InstallNamespace), metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				tlsSecret := helpers.GetTlsSecret(secretName, testHelper.InstallNamespace)
+				glooResources.Secrets = gloov1.SecretList{tlsSecret}
 
 				// Modify the VirtualService to include the necessary SslConfig
 				testRunnerVs.SslConfig = &ssl.SslConfig{
 					SslSecrets: &ssl.SslConfig_SecretRef{
 						SecretRef: &core.ResourceRef{
-							Name:      createdSecret.GetName(),
-							Namespace: createdSecret.GetNamespace(),
+							Name:      tlsSecret.GetMetadata().GetName(),
+							Namespace: tlsSecret.GetMetadata().GetNamespace(),
 						},
 					},
 				}
-			})
-
-			AfterEach(func() {
-				err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("works with ssl", func() {
@@ -1369,8 +1362,8 @@ var _ = Describe("Kube2e: gateway", func() {
 
 			BeforeEach(func() {
 				// Create secret to use for ssl routing
-				createdSecret, err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Create(ctx, helpers.GetKubeSecret(secretName, testHelper.InstallNamespace), metav1.CreateOptions{})
-				Expect(err).NotTo(HaveOccurred())
+				tlsSecret := helpers.GetTlsSecret(secretName, testHelper.InstallNamespace)
+				glooResources.Secrets = gloov1.SecretList{tlsSecret}
 
 				tcpGateway := defaults.DefaultTcpGateway(testHelper.InstallNamespace)
 				tcpGateway.GetTcpGateway().TcpHosts = []*gloov1.TcpHost{{
@@ -1385,8 +1378,8 @@ var _ = Describe("Kube2e: gateway", func() {
 						SniDomains: []string{httpEchoClusterName},
 						SslSecrets: &ssl.SslConfig_SecretRef{
 							SecretRef: &core.ResourceRef{
-								Name:      createdSecret.GetName(),
-								Namespace: createdSecret.GetNamespace(),
+								Name:      tlsSecret.GetMetadata().GetName(),
+								Namespace: tlsSecret.GetMetadata().GetNamespace(),
 							},
 						},
 						// Force http1, as defaulting to 2 fails. The service in question is an http1 service, but as this
@@ -1398,13 +1391,6 @@ var _ = Describe("Kube2e: gateway", func() {
 
 				glooResources.Gateways = gatewayv1.GatewayList{tcpGateway}
 
-			})
-
-			AfterEach(func() {
-				// It is possible the state has not fully reconciled yet, and we could hit a validation error due to the gateway that references the secret.
-				Eventually(func() error {
-					return resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-				}, "10s", "1s").ShouldNot(HaveOccurred())
 			})
 
 			It("correctly routes to the service (tcp/tls)", func() {
@@ -2099,6 +2085,77 @@ spec:
 				}
 			})
 
+			Context("secret validation", func() {
+				const secretName = "tls-secret"
+
+				BeforeEach(func() {
+					// Create secret to use for ssl routing
+					tlsSecret := helpers.GetTlsSecret(secretName, testHelper.InstallNamespace)
+					glooResources.Secrets = gloov1.SecretList{tlsSecret}
+
+					// Modify the VirtualService to include the created SslConfig
+					testRunnerVs.SslConfig = &ssl.SslConfig{
+						SslSecrets: &ssl.SslConfig_SecretRef{
+							SecretRef: &core.ResourceRef{
+								Name:      tlsSecret.GetMetadata().GetName(),
+								Namespace: tlsSecret.GetMetadata().GetNamespace(),
+							},
+						},
+					}
+				})
+
+				AfterEach(func() {
+					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+					// Some tests delete the Secret for assertions. The KubeClient does not have an "IgnoreNotFound" field, so we check for
+					// either a nil error indicating a successful deletion, or for the Secret to not be found indicating it was previously deleted as part of a test.
+					Expect(err).To(Or(
+						Not(HaveOccurred()),
+						MatchError(errors.NewNotFound(corev1.Resource("secrets"), secretName).Error()),
+					))
+				})
+
+				// There are times when the VirtualService + Proxy do not update Status with the error when deleting the referenced Secret, therefore the validation error doesn't occur.
+				// It isn't until later - either a few minutes and/or after forcing an update by updating the VS - that the error status appears.
+				// The reason is still unknown, so we retry on flakes in the meantime.
+				It("should act as expected with secret validation", FlakeAttempts(3), func() {
+					By("failing to delete a secret that is in use")
+					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(matchers2.ContainSubstrings([]string{"admission webhook", "SSL secret not found", secretName}))
+
+					By("successfully deleting a secret that is no longer in use")
+					// We patch the VirtualService to remove the ssl reference, allowing the Secret to be removed
+					err = helpers.PatchResource(
+						ctx,
+						&core.ResourceRef{
+							Namespace: testHelper.InstallNamespace,
+							Name:      testRunnerVs.GetMetadata().Name,
+						},
+						func(resource resources.Resource) resources.Resource {
+							vs := resource.(*gatewayv1.VirtualService)
+							vs.SslConfig = nil
+							return vs
+						},
+						resourceClientset.VirtualServiceClient().BaseClient())
+					Expect(err).NotTo(HaveOccurred())
+					helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+						return resourceClientset.VirtualServiceClient().Read(testHelper.InstallNamespace, testRunnerVs.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})
+					})
+
+					err = resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("can delete a secret that is not in use", func() {
+					tlsSecret := helpers.GetKubeSecret("tls-secret-2", testHelper.InstallNamespace)
+					tlsSecret, err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Create(ctx, tlsSecret, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					err = resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, tlsSecret.GetName(), metav1.DeleteOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				})
+			})
+
 		})
 
 		When("allowWarnings=true", Ordered, func() {
@@ -2527,78 +2584,6 @@ spec:
 						g.Expect(rlc.Status.Message).Should(ContainSubstring("enterprise-only"))
 						return nil
 					}, "15s", "0.5s").ShouldNot(HaveOccurred())
-				})
-			})
-		})
-
-		Context("resource CRUD validation", func() {
-			Context("secret validation", func() {
-				const secretName = "tls-secret"
-
-				BeforeEach(func() {
-					var err error
-					// Create secret to use for ssl routing
-					tlsSecret := helpers.GetKubeSecret(secretName, testHelper.InstallNamespace)
-					tlsSecret, err = resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Create(ctx, tlsSecret, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					// Modify the VirtualService to include the created SslConfig
-					testRunnerVs.SslConfig = &ssl.SslConfig{
-						SslSecrets: &ssl.SslConfig_SecretRef{
-							SecretRef: &core.ResourceRef{
-								Name:      tlsSecret.GetName(),
-								Namespace: tlsSecret.GetNamespace(),
-							},
-						},
-					}
-				})
-
-				AfterEach(func() {
-					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-					// Some tests delete the Secret for assertions. The KubeClient does not have an "IgnoreNotFound" field, so we check for
-					// either a nil error indicating a successful deletion, or for the Secret to not be found indicating it was previously deleted as part of a test.
-					Expect(err).To(Or(
-						Not(HaveOccurred()),
-						MatchError(errors.NewNotFound(corev1.Resource("secrets"), secretName).Error()),
-					))
-				})
-
-				It("should act as expected with secret validation", func() {
-					By("failing to delete a secret that is in use")
-					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(matchers2.ContainSubstrings([]string{"admission webhook", "SSL secret not found", secretName}))
-
-					By("successfully deleting a secret that is no longer in use")
-					// We patch the VirtualService to remove the ssl reference, allowing the Secret to be removed
-					err = helpers.PatchResource(
-						ctx,
-						&core.ResourceRef{
-							Namespace: testHelper.InstallNamespace,
-							Name:      testRunnerVs.GetMetadata().Name,
-						},
-						func(resource resources.Resource) resources.Resource {
-							vs := resource.(*gatewayv1.VirtualService)
-							vs.SslConfig = nil
-							return vs
-						},
-						resourceClientset.VirtualServiceClient().BaseClient())
-					Expect(err).NotTo(HaveOccurred())
-					helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
-						return resourceClientset.VirtualServiceClient().Read(testHelper.InstallNamespace, testRunnerVs.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})
-					})
-
-					err = resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-					Expect(err).NotTo(HaveOccurred())
-				})
-
-				It("can delete a secret that is not in use", func() {
-					tlsSecret := helpers.GetKubeSecret("tls-secret-2", testHelper.InstallNamespace)
-					tlsSecret, err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Create(ctx, tlsSecret, metav1.CreateOptions{})
-					Expect(err).NotTo(HaveOccurred())
-
-					err = resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, tlsSecret.GetName(), metav1.DeleteOptions{})
-					Expect(err).NotTo(HaveOccurred())
 				})
 			})
 		})

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -3,12 +3,13 @@ package gateway_test
 import (
 	"context"
 	"fmt"
-	matchers2 "github.com/solo-io/gloo/test/gomega/matchers"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"os"
 	"os/exec"
 	"strings"
 	"time"
+
+	matchers2 "github.com/solo-io/gloo/test/gomega/matchers"
+	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/google/uuid"
 

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	matchers2 "github.com/solo-io/gloo/test/gomega/matchers"
-	"k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/google/uuid"
 
@@ -2103,16 +2102,6 @@ spec:
 							},
 						},
 					}
-				})
-
-				AfterEach(func() {
-					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-					// Some tests delete the Secret for assertions. The KubeClient does not have an "IgnoreNotFound" field, so we check for
-					// either a nil error indicating a successful deletion, or for the Secret to not be found indicating it was previously deleted as part of a test.
-					Expect(err).To(Or(
-						Not(HaveOccurred()),
-						MatchError(errors.NewNotFound(corev1.Resource("secrets"), secretName).Error()),
-					))
 				})
 
 				// There are times when the VirtualService + Proxy do not update Status with the error when deleting the referenced Secret, therefore the validation error doesn't occur.


### PR DESCRIPTION
_manual backport of #8795_

# Description

Fixing flakes seen by adding retries.

## Flake fix information
### "secret validation [It] should act as expected with secret validation" flake
The `FlakeAttempt` is a general (hot)fix.

There are times during our CI tests when we _do not_ get a validation error when deleting a `Secret` that is referenced elsewhere. 
This was an issue I previously hit constantly in 1.14- for 1/2 of runs, but after ~20 runs, I haven't reproduced it locally. In the 1.14 tests, I saw that the VS/proxy did not have an error status until way after (~1 minute, plus I added an annotation to try and force an update). Something similar could be happening here?

My only hypothesis is that resources (specifically the Secret) are created and deleted _too fast_... maybe even _before_ the VS updates to reference it, which is why it deletes with no issue. If not, then more thorough investigation needs to be done either in our tests and/or translation + proxy code.

### "native ssl [It] works with ssl" flake
Secrets are now handled through our SnapshotWriter. This avoids the previous possibility of the Secret failing to be deleted because the VirtualService referencing it still existed. The SnapshotWriter handles creating + deleting resources in order of dependencies, so it correctly creates + deletes secrets in relation to resources that reference it.

## Code changes
- Create a 'Secret creator' helper that returns an internal Secret - as opposed to the existing one that returns a kube secret.
- Passing Secrets into glooResources so the SnapshotWriter handles creating + deleting them.
- Add `FlakeAttempts` to flaky test that needs further investigation.

# Context

We saw these gateway_test flakes in recent nightly tests, after introducing delete validation through #8740.
- secret failed to delete flake: [1](https://github.com/solo-io/gloo/actions/runs/6491470077), [2](https://github.com/solo-io/gloo/actions/runs/6504230547)
- no error occurred when deleting secret flake: [1](https://github.com/solo-io/gloo/actions/runs/6478192275)

## Interesting decisions
 
Decided on using `FlakeAttempts` for one of the flakes. I have not been able to reproduce locally as of now, so this is just a patch in the meantime. This was something I previously ran in 1.14-, the difference being that in the older version it happened in ~1/2 of runs, whereas I haven't hit this yet (after 20 runs).

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
