### PR TITLE
AWS IRSA Vault guide for Docs review

### DIFF
--- a/changelog/v1.17.0-beta2/vault-renewal-docs.yaml
+++ b/changelog/v1.17.0-beta2/vault-renewal-docs.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: >- 
-      Update the AWS IRSA guide

--- a/changelog/v1.17.0-beta2/vault-renewal-docs.yaml
+++ b/changelog/v1.17.0-beta2/vault-renewal-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >- 
+      Update the AWS IRSA guide

--- a/changelog/v1.17.0-beta3/vault-renewal-docs.yaml
+++ b/changelog/v1.17.0-beta3/vault-renewal-docs.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >- 
+      Update the AWS IRSA guide

--- a/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
+++ b/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
@@ -66,7 +66,7 @@ cat <<EOF > trust-relationship.json
 EOF
 
 export VAULT_AUTH_ROLE_NAME="dev-role-iam-${CLUSTER_NAME}"
-export VAULT_AUTH_ROLE_ARN=$([[ $(aws iam list-roles --query "Roles[?RoleName=='${VAULT_AUTH_ROLE_NAME}'].Arn" --output text) == "" ]] \
+export VAULT_AUTH_ROLE_ARN=$([[ $(aws iam list-roles --query "Roles[?RoleName=='${VAULT_AUTH_ROLE_NAME}'].Arn" --output text) = "" ]] \
 	&& aws iam create-role \
 		--role-name $VAULT_AUTH_ROLE_NAME \
 		--assume-role-policy-document file://trust-relationship.json \
@@ -106,7 +106,7 @@ cat <<EOF > gloo-vault-auth-policy.json
 }
 EOF
 
-export VAULT_AUTH_POLICY_ARN=$([[ $(aws iam list-policies --query "Policies[?PolicyName=='${VAULT_AUTH_POLICY_NAME}'].Arn" --output text) == "" ]] \
+export VAULT_AUTH_POLICY_ARN=$([[ $(aws iam list-policies --query "Policies[?PolicyName=='${VAULT_AUTH_POLICY_NAME}'].Arn" --output text) = "" ]] \
     && aws iam create-policy \
         --region=${AWS_REGION} \
         --policy-name="${VAULT_AUTH_POLICY_NAME}" \
@@ -213,7 +213,7 @@ kubectl -n vault exec vault-0 -- vault write auth/aws/role/${VAULT_AUTH_ROLE_NAM
 	auth_type=iam \
     bound_iam_principal_arn="${VAULT_AUTH_ROLE_ARN}" \
     policies=dev \
-    max_ttl=24h
+    max_ttl=15m
 ```
 
 If this fails see [Access denied due to identity-based policies – implicit denial](#access-denied-due-to-identity-based-policies--implicit-denial)

--- a/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
+++ b/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
@@ -15,7 +15,7 @@ Start by creating the necessary permissions in AWS.
 
 ### Step 1: Create a cluster with OIDC
 
-To configure IRSA, create or use an EKS cluster with an associated OpenID Provider (OIDC). Be sure to use a cluster that you have not yet installed Gloo Edge into.
+To configure IRSA, create or use an EKS cluster with an associated OpenID Provider (OIDC). Be sure to use a cluster name that has not previously been used to create the AWS vault permissions in this guide.
 
 1. Save the following details in environment variables.
    ```shell
@@ -292,7 +292,7 @@ Code: 400. Errors:
 
 To create and associate the necessary policy:
 
-1. Set an environment variable with the assumed role. You can find the value in your error message.
+1. Set an environment variable with the assumed role. You can find the value in your error message. In the example above, the `<role-name>` would be `foo-role`
    ```shell
    export VAULT_ASSUMED_ROLE=<role>
    ```

--- a/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
+++ b/docs/content/guides/integrations/vault/aws-irsa-auth/_index.md
@@ -15,7 +15,7 @@ Start by creating the necessary permissions in AWS.
 
 ### Step 1: Create a cluster with OIDC
 
-To configure IRSA, create or use an EKS cluster with an associated OpenID Provider (OIDC). Be sure to use a cluster name that has not previously been used to create the AWS vault permissions in this guide.
+To configure IRSA, create or use an EKS cluster with an associated OpenID Provider (OIDC). Be sure to use a cluster name that has not previously been used to create the AWS vault permissions in this guide. For more information about creating an EKS cluster in AWS, see [Getting started with Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/getting-started.html).
 
 1. Save the following details in environment variables.
    ```shell
@@ -292,7 +292,7 @@ Code: 400. Errors:
 
 To create and associate the necessary policy:
 
-1. Set an environment variable with the assumed role. You can find the value in your error message. In the example above, the `<role-name>` would be `foo-role`
+1. Set an environment variable with the assumed role. You can find the value in your error message. In the example above, the `<role-name>` would be `foo-role`.
    ```shell
    export VAULT_ASSUMED_ROLE=<role>
    ```


### PR DESCRIPTION
# Description

This guide was updated with https://github.com/solo-io/gloo/pull/9009, and I don't believe it has been through a review by the docs team.

Please review the entire document instead of just the changeset.

# Updates
* Simplified the logic around the creation of the VAULT_AUTH_ROLE and VAULT_AUTH_POLICY. Previously we were checking if the role/policy existed already and returning the arn if it did.  This made the logic difficult to read and was also assuming the existing entity was properly configured for the purposes of the guide.
* Updated the troubleshooting section to use the command line instead of the console.