### PR TITLE
Introduce Stalebot

### DIFF
--- a/.github/workflows/stalebot.yaml
+++ b/.github/workflows/stalebot.yaml
@@ -1,0 +1,35 @@
+name: Stalebot
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    # Everyday 6am EST
+    - cron: "0 10 * * *"
+
+env:
+  DAYS_BEFORE_ISSUE_STALE: 180
+  DAYS_BEFORE_ISSUE_CLOSE: 180
+
+jobs:
+  close-stale-issues:
+    name: Close Stale Issues
+    runs-on: ubuntu-22.04
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/stale@v8 # https://github.com/actions/stale
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-issue-stale: ${{ env.DAYS_BEFORE_ISSUE_STALE }}
+          days-before-issue-close: ${{ env.DAYS_BEFORE_ISSUE_CLOSE }}
+          stale-issue-message: >
+            This issue has been marked as stale because of no activity in the last ${{ env.DAYS_BEFORE_ISSUE_STALE }} days.
+            It will be closed in the next ${{ env.DAYS_BEFORE_ISSUE_CLOSE }} days unless it is tagged "no stalebot" or other activity occurs.
+          close-issue-message: >
+            This issue has been closed due to no activity in the last 12 months.
+          stale-issue-label: 'stale' # https://github.com/solo-io/gloo/labels/stale
+          exempt-issue-labels: 'no stalebot' # https://github.com/solo-io/gloo/labels/no%20stalebot
+          enable-statistics: true
+          operations-per-run: 1000
+          ascending: true # asc means oldest first
+          # debug-only: true # dry-run for debugging

--- a/changelog/v1.16.0-beta29/stalebot.yaml
+++ b/changelog/v1.16.0-beta29/stalebot.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >
+      Introduce stalebot action.
+      
+      skipCI-docs-build:true
+      skipCI-kube-tests:true


### PR DESCRIPTION
# Description

Introduce a stalebot to actively manage the issues in this project.


# Context

Inspired by: https://github.com/solo-io/gloo-mesh-enterprise/blob/main/.github/workflows/stalebot.yaml

All I did was extend the window between when issues are labeled stale, and issues are closed.

## Interesting decisions
 -

## Testing steps
-

## Notes for reviewers
- I reached out to the product team for confirmation (https://solo-io-corp.slack.com/archives/C03L190TQDA/p1701777887923179) and got buy in from @kcbabo @SantoDE @chrisgaun 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
