### PR TITLE
Add errname linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -16,6 +16,7 @@ linters:
     # If you see a linter that can be added, please do so.
     # See: https://github.com/solo-io/gloo-mesh-enterprise/blob/main/.golangci.yaml for a reference
     - ginkgolinter
+    - errname
 
 # Settings dedicated to specific linters.
 linters-settings: {}

--- a/changelog/v1.17.0-beta3/add-linters.yaml
+++ b/changelog/v1.17.0-beta3/add-linters.yaml
@@ -4,4 +4,5 @@ changelog:
   resolvesIssue: false
   description: >-
     Add linters:
+      - errname
     skipCI-docs-build:true

--- a/changelog/v1.17.0-beta3/linter-errname.yaml
+++ b/changelog/v1.17.0-beta3/linter-errname.yaml
@@ -1,5 +1,5 @@
 changelog:
-  type: NON_USER_FACING
+- type: NON_USER_FACING
   issueLink: https://github.com/solo-io/gloo/issues/6686
   resolvesIssue: false
   description: >-

--- a/changelog/v1.17.0-beta3/linter-errname.yaml
+++ b/changelog/v1.17.0-beta3/linter-errname.yaml
@@ -1,0 +1,8 @@
+changelog:
+  type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/6686
+  resolvesIssue: false
+  description: >-
+    Add errname linter
+    skipCI-docs-build:true
+

--- a/changelog/v1.17.0-beta3/linter-errname.yaml
+++ b/changelog/v1.17.0-beta3/linter-errname.yaml
@@ -1,8 +1,0 @@
-changelog:
-- type: NON_USER_FACING
-  issueLink: https://github.com/solo-io/gloo/issues/6686
-  resolvesIssue: false
-  description: >-
-    Add errname linter
-    skipCI-docs-build:true
-

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Helm Test", func() {
 			}
 			selector         map[string]string
 			testManifest     TestManifest
-			renderErr        error
+			renderErr        error //nolint:errname // not used as sentinel error
 			statsAnnotations map[string]string
 		)
 

--- a/projects/discovery/pkg/fds/updater.go
+++ b/projects/discovery/pkg/fds/updater.go
@@ -19,7 +19,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/translator"
 )
 
