### PR TITLE
fix: slow start aggression (#9031)

### DIFF
--- a/changelog/v1.16.1/fix-envoy-slow-start-agression.yaml
+++ b/changelog/v1.16.1/fix-envoy-slow-start-agression.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/pull/9031
+    resolvesIssue: false
+    description: Add missing required runtime key for aggression in slow start config.


### PR DESCRIPTION
Backport slow aggression fix.

* fix: slow start aggression

* create changelog

* update version for the changelog

* update runtime key to be configurable per cluster
