### PR TITLE
Add tech debt issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/TECH_DEBT.yml
+++ b/.github/ISSUE_TEMPLATE/TECH_DEBT.yml
@@ -1,0 +1,39 @@
+name: Tech Debt/Code Improvement
+description: Track existing technical debt or suggest ideas for code improvement.
+labels: ["Type: Tech Debt"]
+body:
+  - type: dropdown
+    id: product
+    attributes:
+      label: Gloo Edge Product
+      description: Which Edge product are you using?
+      options:
+        - Open Source
+        - Enterprise
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Gloo Edge Version
+      description: What version of your product are you using? Please specify a specific patch version
+      placeholder: eg v1.14.2
+    validations:
+      required: true
+  - type: textarea
+    id: problem-details
+    attributes:
+      label: Do you have a suggestion for code improvement or tracking existing technical debt? Please describe.
+      description: A clear and concise description of what the current tech debt or code deficiency is.
+      placeholder: e.g. Bumping a dependency, Refactoring, etc.
+  - type: textarea
+    id: solution-details
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen
+      placeholder: Ex. The dependency on [...] should be bumped to [...] because [...]
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context, links, screenshots etc. related to the request

--- a/.github/ISSUE_TEMPLATE/TECH_DEBT.yml
+++ b/.github/ISSUE_TEMPLATE/TECH_DEBT.yml
@@ -2,24 +2,6 @@ name: Tech Debt/Code Improvement
 description: Track existing technical debt or suggest ideas for code improvement.
 labels: ["Type: Tech Debt"]
 body:
-  - type: dropdown
-    id: product
-    attributes:
-      label: Gloo Edge Product
-      description: Which Edge product are you using?
-      options:
-        - Open Source
-        - Enterprise
-    validations:
-      required: true
-  - type: input
-    id: version
-    attributes:
-      label: Gloo Edge Version
-      description: What version of your product are you using? Please specify a specific patch version
-      placeholder: eg v1.14.2
-    validations:
-      required: true
   - type: textarea
     id: problem-details
     attributes:

--- a/changelog/v1.17.0-beta2/tech-debt-issue-template.yaml
+++ b/changelog/v1.17.0-beta2/tech-debt-issue-template.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Add issue template for tracking tech debt and code improvement
+    skipCI-kube-tests:true
+    skipCI-docs-build:true
+


### PR DESCRIPTION
# Description

Add an issue template for tracking tech debt and code improvements akin to the one in Gloo Mesh Enterprise ([link](https://github.com/solo-io/gloo-mesh-enterprise/blob/main/.github/ISSUE_TEMPLATE/tech_debt.md?plain=1))