-var errorUndetectableUpstream = errors.New("upstream type cannot be detected")
+var errUndetectableUpstream = errors.New("upstream type cannot be detected")
 
 type UpstreamWriterClient interface {
 	Write(resource *v1.Upstream, opts clients.WriteOpts) (*v1.Upstream, error)
@@ -270,7 +270,7 @@ func (u *updaterUpdater) detectType(url_ url.URL) ([]*detectResult, error) {
 			}
 			if numResultsReceived == len(u.functionalPlugins) {
 				if len(results) == 0 {
-					return nil, errorUndetectableUpstream
+					return nil, errUndetectableUpstream
 				}
 				return results, nil
 			}
@@ -315,7 +315,7 @@ func (u *updaterUpdater) Run() error {
 		// try to detect the type
 		res, err := u.detectType(*resolvedUrl)
 		if err != nil {
-			if err == errorUndetectableUpstream {
+			if err == errUndetectableUpstream {
 				// TODO(yuval-k): at this point all discoveries gave up.
 				// do we want to mark an upstream as undetected persistently so we do not detect it anymore?
 			}

--- a/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig.go
+++ b/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig.go
@@ -25,8 +25,8 @@ var (
 	ProvideNamespaceAndNameError = func(namespace, secretName string) error {
 		return errors.Errorf("provide both a secret namespace [%v] and secret name [%v]", namespace, secretName)
 	}
-	EmptyQueryError       = errors.Errorf("query must not be empty")
-	InvalidRefFormatError = errors.Errorf("invalid format: provide namespaced names for config maps (namespace.configMapName)")
+	ErrEmptyQuery       = errors.Errorf("query must not be empty")
+	ErrInvalidRefFormat = errors.Errorf("invalid format: provide namespaced names for config maps (namespace.configMapName)")
 )
 
 func AuthConfigCreate(opts *options.Options, optionsFunc ...cliutils.OptionsFunc) *cobra.Command {
@@ -184,14 +184,14 @@ func authFromOpts(ac *extauth.AuthConfig, input options.InputAuthConfig) error {
 		query := opaAuth.Query
 
 		if len(query) == 0 {
-			return EmptyQueryError
+			return ErrEmptyQuery
 		}
 
 		for _, moduleRef := range opaAuth.Modules {
 
 			splits := strings.Split(moduleRef, ".")
 			if len(splits) != 2 {
-				return InvalidRefFormatError
+				return ErrInvalidRefFormat
 			}
 			namespace := splits[0]
 			name := splits[1]

--- a/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig_test.go
+++ b/projects/gloo/cli/pkg/cmd/create/authconfig/authconfig_test.go
@@ -244,7 +244,7 @@ var _ = Describe("AuthConfig", func() {
 	Context("OPA auth config errors", func() {
 		It("throws error if no query provided ", func() {
 			_, err := testutils.GlooctlOut("create ac --name ac1 --enable-opa-auth")
-			Expect(err).To(MatchError(authconfig.EmptyQueryError))
+			Expect(err).To(MatchError(authconfig.ErrEmptyQuery))
 		})
 	})
 

--- a/projects/gloo/pkg/plugins/cors/plugin.go
+++ b/projects/gloo/pkg/plugins/cors/plugin.go
@@ -36,8 +36,8 @@ const (
 )
 
 var (
-	InvalidRouteActionError = errors.New("cannot use cors plugin on non-Route_Route route actions")
-	pluginStage             = plugins.DuringStage(plugins.CorsStage)
+	ErrInvalidRouteAction = errors.New("cannot use cors plugin on non-Route_Route route actions")
+	pluginStage           = plugins.DuringStage(plugins.CorsStage)
 )
 
 type plugin struct {
@@ -98,7 +98,7 @@ func (p *plugin) ProcessRoute(params plugins.RouteParams, in *v1.Route, out *env
 
 	// the cors filter can only be used on routes that are of type envoyroute.Route_Route
 	if out.GetAction() != nil && out.GetRoute() == nil {
-		return InvalidRouteActionError
+		return ErrInvalidRouteAction
 	}
 	// we have already ensured that the output route action is either nil or of the proper type
 	// if it is nil, we initialize it prior to transforming it

--- a/projects/gloo/pkg/plugins/tcp/plugin.go
+++ b/projects/gloo/pkg/plugins/tcp/plugin.go
@@ -87,7 +87,7 @@ func (p *plugin) CreateTcpFilterChains(params plugins.Params, parentListener *v1
 				// special error object, and the caller will handle conversion
 				// from error to warning
 				// https://github.com/solo-io/solo-projects/issues/5163
-				multiErr.Errors = append(multiErr.Errors, &validation.TcpHostWarning{
+				multiErr.Errors = append(multiErr.Errors, &validation.TcpHostWarningError{
 					Err:      err,
 					ErrLevel: validation.ErrorLevels_WARNING,
 					Context: validation.ErrorLevelContext{

--- a/projects/gloo/pkg/utils/route_action.go
+++ b/projects/gloo/pkg/utils/route_action.go
@@ -7,12 +7,12 @@ import (
 )
 
 var (
-	InvalidRouteActionError = errors.New("cannot use this plugin on non-Route_Route route actions")
+	ErrInvalidRouteAction = errors.New("cannot use this plugin on non-Route_Route route actions")
 )
 
 func EnsureRouteAction(out *envoy_config_route_v3.Route) error {
 	if out.GetAction() != nil && out.GetRoute() == nil {
-		return InvalidRouteActionError
+		return ErrInvalidRouteAction
 	}
 	// we have already ensured that the output route action is either nil or of the proper type
 	// if it is nil, we initialize it prior to transforming it

--- a/projects/gloo/pkg/utils/validation/proxy_validation.go
+++ b/projects/gloo/pkg/utils/validation/proxy_validation.go
@@ -43,29 +43,29 @@ type ErrorWithKnownLevel interface {
 	GetError() error
 }
 
-// TcpHostWarning implements ErrorWithKnownLevel; it is intended to allow
+// TcpHostWarningError implements ErrorWithKnownLevel; it is intended to allow
 // reporting certain errors as warnings and others as errors, and provides the
 // necessary context required for reporting errors as such
-type TcpHostWarning struct {
+type TcpHostWarningError struct {
 	Err      error
 	ErrLevel string
 	Context  ErrorLevelContext
 }
 
-func (tcpHostWarning *TcpHostWarning) ErrorLevel() string {
+func (tcpHostWarning *TcpHostWarningError) ErrorLevel() string {
 	return tcpHostWarning.ErrLevel
 }
 
-func (tcpHostWarning *TcpHostWarning) Error() string {
+func (tcpHostWarning *TcpHostWarningError) Error() string {
 	return fmt.Sprintf("TcpHost error: %v", tcpHostWarning.Err)
 }
 
-func (tcpHostWarning *TcpHostWarning) GetContext() ErrorLevelContext {
+func (tcpHostWarning *TcpHostWarningError) GetContext() ErrorLevelContext {
 	return tcpHostWarning.Context
 }
 
 // return the instance of the Error this object is wrapping
-func (tcpHostWarning *TcpHostWarning) GetError() error {
+func (tcpHostWarning *TcpHostWarningError) GetError() error {
 	return tcpHostWarning.Err
 }
 

--- a/test/kube2e/upgrade/upgrade_utils.go
+++ b/test/kube2e/upgrade/upgrade_utils.go
@@ -32,7 +32,7 @@ func GetUpgradeVersions(ctx context.Context, repoName string) (*versionutils.Ver
 		return nil, nil, changelogutils.ReadChangelogDirError(changelogReadErr)
 	}
 	latestRelease, upcomingRelease, upcomingReleaseErr := version.ChangelogDirForLatestRelease(files...)
-	if upcomingReleaseErr != nil && !errors.Is(upcomingReleaseErr, version.FirstReleaseError) {
+	if upcomingReleaseErr != nil && !errors.Is(upcomingReleaseErr, version.ErrFirstRelease) {
 		return nil, nil, upcomingReleaseErr
 	}
 

--- a/test/testutils/version/changelog.go
+++ b/test/testutils/version/changelog.go
@@ -59,14 +59,14 @@ func ChangelogDirForLatestRelease[T namedEntry](files ...T) (
 	sort.Sort(sortableVersionSlice(versions))
 
 	if versions[len(versions)-1].Minor != versions[len(versions)-2].Minor {
-		err = FirstReleaseError
+		err = ErrFirstRelease
 	}
 	return versions[len(versions)-2], versions[len(versions)-1], err
 }
 
 var (
-	// FirstReleaseError is returned when the changelog dir is for the first release of a minor version
-	FirstReleaseError = errors.New("First Release of Minor")
+	// ErrFirstRelease is returned when the changelog dir is for the first release of a minor version
+	ErrFirstRelease = errors.New("First Release of Minor")
 )
 
 // versionSort is a helper type for sorting versions in a slice

--- a/test/testutils/version/changelog_test.go
+++ b/test/testutils/version/changelog_test.go
@@ -37,7 +37,7 @@ var _ = Describe("upgrade utils unit tests", func() {
 			Expect(ver.String()).To(Equal("v1.7.1"), fmt.Sprintf("%v", baseEntries))
 			Expect(err).To(HaveOccurred())
 			Expect(curVer.String()).To(Equal("v1.8.0-beta1"), fmt.Sprintf("%v", baseEntries))
-			Expect(err).To(Equal(version.FirstReleaseError))
+			Expect(err).To(Equal(version.ErrFirstRelease))
 		})
 	})
 


### PR DESCRIPTION
# Description

Enable `errname` linter to ensure our error variables and types conform to idiomatic Go