### PR TITLE
Fix 12/8/2023 CVEs

### DIFF
--- a/changelog/v1.16.0-beta29/fix-dec-8-2023-cves.yaml
+++ b/changelog/v1.16.0-beta29/fix-dec-8-2023-cves.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: linux
+    dependencyRepo: alpine
+    dependencyTag: 3.17.6

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -1,6 +1,6 @@
 options:
   env:
-    - "_GO_VERSION=1.21.4"
+    - "_GO_VERSION=1.21.5"
 
 steps:
 - name: gcr.io/cloud-builders/gsutil

--- a/docs/content/guides/dev/writing_auth_plugins/_index.md
+++ b/docs/content/guides/dev/writing_auth_plugins/_index.md
@@ -387,7 +387,7 @@ RUN chmod +x $VERIFY_SCRIPT
 RUN $VERIFY_SCRIPT -pluginDir plugins -manifest plugins/plugin_manifest.yaml
 
 # This stage builds the final image containing just the plugin .so files. It can really be any linux/amd64 image.
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 # Copy compiled plugin file from previous stage
 RUN mkdir /compiled-auth-plugins

--- a/docs/content/guides/security/tls/Dockerfile
+++ b/docs/content/guides/security/tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY cert.pem /cert.pem
 COPY key.pem /key.pem

--- a/docs/examples/session-affinity/Dockerfile
+++ b/docs/examples/session-affinity/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/docs/examples/xslt-guide/Dockerfile
+++ b/docs/examples/xslt-guide/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates curl \

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/jobs/certgen/cmd/Dockerfile
+++ b/jobs/certgen/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/kubectl:1.28.4 as kubectl
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache
 

--- a/projects/accesslogger/cmd/Dockerfile
+++ b/projects/accesslogger/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 RUN apk -U upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*

--- a/projects/discovery/cmd/Dockerfile
+++ b/projects/discovery/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/projects/gloo/Dockerfile
+++ b/projects/gloo/Dockerfile
@@ -34,6 +34,6 @@ RUN CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=linux go build \
     projects/gloo/cmd/main.go
 
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 ARG GOARCH
 COPY --from=build-env /go/src/github.com/solo-io/gloo/gloo-linux-${GOARCH} /

--- a/projects/ingress/cmd/Dockerfile
+++ b/projects/ingress/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/sds/cmd/Dockerfile
+++ b/projects/sds/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 


### PR DESCRIPTION
# Description

Fixing new CVEs caught

## API changes
- Update Go version to `1.21.5`
- Update Alpine to `3.17.6` to fix https://github.com/advisories/GHSA-xw78-pcr6-wrg8

# Context

## Testing steps

```bash
VERSION=<version> make docker -B
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:<version>"; done
```

### Before
```
quay.io/solo-io/gloo:main-oss-prefix (ubuntu 20.04)
===================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/gloo-envoy-wrapper:main-oss-prefix (ubuntu 20.04)
=================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/discovery:main-oss-prefix (alpine 3.17.3)
=========================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/ingress:main-oss-prefix (alpine 3.17.3)
=======================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/sds:main-oss-prefix (alpine 3.17.3)
===================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/certgen:main-oss-prefix (alpine 3.17.3)
=======================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/access-logger:main-oss-prefix (alpine 3.17.3)
=============================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/kubectl:main-oss-prefix (alpine 3.17.3)
=======================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.10-r0         │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘
```


### After
```
quay.io/solo-io/gloo:main-oss-postfix (ubuntu 20.04)
====================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/gloo-envoy-wrapper:main-oss-postfix (ubuntu 20.04)
==================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/discovery:main-oss-postfix (alpine 3.17.6)
==========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/ingress:main-oss-postfix (alpine 3.17.6)
========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/sds:main-oss-postfix (alpine 3.17.6)
====================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/certgen:main-oss-postfix (alpine 3.17.6)
========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/access-logger:main-oss-postfix (alpine 3.17.6)
==============================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/kubectl:main-oss-postfix (alpine 3.17.6)
========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```

## Notes for reviewers


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
