### PR TITLE
[1.14] Fix 12/8/2023 CVEs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ ifeq ($(GOOS),)
 endif
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=$(GOARCH)
-GOLANG_VERSION := golang:1.20.1-alpine
+GOLANG_VERSION := golang:1.20.12-alpine3.18
 
 # Passed by cloudbuild
 GCLOUD_PROJECT_ID := $(GCLOUD_PROJECT_ID)

--- a/changelog/v1.14.28/fix-dec-8-2023-cves.yaml
+++ b/changelog/v1.14.28/fix-dec-8-2023-cves.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: linux
+    dependencyRepo: alpine
+    dependencyTag: 3.17.6
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: cloud-builders
+    dependencyTag: 0.7.1

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.7.1'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -44,7 +44,7 @@ steps:
   - 'us-central1-a'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   id: 'docker-push-extended'
   args:
   - 'docker-push-extended'
@@ -65,7 +65,7 @@ steps:
   waitFor:
   - 'docker-push-extended'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   id: 'release-chart'
   dir: *dir
   args:
@@ -82,7 +82,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.7.1'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -23,7 +23,7 @@ steps:
     cd /go/pkg
     gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   id: 'prepare-envoy'
   dir: *dir
   entrypoint: 'bash'
@@ -68,7 +68,7 @@ steps:
   waitFor:
   - 'prepare-gcr-zone'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
   id: 'prepare-test-tools'
   dir: *dir
   args:
@@ -79,7 +79,7 @@ steps:
   - 'prepare-gcr-zone'
   - 'prepare-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.1'
   id: 'run-tests'
   dir: *dir
   entrypoint: 'make'
@@ -90,7 +90,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.6.8'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.1'
   id: 'run-e2e-tests'
   dir: *dir
   entrypoint: 'make'

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -8,17 +8,17 @@ steps:
     path: '/go/pkg'
   id: 'untar-mod-cache'
 
-- name: 'golang:1.20.1'
+- name: 'golang:1.20.12'
   args: ['go', 'mod', 'download']
   volumes: *vol
   id: 'download'
 
-- name: 'golang:1.20.1'
+- name: 'golang:1.20.12'
   args: ['go', 'mod', 'tidy']
   volumes: *vol
   id: 'tidy'
 
-- name: 'golang:1.20.1'
+- name: 'golang:1.20.12'
   entrypoint: 'bash'
   volumes: *vol
   args: ['-c', ' cd /go/pkg && tar -zvcf gloo-mod.tar.gz mod']

--- a/docs/content/guides/dev/writing_auth_plugins/_index.md
+++ b/docs/content/guides/dev/writing_auth_plugins/_index.md
@@ -387,7 +387,7 @@ RUN chmod +x $VERIFY_SCRIPT
 RUN $VERIFY_SCRIPT -pluginDir plugins -manifest plugins/plugin_manifest.yaml
 
 # This stage builds the final image containing just the plugin .so files. It can really be any linux/amd64 image.
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 # Copy compiled plugin file from previous stage
 RUN mkdir /compiled-auth-plugins

--- a/docs/content/guides/security/tls/Dockerfile
+++ b/docs/content/guides/security/tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY cert.pem /cert.pem
 COPY key.pem /key.pem

--- a/docs/examples/session-affinity/Dockerfile
+++ b/docs/examples/session-affinity/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/docs/examples/xslt-guide/Dockerfile
+++ b/docs/examples/xslt-guide/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates curl \

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/jobs/certgen/cmd/Dockerfile
+++ b/jobs/certgen/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/kubectl:1.25.15 as kubectl
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache
 

--- a/projects/accesslogger/cmd/Dockerfile
+++ b/projects/accesslogger/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 RUN apk -U upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*

--- a/projects/discovery/cmd/Dockerfile
+++ b/projects/discovery/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/projects/gloo/Dockerfile
+++ b/projects/gloo/Dockerfile
@@ -34,6 +34,6 @@ RUN CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=linux go build \
     projects/gloo/cmd/main.go
 
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 ARG GOARCH
 COPY --from=build-env /go/src/github.com/solo-io/gloo/gloo-linux-${GOARCH} /

