### PR TITLE
[1.16] Get dumps from envoy and log these dumps on test failures

### DIFF
--- a/changelog/v1.16.0-rc2/expand-cli-gateway.yaml
+++ b/changelog/v1.16.0-rc2/expand-cli-gateway.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Refactor getting dumps from the proxy. Also export this new method which is quite useful in debugging failures, especially in CI.
+

--- a/projects/gloo/pkg/utils/sort_routes_test.go
+++ b/projects/gloo/pkg/utils/sort_routes_test.go
@@ -1,10 +1,11 @@
-package utils
+package utils_test
 
 import (
 	"math/rand"
 	"time"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 	"github.com/solo-io/gloo/test/helpers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -93,7 +94,7 @@ var _ = Describe("PathAsString", func() {
 			rand.Shuffle(len(expectedRoutes), func(i, j int) {
 				expectedRoutes[i], expectedRoutes[j] = expectedRoutes[j], expectedRoutes[i]
 			})
-			SortRoutesByPath(expectedRoutes)
+			utils.SortRoutesByPath(expectedRoutes)
 			Expect(expectedRoutes).To(Equal(sortedRoutes))
 		}
 
@@ -106,7 +107,7 @@ var _ = Describe("PathAsString", func() {
 			makeUnSortedRoutesWrongLength(),
 			makeUnSortedRoutesWrongLengthPriority(),
 		} {
-			SortRoutesByPath(unsortedRoutes)
+			utils.SortRoutesByPath(unsortedRoutes)
 			Expect(unsortedRoutes).To(Equal(makeSortedRoutes()))
 		}
 	})
@@ -140,7 +141,7 @@ var _ = Describe("PathAsString", func() {
 			rand.Shuffle(len(expectedRoutes), func(i, j int) {
 				expectedRoutes[i], expectedRoutes[j] = expectedRoutes[j], expectedRoutes[i]
 			})
-			SortRoutesByPath(expectedRoutes)
+			utils.SortRoutesByPath(expectedRoutes)
 			Expect(expectedRoutes).To(Equal(sortedRoutes))
 		}
 
@@ -148,7 +149,7 @@ var _ = Describe("PathAsString", func() {
 			makeSortedMultiMatcherRoutes(),
 			makeMultiMatcherRoutesWrongPathPriority(),
 		} {
-			SortRoutesByPath(unsortedRoutes)
+			utils.SortRoutesByPath(unsortedRoutes)
 			Expect(unsortedRoutes).To(Equal(makeSortedMultiMatcherRoutes()))
 		}
 	})
@@ -162,7 +163,7 @@ var _ = Describe("PathAsString", func() {
 			{Matchers: []*matchers.Matcher{helpers.MakeMatcher(helpers.ExactPath, 10)}},
 			{Matchers: nil},
 		}
-		SortRoutesByPath(routes)
+		utils.SortRoutesByPath(routes)
 		Expect(routes).To(Equal(sortedRoutes))
 	})
 
@@ -229,7 +230,7 @@ var _ = Describe("PathAsString", func() {
 				},
 			},
 		}
-		SortRoutesByPath(routes)
+		utils.SortRoutesByPath(routes)
 		Expect(routes).To(Equal(sortedRoutes))
 	})
 })

