### PR TITLE
track generation at report time

### DIFF
--- a/projects/gateway2/reports/reporter.go
+++ b/projects/gateway2/reports/reporter.go
@@ -13,8 +13,9 @@ type ReportMap struct {
 }
 
 type GatewayReport struct {
-	conditions []metav1.Condition
-	listeners  map[string]*ListenerReport
+	conditions         []metav1.Condition
+	listeners          map[string]*ListenerReport
+	observedGeneration int64
 }
 
 type ListenerReport struct {
@@ -22,7 +23,8 @@ type ListenerReport struct {
 }
 
 type RouteReport struct {
-	parents map[ParentRefKey]*ParentRefReport
+	parents            map[ParentRefKey]*ParentRefReport
+	observedGeneration int64
 }
 
 type ParentRefReport struct {
@@ -50,6 +52,7 @@ func (r *ReportMap) Gateway(gateway *gwv1.Gateway) *GatewayReport {
 	gr := r.gateways[key]
 	if gr == nil {
 		gr = &GatewayReport{}
+		gr.observedGeneration = gateway.Generation
 		r.gateways[key] = gr
 	}
 	return gr
@@ -60,6 +63,7 @@ func (r *ReportMap) route(route *gwv1.HTTPRoute) *RouteReport {
 	rr := r.routes[key]
 	if rr == nil {
 		rr = &RouteReport{}
+		rr.observedGeneration = route.Generation
 		r.routes[key] = rr
 	}
 	return rr
@@ -192,7 +196,6 @@ type Reporter interface {
 }
 
 type GatewayReporter interface {
-	// report an error on the given listener
 	Listener(listener *gwv1.Listener) ListenerReporter
 	SetCondition(condition GatewayCondition)
 }

--- a/projects/gateway2/reports/reporter.go
+++ b/projects/gateway2/reports/reporter.go
@@ -46,26 +46,37 @@ func NewReportMap() ReportMap {
 	}
 }
 
-// Exported for unit test, validation_test.go can be refactored to reduce this visibility
+// Returns a GatewayReport for the provided Gateway, nil if there is not a report present.
+// This is different than the Reporter.Gateway() method, as we need to understand when
+// reports are not generated for a Gateway that has been translated.
+//
+// NOTE: Exported for unit testing, validation_test.go should be refactored to reduce this visibility
 func (r *ReportMap) Gateway(gateway *gwv1.Gateway) *GatewayReport {
 	key := client.ObjectKeyFromObject(gateway)
-	gr := r.gateways[key]
-	if gr == nil {
-		gr = &GatewayReport{}
-		gr.observedGeneration = gateway.Generation
-		r.gateways[key] = gr
-	}
+	return r.gateways[key]
+}
+
+func (r *ReportMap) newGatewayReport(gateway *gwv1.Gateway) *GatewayReport {
+	gr := &GatewayReport{}
+	gr.observedGeneration = gateway.Generation
+	key := client.ObjectKeyFromObject(gateway)
+	r.gateways[key] = gr
 	return gr
 }
 
+// Returns a RouteReport for the provided HTTPRoute, nil if there is not a report present.
+// This is different than the Reporter.Route() method, as we need to understand when
+// reports are not generated for a HTTPRoute that has been translated.
 func (r *ReportMap) route(route *gwv1.HTTPRoute) *RouteReport {
 	key := client.ObjectKeyFromObject(route)
-	rr := r.routes[key]
-	if rr == nil {
-		rr = &RouteReport{}
-		rr.observedGeneration = route.Generation
-		r.routes[key] = rr
-	}
+	return r.routes[key]
+}
+
+func (r *ReportMap) newRouteReport(route *gwv1.HTTPRoute) *RouteReport {
+	rr := &RouteReport{}
+	rr.observedGeneration = route.Generation
+	key := client.ObjectKeyFromObject(route)
+	r.routes[key] = rr
 	return rr
 }
 
@@ -131,11 +142,19 @@ type reporter struct {
 }
 
 func (r *reporter) Gateway(gateway *gwv1.Gateway) GatewayReporter {
-	return r.report.Gateway(gateway)
+	gr := r.report.Gateway(gateway)
+	if gr == nil {
+		gr = r.report.newGatewayReport(gateway)
+	}
+	return gr
 }
 
 func (r *reporter) Route(route *gwv1.HTTPRoute) HTTPRouteReporter {
-	return r.report.route(route)
+	rr := r.report.route(route)
+	if rr == nil {
+		rr = r.report.newRouteReport(route)
+	}
+	return rr
 }
 
 func getParentRefKey(parentRef *gwv1.ParentReference) ParentRefKey {

--- a/projects/gateway2/reports/reporter_test.go
+++ b/projects/gateway2/reports/reporter_test.go
@@ -92,7 +92,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 			acceptedCond := meta.FindStatusCondition(status.Listeners[0].Conditions, string(gwv1.ListenerConditionAccepted))
 			oldTransitionTime := acceptedCond.LastTransitionTime
 
-			gw.Status = status
+			gw.Status = *status
 			status = rm.BuildGWStatus(context.Background(), *gw)
 
 			Expect(status).NotTo(BeNil())
@@ -187,7 +187,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 			resolvedRefs := meta.FindStatusCondition(status.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
 			oldTransitionTime := resolvedRefs.LastTransitionTime
 
-			route.Status = status
+			route.Status = *status
 			status = rm.BuildRouteStatus(context.Background(), route, "gloo-gateway")
 
 			Expect(status).NotTo(BeNil())

--- a/projects/gateway2/reports/reporter_test.go
+++ b/projects/gateway2/reports/reporter_test.go
@@ -21,6 +21,11 @@ var _ = Describe("Reporting Infrastructure", func() {
 		It("should build all positive conditions with an empty report", func() {
 			gw := gw()
 			rm := reports.NewReportMap()
+
+			reporter := reports.NewReporter(&rm)
+			// initialize GatewayReporter to mimic translation loop (i.e. report gets initialized for all GWs)
+			reporter.Gateway(gw)
+
 			status := rm.BuildGWStatus(context.Background(), *gw)
 
 			Expect(status).NotTo(BeNil())
@@ -72,6 +77,11 @@ var _ = Describe("Reporting Infrastructure", func() {
 		It("should not modify LastTransitionTime for existing conditions that have not changed", func() {
 			gw := gw()
 			rm := reports.NewReportMap()
+
+			reporter := reports.NewReporter(&rm)
+			// initialize GatewayReporter to mimic translation loop (i.e. report gets initialized for all GWs)
+			reporter.Gateway(gw)
+
 			status := rm.BuildGWStatus(context.Background(), *gw)
 
 			Expect(status).NotTo(BeNil())
@@ -103,6 +113,10 @@ var _ = Describe("Reporting Infrastructure", func() {
 		It("should build all positive route conditions with an empty report", func() {
 			route := route()
 			rm := reports.NewReportMap()
+
+			reporter := reports.NewReporter(&rm)
+			// initialize RouteReporter to mimic translation loop (i.e. report gets initialized for all Routes)
+			reporter.Route(&route)
 
 			status := rm.BuildRouteStatus(context.Background(), route, "gloo-gateway")
 
@@ -159,6 +173,10 @@ var _ = Describe("Reporting Infrastructure", func() {
 		It("should not modify LastTransitionTime for existing conditions that have not changed", func() {
 			route := route()
 			rm := reports.NewReportMap()
+
+			reporter := reports.NewReporter(&rm)
+			// initialize RouteReporter to mimic translation loop (i.e. report gets initialized for all Routes)
+			reporter.Route(&route)
 
 			status := rm.BuildRouteStatus(context.Background(), route, "gloo-gateway")
 

--- a/projects/gateway2/reports/status.go
+++ b/projects/gateway2/reports/status.go
@@ -23,9 +23,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) gwv1.Gat
 			return l.Name == lis.Name
 		})
 		for _, lisCondition := range lisReport.Status.Conditions {
-			// the report was generated over a single pass of translation, safe to set generation here
-			// assuming statuses are synced and reported in the same pass
-			lisCondition.ObservedGeneration = gw.Generation
+			lisCondition.ObservedGeneration = gwReport.observedGeneration
 
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 			if oldLisStatusIndex != -1 {
@@ -43,9 +41,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) gwv1.Gat
 
 	finalConditions := make([]metav1.Condition, 0)
 	for _, gwCondition := range gwReport.GetConditions() {
-		// the report was generated over a single pass of translation, safe to set generation here
-		// assuming statuses are synced and reported in the same pass
-		gwCondition.ObservedGeneration = gw.Generation
+		gwCondition.ObservedGeneration = gwReport.observedGeneration
 
 		// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(gw.Status.Conditions, gwCondition.Type); cond != nil {
@@ -78,9 +74,7 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, route gwv1.HTTPRoute, 
 
 		finalConditions := make([]metav1.Condition, 0, len(parentStatusReport.Conditions))
 		for _, pCondition := range parentStatusReport.Conditions {
-			// the report was generated over a single pass of translation, safe to set generation here
-			// assuming statuses are synced and reported in the same pass
-			pCondition.ObservedGeneration = route.Generation
+			pCondition.ObservedGeneration = routeReport.observedGeneration
 
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 			if cond := meta.FindStatusCondition(currentParentRefConditions, pCondition.Type); cond != nil {

--- a/projects/gateway2/reports/status.go
+++ b/projects/gateway2/reports/status.go
@@ -75,9 +75,9 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, route gwv1.HTTPRoute, 
 	if routeReport == nil {
 		// a route report may be missing because of the disconnect between when routes are retrieved for translation,
 		// which the query engine performs inside gateway_translator.go/TranslateProxy(), and when the list of routes
-		// for status syncing is retrieved, which happens in xds_syncer.go/syncRouteStatus().
+		// for status syncing is retrieved after translation, separately in xds_syncer.go/syncRouteStatus().
 		// Since there may have been additions/deletions in that window, a missing route report will just be treated
-		// as informational and we will return an empty status
+		// as informational and we will return nil, signaling to status syncer to not touch this Routes status.
 		contextutils.LoggerFrom(ctx).Infof(missingRouteReportErr, route.Name, route.Namespace)
 		return nil
 	}

--- a/projects/gateway2/translator/gateway_translator.go
+++ b/projects/gateway2/translator/gateway_translator.go
@@ -45,9 +45,6 @@ func (t *translator) TranslateProxy(
 	queries query.GatewayQueries,
 	reporter reports.Reporter,
 ) *v1.Proxy {
-	if !listener.ValidateGateway(gateway, queries, reporter) {
-		return nil
-	}
 
 	routesForGw, err := queries.GetRoutesForGw(ctx, gateway)
 	if err != nil {

--- a/projects/gateway2/translator/listener/validation.go
+++ b/projects/gateway2/translator/listener/validation.go
@@ -3,7 +3,6 @@ package listener
 import (
 	"slices"
 
-	"github.com/solo-io/gloo/projects/gateway2/query"
 	"github.com/solo-io/gloo/projects/gateway2/reports"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -12,13 +11,6 @@ import (
 const NormalizedHTTPSTLSType = "HTTPS/TLS"
 const DefaultHostname = "*"
 const HTTPRouteKind = "HTTPRoute"
-
-// TODO: cross-listener validation
-// return valid for translation
-func ValidateGateway(gateway *gwv1.Gateway, inputs query.GatewayQueries, reporter reports.Reporter) bool {
-
-	return true
-}
 
 type portProtocol struct {
 	hostnames map[gwv1.Hostname]int
@@ -220,31 +212,3 @@ func getGroupName() *gwv1.Group {
 	g := gwv1.Group(gwv1.GroupName)
 	return &g
 }
-
-// func validateRoutes(
-// 	queries query.GatewayQueries,
-// 	reporter reports.Reporter,
-// 	routes []gwv1.HTTPRoute) {
-// 	for _, route := range routes {
-// 		for _, rule := range route.Spec.Rules {
-// 			for _, backendRef := range rule.BackendRefs {
-// 				_, err := queries.GetBackendForRef(context.TODO(), queries.ObjToFrom(&route), &backendRef)
-// 				if err != nil {
-// 					if err == query.ErrMissingReferenceGrant {
-// 						reporter.Route(&route).SetCondition(reports.HTTPRouteCondition{
-// 							Type:   gwv1.RouteConditionResolvedRefs,
-// 							Status: metav1.ConditionFalse,
-// 							Reason: gwv1.RouteReasonRefNotPermitted,
-// 						})
-// 					} else if errors.IsNotFound(err) {
-// 						reporter.Route(&route).SetCondition(reports.HTTPRouteCondition{
-// 							Type:   gwv1.RouteConditionResolvedRefs,
-// 							Status: metav1.ConditionFalse,
-// 							Reason: gwv1.RouteReasonBackendNotFound,
-// 						})
-// 					}
-// 				}
-// 			}
-// 		}
-// 	}
-// }

--- a/projects/gateway2/translator/plugins/headermodifier/header_modifier_plugin.go
+++ b/projects/gateway2/translator/plugins/headermodifier/header_modifier_plugin.go
@@ -13,15 +13,15 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-var _ plugins.RoutePlugin = &Plugin{}
+var _ plugins.RoutePlugin = &plugin{}
 
-type Plugin struct{}
+type plugin struct{}
 
-func NewPlugin() *Plugin {
-	return &Plugin{}
+func NewPlugin() *plugin {
+	return &plugin{}
 }
 
-func (p *Plugin) ApplyRoutePlugin(
+func (p *plugin) ApplyRoutePlugin(
 	ctx context.Context,
 	routeCtx *plugins.RouteContext,
 	outputRoute *v1.Route,
@@ -46,7 +46,7 @@ func (p *Plugin) ApplyRoutePlugin(
 	return nil
 }
 
-func (p *Plugin) applyRequestFilter(
+func (p *plugin) applyRequestFilter(
 	config *gwv1.HTTPHeaderFilter,
 	outputRoute *v1.Route,
 ) error {
@@ -63,7 +63,7 @@ func (p *Plugin) applyRequestFilter(
 	return nil
 }
 
-func (p *Plugin) applyResponseFilter(
+func (p *plugin) applyResponseFilter(
 	config *gwv1.HTTPHeaderFilter,
 	outputRoute *v1.Route,
 ) error {

--- a/projects/gateway2/translator/plugins/redirect/redirect_plugin.go
+++ b/projects/gateway2/translator/plugins/redirect/redirect_plugin.go
@@ -11,15 +11,15 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-var _ plugins.RoutePlugin = &Plugin{}
+var _ plugins.RoutePlugin = &plugin{}
 
-type Plugin struct{}
+type plugin struct{}
 
-func NewPlugin() *Plugin {
-	return &Plugin{}
+func NewPlugin() *plugin {
+	return &plugin{}
 }
 
-func (p *Plugin) ApplyRoutePlugin(
+func (p *plugin) ApplyRoutePlugin(
 	ctx context.Context,
 	routeCtx *plugins.RouteContext,
 	outputRoute *v1.Route,

--- a/projects/gateway2/translator/plugins/urlrewrite/url_rewrite_plugin.go
+++ b/projects/gateway2/translator/plugins/urlrewrite/url_rewrite_plugin.go
@@ -13,15 +13,15 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-var _ plugins.RoutePlugin = &Plugin{}
+var _ plugins.RoutePlugin = &plugin{}
 
-type Plugin struct{}
+type plugin struct{}
 
-func NewPlugin() *Plugin {
-	return &Plugin{}
+func NewPlugin() *plugin {
+	return &plugin{}
 }
 
-func (p *Plugin) ApplyRoutePlugin(
+func (p *plugin) ApplyRoutePlugin(
 	ctx context.Context,
 	routeCtx *plugins.RouteContext,
 	outputRoute *v1.Route,

--- a/projects/gateway2/xds/xds_syncer.go
+++ b/projects/gateway2/xds/xds_syncer.go
@@ -359,8 +359,7 @@ func (s *XdsSyncer) syncRouteStatus(ctx context.Context, rm reports.ReportMap) {
 	}
 
 	for _, route := range rl.Items {
-		// Pike
-		route := route
+		route := route // pike
 		route.Status = rm.BuildRouteStatus(ctx, route, s.controllerName)
 		if err := s.cli.Status().Update(ctx, &route); err != nil {
 			logger.Error(err)

--- a/projects/gateway2/xds/xds_syncer.go
+++ b/projects/gateway2/xds/xds_syncer.go
@@ -360,9 +360,11 @@ func (s *XdsSyncer) syncRouteStatus(ctx context.Context, rm reports.ReportMap) {
 
 	for _, route := range rl.Items {
 		route := route // pike
-		route.Status = rm.BuildRouteStatus(ctx, route, s.controllerName)
-		if err := s.cli.Status().Update(ctx, &route); err != nil {
-			logger.Error(err)
+		if status := rm.BuildRouteStatus(ctx, route, s.controllerName); status != nil {
+			route.Status = *status
+			if err := s.cli.Status().Update(ctx, &route); err != nil {
+				logger.Error(err)
+			}
 		}
 	}
 }
@@ -370,13 +372,13 @@ func (s *XdsSyncer) syncRouteStatus(ctx context.Context, rm reports.ReportMap) {
 func (s *XdsSyncer) syncStatus(ctx context.Context, rm reports.ReportMap, gwl apiv1.GatewayList) {
 	ctx = contextutils.WithLogger(ctx, "statusSyncer")
 	logger := contextutils.LoggerFrom(ctx)
-	//TODO(Law): bail out early if possible
-	//TODO(Law): do another Get on the gw?
-	//TODO(Law): add generation changed predicate
 	for _, gw := range gwl.Items {
-		gw.Status = rm.BuildGWStatus(ctx, gw)
-		if err := s.cli.Status().Patch(ctx, &gw, client.Merge); err != nil {
-			logger.Error(err)
+		gw := gw // pike
+		if status := rm.BuildGWStatus(ctx, gw); status != nil {
+			gw.Status = *status
+			if err := s.cli.Status().Patch(ctx, &gw, client.Merge); err != nil {
+				logger.Error(err)
+			}
 		}
 	}
 }


### PR DESCRIPTION
In order to consistently report the Generation while updating statuses for `Gateways` and `HTTPRoutes`, we will track it as part of reporting.

There are differences with how the Gateways and Routes are retrieved for translation and reporting:
* Gateways are retrieved as a List and passed to translation, then the same list is passed for status syncing
  * This means we could not track generation as part of reporting, but for consistency we will do so
  * If we do not have a report for a translated Gateway, something is wrong, and we will dpanic
* Routes are retrieved via query engine inside translation, so another retrieval step occurs to sync their status
  * So the generation could change or routes could be added in this window
  * If we do not have a report for a route, we can't be sure if this is a problem, so we will log (INFO) and punt

