### PR TITLE
add RouteOption route plugin

### DIFF
--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
 	"github.com/solo-io/gloo/projects/gateway2/deployer"
 	"github.com/solo-io/gloo/projects/gateway2/query"
 	corev1 "k8s.io/api/core/v1"
@@ -52,6 +53,7 @@ func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 		controllerBuilder.watchHttpRoute,
 		controllerBuilder.watchReferenceGrant,
 		controllerBuilder.watchNamespaces,
+		controllerBuilder.watchRouteOptions,
 		controllerBuilder.addIndexes,
 	)
 
@@ -179,10 +181,27 @@ func (c *controllerBuilder) watchNamespaces(ctx context.Context) error {
 	return nil
 }
 
+func (c *controllerBuilder) watchRouteOptions(ctx context.Context) error {
+	err := ctrl.NewControllerManagedBy(c.cfg.Mgr).
+		For(&sologatewayv1.RouteOption{}).
+		Complete(reconcile.Func(c.reconciler.ReconcileRouteOptions))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 type controllerReconciler struct {
 	cli    client.Client
 	scheme *runtime.Scheme
 	kick   func(ctx context.Context)
+}
+
+func (r *controllerReconciler) ReconcileRouteOptions(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// eventually reconcile only effected routes/listeners etc
+	log.FromContext(ctx).Info("LAW: triggering reconcile for RouteOptions")
+	r.kick(ctx)
+	return ctrl.Result{}, nil
 }
 
 func (r *controllerReconciler) ReconcileNamespaces(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -199,13 +199,11 @@ type controllerReconciler struct {
 
 func (r *controllerReconciler) ReconcileRouteOptions(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// eventually reconcile only effected routes/listeners etc
-	log.FromContext(ctx).Info("LAW: triggering reconcile for RouteOptions")
 	r.kick(ctx)
 	return ctrl.Result{}, nil
 }
 
 func (r *controllerReconciler) ReconcileNamespaces(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
 	// reconcile all gateways with namespace selector
 	r.kick(ctx)
 	return ctrl.Result{}, nil

--- a/projects/gateway2/controller/scheme/scheme.go
+++ b/projects/gateway2/controller/scheme/scheme.go
@@ -3,6 +3,7 @@ package scheme
 import (
 	"os"
 
+	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -13,7 +14,7 @@ import (
 func NewScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	for _, f := range []func(*runtime.Scheme) error{
-		apiv1.AddToScheme, apiv1beta1.AddToScheme, corev1.AddToScheme, appsv1.AddToScheme,
+		apiv1.AddToScheme, apiv1beta1.AddToScheme, corev1.AddToScheme, appsv1.AddToScheme, sologatewayv1.AddToScheme,
 	} {
 		if err := f(scheme); err != nil {
 			os.Exit(1)

--- a/projects/gateway2/examples/example-http-route-with-header-modifier.yaml
+++ b/projects/gateway2/examples/example-http-route-with-header-modifier.yaml
@@ -1,0 +1,45 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: gw
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 8080
+    filters:
+    - type: RequestHeaderModifier
+      requestHeaderModifier:
+        add:
+        - name: my-header-name
+          value: my-header-value
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    app.kubernetes.io/name: nginx
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: http-web-svc
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+    - containerPort: 80
+      name: http-web-svc

--- a/projects/gateway2/examples/example-http-route-with-route-options.yaml
+++ b/projects/gateway2/examples/example-http-route-with-route-options.yaml
@@ -1,0 +1,57 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: gw
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 8080
+    filters:
+    - type: ExtensionRef
+      extensionRef:
+        group: gateway.solo.io
+        kind: RouteOption
+        name: foo
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: foo
+spec:
+  options:
+    retries:
+      retryOn: 'connect-failure'
+      numRetries: 3
+      perTryTimeout: '5s'
+    timeout: 10s
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+spec:
+  selector:
+    app.kubernetes.io/name: nginx
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: http-web-svc
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+    - containerPort: 80
+      name: http-web-svc

--- a/projects/gateway2/helm/gloo-gateway/templates/rbac.yaml
+++ b/projects/gateway2/helm/gloo-gateway/templates/rbac.yaml
@@ -30,6 +30,11 @@ rules:
   - endpointslices
   verbs: ["get", "list", "watch"]
 - apiGroups:
+  - "gateway.solo.io"
+  resources:
+  - routeoptions
+  verbs: ["get", "list", "watch"]
+- apiGroups:
   - "gateway.networking.k8s.io"
   resources:
   - gatewayclasses/status

--- a/projects/gateway2/kind.sh
+++ b/projects/gateway2/kind.sh
@@ -1,8 +1,13 @@
+set -x
+
 kind create cluster
 
 SCRIPTPATH=$( cd "$(dirname "$0")" && pwd -P )
 
 kubectl apply -f $SCRIPTPATH/crds/gateway-crds.yaml
+
+# TODO: make this smarter if desired; simple relative path works for now
+kubectl apply -f $SCRIPTPATH/../../install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
 
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.7/config/manifests/metallb-native.yaml
 

--- a/projects/gateway2/kind.sh
+++ b/projects/gateway2/kind.sh
@@ -1,5 +1,3 @@
-set -x
-
 kind create cluster
 
 SCRIPTPATH=$( cd "$(dirname "$0")" && pwd -P )

--- a/projects/gateway2/translator/plugins/registry/plugin_registry.go
+++ b/projects/gateway2/translator/plugins/registry/plugin_registry.go
@@ -6,6 +6,7 @@ import (
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/headermodifier"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/mirror"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/redirect"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/routeoptions"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/urlrewrite"
 )
 
@@ -41,6 +42,7 @@ func buildPlugins(queries query.GatewayQueries) []plugins.Plugin {
 		headermodifier.NewPlugin(),
 		mirror.NewPlugin(queries),
 		redirect.NewPlugin(),
+		routeoptions.NewPlugin(queries),
 		urlrewrite.NewPlugin(),
 	}
 }

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
@@ -12,6 +12,11 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+var gk = schema.GroupKind{
+	Group: sologatewayv1.RouteOptionGVK.Group,
+	Kind:  sologatewayv1.RouteOptionGVK.Kind,
+}
+
 type plugin struct {
 	queries query.GatewayQueries
 }
@@ -27,17 +32,11 @@ func (p *plugin) ApplyRoutePlugin(
 	routeCtx *plugins.RouteContext,
 	outputRoute *v1.Route,
 ) error {
-	gk := schema.GroupKind{
-		Group: sologatewayv1.RouteOptionGVK.Group,
-		Kind:  sologatewayv1.RouteOptionGVK.Kind,
-	}
-	// contextutils.LoggerFrom(ctx).Debugf("LAW: looking for RouteOption filter with gk: %+v", gk)
 	filter := utils.FindExtensionRefFilter(routeCtx, gk)
 	if filter == nil {
 		return nil
 	}
 
-	// contextutils.LoggerFrom(ctx).Debugf("LAW: found RouteOptions filter: %+v", filter)
 	routeOption := &solokubev1.RouteOption{}
 	err := utils.GetExtensionRefObj(context.Background(), routeCtx, p.queries, filter.ExtensionRef, routeOption)
 	if err != nil {

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
@@ -2,14 +2,22 @@ package routeoptions
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
 	"github.com/solo-io/gloo/projects/gateway2/query"
+	"github.com/solo-io/gloo/projects/gateway2/reports"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/utils"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/go-utils/contextutils"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
 var gk = schema.GroupKind{
@@ -40,12 +48,37 @@ func (p *plugin) ApplyRoutePlugin(
 	routeOption := &solokubev1.RouteOption{}
 	err := utils.GetExtensionRefObj(context.Background(), routeCtx, p.queries, filter.ExtensionRef, routeOption)
 	if err != nil {
-		return nil
+		switch {
+		case apierrors.IsNotFound(err):
+			routeCtx.Reporter.SetCondition(reports.HTTPRouteCondition{
+				Type:    gwv1.RouteConditionResolvedRefs,
+				Status:  metav1.ConditionFalse,
+				Reason:  gwv1.RouteReasonBackendNotFound,
+				Message: formatNotFoundMessage(routeCtx, filter),
+			})
+		case errors.Is(err, utils.ErrTypesNotEqual):
+		case errors.Is(err, utils.ErrNotSettable):
+			contextutils.LoggerFrom(ctx).DPanicf("developer error while getting RouteOptions as ExtensionRef: %v", err)
+		default:
+			contextutils.LoggerFrom(ctx).Errorf("error while getting RouteOptions as ExtensionRef: %v", err)
+		}
+		return err
 	}
+
 	if routeOption.Spec.Options != nil {
 		// set options from RouteOptions resource and clobber any existing options
 		// should be revisited if/when we support merging options from e.g. other HTTPRouteFilters
 		outputRoute.Options = routeOption.Spec.Options
 	}
 	return nil
+}
+
+func formatNotFoundMessage(routeCtx *plugins.RouteContext, filter *gwv1.HTTPRouteFilter) string {
+	return fmt.Sprintf(
+		"extensionRef '%s' of type %s.%s in namespace '%s' not found",
+		filter.ExtensionRef.Group,
+		filter.ExtensionRef.Kind,
+		filter.ExtensionRef.Name,
+		routeCtx.Route.GetNamespace(),
+	)
 }

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
@@ -1,0 +1,52 @@
+package routeoptions
+
+import (
+	"context"
+
+	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
+	"github.com/solo-io/gloo/projects/gateway2/query"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/utils"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+type plugin struct {
+	queries query.GatewayQueries
+}
+
+func NewPlugin(queries query.GatewayQueries) *plugin {
+	return &plugin{
+		queries,
+	}
+}
+
+func (p *plugin) ApplyRoutePlugin(
+	ctx context.Context,
+	routeCtx *plugins.RouteContext,
+	outputRoute *v1.Route,
+) error {
+	gk := schema.GroupKind{
+		Group: sologatewayv1.RouteOptionGVK.Group,
+		Kind:  sologatewayv1.RouteOptionGVK.Kind,
+	}
+	// contextutils.LoggerFrom(ctx).Debugf("LAW: looking for RouteOption filter with gk: %+v", gk)
+	filter := utils.FindExtensionRefFilter(routeCtx, gk)
+	if filter == nil {
+		return nil
+	}
+
+	// contextutils.LoggerFrom(ctx).Debugf("LAW: found RouteOptions filter: %+v", filter)
+	routeOption := &solokubev1.RouteOption{}
+	err := utils.GetExtensionRefObj(context.Background(), routeCtx, p.queries, filter.ExtensionRef, routeOption)
+	if err != nil {
+		return nil
+	}
+	if routeOption.Spec.Options != nil {
+		// set options from RouteOptions resource and clobber any existing options
+		// should be revisited if/when we support merging options from e.g. other HTTPRouteFilters
+		outputRoute.Options = routeOption.Spec.Options
+	}
+	return nil
+}

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin_test.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin_test.go
@@ -1,0 +1,73 @@
+package routeoptions
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/filtertests"
+	"github.com/solo-io/gloo/projects/gateway2/translator/testutils"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/faultinjection"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+var _ = Describe("RouteOptionsPlugin", func() {
+	DescribeTable(
+		"applying RouteOptions to translated routes",
+		func(
+			filter gwv1.HTTPRouteFilter,
+			expectedRoute *v1.Route,
+		) {
+			deps := []client.Object{routeOption()}
+			queries := testutils.BuildGatewayQueries(deps)
+			plugin := NewPlugin(queries)
+			filtertests.AssertExpectedRoute(
+				plugin,
+				expectedRoute,
+				true,
+				filter,
+			)
+		},
+		Entry(
+			"applies fault injecton RouteOptions directly from resource to output route",
+			gwv1.HTTPRouteFilter{
+				Type: gwv1.HTTPRouteFilterExtensionRef,
+				ExtensionRef: &gwv1.LocalObjectReference{
+					Group: gwv1.Group(sologatewayv1.RouteOptionGVK.Group),
+					Kind:  gwv1.Kind(sologatewayv1.RouteOptionGVK.Kind),
+					Name:  "policy",
+				},
+			},
+			&v1.Route{
+				Options: &v1.RouteOptions{
+					Faults: &faultinjection.RouteFaults{
+						Abort: &faultinjection.RouteAbort{
+							Percentage: 1,
+						},
+					},
+				},
+			},
+		),
+	)
+})
+
+func routeOption() *solokubev1.RouteOption {
+	return &solokubev1.RouteOption{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy",
+			Namespace: "default",
+		},
+		Spec: sologatewayv1.RouteOption{
+			Options: &v1.RouteOptions{
+				Faults: &faultinjection.RouteFaults{
+					Abort: &faultinjection.RouteAbort{
+						Percentage: 1.00,
+					},
+				},
+			},
+		},
+	}
+}

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_suite_test.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_suite_test.go
@@ -1,0 +1,13 @@
+package routeoptions
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHeadermodifier(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RouteOptions Suite")
+}

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_suite_test.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_suite_test.go
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestHeadermodifier(t *testing.T) {
+func TestRouteOptionsPlugin(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "RouteOptions Suite")
+	RunSpecs(t, "RouteOptions Plugin Suite")
 }

--- a/projects/gateway2/translator/plugins/utils/plugin_utils.go
+++ b/projects/gateway2/translator/plugins/utils/plugin_utils.go
@@ -44,6 +44,8 @@ func FindAppliedRouteFilter(
 	return nil
 }
 
+// Finds the first instance of an ExtensionRef filter that references the supplied GroupKind in the Rule being processed.
+// Returns nil if the Rule doesn't contain a matching ExtensionRef filter
 func FindExtensionRefFilter(
 	routeCtx *plugins.RouteContext,
 	gk schema.GroupKind,
@@ -59,6 +61,10 @@ func FindExtensionRefFilter(
 	return nil
 }
 
+// Uses the provided query engine to retrieve an ExtensionRef object and set the value of `obj` to point to it.
+// The type of `obj` must match the type referenced in the extensionRef and must be a pointer.
+// An error will be returned if the Get was unsuccessful or if the type passed is not valid.
+// A nil error indicates success and `obj` should be usable as normal.
 func GetExtensionRefObj(
 	ctx context.Context,
 	routeCtx *plugins.RouteContext,

--- a/projects/gateway2/translator/plugins/utils/plugin_utils.go
+++ b/projects/gateway2/translator/plugins/utils/plugin_utils.go
@@ -61,6 +61,11 @@ func FindExtensionRefFilter(
 	return nil
 }
 
+var (
+	ErrTypesNotEqual = fmt.Errorf("types not equal")
+	ErrNotSettable   = fmt.Errorf("can't set value")
+)
+
 // Uses the provided query engine to retrieve an ExtensionRef object and set the value of `obj` to point to it.
 // The type of `obj` must match the type referenced in the extensionRef and must be a pointer.
 // An error will be returned if the Get was unsuccessful or if the type passed is not valid.
@@ -77,11 +82,16 @@ func GetExtensionRefObj(
 		return err
 	}
 	if reflect.TypeOf(obj) != reflect.TypeOf(localObj) {
-		return fmt.Errorf("types not equal")
+		return fmt.Errorf(
+			"%w: passed Obj typeOf: '%v' localObj typeOf: '%v'",
+			ErrTypesNotEqual,
+			reflect.TypeOf(obj),
+			reflect.TypeOf(localObj),
+		)
 	}
 	elem := reflect.ValueOf(obj).Elem()
 	if !elem.CanSet() {
-		return fmt.Errorf("can't set value")
+		return ErrNotSettable
 	}
 	elem.Set(reflect.ValueOf(localObj).Elem())
 	return nil

--- a/projects/gateway2/translator/plugins/utils/utils_test.go
+++ b/projects/gateway2/translator/plugins/utils/utils_test.go
@@ -20,7 +20,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-func TestValidate(t *testing.T) {
+func TestExtensionRefUtils(t *testing.T) {
 	g := NewWithT(t)
 	deps := []client.Object{routeOption()}
 	queries := testutils.BuildGatewayQueries(deps)

--- a/projects/gateway2/translator/plugins/utils/utils_test.go
+++ b/projects/gateway2/translator/plugins/utils/utils_test.go
@@ -1,0 +1,76 @@
+package utils_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/gomega"
+
+	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/utils"
+	"github.com/solo-io/gloo/projects/gateway2/translator/testutils"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/faultinjection"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestValidate(t *testing.T) {
+	g := NewWithT(t)
+	deps := []client.Object{routeOption()}
+	queries := testutils.BuildGatewayQueries(deps)
+
+	rtCtx := routeContext()
+	gk := schema.GroupKind{
+		Group: sologatewayv1.RouteOptionGVK.Group,
+		Kind:  sologatewayv1.RouteOptionGVK.Kind,
+	}
+	filter := utils.FindExtensionRefFilter(&rtCtx, gk)
+	g.Expect(filter).ToNot(BeNil())
+
+	routeOption := &solokubev1.RouteOption{}
+	err := utils.GetExtensionRefObj(context.Background(), &rtCtx, queries, filter.ExtensionRef, routeOption)
+	g.Expect(err).To(BeNil())
+	g.Expect(routeOption.Spec.GetOptions().GetFaults().GetAbort().GetPercentage()).To(BeEquivalentTo(1))
+}
+
+func routeOption() *solokubev1.RouteOption {
+	return &solokubev1.RouteOption{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy",
+			Namespace: "default",
+		},
+		Spec: sologatewayv1.RouteOption{
+			Options: &v1.RouteOptions{
+				Faults: &faultinjection.RouteFaults{
+					Abort: &faultinjection.RouteAbort{
+						Percentage: 1.00,
+					},
+				},
+			},
+		},
+	}
+}
+
+func routeContext() plugins.RouteContext {
+	return plugins.RouteContext{
+		Route: &gwv1.HTTPRoute{},
+		Rule: &gwv1.HTTPRouteRule{
+			Filters: []gwv1.HTTPRouteFilter{
+				{
+					Type: gwv1.HTTPRouteFilterExtensionRef,
+					ExtensionRef: &gwv1.LocalObjectReference{
+						Group: gwv1.Group(sologatewayv1.RouteOptionGVK.Group),
+						Kind:  gwv1.Kind(sologatewayv1.RouteOptionGVK.Kind),
+						Name:  "policy",
+					},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
Add support for watching and translating `RouteOptions`.

Controller now watches `RouteOptions` similar to other API types and will `Kick()` the reconciler when an event happens. I explored trying to make the controller updates generic, but there didn't seem like a straightforward way to do so that wasn't contrived. Given that the only other type which will follow this specific model is `VHostOptions`, while the rest of the policies will come from the Platform APIs, this method of adding to the controller seems to make sense to me.

New `RouteOptions` plugin added, along with util methods to handle the `ExtensionRef` filter along with the actual retrieval of the referenced object, which ultimately happens inside query engine.

Original PR: https://github.com/solo-io/gloo/pull/8984