### PR TITLE
1.13: mod: bump both kubectl and alpine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,7 +134,7 @@ ifeq ($(GOOS),)
 endif
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=$(GOARCH)
-GOLANG_VERSION := golang:1.20-alpine
+GOLANG_VERSION := golang:1.20-alpine3.18
 
 # Passed by cloudbuild
 GCLOUD_PROJECT_ID := $(GCLOUD_PROJECT_ID)

--- a/changelog/v1.13.34/kubectl-bump.yaml
+++ b/changelog/v1.13.34/kubectl-bump.yaml
@@ -1,0 +1,18 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink:  https://github.com/solo-io/gloo/issues/8946
+    description: >
+      Update bitnami/kubectl image to 1.24.16 to pick up fix for CVE-2023-39325
+    resolvesIssue: false
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: alpine
+    dependencyRepo: alpine
+    dependencyTag: 3.17.2
+    description: Update Alpine images to latest 3.17.6
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: cloud-builders
+    issueLink: https://github.com/solo-io/solo-projects/issues/5550
+    dependencyTag: 0.7.1
+    resolvesIssue: false
+    description: Update Go build version for https://nvd.nist.gov/vuln/detail/CVE-2023-39326 same as enterprise

--- a/changelog/v1.13.34/kubectl-bump.yaml
+++ b/changelog/v1.13.34/kubectl-bump.yaml
@@ -7,7 +7,7 @@ changelog:
   - type: DEPENDENCY_BUMP
     dependencyOwner: alpine
     dependencyRepo: alpine
-    dependencyTag: 3.17.2
+    dependencyTag: 3.17.6
     description: Update Alpine images to latest 3.17.6
   - type: DEPENDENCY_BUMP
     dependencyOwner: solo-io

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
 # gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo,_PR_NUM=<<insert PR Number here>> --project solo-public
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.7.1'
   args:
     - "--repo-name"
     - "$REPO_NAME"
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['prepare-workspace']
   id: 'get-envoy'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   entrypoint: 'bash'
   args: ['-c', 'make proxycontroller']
   dir: '/workspace/gloo/example/proxycontroller'
@@ -68,7 +68,7 @@ steps:
 
 # Docker related setup
 # grab this container immediately in parallel
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.1'
   entrypoint: ls
   waitFor: ['-']
   id: 'grab-ginkgo-container'
@@ -82,12 +82,12 @@ steps:
   waitFor: ['set-gcr-zone']
   id: 'get-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   args: ['install-go-tools']
   dir: *dir
   id: 'install-go-tools'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.1'
   entrypoint: make
   env:
   - 'ACK_GINKGO_RC=true'
@@ -117,7 +117,7 @@ steps:
   id: 'docker-login'
 
   # 1) Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   args: ['docker-push-extended']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -138,7 +138,7 @@ steps:
   waitFor: ['docker-push-extended']
   id: 'gcr-auth'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   args: ['fetch-package-and-save-helm', 'render-manifests', 'upload-github-release-assets', 'push-chart-to-registry', '-B']
   env:
     - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -152,7 +152,7 @@ steps:
   id: 'release-chart'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   args: ['docker-push-retag']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'

--- a/docs/content/guides/dev/writing_auth_plugins/_index.md
+++ b/docs/content/guides/dev/writing_auth_plugins/_index.md
@@ -387,7 +387,7 @@ RUN chmod +x $VERIFY_SCRIPT
 RUN $VERIFY_SCRIPT -pluginDir plugins -manifest plugins/plugin_manifest.yaml
 
 # This stage builds the final image containing just the plugin .so files. It can really be any linux/amd64 image.
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 # Copy compiled plugin file from previous stage
 RUN mkdir /compiled-auth-plugins

--- a/docs/content/guides/security/tls/Dockerfile
+++ b/docs/content/guides/security/tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY cert.pem /cert.pem
 COPY key.pem /key.pem

--- a/docs/examples/session-affinity/Dockerfile
+++ b/docs/examples/session-affinity/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/docs/examples/xslt-guide/Dockerfile
+++ b/docs/examples/xslt-guide/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates curl \

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/jobs/certgen/cmd/Dockerfile
+++ b/jobs/certgen/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
-FROM bitnami/kubectl:1.24.7 as kubectl
+FROM bitnami/kubectl:1.24.16 as kubectl
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache
 

--- a/projects/accesslogger/cmd/Dockerfile
+++ b/projects/accesslogger/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 RUN apk -U upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*

--- a/projects/discovery/cmd/Dockerfile
+++ b/projects/discovery/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/projects/gloo/Dockerfile
+++ b/projects/gloo/Dockerfile
@@ -34,6 +34,6 @@ RUN CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=linux go build \
     projects/gloo/cmd/main.go
 
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 ARG GOARCH
 COPY --from=build-env /go/src/github.com/solo-io/gloo/gloo-linux-${GOARCH} /

--- a/projects/ingress/cmd/Dockerfile
+++ b/projects/ingress/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/sds/cmd/Dockerfile
+++ b/projects/sds/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 


### PR DESCRIPTION
Kubectl bump, alpine patch bump 

Alpine just as might as well.
Bitnami kubectl image to get security updates for [CVE-2023-39325](https://github.com/advisories/GHSA-4374-p667-p6c8)

go pin until fslibrary issue with alpine bump is resolved


Reviews:
- check that kubectl job has the right value
- check that alpine layer has the correct value
- run cloud build locally see the built images go version


This fixes the kubectl cve which as always can be checked by running a trivy scan before and after.
It should be run something like this for ease of use
` VERSION=1.13/kubectl-bump
 make docker 
 git checkout main
 go run github.com/solo-io/go-utils/securityscanutils/cli scan-version -v \
		-r quay.io/solo-io\
		-t $(VERSION)\
		--images gloo,gloo-envoy-wrapper,discovery,ingress,sds,certgen,access-logger,kubectl

`

make sure that your local go has no cves though or else it will appear

you should see each image reported with no vulnerabilites


the output is like 

`No Vulnerabilities Found for quay.io/solo-io/access-logger:1.13/kubectl-bump (alpine 3.17.6)

No Vulnerabilities Found for quay.io/solo-io/certgen:1.13/kubectl-bump (alpine 3.17.6)

No Vulnerabilities Found for quay.io/solo-io/discovery:1.13/kubectl-bump (alpine 3.17.6)

No Vulnerabilities Found for quay.io/solo-io/gloo-envoy-wrapper:1.13/kubectl-bump (alpine 3.17.6)

No Vulnerabilities Found for quay.io/solo-io/gloo:1.13/kubectl-bump (alpine 3.17.6)


No Vulnerabilities Found for quay.io/solo-io/ingress:1.13/kubectl-bump (alpine 3.17.6)


No Vulnerabilities Found for quay.io/solo-io/kubectl:1.13/kubectl-bump (alpine 3.17.6)

No Vulnerabilities Found for quay.io/solo-io/sds:1.13/kubectl-bump (alpine 3.17.6)
`
