### PR TITLE
remove old flags from glooctl

### DIFF
--- a/projects/gloo/cli/pkg/cmd/root.go
+++ b/projects/gloo/cli/pkg/cmd/root.go
@@ -5,14 +5,11 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/demo"
 	v2 "github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/install/v2"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
 	"k8s.io/kubectl/pkg/cmd"
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/check"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/get"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/upgrade"
 	versioncmd "github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/version"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/flagutils"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/prerun"
@@ -83,27 +80,26 @@ func GlooCli() *cobra.Command {
 
 	optionsFunc := func(app *cobra.Command) {
 		pflags := app.PersistentFlags()
-		pflags.BoolVarP(&opts.Top.Interactive, "interactive", "i", false, "use interactive mode")
+		// pflags.BoolVarP(&opts.Top.Interactive, "interactive", "i", false, "use interactive mode")
 		pflags.StringVarP(&opts.Top.ConfigFilePath, "config", "c", DefaultConfigPath, "set the path to the glooctl config file")
-		flagutils.AddConsulConfigFlags(pflags, &opts.Top.Consul)
 		flagutils.AddKubeContextFlag(pflags, &opts.Top.KubeContext)
 
 		opts.Top.Ctx = context.WithValue(opts.Top.Ctx, "top", opts.Top.ContextAccessible)
 
 		app.SuggestionsMinimumDistance = 1
 		app.AddCommand(
-			get.RootCmd(opts),
+			// get.RootCmd(opts),
 			// del.RootCmd(opts),
 			// install.InstallCmd(opts),
 			v2.InstallCmd(opts),
 			v2.UninstallCmd(opts),
-			demo.RootCmd(opts),
+			// demo.RootCmd(opts),
 			// add.RootCmd(opts),
 			// remove.RootCmd(opts),
 			// route.RootCmd(opts),
 			// create.RootCmd(opts),
 			// edit.RootCmd(opts),
-			upgrade.RootCmd(opts),
+			// upgrade.RootCmd(opts),
 			// gateway.RootCmd(opts),
 			check.RootCmd(opts),
 			// check_crds.RootCmd(opts),

--- a/projects/gloo/cli/pkg/flagutils/common.go
+++ b/projects/gloo/cli/pkg/flagutils/common.go
@@ -1,11 +1,9 @@
 package flagutils
 
 import (
-	"github.com/hashicorp/consul/api"
 	vaultapi "github.com/hashicorp/vault/api"
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options/contextoptions"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/printers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/bootstrap/clients"
 	"github.com/spf13/pflag"
@@ -58,26 +56,6 @@ func AddVerboseFlag(set *pflag.FlagSet, opts *options.Options) {
 
 func AddKubeConfigFlag(set *pflag.FlagSet, kubeConfig *string) {
 	set.StringVarP(kubeConfig, clientcmd.RecommendedConfigPathFlag, "", "", "kubeconfig to use, if not standard one")
-}
-
-func AddConsulConfigFlags(set *pflag.FlagSet, consul *contextoptions.Consul) {
-	config := api.DefaultConfig()
-	set.BoolVar(&consul.UseConsul, "use-consul", false, "use Consul Key-Value storage as the "+
-		"backend for reading and writing config (VirtualServices, Upstreams, and Proxies)")
-	set.StringVar(&consul.RootKey, "consul-root-key", clients.DefaultRootKey, "key prefix for for Consul key-value storage.")
-	set.StringVar(&config.Address, "consul-address", config.Address, "address of the Consul server. "+
-		"Use with --use-consul")
-	set.StringVar(&config.Scheme, "consul-scheme", config.Scheme, "URI scheme for the Consul server. "+
-		"Use with --use-consul")
-	set.StringVar(&config.Datacenter, "consul-datacenter", config.Datacenter, "Datacenter to use. If not provided, the default agent datacenter is used. "+
-		"Use with --use-consul")
-	set.StringVar(&config.Token, "consul-token", config.Token, "Token is used to provide a per-request ACL token which overrides the agent's default token. "+
-		"Use with --use-consul")
-	set.BoolVar(&consul.AllowStaleReads, "consul-allow-stale-reads", false, "Allows reading using Consul's stale consistency mode.")
-
-	consul.Client = func() (client *api.Client, e error) {
-		return api.NewClient(config)
-	}
 }
 
 func AddVaultSecretFlags(set *pflag.FlagSet, vault *options.Vault) {


### PR DESCRIPTION
as version 2 focuses on the k8s gateway api, there will be no support for using consul as an api storage backend.