### PR TITLE
[Main/1.16] Pin alpine to 3.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,7 @@ endif
 GOOS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=$(GOARCH)
-GOLANG_ALPINE_IMAGE_NAME = golang:$(shell go version | egrep -o '([0-9]+\.[0-9]+)')-alpine
+GOLANG_ALPINE_IMAGE_NAME = golang:$(shell go version | egrep -o '([0-9]+\.[0-9]+)')-alpine3.18
 
 TEST_ASSET_DIR := $(ROOTDIR)/_test
 

--- a/changelog/v1.16.0-beta29/pin-alpine.yaml
+++ b/changelog/v1.16.0-beta29/pin-alpine.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Update golang/alpine docker images to pin alpine to 3.18 


### PR DESCRIPTION
# Description
 - Update golang/alpine docker images to pin alpine to 3.18