### PR TITLE
Fix upgrade issues from v1.15.16, v1.14.27 and v1.13.32 to v1.16.0-beta20+

### DIFF
--- a/changelog/v1.16.0-beta25/fix-nightlies.yaml
+++ b/changelog/v1.16.0-beta25/fix-nightlies.yaml
@@ -6,7 +6,7 @@ changelog:
     Fix upgrade issues from v1.15.16, v1.14.27 and v1.13.32 to v1.16.0-beta20+. This was caused due to the resource-rollout RBAC being a pre-upgrade/install helm hook in v1.16.0-beta20+ while not being a hook in the latest LTS releases. This fix moves the resource-rollout RBAC out of the pre-upgrade/install hook in this release.
     Upgrades from v1.16.0-beta20+ will require running the following commands prior to the upgrade to cleanup the pre-upgrade/install resource-rollout RBAC helm hooks.
     ```
-    export RELEASE_NAMESPACE="{{ .Release.Namespace }}"
+    export RELEASE_NAMESPACE="gloo-system"  # replace this with the installation namespace
     export RBAC_SUFFIX=`kubectl get ClusterRole | grep gloo-resource-rollout | sed 's/gloo-resource-rollout//g' | cut -d ' ' -f 1`
     kubectl delete ClusterRole gloo-resource-rollout$RBAC_SUFFIX
     kubectl delete ClusterRoleBinding gloo-resource-rollout$RBAC_SUFFIX

--- a/changelog/v1.16.0-beta25/fix-nightlies.yaml
+++ b/changelog/v1.16.0-beta25/fix-nightlies.yaml
@@ -1,0 +1,16 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/8902
+  resolvesIssue: false
+  description: >-
+    Fix upgrade issues from v1.15.16, v1.14.27 and v1.13.32 to v1.16.0-beta20+. This was caused due to the resource-rollout RBAC being a pre-upgrade/install helm hook in v1.16.0-beta20+ while not being a hook in the latest LTS releases. This fix moves the resource-rollout RBAC out of the pre-upgrade/install hook in this release.
+    Upgrades from v1.16.0-beta20+ will require running the following commands prior to the upgrade to cleanup the pre-upgrade/install resource-rollout RBAC helm hooks.
+    ```
+    export RELEASE_NAMESPACE="{{ .Release.Namespace }}"
+    export RBAC_SUFFIX=`kubectl get ClusterRole | grep gloo-resource-rollout | sed 's/gloo-resource-rollout//g' | cut -d ' ' -f 1`
+    kubectl delete ClusterRole gloo-resource-rollout$RBAC_SUFFIX
+    kubectl delete ClusterRoleBinding gloo-resource-rollout$RBAC_SUFFIX
+    kubectl delete Role gloo-resource-rollout -n $RELEASE_NAMESPACE
+    kubectl delete RoleBinding gloo-resource-rollout -n $RELEASE_NAMESPACE
+    kubectl delete ServiceAccount gloo-resource-rollout -n $RELEASE_NAMESPACE
+    ```

--- a/install/helm/gloo/templates/5-resource-rollout-job-clusterrole.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-clusterrole.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "0" # must be created before rollout job
 rules:
 - apiGroups: ["gateway.solo.io"]
   resources: ["*"]

--- a/install/helm/gloo/templates/5-resource-rollout-job-clusterrolebinding.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-clusterrolebinding.yaml
@@ -8,9 +8,6 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "0" # must be created before rollout job
 roleRef:
   kind: ClusterRole
   name: gloo-resource-rollout{{ include "gloo.rbacNameSuffix" . }}

--- a/install/helm/gloo/templates/5-resource-rollout-job-role.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-role.yaml
@@ -9,9 +9,6 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "0" # must be created before rollout job
 rules:
 - apiGroups: ["apps"]
   resources: ["deployments"]

--- a/install/helm/gloo/templates/5-resource-rollout-job-rolebinding.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-rolebinding.yaml
@@ -9,9 +9,6 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "0" # must be created before rollout job
 roleRef:
   kind: Role
   name: gloo-resource-rollout

--- a/install/helm/gloo/templates/5-resource-rollout-job-service-account.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-job-service-account.yaml
@@ -7,9 +7,6 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "0" # must be created before rollout job
   name: gloo-resource-rollout
   namespace: {{ .Release.Namespace }}
 {{- end -}}{{/* if .Values.global.glooRbac.create */}}

--- a/test/kube2e/upgrade/upgrade_test.go
+++ b/test/kube2e/upgrade/upgrade_test.go
@@ -354,7 +354,7 @@ func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, targetRelea
 
 func uninstallGloo(testHelper *helper.SoloTestHelper, ctx context.Context, cancel context.CancelFunc) {
 	Expect(testHelper).ToNot(BeNil())
-	err := testHelper.UninstallGloo()
+	err := testHelper.UninstallGlooAll()
 	Expect(err).NotTo(HaveOccurred())
 	_, err = kube2e.MustKubeClient().CoreV1().Namespaces().Get(ctx, testHelper.InstallNamespace, metav1.GetOptions{})
 	Expect(apierrors.IsNotFound(err)).To(BeTrue())


### PR DESCRIPTION
# Description

Fix upgrade issues from v1.15.16, v1.14.27 and v1.13.32 to v1.16.0-beta20+
The upgrade failure was caused due to 1.16 having the resource rollout RBAC as a pre-install hook while on 1.13-1.15, it is no longer a hook. 

Understanding the issue :
- When a non-hook resource is made into a pre-upgrade hook and the chart is upgraded, helm starts with deploying the pre-upgrade hook - all good.
- Once the pre-hook phase is complete, helm will decide whether or not to delete the hook based on the deletion policy. In this case, the policy is not to delete the hook on success.
- Next, when deploying the resources as part of the upgrade, helm identifies resources that belong to the chart and deletes all resources in the old chart which do not exist in the upgraded chart - this includes the resource which was made into a pre-hook. This causes the issue. The resource-rollout RBAC is deleted even though it is now a pre-upgrade hook and the rollout job does not get the service account token to run which leads to a failed install.

```
# Install the latest LTS of Gloo Edge
[16:56:45] ~/lab/gloo ➦ fix-nightlies $ helm install gloo gloo/gloo --version v1.15.16 -n gloo-system --wait --wait-for-jobs --set gatewayProxies.gatewayProxy.service.type=ClusterIP --create-namespace --values /Users/djumani/lab/gloo/test/kube2e/upgrade/artifacts/helm.yaml --set gateway.validation.failurePolicy=Fail --set gateway.validation.allowWarnings=false --set gateway.validation.alwaysAcceptResources=false
NAME: gloo
LAST DEPLOYED: Wed Nov 15 16:57:22 2023
NAMESPACE: gloo-system
STATUS: deployed
REVISION: 1
TEST SUITE: None

