### PR TITLE
Gateway validation flake fix

### DIFF
--- a/changelog/v1.17.0-beta6/validation-test-flake-fix.yaml
+++ b/changelog/v1.17.0-beta6/validation-test-flake-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/9118
+    resolvesIssue: true
+    description: Fix flake in secret validation tests

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -59,7 +59,7 @@ func StartTestHelper() {
 
 	// Allow skipping of install step for running multiple times
 	if !kubeutils2.ShouldSkipInstall() {
-		installGloo()
+		//installGloo()
 	}
 
 	resourceClientset, err = kube2e.NewDefaultKubeResourceClientSet(ctx)
@@ -81,7 +81,7 @@ func installGloo() {
 	helmValuesFile := filepath.Join(cwd, "artifacts", "helm.yaml")
 
 	err = testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", helmValuesFile))
-	Expect(err).NotTo(HaveOccurred())
+	//Expect(err).NotTo(HaveOccurred())
 
 	// Check that everything is OK
 	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -59,7 +59,7 @@ func StartTestHelper() {
 
 	// Allow skipping of install step for running multiple times
 	if !kubeutils2.ShouldSkipInstall() {
-		//installGloo()
+		installGloo()
 	}
 
 	resourceClientset, err = kube2e.NewDefaultKubeResourceClientSet(ctx)
@@ -81,7 +81,7 @@ func installGloo() {
 	helmValuesFile := filepath.Join(cwd, "artifacts", "helm.yaml")
 
 	err = testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", helmValuesFile))
-	//Expect(err).NotTo(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 
 	// Check that everything is OK
 	kube2e.GlooctlCheckEventuallyHealthy(1, testHelper, "90s")

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -2112,6 +2112,11 @@ spec:
 				// It isn't until later - either a few minutes and/or after forcing an update by updating the VS - that the error status appears.
 				// The reason is still unknown, so we retry on flakes in the meantime.
 				It("should act as expected with secret validation", FlakeAttempts(3), func() {
+					By("waiting for the modified VS to be accepted")
+					helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
+						return resourceClientset.VirtualServiceClient().Read(testHelper.InstallNamespace, testRunnerVs.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})
+					})
+
 					By("failing to delete a secret that is in use")
 					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
 					Expect(err).To(HaveOccurred())
@@ -2138,8 +2143,9 @@ spec:
 					})
 
 					// Although these tests delete the secret handled by our SnapshotWriter, because we set `IgnoreNotFound` when deleting snapshot resources, this won't cause an issue.
-					err = resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						return resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+					}).WithPolling(50 * time.Millisecond).WithTimeout(30 * time.Second).ShouldNot(HaveOccurred())
 				})
 
 				It("can delete a secret that is not in use", func() {

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -2114,7 +2114,7 @@ spec:
 				It("should act as expected with secret validation", FlakeAttempts(3), func() {
 					By("waiting for the modified VS to be accepted")
 					helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
-						return resourceClientset.VirtualServiceClient().Read(testHelper.InstallNamespace, testRunnerVs.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})
+						return resourceClientset.VirtualServiceClient().Read(testHelper.InstallNamespace, testServerVs.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})
 					})
 
 					By("failing to delete a secret that is in use")

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -2145,7 +2145,7 @@ spec:
 					// Although these tests delete the secret handled by our SnapshotWriter, because we set `IgnoreNotFound` when deleting snapshot resources, this won't cause an issue.
 					Eventually(func() error {
 						return resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-					}).WithPolling(50 * time.Millisecond).WithTimeout(30 * time.Second).ShouldNot(HaveOccurred())
+					}).WithPolling(500 * time.Millisecond).WithTimeout(30 * time.Second).ShouldNot(HaveOccurred())
 				})
 
 				It("can delete a secret that is not in use", func() {


### PR DESCRIPTION
# Description

- Add a wait for resources to be accepted and wrap an assertion in an `Eventually` to resolve a test flake

# Context

This test has been failing often on k8s 1.24 on nightlies
I was also able to reproduce this locally

It's not clear why it fails in k8s 1.24 but not 1.28 or what caused the test to start failing per se

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9118