--- a/projects/ingress/cmd/Dockerfile
+++ b/projects/ingress/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/sds/cmd/Dockerfile
+++ b/projects/sds/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 


### PR DESCRIPTION
# Description

Fixing new CVEs caught

## API changes
- Upgraded to alpine:3.17.6 to fix https://github.com/advisories/GHSA-xw78-pcr6-wrg8

## CI changes
- Bumped Go version + Cloudbuild for https://github.com/advisories/GHSA-9f76-wg39-x86h

# Context

While working on the 1.14 CVEs, I caught a new one regarding the `libssl` library in alpine `3.17.3`, which needed updating.

## Testing steps

```bash
VERSION=<version> make docker -B
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:<version>"; done
```

### Before
```
quay.io/solo-io/gloo:v1.14.x-oss-prefix (alpine 3.17.5)
=======================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/gloo-envoy-wrapper:v1.14.x-oss-prefix (alpine 3.17.5)
=====================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/discovery:v1.14.x-oss-prefix (alpine 3.17.3)
============================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/ingress:v1.14.x-oss-prefix (alpine 3.17.3)
==========================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/sds:v1.14.x-oss-prefix (alpine 3.17.3)
======================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/certgen:v1.14.x-oss-prefix (alpine 3.17.3)
==========================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/access-logger:v1.14.x-oss-prefix (alpine 3.17.3)
================================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/kubectl:v1.14.x-oss-prefix (alpine 3.17.3)
==========================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.10-r0         │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

usr/local/bin/kubectl (gobinary)
================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌────────────────────────────────┬───────────────┬──────────┬─────────────────────┬───────────────┬───────────────────────────────────────────┐
│            Library             │ Vulnerability │ Severity │  Installed Version  │ Fixed Version │                   Title                   │
├────────────────────────────────┼───────────────┼──────────┼─────────────────────┼───────────────┼───────────────────────────────────────────┤
│ github.com/docker/distribution │ CVE-2023-2253 │ HIGH     │ v2.8.1+incompatible │ 2.8.2-beta.1  │ DoS from malicious API request            │
│                                │               │          │                     │               │ https://avd.aquasec.com/nvd/cve-2023-2253 │
└────────────────────────────────┴───────────────┴──────────┴─────────────────────┴───────────────┴───────────────────────────────────────────┘
```

### After
```
quay.io/solo-io/gloo:v1.14.x-oss-postfix (alpine 3.17.5)
========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/gloo-envoy-wrapper:v1.14.x-oss-postfix (alpine 3.17.5)
======================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/discovery:v1.14.x-oss-postfix (alpine 3.17.6)
=============================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/ingress:v1.14.x-oss-postfix (alpine 3.17.6)
===========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/sds:v1.14.x-oss-postfix (alpine 3.17.6)
=======================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/certgen:v1.14.x-oss-postfix (alpine 3.17.6)
===========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/access-logger:v1.14.x-oss-postfix (alpine 3.17.6)
=================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/kubectl:v1.14.x-oss-postfix (alpine 3.17.6)
===========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/kubectl (gobinary)
================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌────────────────────────────────┬───────────────┬──────────┬─────────────────────┬───────────────┬───────────────────────────────────────────┐
│            Library             │ Vulnerability │ Severity │  Installed Version  │ Fixed Version │                   Title                   │
├────────────────────────────────┼───────────────┼──────────┼─────────────────────┼───────────────┼───────────────────────────────────────────┤
│ github.com/docker/distribution │ CVE-2023-2253 │ HIGH     │ v2.8.1+incompatible │ 2.8.2-beta.1  │ DoS from malicious API request            │
│                                │               │          │                     │               │ https://avd.aquasec.com/nvd/cve-2023-2253 │
└────────────────────────────────┴───────────────┴──────────┴─────────────────────┴───────────────┴───────────────────────────────────────────┘
```

## Notes for reviewers

- There was a CVE caught in the `bitnami/kubectl` image, although there aren't any newer releases there which we can upgrade to.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->