# Upgrade to the latest 1.16 beta
[17:03:39] ~/lab/gloo ➦ fix-nightlies $ helm upgrade gloo gloo/gloo --version v1.16.0-beta24 -n gloo-system --wait --wait-for-jobs --set gatewayProxies.gatewayProxy.service.type=ClusterIP --create-namespace --values /Users/djumani/lab/gloo/test/kube2e/upgrade/artifacts/helm.yaml
Error: UPGRADE FAILED: context deadline exceeded

# Identify the reason for the failure
[17:04:22] ~/lab/gloo ➦ fix-nightlies $ kg describe pod/gloo-resource-rollout-p6tzk
...
Events:
  Type     Reason       Age               From               Message
  ----     ------       ----              ----               -------
  Warning  FailedMount  1s (x6 over 16s)  kubelet            MountVolume.SetUp failed for volume "kube-api-access-m2zt6" : failed to fetch token: serviceaccounts "gloo-resource-rollout" not found

```

After discussing the potential solutions mentioned [here](https://github.com/solo-io/gloo/issues/8902), it was decided to fix this by removing the RBAC from pre-hooks in main.
While this fixes upgrades from LTS, it breaks upgrades from v1.16.0-beta20+. This is the best option as they are only beta releases and upgrade notes can be added.
Upgrades from v1.16.0-beta20+ will require running the following commands prior to an install
```
export RELEASE_NAMESPACE="gloo-system"  # replace this with the installation namespace
export RBAC_SUFFIX=`kubectl get ClusterRole | grep gloo-resource-rollout | sed 's/gloo-resource-rollout//g' | cut -d ' ' -f 1`
kubectl delete ClusterRole gloo-resource-rollout$RBAC_SUFFIX
kubectl delete ClusterRoleBinding gloo-resource-rollout$RBAC_SUFFIX
kubectl delete Role gloo-resource-rollout -n $RELEASE_NAMESPACE
kubectl delete RoleBinding gloo-resource-rollout -n $RELEASE_NAMESPACE
kubectl delete ServiceAccount gloo-resource-rollout -n $RELEASE_NAMESPACE
```

## Helm changes
- Removed the resource rollout RBAC from being pre-hooks

# Context

https://github.com/solo-io/gloo/issues/8902
https://github.com/solo-io/gloo/actions/runs/6845891908

## Interesting decisions
 
N/A

## Testing steps

### From latest LTS to main
```
[16:56:45] ~/lab/gloo ➦ fix-nightlies $ helm install gloo gloo/gloo --version v1.15.16 -n gloo-system --wait --wait-for-jobs --set gatewayProxies.gatewayProxy.service.type=ClusterIP --create-namespace --values /Users/djumani/lab/gloo/test/kube2e/upgrade/artifacts/helm.yaml --set gateway.validation.failurePolicy=Fail --set gateway.validation.allowWarnings=false --set gateway.validation.alwaysAcceptResources=false
NAME: gloo
LAST DEPLOYED: Wed Nov 15 16:57:22 2023
NAMESPACE: gloo-system
STATUS: deployed
REVISION: 1
TEST SUITE: None

