### PR TITLE
fix nightly compilation failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -191,6 +191,7 @@ run-tests: GINKGO_FLAGS += --label-filter="!end-to-end && !performance"
 run-tests: test
 
 .PHONY: run-performance-tests
+run-performance-tests: GINKGO_FLAGS += -skip-package=gateway2 ## gateway2 conformance tests need to be compiled a certain way, so explicitly skip so it doesn't try compiling
 run-performance-tests: GINKGO_FLAGS += --label-filter="performance" ## Run only tests with the Performance label
 run-performance-tests: test
 

--- a/changelog/v1.17.0-beta7/fix-nightly-gw2.yaml
+++ b/changelog/v1.17.0-beta7/fix-nightly-gw2.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NON_USER_FACING  
+  description: >- 
+   Exclude gateway2 tests from nightly performance tests to avoid compilation failure.
+   skipCI-kube-tests:true
+   skipCI-docs-build:true


### PR DESCRIPTION
The nightly OSS performance test suite was [failing](https://github.com/solo-io/gloo/actions/runs/7751635213/job/21139853735) with:
```
There were failures detected in the following suites:
  conformance ./projects/gateway2/tests/conformance [Compilation failure]
```
Since these tests are not part of the performance suite, just explicitly exclude them.

Output after adding the skip:
```
Will skip:
  ./projects/gateway2/controller
  ./projects/gateway2/deployer
  ./projects/gateway2/ports
  ./projects/gateway2/query
  ./projects/gateway2/reports
  ./projects/gateway2/tests/conformance
  ./projects/gateway2/translator
  ./projects/gateway2/translator/httproute
  ./projects/gateway2/translator/listener
  ./projects/gateway2/translator/plugins/headermodifier
  ./projects/gateway2/translator/plugins/mirror
  ./projects/gateway2/translator/plugins/redirect
  ./projects/gateway2/translator/plugins/routeoptions
  ./projects/gateway2/translator/plugins/urlrewrite
  ./projects/gateway2/translator/plugins/utils
  ./projects/gateway2/translator/routeutils
  ./projects/gateway2/xds
...
(perf tests are run)
```