### PR TITLE
Bump min scanned version to v1.13.0

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -2,7 +2,7 @@ name: Docs
 
 env:
     SLACK_DEBUG_TESTING: false      # when set to "true", send notifications to #slack-integration-testing.  Otherwise, post to #edge-team-bots
-    MIN_SCANNED_VERSION: 'v1.12.0'  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
+    MIN_SCANNED_VERSION: 'v1.13.0'  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
 on:
   push:
     branches:

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
     - 'main'
+    - 'v.16.x'
     - 'v1.15.x'
     - 'v1.14.x'
     - 'v1.13.x'
-    - 'v1.12.x'
   pull_request:
     branches:
     - 'main'

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -7,7 +7,7 @@ on:
   push:
     branches:
     - 'main'
-    - 'v.16.x'
+    - 'v1.16.x'
     - 'v1.15.x'
     - 'v1.14.x'
     - 'v1.13.x'

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -37,7 +37,7 @@ jobs:
         env:
           SCAN_DIR: _output/scans
           IMAGE_REGISTRY: quay.io/solo-io
-          MIN_SCANNED_VERSION: 'v1.12.0' # ⚠️ you should also change docs-gen.yaml ⚠️
+          MIN_SCANNED_VERSION: 'v1.13.0' # ⚠️ you should also change docs-gen.yaml ⚠️
         run: |
           mkdir -p $SCAN_DIR
           make run-security-scan

--- a/Makefile
+++ b/Makefile
@@ -817,7 +817,7 @@ build-test-chart: ## Build the Helm chart and place it in the _test directory
 SCAN_DIR ?= $(OUTPUT_DIR)/scans
 SCAN_BUCKET ?= solo-gloo-security-scans
 # The minimum version to scan with trivy
-MIN_SCANNED_VERSION ?= v1.12.0
+MIN_SCANNED_VERSION ?= v1.13.0
 
 .PHONY: run-security-scans
 run-security-scan:

--- a/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
+++ b/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
@@ -1,8 +1,9 @@
 changelog:
   - type: NON_USER_FACING
     description: >-
-      Update the MIN_SCANNED_VERSION to v1.13 in docs-gen.yaml so v1.12 does not get scanned for vulnerabilities.
+      Update the MIN_SCANNED_VERSION to v1.13 in docs-gen.yaml so v1.12 does not get scanned for vulnerabilities and update
+      docs gen to drop v1.12 and add v1.16 to reflect currently supported LTS branches.
       skipCI-kube-tests:true
       skipCI-docs-build:true
-    issueLink: https://github.com/solo-io/solo-projects/issues/5703
+    issueLink: https://github.com/solo-io/gloo/issues/9084
     resolvesIssue: true

--- a/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
+++ b/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update the MIN_SCANNED_VERSION to v1.13 in docs-gen.yaml so v1.12 does not get scanned for vulnerabilities.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
+++ b/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
@@ -4,3 +4,5 @@ changelog:
       Update the MIN_SCANNED_VERSION to v1.13 in docs-gen.yaml so v1.12 does not get scanned for vulnerabilities.
       skipCI-kube-tests:true
       skipCI-docs-build:true
+    issueLink: https://github.com/solo-io/solo-projects/issues/5703
+    resolvesIssue: true

--- a/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
+++ b/changelog/v1.17.0-beta5/bump-security-scan-min-version.yaml
@@ -7,3 +7,10 @@ changelog:
       skipCI-docs-build:true
     issueLink: https://github.com/solo-io/gloo/issues/9084
     resolvesIssue: true
+  - type: NON_USER_FACING
+    description: >-
+      This also resolves the outstanding solo-projects issue with 1.12 CVEs 
+      skipCI-kube-tests:true
+      skipCI-docs-build:true
+    issueLink: https://github.com/solo-io/solo-projects/issues/5703
+    resolvesIssue: true

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -11,7 +11,7 @@ HUGO_VERSION := 0.81.0
 SOLO_HUGO_THEME_REVISION := v0.0.27
 
 # The minimum version to maintain in our public docs
-MIN_SCANNED_VERSION ?= v1.12.0
+MIN_SCANNED_VERSION ?= v1.13.0
 
 #----------------------------------------------------------------------------------
 # Docs


### PR DESCRIPTION
# Description

Update docs gen to reflect currently supported LTS branches

## Docs changes
- Bump `MIN_SCANNED_VERSION` in all places to v1.13.0
- Remove v1.12.x and add v1.16.x as docs version to generate

# Context

This bump needs to occur whenever we drop support for an LTS branch

This change affects docsgen for both OSS and EE

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9084
resolves https://github.com/solo-io/solo-projects/issues/5703