### PR TITLE
projects/gloo/cli/pkg/cmd/check-crds: fix dropped error

### DIFF
--- a/projects/gloo/cli/pkg/cmd/check-crds/root.go
+++ b/projects/gloo/cli/pkg/cmd/check-crds/root.go
@@ -136,6 +136,9 @@ func preprocessCRD(crd *apiextv1.CustomResourceDefinition) {
 func getCRDsInCluster(ctx context.Context) ([]apiextv1.CustomResourceDefinition, error) {
 	crds := []apiextv1.CustomResourceDefinition{}
 	kubecontext, err := contextoptions.KubecontextFrom(ctx)
+	if err != nil {
+		return nil, err
+	}
 	out, err := cliutil.KubectlOut(nil, "get", "crd", "--context", kubecontext)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This fixes a dropped `err` variable in the `projects/gloo/cli/pkg/cmd/check-crds` package.