### PR TITLE
pkg/plugins/transformation: fix dropped test error

### DIFF
--- a/projects/gloo/pkg/plugins/transformation/plugin_test.go
+++ b/projects/gloo/pkg/plugins/transformation/plugin_test.go
@@ -834,6 +834,7 @@ var _ = Describe("Plugin", func() {
 					StagedTransformations: inputTransform,
 				},
 			}, out)
+			Expect(err).NotTo(HaveOccurred())
 			filters, err := p.(plugins.HttpFilterPlugin).HttpFilters(plugins.Params{Ctx: ctx}, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(filters)).To(Equal(2))


### PR DESCRIPTION
This fixes a dropped `err` variable in the tests for `pkg/plugins/transformation`.