### PR TITLE
[1.15] Bump Alpine to 3.17.6

### DIFF
--- a/changelog/v1.15.18/bump-alpine-3.17.6.yaml
+++ b/changelog/v1.15.18/bump-alpine-3.17.6.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: linux
+    dependencyRepo: alpine
+    dependencyTag: 3.17.6

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -1,6 +1,6 @@
 options:
   env:
-    - "_GO_VERSION=1.20.1"
+    - "_GO_VERSION=1.20.12"
 
 steps:
 - name: gcr.io/cloud-builders/gsutil

--- a/docs/content/guides/dev/writing_auth_plugins/_index.md
+++ b/docs/content/guides/dev/writing_auth_plugins/_index.md
@@ -387,7 +387,7 @@ RUN chmod +x $VERIFY_SCRIPT
 RUN $VERIFY_SCRIPT -pluginDir plugins -manifest plugins/plugin_manifest.yaml
 
 # This stage builds the final image containing just the plugin .so files. It can really be any linux/amd64 image.
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 # Copy compiled plugin file from previous stage
 RUN mkdir /compiled-auth-plugins

--- a/docs/content/guides/security/tls/Dockerfile
+++ b/docs/content/guides/security/tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY cert.pem /cert.pem
 COPY key.pem /key.pem

--- a/docs/examples/session-affinity/Dockerfile
+++ b/docs/examples/session-affinity/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/docs/examples/xslt-guide/Dockerfile
+++ b/docs/examples/xslt-guide/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates curl \

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/jobs/certgen/cmd/Dockerfile
+++ b/jobs/certgen/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitnami/kubectl:1.27.8 as kubectl
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache
 

--- a/projects/accesslogger/cmd/Dockerfile
+++ b/projects/accesslogger/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 RUN apk -U upgrade && apk add ca-certificates && rm -rf /var/cache/apk/*

--- a/projects/discovery/cmd/Dockerfile
+++ b/projects/discovery/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/projects/gloo/Dockerfile
+++ b/projects/gloo/Dockerfile
@@ -34,6 +34,6 @@ RUN CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=linux go build \
     projects/gloo/cmd/main.go
 
 
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 ARG GOARCH
 COPY --from=build-env /go/src/github.com/solo-io/gloo/gloo-linux-${GOARCH} /

--- a/projects/ingress/cmd/Dockerfile
+++ b/projects/ingress/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 

--- a/projects/sds/cmd/Dockerfile
+++ b/projects/sds/cmd/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.3
+FROM alpine:3.17.6
 
 ARG GOARCH=amd64
 


### PR DESCRIPTION
# Description

Bumping Alpine to latest patch release to fix CVEs.

## API changes
- Bump `alpine` base image to 3.17.6

# Context

While working on other CVEs, I caught some on the Alpine image we use (3.17.3). Bumping to the latest release resolves them.

## Testing Steps

```
VERSION=<version> make docker -B
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:<version>"; done
```

### Before
```
quay.io/solo-io/gloo:1.15.x-prefix (ubuntu 20.04)
=================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/gloo-envoy-wrapper:1.15.x-prefix (ubuntu 20.04)
===============================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/discovery:1.15.x-prefix (alpine 3.17.3)
=======================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/ingress:1.15.x-prefix (alpine 3.17.3)
=====================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/sds:1.15.x-prefix (alpine 3.17.3)
=================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/certgen:1.15.x-prefix (alpine 3.17.3)
=====================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/access-logger:1.15.x-prefix (alpine 3.17.3)
===========================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.8-r3          │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

quay.io/solo-io/kubectl:1.15.x-prefix (alpine 3.17.3)
=====================================================
Total: 2 (HIGH: 2, CRITICAL: 0)

┌────────────┬───────────────┬──────────┬───────────────────┬───────────────┬────────────────────────────────────────────────────────┐
│  Library   │ Vulnerability │ Severity │ Installed Version │ Fixed Version │                         Title                          │
├────────────┼───────────────┼──────────┼───────────────────┼───────────────┼────────────────────────────────────────────────────────┤
│ libcrypto3 │ CVE-2023-5363 │ HIGH     │ 3.0.10-r0         │ 3.0.12-r0     │ openssl: Incorrect cipher key and IV length processing │
│            │               │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-5363              │
├────────────┤               │          │                   │               │                                                        │
│ libssl3    │               │          │                   │               │                                                        │
│            │               │          │                   │               │                                                        │
└────────────┴───────────────┴──────────┴───────────────────┴───────────────┴────────────────────────────────────────────────────────┘

usr/local/bin/kubectl (gobinary)
================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌────────────────────────────────┬───────────────┬──────────┬─────────────────────┬───────────────┬───────────────────────────────────────────┐
│            Library             │ Vulnerability │ Severity │  Installed Version  │ Fixed Version │                   Title                   │
├────────────────────────────────┼───────────────┼──────────┼─────────────────────┼───────────────┼───────────────────────────────────────────┤
│ github.com/docker/distribution │ CVE-2023-2253 │ HIGH     │ v2.8.1+incompatible │ 2.8.2-beta.1  │ DoS from malicious API request            │
│                                │               │          │                     │               │ https://avd.aquasec.com/nvd/cve-2023-2253 │
└────────────────────────────────┴───────────────┴──────────┴─────────────────────┴───────────────┴───────────────────────────────────────────┘
```

### After
```

quay.io/solo-io/gloo:1.15.x-postfix (ubuntu 20.04)
==================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/gloo-envoy-wrapper:1.15.x-postfix (ubuntu 20.04)
================================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/discovery:1.15.x-postfix (alpine 3.17.6)
========================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/ingress:1.15.x-postfix (alpine 3.17.6)
======================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/sds:1.15.x-postfix (alpine 3.17.6)
==================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/certgen:1.15.x-postfix (alpine 3.17.6)
======================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/access-logger:1.15.x-postfix (alpine 3.17.6)
============================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


quay.io/solo-io/kubectl:1.15.x-postfix (alpine 3.17.6)
======================================================
Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/kubectl (gobinary)
================================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌────────────────────────────────┬───────────────┬──────────┬─────────────────────┬───────────────┬───────────────────────────────────────────┐
│            Library             │ Vulnerability │ Severity │  Installed Version  │ Fixed Version │                   Title                   │
├────────────────────────────────┼───────────────┼──────────┼─────────────────────┼───────────────┼───────────────────────────────────────────┤
│ github.com/docker/distribution │ CVE-2023-2253 │ HIGH     │ v2.8.1+incompatible │ 2.8.2-beta.1  │ DoS from malicious API request            │
│                                │               │          │                     │               │ https://avd.aquasec.com/nvd/cve-2023-2253 │
└────────────────────────────────┴───────────────┴──────────┴─────────────────────┴───────────────┴───────────────────────────────────────────┘
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->