### PR TITLE
When running `glooctl instio inject` the version detected needs to be without V

### DIFF
--- a/changelog/v1.16.0-beta29/glooctl-versioning.yaml
+++ b/changelog/v1.16.0-beta29/glooctl-versioning.yaml
@@ -2,4 +2,4 @@ changelog:
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/pull/8983
     resolvesIssue: true
-    description: >- Update glooctl inject for sds to not include v in the version
+    description: Update glooctl inject for sds to not include v in the version

--- a/changelog/v1.16.0-beta29/glooctl-versioning.yaml
+++ b/changelog/v1.16.0-beta29/glooctl-versioning.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/pull/8983
+    resolvesIssue: true
+    description: >- Update glooctl inject for sds to not include v in the version

--- a/projects/gloo/cli/pkg/cmd/istio/inject.go
+++ b/projects/gloo/cli/pkg/cmd/istio/inject.go
@@ -166,7 +166,7 @@ func istioInject(args []string, opts *options.Options) error {
 
 // addSdsSidecar adds an SDS sidecar to the given deployment's containers
 func addSdsSidecar(ctx context.Context, deployment *appsv1.Deployment, glooNamespace string) error {
-	glooVersion, err := GetGlooVersion(ctx, glooNamespace)
+	glooVersion, err := GetGlooVersionWithoutV(ctx, glooNamespace)
 	if err != nil {
 		return ErrGlooVerUndetermined
 	}

--- a/projects/gloo/cli/pkg/cmd/istio/sidecars/sds.go
+++ b/projects/gloo/cli/pkg/cmd/istio/sidecars/sds.go
@@ -8,6 +8,7 @@ import (
 // GetSdsSidecar returns an SDS Sidecar of the given gloo
 // release version to run alongside istio and gateway-proxy
 // containers in the gateway-proxy pod
+// the version string passed should not contain a "v"
 func GetSdsSidecar(version string) corev1.Container {
 	return corev1.Container{
 		Name:            "sds",


### PR DESCRIPTION
# Description

When running `glooctl instio inject` the version detected needs to be without V so that the actual image can be found.

## Code changes
- Change `GetVersion` to `GetVersionWithoutV`

# Context

I run into that, when testing `glooctl istio inject`

## Testing steps

Run in an non istio injected environment
`glooctl istio inject` and you will see ERR_IMAGE_PULL.

```
│   Normal   BackOff    9s                 kubelet            Back-off pulling image "quay.io/solo-io/sds:v1.15.17"                                                                               │
│   Warning  Failed     9s                 kubelet            Error: ImagePullBackOff
```

With that change, all is well.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/pull/8983