### PR TITLE
Remove WasmHub and wasme from Edge docs

### DIFF
--- a/changelog/v1.17.0-beta9/docs-rm-wasm.yaml
+++ b/changelog/v1.17.0-beta9/docs-rm-wasm.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: NON_USER_FACING  
+  description: >- 
+    Removes references to WebAssembly Hub and `wasme` CLI.
+    Updates the old WAH image to one stored in GCR.
+    skipCI-kube-tests:true
+  issueLink: https://github.com/solo-io/doctopus/issues/79
+  resolvesIssue: false

--- a/docs/content/installation/advanced_configuration/wasm.md
+++ b/docs/content/installation/advanced_configuration/wasm.md
@@ -20,36 +20,24 @@ The [upstream Envoy Wasm filter](https://www.envoyproxy.io/docs/envoy/latest/con
 
 WebAssembly provides a safe, secure, and dynamic way of extending infrastructure with the programming language of your choice.
 
-1. Get a Wasm image. Review the following resources to help.
-   * [WebAssembly Hub](https://webassemblyhub.io/repositories/) to use an existing Wasm image repository.
-   * [WebAssembly Developer's Guide](https://webassembly.org/getting-started/developers-guide/) for more information on building your own Wasm image.
-   * [Solo's `wasme` CLI tool](https://docs.solo.io/web-assembly-hub/latest/tutorial_code/getting_started/) with starter kits that makes it easy to build and push Wasm modules to WebAssembly Hub.
-
-   Example steps with `wasme` CLI: For more information, see the [Build tutorial](https://docs.solo.io/web-assembly-hub/latest/tutorial_code/build_tutorials/building_cpp_filters/).
-   1. Start a C++ filter for Gloo.
-      ```sh
-      wasme init --language cpp --platform gloo --platform-version 1.13.x ./my-filter
-      ```
-   2. Build the filter into a Wasm image.
-      ```sh
-      cd my-filter
-      wasme build cpp --store ./wasmstore . -t my-wasm-filter:v1.0
-      ```
+1. Get a Wasm image. For more information on building your own Wasm image, see the [WebAssembly Developer's Guide](https://webassembly.org/getting-started/developers-guide/). 
 
 2. Prepare your Wasm image for use with Gloo Edge Enterprise. Review the following options.
-   * **Store in an image repository like WebAssembly Hub**: Solo provides [WebAssembly Hub](https://webassemblyhub.io/) as the simplest way to share and consume Wasm Envoy repositories. When you use the `wasme` CLI tool, you can push the image directly to your WebAssembly Hub repository. The resulting image repository is in a format similar to the following: `webassemblyhub.io/<username>/<filter-name>:<tag>`.
-   * **Load the Wasm file directly into the filter**: If your filter is not hosted in an image repository such as WebAssembly Hub, you can refer to the filepath directly, such as `<directory>/<filter-name>.wasm`.
-   * **Use an init container**: In some circumstances, you might not be able to use an image repository due to enterprise networking restrictions. Instead, you can use an `initContainer` on the Gloo Edge `gatewayProxy` deployment to load a `.wasm` file into a shared `volume`.
+
+   * Store in an OCI-compliant image repository. This guide uses an example Wasm image from Solo's public Google Container Registry.
+   * Load the Wasm file directly into the filter. If your filter is not hosted in an image repository, you can refer to the filepath directly, such as `<directory>/<filter-name>.wasm`.
+   * Use an init container. In some circumstances, you might not be able to use an image repository due to enterprise networking restrictions. Instead, you can use an `initContainer` on the Gloo Edge `gatewayProxy` deployment to load a `.wasm` file into a shared `volume`.
 
 ## Configure Gloo Edge to use a Wasm filter {#configuration}
 
 Now that Gloo Edge Enterprise is installed and you have your Wasm image, you are ready to configure Gloo Edge to use the Wasm filter. You add the filter to your gateway proxy configuration. For more information, check out the {{% protobuf name="wasm.options.gloo.solo.io.PluginSource" display="API docs"%}}.
 
 {{< tabs >}} 
-{{% tab name="From WebAssembly Hub" %}}
+{{% tab name="From an image registry" %}}
 1. Get the configuration for your `gateway-proxy` gateway.
    ```shell
    kubectl get -n gloo-system gateways.gateway.solo.io gateway-proxy -o yaml > gateway-proxy.yaml
+   open gateway-proxy.yaml
    ```
 2. Add the reference to your Wasm filter in the `httpGateway` section as follows.
    ```yaml
@@ -60,7 +48,7 @@ Now that Gloo Edge Enterprise is installed and you have your Wasm image, you are
            - config:
                '@type': type.googleapis.com/google.protobuf.StringValue
                value: "world"
-             image: webassemblyhub.io/yuval/add-header:v0.1
+             image: gcr.io/solo-public/docs/assemblyscript-test:istio-1.8
              name: add-header
              rootId: add_header
    ```
@@ -241,9 +229,3 @@ Now that your `gateway-proxy` gateway is updated, the hard work has been done. A
    < 
    [{"id":1,"name":"Dog","status":"available"},{"id":2,"name":"Cat","status":"pending"}]
    {{< /highlight >}}
-
-## References
-
-* [WebAssembly Hub](https://webassemblyhub.io/) for sharing and reusing Wasm filters.
-* [Solo's `wasme` CLI tool](https://docs.solo.io/web-assembly-hub/latest/installation/) for building and deploying Wasm filters for Gloo Edge Enterprise, Istio, and Envoy.
-* [Solo's `wasm` GitHub repo](https://github.com/solo-io/wasm) for the `wasme` tool.


### PR DESCRIPTION
# Description

* Removes references to WebAssembly Hub and `wasme` CLI.
* Updates the old WAH image to one stored in GCR.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- N/A I have added tests that prove my fix is effective or that my feature works
