### PR TITLE
Update MIN_SCANNED_VERSION version in docs-gen.yaml to v1.12

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -2,7 +2,7 @@ name: Docs
 
 env:
     SLACK_DEBUG_TESTING: false      # when set to "true", send notifications to #slack-integration-testing.  Otherwise, post to #edge-team-bots
-    MIN_SCANNED_VERSION: 'v1.11.0'  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
+    MIN_SCANNED_VERSION: 'v1.12.0'  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
 on:
   push:
     branches:

--- a/changelog/v1.16.0-beta29/update-docs-gen-scanner-min-version-1.12.yaml
+++ b/changelog/v1.16.0-beta29/update-docs-gen-scanner-min-version-1.12.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update the MIN_SCANNED_VERSION to v1.12 in docs-gen.yaml so v1.11 does not get scanned for vulnerabilities.

--- a/changelog/v1.16.0-beta29/update-docs-gen-scanner-min-version-1.12.yaml
+++ b/changelog/v1.16.0-beta29/update-docs-gen-scanner-min-version-1.12.yaml
@@ -1,3 +1,6 @@
 changelog:
   - type: NON_USER_FACING
-    description: Update the MIN_SCANNED_VERSION to v1.12 in docs-gen.yaml so v1.11 does not get scanned for vulnerabilities.
+    description: >-
+      Update the MIN_SCANNED_VERSION to v1.12 in docs-gen.yaml so v1.11 does not get scanned for vulnerabilities.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

We run & publish security scans through `docs-gen.yaml`, and did not update the MIN_SCANNED_VERSION to our latest least-supported-version.

## CI changes

- We now only scan v1.12+ releases on pushes on our supported (v1.12+) branches.

# Context

Our security scans reported CVEs for v1.11 of Gloo OSS + EE. We should not be scanning these versions as they fall outside of our current support (N-3 -> 15-3 -> 12).
- https://github.com/solo-io/gloo/issues/8955
- https://github.com/solo-io/solo-projects/issues/5555

We [missed this](https://github.com/solo-io/gloo/pull/8703) when updating our scanner + docs.

# Checklist:

- [x] I have performed a self-review of my own code