--- a/projects/gloo/pkg/utils/ssl.go
+++ b/projects/gloo/pkg/utils/ssl.go
@@ -321,7 +321,7 @@ func (s *sslConfigTranslator) ResolveCommonSslConfig(cs CertSource, secrets v1.S
 			return nil, InvalidTlsSecretError(nil, err)
 		}
 	} else if sslSds := cs.GetSds(); sslSds != nil {
-		tlsContext, err := s.handleSds(sslSds, verifySanListToMatchSanList(cs.GetVerifySubjectAltName()))
+		tlsContext, err := s.handleSds(sslSds, VerifySanListToMatchSanList(cs.GetVerifySubjectAltName()))
 		if err != nil {
 			return nil, err
 		}
@@ -376,7 +376,7 @@ func (s *sslConfigTranslator) ResolveCommonSslConfig(cs CertSource, secrets v1.S
 		return nil, eris.Errorf("both or none of cert chain and private key must be provided")
 	}
 
-	sanList := verifySanListToMatchSanList(cs.GetVerifySubjectAltName())
+	sanList := VerifySanListToMatchSanList(cs.GetVerifySubjectAltName())
 
 	if rootCaData != nil {
 		validationCtx := &envoyauth.CommonTlsContext_ValidationContext{
@@ -478,7 +478,7 @@ func convertVersion(v ssl.SslParameters_ProtocolVersion) (envoyauth.TlsParameter
 	return envoyauth.TlsParameters_TLS_AUTO, TlsVersionNotFoundError(v)
 }
 
-func verifySanListToMatchSanList(sanList []string) []*envoymatcher.StringMatcher {
+func VerifySanListToMatchSanList(sanList []string) []*envoymatcher.StringMatcher {
 	var matchSanList []*envoymatcher.StringMatcher
 	for _, san := range sanList {
 		matchSan := &envoymatcher.StringMatcher{

--- a/projects/gloo/pkg/utils/ssl_test.go
+++ b/projects/gloo/pkg/utils/ssl_test.go
@@ -1,4 +1,4 @@
-package utils
+package utils_test
 
 import (
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -12,6 +12,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/constants"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
+	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 	gloohelpers "github.com/solo-io/gloo/test/helpers"
 	. "github.com/solo-io/go-utils/testutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
@@ -26,11 +27,11 @@ var _ = Describe("Ssl", func() {
 		tlsSecret              *v1.TlsSecret
 		secret                 *v1.Secret
 		secrets                v1.SecretList
-		configTranslator       *sslConfigTranslator
-		resolveCommonSslConfig func(cs CertSource, secrets v1.SecretList) (*envoyauth.CommonTlsContext, error)
+		configTranslator       utils.SslConfigTranslator
+		resolveCommonSslConfig func(cs utils.CertSource, secrets v1.SecretList) (*envoyauth.CommonTlsContext, error)
 	)
 
-	resolveCommonSslConfig = func(cs CertSource, secrets v1.SecretList) (*envoyauth.CommonTlsContext, error) {
+	resolveCommonSslConfig = func(cs utils.CertSource, secrets v1.SecretList) (*envoyauth.CommonTlsContext, error) {
 		return configTranslator.ResolveCommonSslConfig(cs, secrets, false)
 	}
 
@@ -56,16 +57,16 @@ var _ = Describe("Ssl", func() {
 					},
 				},
 			}
-			configTranslator = NewSslConfigTranslator()
+			configTranslator = utils.NewSslConfigTranslator()
 
 		})
 
 		DescribeTable("should resolve from files",
-			func(c func() CertSource) {
+			func(c func() utils.CertSource) {
 				ValidateCommonContextFiles(resolveCommonSslConfig(c(), nil))
 			},
-			Entry("upstreamCfg", func() CertSource { return upstreamCfg }),
-			Entry("downstreamCfg", func() CertSource { return downstreamCfg }),
+			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
+			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
 		)
 
 		Context("san", func() {
@@ -73,7 +74,7 @@ var _ = Describe("Ssl", func() {
 				upstreamCfg.SslSecrets.(*ssl.UpstreamSslConfig_SslFiles).SslFiles.RootCa = ""
 				upstreamCfg.VerifySubjectAltName = []string{"test"}
 				_, err := resolveCommonSslConfig(upstreamCfg, nil)
-				Expect(err).To(Equal(RootCaMustBeProvidedError))
+				Expect(err).To(Equal(utils.RootCaMustBeProvidedError))
 			})
 
 			It("should add SAN verification when provided", func() {
@@ -81,7 +82,7 @@ var _ = Describe("Ssl", func() {
 				c, err := resolveCommonSslConfig(upstreamCfg, nil)
 				Expect(err).NotTo(HaveOccurred())
 				vctx := c.ValidationContextType.(*envoyauth.CommonTlsContext_ValidationContext).ValidationContext
-				Expect(vctx.MatchSubjectAltNames).To(Equal(verifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
+				Expect(vctx.MatchSubjectAltNames).To(Equal(utils.VerifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
 			})
 
 			It("should _not_ error with only a rootca", func() {
@@ -123,11 +124,11 @@ var _ = Describe("Ssl", func() {
 					SecretRef: ref,
 				},
 			}
-			configTranslator = NewSslConfigTranslator()
+			configTranslator = utils.NewSslConfigTranslator()
 		})
 
 		It("should error with no secret", func() {
-			configTranslator = NewSslConfigTranslator()
+			configTranslator = utils.NewSslConfigTranslator()
 			_, err := resolveCommonSslConfig(upstreamCfg, nil)
 			Expect(err).To(HaveOccurred())
 		})
@@ -136,56 +137,56 @@ var _ = Describe("Ssl", func() {
 			secret.Kind = &v1.Secret_Aws{}
 			_, err := resolveCommonSslConfig(upstreamCfg, secrets)
 			Expect(err).To(HaveOccurred())
-			Expect(err).To(HaveInErrorChain(NotTlsSecretError(secret.GetMetadata().Ref())))
+			Expect(err).To(HaveInErrorChain(utils.NotTlsSecretError(secret.GetMetadata().Ref())))
 		})
 
 		DescribeTable("should resolve from secret refs",
-			func(c func() CertSource) {
+			func(c func() utils.CertSource) {
 				ValidateCommonContextInline(resolveCommonSslConfig(c(), secrets))
 			},
-			Entry("upstreamCfg", func() CertSource { return upstreamCfg }),
-			Entry("downstreamCfg", func() CertSource { return downstreamCfg }),
+			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
+			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
 		)
 		DescribeTable("should fail if only cert is not provided",
-			func(c func() CertSource) {
+			func(c func() utils.CertSource) {
 				tlsSecret.CertChain = ""
 				_, err := resolveCommonSslConfig(c(), secrets)
 				Expect(err).To(HaveOccurred())
 
 			},
-			Entry("upstreamCfg", func() CertSource { return upstreamCfg }),
-			Entry("downstreamCfg", func() CertSource { return downstreamCfg }),
+			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
+			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
 		)
 		DescribeTable("should fail if only private key is not provided",
-			func(c func() CertSource) {
+			func(c func() utils.CertSource) {
 				tlsSecret.PrivateKey = ""
 				_, err := resolveCommonSslConfig(c(), secrets)
 				Expect(err).To(HaveOccurred())
 
 			},
-			Entry("upstreamCfg", func() CertSource { return upstreamCfg }),
-			Entry("downstreamCfg", func() CertSource { return downstreamCfg }),
+			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
+			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
 		)
 		DescribeTable("should fail if invalid private key is provided",
-			func(c func() CertSource) {
+			func(c func() utils.CertSource) {
 				tlsSecret.PrivateKey = "bad_private_key"
 				_, err := resolveCommonSslConfig(c(), secrets)
 				Expect(err).To(HaveOccurred())
 
 			},
-			Entry("upstreamCfg", func() CertSource { return upstreamCfg }),
-			Entry("downstreamCfg", func() CertSource { return downstreamCfg }),
+			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
+			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
 		)
 		DescribeTable("should not have validation context if no rootca",
-			func(c func() CertSource) {
+			func(c func() utils.CertSource) {
 				tlsSecret.RootCa = ""
 				cfg, err := resolveCommonSslConfig(c(), secrets)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cfg.ValidationContextType).To(BeNil())
 
 			},
-			Entry("upstreamCfg", func() CertSource { return upstreamCfg }),
-			Entry("downstreamCfg", func() CertSource { return downstreamCfg }),
+			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
+			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
 		)
 
 		It("should disable tls session if disableStatelessTlsSessionResumption is true", func() {
@@ -322,9 +323,9 @@ var _ = Describe("Ssl", func() {
 				tlsSecret.RootCa = ""
 				upstreamCfg.VerifySubjectAltName = []string{"test"}
 				_, err := configTranslator.ResolveCommonSslConfig(upstreamCfg, secrets, true)
-				Expect(err).To(Equal(RootCaMustBeProvidedError))
+				Expect(err).To(Equal(utils.RootCaMustBeProvidedError))
 				_, err = configTranslator.ResolveCommonSslConfig(upstreamCfg, secrets, false)
-				Expect(err).To(Equal(RootCaMustBeProvidedError))
+				Expect(err).To(Equal(utils.RootCaMustBeProvidedError))
 			})
 
 			It("should add SAN verification when provided", func() {
@@ -332,12 +333,12 @@ var _ = Describe("Ssl", func() {
 				c, err := configTranslator.ResolveCommonSslConfig(upstreamCfg, secrets, false)
 				Expect(err).NotTo(HaveOccurred())
 				vctx := c.ValidationContextType.(*envoyauth.CommonTlsContext_ValidationContext).ValidationContext
-				Expect(vctx.MatchSubjectAltNames).To(Equal(verifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
+				Expect(vctx.MatchSubjectAltNames).To(Equal(utils.VerifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
 
 				c, err = configTranslator.ResolveCommonSslConfig(upstreamCfg, secrets, true)
 				Expect(err).NotTo(HaveOccurred())
 				vctx = c.ValidationContextType.(*envoyauth.CommonTlsContext_ValidationContext).ValidationContext
-				Expect(vctx.MatchSubjectAltNames).To(Equal(verifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
+				Expect(vctx.MatchSubjectAltNames).To(Equal(utils.VerifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
 			})
 		})
 
@@ -380,7 +381,7 @@ var _ = Describe("Ssl", func() {
 					Sds: sdsConfig,
 				},
 			}
-			configTranslator = NewSslConfigTranslator()
+			configTranslator = utils.NewSslConfigTranslator()
 		})
 
 		It("should have a sds setup with a default cluster name", func() {
@@ -505,7 +506,7 @@ var _ = Describe("Ssl", func() {
 				sdsConfig.ValidationContextName = ""
 				upstreamCfg.VerifySubjectAltName = []string{"test"}
 				_, err := resolveCommonSslConfig(upstreamCfg, nil)
-				Expect(err).To(Equal(MissingValidationContextError))
+				Expect(err).To(Equal(utils.MissingValidationContextError))
 			})
 
 			It("should add SAN verification when provided", func() {
@@ -513,7 +514,7 @@ var _ = Describe("Ssl", func() {
 				c, err := resolveCommonSslConfig(upstreamCfg, nil)
 				Expect(err).NotTo(HaveOccurred())
 				vctx := c.ValidationContextType.(*envoyauth.CommonTlsContext_CombinedValidationContext).CombinedValidationContext
-				Expect(vctx.DefaultValidationContext.MatchSubjectAltNames).To(Equal(verifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
+				Expect(vctx.DefaultValidationContext.MatchSubjectAltNames).To(Equal(utils.VerifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
 			})
 		})
 	})
@@ -541,7 +542,7 @@ var _ = Describe("Ssl", func() {
 					Sds: sdsConfig,
 				},
 			}
-			configTranslator = NewSslConfigTranslator()
+			configTranslator = utils.NewSslConfigTranslator()
 		})
 
 		It("should have a sds setup with a file-based metadata", func() {
@@ -569,10 +570,10 @@ var _ = Describe("Ssl", func() {
 					LocalCredentials: &envoycore.GrpcService_GoogleGrpc_GoogleLocalCredentials{},
 				},
 			}))
-			Expect(getGrpcConfig(vctx).CredentialsFactoryName).To(Equal(MetadataPluginName))
+			Expect(getGrpcConfig(vctx).CredentialsFactoryName).To(Equal(utils.MetadataPluginName))
 
 			credPlugin := getGrpcConfig(vctx).CallCredentials[0].CredentialSpecifier.(*envoycore.GrpcService_GoogleGrpc_CallCredentials_FromPlugin).FromPlugin
-			Expect(credPlugin.Name).To(Equal(MetadataPluginName))
+			Expect(credPlugin.Name).To(Equal(utils.MetadataPluginName))
 			var credConfig envoygrpccredential.FileBasedMetadataConfig
 			ptypes.UnmarshalAny(credPlugin.GetTypedConfig(), &credConfig)
 
@@ -592,7 +593,7 @@ var _ = Describe("Ssl", func() {
 				sdsConfig.ValidationContextName = ""
 				upstreamCfg.VerifySubjectAltName = []string{"test"}
 				_, err := resolveCommonSslConfig(upstreamCfg, nil)
-				Expect(err).To(Equal(MissingValidationContextError))
+				Expect(err).To(Equal(utils.MissingValidationContextError))
 			})
 
 			It("should add SAN verification when provided", func() {
@@ -600,7 +601,7 @@ var _ = Describe("Ssl", func() {
 				c, err := resolveCommonSslConfig(upstreamCfg, nil)
 				Expect(err).NotTo(HaveOccurred())
 				vctx := c.ValidationContextType.(*envoyauth.CommonTlsContext_CombinedValidationContext).CombinedValidationContext
-				Expect(vctx.DefaultValidationContext.MatchSubjectAltNames).To(Equal(verifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
+				Expect(vctx.DefaultValidationContext.MatchSubjectAltNames).To(Equal(utils.VerifySanListToMatchSanList(upstreamCfg.VerifySubjectAltName)))
 			})
 		})
 	})
@@ -608,7 +609,7 @@ var _ = Describe("Ssl", func() {
 	Context("ssl parameters", func() {
 
 		BeforeEach(func() {
-			configTranslator = NewSslConfigTranslator()
+			configTranslator = utils.NewSslConfigTranslator()
 		})
 
 		It("should return nil for nil SslParameters", func() {

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -2,20 +2,33 @@ package helpers
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/solo-io/gloo/pkg/cliutil/install"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/gateway"
 	"github.com/solo-io/skv2/codegen/util"
 )
 
 var (
-	outDir = filepath.Join(util.GetModuleRoot(), "_output", "kube2e-artifacts")
+	kubeOutDir  = filepath.Join(util.GetModuleRoot(), "_output", "kube2e-artifacts")
+	envoyOutDir = filepath.Join(kubeOutDir, "envoy-dump")
 )
+
+// StandardGlooDumpOnFail creates adump of the kubernetes state and certain envoy data from the admin interface when a test fails
+// Look at `KubeDumpOnFail` && `EnvoyDumpOnFail` for more details
+func StandardGlooDumpOnFail(out io.Writer, namespaces ...string) func() {
+	return func() {
+		KubeDumpOnFail(out, namespaces...)
+		EnvoyDumpOnFail(out, namespaces...)
+	}
+}
 
 // KubeDumpOnFail creates a small dump of the kubernetes state when a test fails.
 // This is useful for debugging test failures.
@@ -28,11 +41,11 @@ var (
 // - yaml representations of all solo.io CRs in the given namespaces
 func KubeDumpOnFail(out io.Writer, namespaces ...string) func() {
 	return func() {
-		setupOutDir()
+		setupOutDir(kubeOutDir)
 
-		recordDockerState(fileAtPath(filepath.Join(outDir, "docker-state.log")))
-		recordProcessState(fileAtPath(filepath.Join(outDir, "process-state.log")))
-		recordKubeState(fileAtPath(filepath.Join(outDir, "kube-state.log")))
+		recordDockerState(fileAtPath(filepath.Join(kubeOutDir, "docker-state.log")))
+		recordProcessState(fileAtPath(filepath.Join(kubeOutDir, "process-state.log")))
+		recordKubeState(fileAtPath(filepath.Join(kubeOutDir, "kube-state.log")))
 
 		recordKubeDump(namespaces...)
 	}
@@ -49,7 +62,7 @@ func recordDockerState(f *os.File) {
 	dockerCmd.Stderr = dockerState
 	err := dockerCmd.Run()
 	if err != nil {
-		f.WriteString("*** Unable to get docker state ***\n")
+		f.WriteString("*** Unable to get docker state ***. Reason: " + err.Error() + " \n")
 		return
 	}
 	f.WriteString("*** Docker state ***\n")
@@ -68,7 +81,7 @@ func recordProcessState(f *os.File) {
 	psCmd.Stderr = psState
 	err := psCmd.Run()
 	if err != nil {
-		f.WriteString("unable to get process state\n")
+		f.WriteString("unable to get process state. Reason: " + err.Error() + " \n")
 		return
 	}
 	f.WriteString("*** Process state ***\n")
@@ -90,12 +103,12 @@ func recordKubeState(f *os.File) {
 	// Ie: More context around the output of the previous command `kubectl get all -A`
 	kubeDescribe, err := kubeCli.KubectlOut(nil, "describe", "all", "-A")
 	if err != nil {
-		f.WriteString("*** Unable to get kube describe ***\n")
+		f.WriteString("*** Unable to get kube describe ***. Reason: " + err.Error() + " \n")
 		return
 	}
 	kubeEndpointsState, err := kubeCli.KubectlOut(nil, "get", "endpoints", "-A")
 	if err != nil {
-		f.WriteString("*** Unable to get endpoint state ***\n")
+		f.WriteString("*** Unable to get endpoint state ***. Reason: " + err.Error() + " \n")
 		return
 	}
 	f.WriteString("*** Kube state ***\n")
@@ -109,12 +122,12 @@ func recordKubeDump(namespaces ...string) {
 	// for each namespace, create a namespace directory that contains...
 	for _, ns := range namespaces {
 		// ...a pod logs subdirectoy
-		if err := recordPods(filepath.Join(outDir, ns, "_pods"), ns); err != nil {
+		if err := recordPods(filepath.Join(kubeOutDir, ns, "_pods"), ns); err != nil {
 			fmt.Printf("error recording pod logs: %f, \n", err)
 		}
 
 		// ...and a subdirectory for each solo.io CRD with non-zero resources
-		if err := recordCRs(filepath.Join(outDir, ns), ns); err != nil {
+		if err := recordCRs(filepath.Join(kubeOutDir, ns), ns); err != nil {
 			fmt.Printf("error recording pod logs: %f, \n", err)
 		}
 	}
@@ -219,18 +232,51 @@ func kubeList(namespace string, target string) ([]string, error) {
 	return toReturn, nil
 }
 
+// EnvoyDumpOnFail creates a small dump of the envoy admin interface when a test fails.
+// This is useful for debugging test failures.
+// The dump is written to _output/envoy-dump.
+// The dump includes:
+// - config dump
+// - stats
+// - clusters
+// - listeners
+func EnvoyDumpOnFail(_ io.Writer, namespaces ...string) func() {
+	return func() {
+		setupOutDir(envoyOutDir)
+		for _, ns := range namespaces {
+			recordEnvoyAdminData(fileAtPath(filepath.Join(envoyOutDir, "config.log")), "/config_dump", ns)
+			recordEnvoyAdminData(fileAtPath(filepath.Join(envoyOutDir, "stats.log")), "/stats", ns)
+			recordEnvoyAdminData(fileAtPath(filepath.Join(envoyOutDir, "clusters.log")), "/clusters", ns)
+			recordEnvoyAdminData(fileAtPath(filepath.Join(envoyOutDir, "listeners.log")), "/listeners", ns)
+		}
+	}
+}
+
+func recordEnvoyAdminData(f *os.File, path string, namespace string) {
+	defer f.Close()
+
+	cfg, err := gateway.GetEnvoyAdminData(context.TODO(), "gateway-proxy", namespace, "/config_dump", 30*time.Second)
+	if err != nil {
+		f.WriteString("*** Unable to get envoy " + path + " dump ***. Reason: " + err.Error() + " \n")
+		return
+	}
+	f.WriteString("*** Envoy " + path + " dump ***\n")
+	f.WriteString(cfg + "\n")
+	f.WriteString("*** End Envoy " + path + " dump ***\n")
+}
+
 // setupOutDir forcibly deletes/creates the output directory
-func setupOutDir() {
-	err := os.RemoveAll(outDir)
+func setupOutDir(outdir string) {
+	err := os.RemoveAll(outdir)
 	if err != nil {
 		fmt.Printf("error removing log directory: %f\n", err)
 	}
-	err = os.MkdirAll(outDir, os.ModePerm)
+	err = os.MkdirAll(outdir, os.ModePerm)
 	if err != nil {
 		fmt.Printf("error creating log directory: %f\n", err)
 	}
 
-	fmt.Println("kube dump artifacts will be stored at: " + outDir)
+	fmt.Println("kube dump artifacts will be stored at: " + outdir)
 }
 
 // fileAtPath creates a file at the given path, and returns the file object

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -55,7 +55,7 @@ func StartTestHelper() {
 
 	testHelper, err = kube2e.GetTestHelper(ctx, namespace)
 	Expect(err).NotTo(HaveOccurred())
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
 
 	// Allow skipping of install step for running multiple times
 	if !kubeutils2.ShouldSkipInstall() {

--- a/test/kube2e/gloo/gloo_suite_test.go
+++ b/test/kube2e/gloo/gloo_suite_test.go
@@ -58,7 +58,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.Background())
 	testHelper, err = kube2e.GetTestHelper(ctx, namespace)
 	Expect(err).NotTo(HaveOccurred())
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
 
 	// Allow skipping of install step for running multiple times
 	if !glootestutils.ShouldSkipInstall() {

--- a/test/kube2e/glooctl/glooctl_suite_test.go
+++ b/test/kube2e/glooctl/glooctl_suite_test.go
@@ -51,7 +51,7 @@ func StartTestHelper() {
 	testHelper, err = kube2e.GetTestHelper(ctx, namespace)
 	Expect(err).NotTo(HaveOccurred())
 	// Register additional fail handlers
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, "istio-system", testHelper.InstallNamespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, "istio-system", testHelper.InstallNamespace))
 
 	if !testutils.ShouldSkipInstall() {
 		installGloo()

--- a/test/kube2e/gloomtls/gloo_mtls_suite_test.go
+++ b/test/kube2e/gloomtls/gloo_mtls_suite_test.go
@@ -53,7 +53,7 @@ func StartTestHelper() {
 
 	testHelper, err = kube2e.GetTestHelper(ctx, namespace)
 	Expect(err).NotTo(HaveOccurred())
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
 
 	// Allow skipping of install step for running multiple times
 	if !testutils.ShouldSkipInstall() {

--- a/test/kube2e/helm/helm_suite_test.go
+++ b/test/kube2e/helm/helm_suite_test.go
@@ -16,5 +16,5 @@ func TestHelm(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, namespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, namespace))
 })

--- a/test/kube2e/helm/helm_test.go
+++ b/test/kube2e/helm/helm_test.go
@@ -18,7 +18,6 @@ import (
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	gatewayv1kube "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/client/clientset/versioned/typed/gateway.solo.io/v1"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/gateway"
-	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/version"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc_json"
@@ -29,7 +28,6 @@ import (
 	"github.com/solo-io/k8s-utils/testutils/helper"
 	"github.com/solo-io/skv2/codegen/util"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/solo-kit/pkg/code-generator/schemagen"
 	admission_v1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -788,21 +786,7 @@ func checkGlooHealthy(testHelper *helper.SoloTestHelper) {
 }
 
 func GetEnvoyCfgDump(testHelper *helper.SoloTestHelper) string {
-	contextWithCancel, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	opts := &options.Options{
-		Metadata: core.Metadata{
-			Namespace: testHelper.InstallNamespace,
-		},
-		Top: options.Top{
-			Ctx: contextWithCancel,
-		},
-		Proxy: options.Proxy{
-			Name: "gateway-proxy",
-		},
-	}
-
-	cfg, err := gateway.GetEnvoyCfgDump(opts)
+	cfg, err := gateway.GetEnvoyAdminData(context.TODO(), "gateway-proxy", testHelper.InstallNamespace, "/config_dump", 5*time.Second)
 	Expect(err).NotTo(HaveOccurred())
 	return cfg
 }

--- a/test/kube2e/ingress/ingress_suite_test.go
+++ b/test/kube2e/ingress/ingress_suite_test.go
@@ -40,7 +40,7 @@ var _ = BeforeSuite(func() {
 	randomNumber := time.Now().Unix() % 10000
 	testHelper, err = kube2e.GetTestHelper(ctx, "ingress-test-"+fmt.Sprintf("%d-%d", randomNumber, parallel.GetParallelProcessCount()))
 	Expect(err).NotTo(HaveOccurred())
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
 	testHelper.Verbose = true
 
 	// Define helm overrides

--- a/test/kube2e/istio/istio_suite_test.go
+++ b/test/kube2e/istio/istio_suite_test.go
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 	testHelper, err = kube2e.GetTestHelper(ctx, installNamespace)
 	Expect(err).NotTo(HaveOccurred())
 
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, testHelper.InstallNamespace))
 
 	err = testutils.Kubectl("create", "ns", testHelper.InstallNamespace)
 	Expect(err).NotTo(HaveOccurred())

--- a/test/kube2e/knative/knative_suite_test.go
+++ b/test/kube2e/knative/knative_suite_test.go
@@ -56,7 +56,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).NotTo(HaveOccurred())
 
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, "knative-serving", testHelper.InstallNamespace))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, "knative-serving", testHelper.InstallNamespace))
 	testHelper.Verbose = true
 
 	// Define helm overrides

--- a/test/kube2e/upgrade/upgrade_suite_test.go
+++ b/test/kube2e/upgrade/upgrade_suite_test.go
@@ -49,7 +49,7 @@ var _ = BeforeSuite(func() {
 	testHelper, err := kube2e.GetTestHelper(suiteCtx, namespace)
 	Expect(err).NotTo(HaveOccurred())
 
-	skhelpers.RegisterPreFailHandler(helpers.KubeDumpOnFail(GinkgoWriter, "upgrade", testHelper.InstallNamespace, "other-ns"))
+	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, "upgrade", testHelper.InstallNamespace, "other-ns"))
 
 	crdDir = filepath.Join(util.GetModuleRoot(), "install", "helm", "gloo", "crds")
 	targetReleasedVersion = kube2e.GetTestReleasedVersion(suiteCtx, "gloo")


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/8986
Refactor getting dumps from the proxy. Also export this new method which is quite useful in debugging failures, especially in CI.
This way the config dump, stats, cluster, listener, heap and other info can be dumped if tests fail in CI making debugging them easier

## API changes
N/A

## Code changes
- Exposed `GetEnvoyDump` in gloo/cli/pkg/cmd/gateway
- Use the newly exposed method to dump data when kube2e tests fail
- Refactored tests in `utils` package to `utils_test` for consistency

## CI changes
N/A

## Docs changes
N/A

## Context
At times failures are difficult to debug in CI as we do not know if there was an issue with the upstream cluster, etc. This way as part of the tests fail handler, the envoy dump can be fetched to make debugging easier

Backport of https://github.com/solo-io/gloo/pull/8986

## Interesting decisions
 
N/A

## Testing steps

N/A

## Notes for reviewers

N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->