### PR TITLE
feat: Allow users to disable extauth sidecar on a per proxy basis

### DIFF
--- a/changelog/v1.16.0-beta25/disable-extauth-sidecar.yaml
+++ b/changelog/v1.16.0-beta25/disable-extauth-sidecar.yaml
@@ -2,5 +2,5 @@ changelog:
 - type: HELM
   issueLink: https://github.com/solo-io/gloo/issues/8430
   resolvesIssue: false
-  description: Adds the new helm value `gatewayproxy.proxyName.disableExtauthSidecar` to disable the extauth sidecar on a given gateway proxy when `global.extensions.extAuth.envoySidecar` is set
+  description: Adds the new helm value `gatewayproxy.proxyName.disableExtauthSidecar` to disable the extauth sidecar on a given gateway proxy when `global.extensions.extAuth.envoySidecar` is set. Defaults to false. This is used with enterprise extauth deployments.
 

--- a/changelog/v1.16.0-beta25/disable-extauth-sidecar.yaml
+++ b/changelog/v1.16.0-beta25/disable-extauth-sidecar.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: HELM
+  issueLink: https://github.com/solo-io/gloo/issues/8430
+  resolvesIssue: false
+  description: Adds the new helm value `gatewayproxy.proxyName.disableExtauthSidecar` to disable the extauth sidecar on a given gateway proxy when `global.extensions.extAuth.envoySidecar` is set
+

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -707,6 +707,7 @@
 |gatewayProxies.NAME.xdsServicePort|uint32||The k8s service port for the xds server. Defaults to the value from .Values.gloo.deployment.xdsPort, but can be overridden to use, for example, xds-relay.|
 |gatewayProxies.NAME.tcpKeepaliveTimeSeconds|uint32||The amount of time in seconds for connections to be idle before sending keep-alive probes. Defaults to 60. See here: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive|
 |gatewayProxies.NAME.disableCoreDumps|bool||If set to true, Envoy will not generate core dumps in the event of a crash. Defaults to false|
+|gatewayProxies.NAME.disableExtauthSidecar|bool||When extAuth.envoySidecar is set to true, every gateway proxy pod will come up with an extauth container. If this setting is set to true, the extauth container will not be added to the gatway proxy pod. Defaults to false|
 |gatewayProxies.NAME.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.gatewayProxy.kind.deployment.replicas|int|1|number of instances to deploy|
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].name|string|||
@@ -956,6 +957,7 @@
 |gatewayProxies.gatewayProxy.xdsServicePort|uint32||The k8s service port for the xds server. Defaults to the value from .Values.gloo.deployment.xdsPort, but can be overridden to use, for example, xds-relay.|
 |gatewayProxies.gatewayProxy.tcpKeepaliveTimeSeconds|uint32|60|The amount of time in seconds for connections to be idle before sending keep-alive probes. Defaults to 60. See here: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive|
 |gatewayProxies.gatewayProxy.disableCoreDumps|bool|false|If set to true, Envoy will not generate core dumps in the event of a crash. Defaults to false|
+|gatewayProxies.gatewayProxy.disableExtauthSidecar|bool|false|When extAuth.envoySidecar is set to true, every gateway proxy pod will come up with an extauth container. If this setting is set to true, the extauth container will not be added to the gatway proxy pod. Defaults to false|
 |gatewayProxies.gatewayProxy.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |ingress.enabled|bool|false||
 |ingress.deployment.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -707,7 +707,7 @@
 |gatewayProxies.NAME.xdsServicePort|uint32||The k8s service port for the xds server. Defaults to the value from .Values.gloo.deployment.xdsPort, but can be overridden to use, for example, xds-relay.|
 |gatewayProxies.NAME.tcpKeepaliveTimeSeconds|uint32||The amount of time in seconds for connections to be idle before sending keep-alive probes. Defaults to 60. See here: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive|
 |gatewayProxies.NAME.disableCoreDumps|bool||If set to true, Envoy will not generate core dumps in the event of a crash. Defaults to false|
