### PR TITLE
[1.15] move resource rollout job cleanup to pre-upgrade hook

### DIFF
--- a/changelog/v1.15.22/move-resource-rollout-cleanup.yaml
+++ b/changelog/v1.15.22/move-resource-rollout-cleanup.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/9033
+  resolvesIssue: false
+  description: When deploying edge with tilt + helm, the resource-rollout-job is deleted before the install completes which causes the deployment to fail. The cleanup for the resource-rollout job is now moved to a pre-upgrade hook to ensure that the job exists so deployments now succeed.

--- a/install/helm/gloo/templates/5-resource-rollout-check-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-check-job.yaml
@@ -100,8 +100,6 @@ spec:
                 echo "Waiting for the resource rollout job to complete"
                 kubectl -n {{ .Release.Namespace }} wait --for=condition=complete job gloo-resource-rollout --timeout={{ .Values.gateway.rolloutJob.timeout }}s || exit 1
 
-                # Clean up the rollout job up so it doesn't cause issues with upgrades
-                kubectl -n {{ .Release.Namespace }} delete job gloo-resource-rollout || exit $?
               fi
 
               # If the resource has been applied, re-applying it should output something like this

--- a/install/helm/gloo/templates/5-resource-rollout-cleanup-job.yaml
+++ b/install/helm/gloo/templates/5-resource-rollout-cleanup-job.yaml
@@ -1,0 +1,117 @@
+{{- if .Values.gateway.rolloutJob.enabled }}
+{{- $image := .Values.gateway.rolloutJob.image }}
+{{- if .Values.global }}
+{{- $image = merge .Values.gateway.rolloutJob.image .Values.global.image }}
+{{- end }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    app: gloo
+    gloo: resource-rollout
+  name: gloo-resource-rollout-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "5" # run this job after the role/rolebinding is created
+    {{- include "gloo.jobHelmDeletePolicySucceededAndBeforeCreation" .Values.gateway.rolloutJob | nindent 4 }}
+spec:
+  {{- include "gloo.jobSpecStandardFields" .Values.gateway.rolloutJob | nindent 2 -}}
+  template:
+    metadata:
+      labels:
+        gloo: resource-rollout
+        sidecar.istio.io/inject: "false"
+        {{- if .Values.gateway.rolloutJob.extraPodLabels }}
+        {{- range $key, $value := .Values.gateway.rolloutJob.extraPodLabels }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{- end }}
+        {{- end }}
+      {{- if or .Values.settings.linkerd .Values.gateway.rolloutJob.extraPodAnnotations }}
+      annotations:
+        {{- if .Values.settings.linkerd }}
+        "linkerd.io/inject": disabled
+        {{- end }}
+        {{- range $key, $value := .Values.gateway.rolloutJob.extraPodAnnotations }}
+        {{ $key | quote }}: {{ $value | quote }}
+        {{- end }}
+      {{- end }}
+    spec:
+      {{- include "gloo.pullSecret" $image | nindent 6 -}}
+      serviceAccountName: gloo-resource-rollout-cleanup
+      {{- include "gloo.podSpecStandardFields" .Values.gateway.rolloutJob | nindent 6 -}}
+      containers:
+        - name: kubectl
+          image: {{template "gloo.image" $image}}
+          imagePullPolicy: {{ $image.pullPolicy }}
+          securityContext:
+            runAsNonRoot: true
+            {{- if not .Values.gateway.rolloutJob.floatingUserId }}
+            runAsUser: {{ printf "%.0f" (float64 .Values.gateway.rolloutJob.runAsUser) -}}
+            {{- end }}
+          {{- with .Values.gateway.rolloutJob.resources }}
+          resources: {{ toYaml . | nindent 12}}
+          {{- end }}
+          command:
+          - /bin/sh
+          - -c
+          - |
+            # Check if the resource rollout job exists
+            kubectl -n {{ .Release.Namespace }} get job gloo-resource-rollout &> /dev/null
+            if [ $? -eq 0 ]
+            then
+              echo "Cleaning up resource-rollout-job"
+              # Clean it up so it doesn't cause issues with upgrades
+              kubectl -n {{ .Release.Namespace }} delete job gloo-resource-rollout || exit $?
+            fi
+{{- if .Values.global.glooRbac.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: gloo
+    gloo: rbac
+  name: gloo-resource-rollout-cleanup
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight":  "0"
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gloo-resource-rollout-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: gloo
+    gloo: rbac
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight":  "0"
+rules:
+- apiGroups: ["batch"]
+  resources: ["jobs"]
+  verbs: ["get", "list", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: gloo-resource-rollout-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: gloo
+    gloo: rbac
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight":  "0"
+roleRef:
+  kind: Role
+  name: gloo-resource-rollout-cleanup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: gloo-resource-rollout-cleanup
+  namespace: {{ .Release.Namespace }}
+{{- end }}{{/* if .Values.global.glooRbac.create */}}
+{{- end }}{{/* if .Values.gateway.rolloutJob.enabled  */}}


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/9094

Tilt supports Helm out-of-the-box via the helm and helm_resource [extension](https://docs.tilt.dev/helm.html#installing-existing-charts). The way helm_resource works is as follows
- It deploys the specified helm chart via helm upgrade --install
- Once installed, it verifies that all the resources in helm get manifest exist

Since the resource-rollout-job is no longer a hook, it needs to be deleted if it exists prior to an upgrade / install since it will not be re-created if it already exists (the default behaviour of helm). This is done as part of the [resource-rollout-check-job](https://github.com/solo-io/gloo/blob/main/install/helm/gloo/templates/5-resource-rollout-check-job.yaml#L104) as a post-install hook for simplicity.
As a consequence, when tilt executes helm get manifests as part of deploying a helm chart, the resource-rollout-job manifest is generated but not found in kubernetes and causes tilt deployments to fail.

This fix moves the deletion of the resource rollout job to a pre upgrade hook. Thus the rollout job exists when tilt checks all the resources after installation / upgrade

Steps to reproduce the issue
- Setup your local cluster `./ci/kind/setup-kind.sh`
- [Install tilt](https://docs.tilt.dev/install.html#macos)
- Create the following `Tiltfile`
  ```
  # -*- mode: Python -*-
  update_settings( k8s_upsert_timeout_secs = 600)
  load('ext://helm_resource', 'helm_resource')
  helm_resource(name='gloo', chart="install/helm/gloo", flags=["--values=./test/kube2e/helm/artifacts/helm.yaml", "--set=gatewayProxies.gatewayProxy.service.type=ClusterIP"])
  ```
- Run `tilt up`
  In the web UI you should see the following error :
  ```
       Error from server (NotFound): jobs.batch "gloo-resource-rollout" not found
       Traceback (most recent call last):
         File "/Users/djumani/Library/Application Support/tilt-dev/tilt_modules/github.com/tilt-dev/tilt-extensions/helm_resource/helm-apply-helper.py", line 82, in <module>
           completed.check_returncode()
         File "/Library/Developer/CommandLineTools/Library/Frameworks/Python3.framework/Versions/3.9/lib/python3.9/subprocess.py", line 460, in check_returncode
           raise CalledProcessError(self.returncode, self.args, self.stdout,
       subprocess.CalledProcessError: Command '['kubectl', 'get', '-oyaml', '-f', '-']' returned non-zero exit status 1.
  ```

## API changes
N/A

## Code changes
N/A

## CI changes
N/A

## Docs changes
N/A

# Context
https://github.com/solo-io/gloo/issues/9033

## Interesting decisions
N/A

## Testing steps
Following the steps mentioned in the description :
### Clean install
- Run `tilt down` to clear the prior installation 
- Run `tilt up`
  The deployment should succeed

### Upgrade
Modify the Tiltfile by changing some random helm value (via the flag parameter in the tiltfile)
eg: (removing the `--set=gatewayProxies.gatewayProxy.service.type=ClusterIP` helm flag
```
helm_resource(name='gloo', chart="install/helm/gloo", flags=["--values=./test/kube2e/helm/artifacts/helm.yaml"])
```
Tilt should automatically detect the changes and upgrade gloo

## Notes for reviewers
N/A

Please proofread comments on ...
N/A

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->