### PR TITLE
1.16/to ga

### DIFF
--- a/changelog/v1.16.0/bump-ga.yaml
+++ b/changelog/v1.16.0/bump-ga.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/5654
+    resolvesIssue: false
+    description: >-
+      Update changelog folder to a full release folder.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/changelog/v1.16.0/bump-ga.yaml
+++ b/changelog/v1.16.0/bump-ga.yaml
@@ -3,6 +3,6 @@ changelog:
     issueLink: https://github.com/solo-io/solo-projects/issues/5654
     resolvesIssue: false
     description: >-
-      Update changelog folder to a full release folder.
+      Update changelog folder to a full release folder for v1.16.0.
       skipCI-kube-tests:true
       skipCI-docs-build:true


### PR DESCRIPTION
Changelog only request to allow for 1.16 release now that the rcs have been soaked and tested for performance degredations.