### PR TITLE
Fix nightly upgrade test failure (#8756)

### DIFF
--- a/changelog/v1.16.0-beta22/fix-nightly-tests.yaml
+++ b/changelog/v1.16.0-beta22/fix-nightly-tests.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix nightly upgrade tests caused after adding the fix for custom readiness probe issue (https://github.com/solo-io/gloo/pull/8831) by waiting for the resource rollout job to be cleaned up prior to an upgrade
+

--- a/test/kube2e/upgrade/upgrade_test.go
+++ b/test/kube2e/upgrade/upgrade_test.go
@@ -311,6 +311,13 @@ func upgradeCrds(crdDir string) {
 }
 
 func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, targetReleasedVersion string, crdDir string, strictValidation bool, additionalArgs []string) {
+	// With the fix for custom readiness probe : https://github.com/solo-io/gloo/pull/8831
+	// The resource rollout job is not longer in a post hook and the job ttl has changed from 60 to 300
+	// As a consequence the job is not automatically cleaned as part of the hook deletion policy
+	// or within the time between installing gloo and upgrading it in the test.
+	// So we wait until the job ttl has expired to be cleaned up to ensure the upgrade passes
+	runAndCleanCommand("kubectl", "-n", defaults.GlooSystem, "wait", "--for=delete", "job", "gloo-resource-rollout", "--timeout=600s")
+
 	upgradeCrds(crdDir)
 
 	valueOverrideFile, cleanupFunc := getHelmUpgradeValuesOverrideFile()


### PR DESCRIPTION
# Description

With the [fix for custom readiness probe](https://github.com/solo-io/gloo/pull/8831), The resource rollout job is not longer in a post hook and the job ttl has changed from 60 t0 300. As a consequence the job is not automatically cleaned as part of the hook deletion policy or within the time between installing gloo and upgrading it in the test. So we wait until the job is deleted after the TTL expires.

# Context

Failure in nightly upgrade test : https://github.com/solo-io/gloo/actions/runs/6780225254/job/18428570372

## Testing steps

```
[10:34:04] ~/lab/gloo ➦ main $ VERSION=1.0.0-ci WAIT_ON_FAIL=1 KUBE2E_TESTS=upgrade make run-kube-e2e-tests
GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore ACK_GINKGO_RC=true ACK_GINKGO_DEPRECATIONS=v2.9.5 /Users/djumani/lab/gloo/_output/.bin/ginkgo -ldflags="-X github.com/solo-io/gloo/pkg/version.Version=1.0.0-ci" \
	-tags=purego --trace -progress -race --fail-fast -fail-on-pending --randomize-all --compilers=5 --json-report=test-report.json --junit-report=junit.xml -output-dir=/Users/djumani/lab/gloo/_output  \
	./test/kube2e/upgrade 
Running Suite: Upgrade Suite - /Users/djumani/lab/gloo/test/kube2e/upgrade
==========================================================================
Random Seed: 1696603195 - will randomize all specs

Will run 8 of 8 specs

.....................

Ran 8 of 8 Specs in 644.937 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS

Ginkgo ran 1 suite in 11m1.999897959s
Test Suite Passed

```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