-|gatewayProxies.NAME.disableExtauthSidecar|bool||When extAuth.envoySidecar is set to true, every gateway proxy pod will come up with an extauth container. If this setting is set to true, the extauth container will not be added to the gatway proxy pod. Defaults to false|
+|gatewayProxies.NAME.disableExtauthSidecar|bool||If set to true, this gateway proxy will not come up with an extauth sidecar container when global.extAuth.envoySidecar is enabled. This setting has no effect otherwise. Defaults to false|
 |gatewayProxies.NAME.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gatewayProxies.gatewayProxy.kind.deployment.replicas|int|1|number of instances to deploy|
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].name|string|||
@@ -957,7 +957,7 @@
 |gatewayProxies.gatewayProxy.xdsServicePort|uint32||The k8s service port for the xds server. Defaults to the value from .Values.gloo.deployment.xdsPort, but can be overridden to use, for example, xds-relay.|
 |gatewayProxies.gatewayProxy.tcpKeepaliveTimeSeconds|uint32|60|The amount of time in seconds for connections to be idle before sending keep-alive probes. Defaults to 60. See here: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive|
 |gatewayProxies.gatewayProxy.disableCoreDumps|bool|false|If set to true, Envoy will not generate core dumps in the event of a crash. Defaults to false|
-|gatewayProxies.gatewayProxy.disableExtauthSidecar|bool|false|When extAuth.envoySidecar is set to true, every gateway proxy pod will come up with an extauth container. If this setting is set to true, the extauth container will not be added to the gatway proxy pod. Defaults to false|
+|gatewayProxies.gatewayProxy.disableExtauthSidecar|bool|false|If set to true, this gateway proxy will not come up with an extauth sidecar container when global.extAuth.envoySidecar is enabled. This setting has no effect otherwise. Defaults to false|
 |gatewayProxies.gatewayProxy.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |ingress.enabled|bool|false||
 |ingress.deployment.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -505,7 +505,7 @@ type GatewayProxy struct {
 	XdsServicePort                 *uint32                          `json:"xdsServicePort,omitempty" desc:"The k8s service port for the xds server. Defaults to the value from .Values.gloo.deployment.xdsPort, but can be overridden to use, for example, xds-relay."`
 	TcpKeepaliveTimeSeconds        *uint32                          `json:"tcpKeepaliveTimeSeconds,omitempty" desc:"The amount of time in seconds for connections to be idle before sending keep-alive probes. Defaults to 60. See here: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive"`
 	DisableCoreDumps               *bool                            `json:"disableCoreDumps,omitempty" desc:"If set to true, Envoy will not generate core dumps in the event of a crash. Defaults to false"`
-	DisableExtauthSidecar          *bool                            `json:"disableExtauthSidecar,omitempty" desc:"When extAuth.envoySidecar is set to true, every gateway proxy pod will come up with an extauth container. If this setting is set to true, the extauth container will not be added to the gatway proxy pod. Defaults to false"`
+	DisableExtauthSidecar          *bool                            `json:"disableExtauthSidecar,omitempty" desc:"If set to true, this gateway proxy will not come up with an extauth sidecar container when global.extAuth.envoySidecar is enabled. This setting has no effect otherwise. Defaults to false"`
 	*KubeResourceOverride
 }
 

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -505,6 +505,7 @@ type GatewayProxy struct {
 	XdsServicePort                 *uint32                          `json:"xdsServicePort,omitempty" desc:"The k8s service port for the xds server. Defaults to the value from .Values.gloo.deployment.xdsPort, but can be overridden to use, for example, xds-relay."`
 	TcpKeepaliveTimeSeconds        *uint32                          `json:"tcpKeepaliveTimeSeconds,omitempty" desc:"The amount of time in seconds for connections to be idle before sending keep-alive probes. Defaults to 60. See here: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/address.proto#envoy-v3-api-msg-config-core-v3-tcpkeepalive"`
 	DisableCoreDumps               *bool                            `json:"disableCoreDumps,omitempty" desc:"If set to true, Envoy will not generate core dumps in the event of a crash. Defaults to false"`
+	DisableExtauthSidecar          *bool                            `json:"disableExtauthSidecar,omitempty" desc:"When extAuth.envoySidecar is set to true, every gateway proxy pod will come up with an extauth container. If this setting is set to true, the extauth container will not be added to the gatway proxy pod. Defaults to false"`
 	*KubeResourceOverride
 }
 

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -9,7 +9,7 @@
 {{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
+{{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
 {{- $ports := list }}
 {{- if not (empty $spec.podTemplate) }}
   {{- $ports = (list $spec.podTemplate.httpPort $spec.podTemplate.httpsPort $spec.podTemplate.extraPorts) }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -9,7 +9,7 @@
 {{- $settings := .Values.settings }}
 {{- $isUpgrade := .Values.gateway.upgrade }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
 {{- $ports := list }}
 {{- if not (empty $spec.podTemplate) }}
   {{- $ports = (list $spec.podTemplate.httpPort $spec.podTemplate.httpsPort $spec.podTemplate.extraPorts) }}

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -3,7 +3,7 @@
 {{- $gatewaySpec := (index . 2) }}
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
+{{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
 {{- if $spec.kind.deployment }}
 {{- if $spec.horizontalPodAutoscaler }}
 apiVersion: {{ $spec.horizontalPodAutoscaler.apiVersion }}

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -3,7 +3,7 @@
 {{- $gatewaySpec := (index . 2) }}
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
 {{- if $spec.kind.deployment }}
 {{- if $spec.horizontalPodAutoscaler }}
 apiVersion: {{ $spec.horizontalPodAutoscaler.apiVersion }}

--- a/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
@@ -3,7 +3,7 @@
 {{- $gatewaySpec := (index . 2) }}
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
 {{- if $spec.kind.deployment}}
 {{- if $spec.podDisruptionBudget }}
 apiVersion: policy/v1

--- a/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
@@ -3,7 +3,7 @@
 {{- $gatewaySpec := (index . 2) }}
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
+{{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
 {{- if $spec.kind.deployment}}
 {{- if $spec.podDisruptionBudget }}
 apiVersion: policy/v1

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -7,7 +7,7 @@
 {{- with (first .) }}
 {{- $global := .Values.global }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) -}}
+{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
 {{- if not $spec.disabled }}
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
 # config_map

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -7,7 +7,7 @@
 {{- with (first .) }}
 {{- $global := .Values.global }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
-{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
+{{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
 {{- if not $spec.disabled }}
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
 # config_map

--- a/install/helm/gloo/templates/_8-default-gateways.tpl
+++ b/install/helm/gloo/templates/_8-default-gateways.tpl
@@ -147,7 +147,7 @@ spec:
 {{- define "gloo.customResources.defaultGateways" -}}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy }}
 {{- range $name, $gatewaySpec := .Values.gatewayProxies }}
-{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
+{{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
 {{- $gatewaySettings := $spec.gatewaySettings }}
 {{- if and $spec.gatewaySettings (not $gatewaySpec.disabled) }}
 {{- $ctx := (list $ $name $spec) }}

--- a/install/helm/gloo/templates/_8-default-gateways.tpl
+++ b/install/helm/gloo/templates/_8-default-gateways.tpl
@@ -147,7 +147,7 @@ spec:
 {{- define "gloo.customResources.defaultGateways" -}}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy }}
 {{- range $name, $gatewaySpec := .Values.gatewayProxies }}
-{{- $spec := deepCopy $gatewaySpec | mergeOverwrite (deepCopy $gatewayProxy) }}
+{{- $spec := include "gloo.util.overwriteWithOmit" (list $gatewaySpec $gatewayProxy $gatewaySpec.omitKeys) | fromJson }}
 {{- $gatewaySettings := $spec.gatewaySettings }}
 {{- if and $spec.gatewaySettings (not $gatewaySpec.disabled) }}
 {{- $ctx := (list $ $name $spec) }}

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -6,10 +6,9 @@ Eg. To generate a proxy config, we mergeOverwrite it with the default gateway-pr
 If we want to preserve the empty value of the gateway and not have them overwritten, we set it to `gloo.omitOverwrite`
 and call `gloo.util.mergeOverwriteWithOmit` when merging. This sets all fields with values equal to this back to empty after the overwrite
 */ -}}
-{{- define "gloo.omitOverwrite" -}}
-DO-NOT-OVERWRITE
-{{- end -}}
-
+{{- define "gloo.omitOverwrite" }}
+{{ printf "\n" }}{{/* This template is set to a new line. There may be scenarios where a field is initailly set to this value and the same field is appended to later on. Since this is just a new line, it won't cause rendering issues */}}
+{{ end -}}
 {{- define "gloo.roleKind" -}}
 {{- if .Values.global.glooRbac.namespaced -}}
 Role

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -112,7 +112,7 @@ ttlSecondsAfterFinished: {{ . }}
 {{- end -}}
 {{- end -}}
 
-{{- /* 
+{{- /*
 This template is used to generate the gloo pod or container security context.
 It takes 2 values:
   .values - the securityContext passed from the user in values.yaml
@@ -209,7 +209,7 @@ Returns the unique Gateway namespaces as defined by the helm values.
 {{- end -}}
 
 
-{{/* 
+{{/*
 Generated the "operations" array for a resource for the ValidatingWebhookConfiguration
 Arguments are a resource name, and a list of resources for which to skip webhook validation for DELETEs
 This list is expected to come from `gateway.validation.webhook.skipDeleteValidationResources`
@@ -224,4 +224,15 @@ Otherwise it will generate ["Create", "Update", "Delete"]
   {{- $operations = append $operations "DELETE" -}}
 {{- end -}}
 {{ toJson  $operations -}}
+{{- end -}}
+
+{{- define "gloo.util.overwriteWithOmit" -}}
+{{- $resource := first . -}}
+{{- $overwrite := index . 1 -}}
+{{- $result := deepCopy $resource | mergeOverwrite (deepCopy $overwrite) -}}
+{{- $omitKeys := index . 2 | default list -}}
+{{- range $key := $omitKeys }}
+  {{- $_ := unset $result $key }}
+{{- end }}
+{{ $result | toJson }}
 {{- end -}}

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -167,6 +167,7 @@ gatewayProxies:
     healthyPanicThreshold: 50
     tcpKeepaliveTimeSeconds: 60
     disableCoreDumps: false
+    disableExtauthSidecar: false
     # intentionally unset, so we default to the gloo service address. if set, this overrides the derived gloo service address
     # xdsServiceAddress: xds-relay.default.svc.cluster.local
     # intentionally unset, so we default to the gloo service port. if set, this overrides .Values.gloo.deployment.xdsPort


### PR DESCRIPTION
# Description

When multiple gateway proxies are defined as well as extauth enabled, a user might want to enable the sidecar for a subset of gateway proxies (since some of them do not require extauth) to reduce resource usage and unnecessary network calls to an unused sidecar.
This feature adds the new helm value `gatewayproxy.proxyName.disableExtauthSidecar` to disable the extauth sidecar on it
It also adds additional helper methods to merge resources while omitting keys in those resources which should not be overwritten if empty

## Helm changes
- Added a new `gatewayproxy.proxyName.disableExtauthSidecar` value

## Code changes
N/A

## CI changes
N/A

## Docs changes
N/A

# Context

https://github.com/solo-io/gloo/issues/8430

## Interesting decisions
 
Had initially thought of the idea to omit fields in an overwrite based on keys as in ddc6774fe70399bdbbd37a870b3f777d9a63f9ab but decided against it as future changes would require modifying those keys if the same field is modified in different locations. Eg: if one part of the code did not want the field modified it would add the key to the list of omitKeys but another part of the code when changing the field would need to remove it from the list

## Testing steps

Unit tests in enterprise to validate the behaviour of the new helm fields and helpers

## Notes for reviewers

N/A

Please proofread comments on ...

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->