[16:58:57] ~/lab/gloo ➦ fix-nightlies $ helm upgrade gloo _test/gloo-1.0.0-ci.tgz -n gloo-system --wait --wait-for-jobs --set gatewayProxies.gatewayProxy.service.type=ClusterIP --create-namespace --values /Users/djumani/lab/gloo/test/kube2e/upgrade/artifacts/helm.yaml --set gateway.validation.failurePolicy=Fail --set gateway.validation.allowWarnings=false --set gateway.validation.alwaysAcceptResources=false
Release "gloo" has been upgraded. Happy Helming!
NAME: gloo
LAST DEPLOYED: Wed Nov 15 16:59:07 2023
NAMESPACE: gloo-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
```
### From v1.16.0-beta24 to main
```
[16:48:02] ~/lab/gloo ➦ fix-nightlies $ helm  install gloo gloo/gloo --version v1.16.0-beta24 -n gloo-system --wait --wait-for-jobs --set gatewayProxies.gatewayProxy.service.type=ClusterIP --create-namespace --values /Users/djumani/lab/gloo/test/kube2e/upgrade/artifacts/helm.yaml
NAME: gloo
LAST DEPLOYED: Wed Nov 15 16:48:10 2023
NAMESPACE: gloo-system
STATUS: deployed
REVISION: 1
TEST SUITE: None

# Cleanup the RBAC so it does not interfere with upgrades

export RELEASE_NAMESPACE="gloo-system"
export RBAC_SUFFIX=`kubectl get ClusterRole | grep gloo-resource-rollout | sed 's/gloo-resource-rollout//g' | cut -d ' ' -f 1`
kubectl delete ClusterRole gloo-resource-rollout$RBAC_SUFFIX
kubectl delete ClusterRoleBinding gloo-resource-rollout$RBAC_SUFFIX
kubectl delete Role gloo-resource-rollout -n $RELEASE_NAMESPACE
kubectl delete RoleBinding gloo-resource-rollout -n $RELEASE_NAMESPACE
kubectl delete ServiceAccount gloo-resource-rollout -n $RELEASE_NAMESPACE

[16:51:16] ~/lab/gloo ➦ fix-nightlies $ helm upgrade gloo _test/gloo-1.0.0-ci.tgz -n gloo-system --wait --wait-for-jobs --set gatewayProxies.gatewayProxy.service.type=ClusterIP --create-namespace --values /Users/djumani/lab/gloo/test/kube2e/upgrade/artifacts/helm.yaml --set gateway.validation.failurePolicy=Fail --set gateway.validation.allowWarnings=false --set gateway.validation.alwaysAcceptResources=false 
Release "gloo" has been upgraded. Happy Helming!
NAME: gloo
LAST DEPLOYED: Wed Nov 15 16:52:23 2023
NAMESPACE: gloo-system
STATUS: deployed
REVISION: 2
TEST SUITE: None
```

### Upgrade tests
Apply the following diff to the upgrade tests
```
diff --git a/test/kube2e/upgrade/upgrade_test.go b/test/kube2e/upgrade/upgrade_test.go
index 08d47e9ee..1606218d0 100644
--- a/test/kube2e/upgrade/upgrade_test.go
+++ b/test/kube2e/upgrade/upgrade_test.go
@@ -318,6 +318,18 @@ func upgradeGloo(testHelper *helper.SoloTestHelper, chartUri string, targetRelea
        // So we wait until the job ttl has expired to be cleaned up to ensure the upgrade passes
        runAndCleanCommand("kubectl", "-n", defaults.GlooSystem, "wait", "--for=delete", "job", "gloo-resource-rollout", "--timeout=600s")
 
+       cleanupCommand := `
+export RELEASE_NAMESPACE="gloo-system"
+export RBAC_SUFFIX="-e2e-test-rbac-suffix"
+kubectl delete ClusterRole gloo-resource-rollout$RBAC_SUFFIX
+kubectl delete ClusterRoleBinding gloo-resource-rollout$RBAC_SUFFIX
+kubectl delete Role gloo-resource-rollout -n $RELEASE_NAMESPACE
+kubectl delete RoleBinding gloo-resource-rollout -n $RELEASE_NAMESPACE
+kubectl delete ServiceAccount gloo-resource-rollout -n $RELEASE_NAMESPACE
+`
+       cmd := exec.Command("bash", "-c", cleanupCommand)
+       cmd.Output()
+
        upgradeCrds(crdDir)
 
        valueOverrideFile, cleanupFunc := getHelmUpgradeValuesOverrideFile()
```
Run the upgrade tests
```
Ran 8 of 8 Specs in 657.548 seconds
SUCCESS! -- 8 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```
## Notes for reviewers

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
