### PR TITLE
backport sds and envoy log helm value

### DIFF
--- a/changelog/v1.16.5/add-sds-log-level.yaml
+++ b/changelog/v1.16.5/add-sds-log-level.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/9006
+    resolvesIssue: true
+    description: >
+      Add helm flags for setting log level on sds container `.Values.global.glooMtls.sds.logLevel` and setting
+      log level on istio-proxy container `global.glooMtls.istioProxy.logLevel`.

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -1192,6 +1192,7 @@
 |global.glooMtls.sds.securityContext.seccompProfile.type|string|||
 |global.glooMtls.sds.securityContext.seccompProfile.localhostProfile|string|||
 |global.glooMtls.sds.securityContext.mergePolicy|string||How to combine the defined security policy with the default security policy. Valid values are "", "no-merge", and "helm-merge". If defined as an empty string or "no-merge", use the defined security context as is.  If "helm-merge", merge this security context with the default security context according to the logic of [the helm 'merge' function](https://helm.sh/docs/chart_template_guide/function_list/#merge-mustmerge). This is intended to be used to modify a field in a security context, while using all other default values. Please note that due to how helm's 'merge' function works, you can not override a 'true' value with a 'false' value, and for that case you will need to define the entire security context and set this values to false. Default value is "".|
+|global.glooMtls.sds.logLevel|string|info|Log level for sds.  Options include "info", "debug", "warn", "error", "panic" and "fatal". Default level is info.|
 |global.glooMtls.envoy.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |global.glooMtls.envoy.image.repository|string|gloo-envoy-wrapper|The image repository (name) for the container.|
 |global.glooMtls.envoy.image.digest|string||The hash digest of the container's image, ie. sha256:12345....|
@@ -1250,6 +1251,7 @@
 |global.glooMtls.istioProxy.securityContext.seccompProfile.type|string|||
 |global.glooMtls.istioProxy.securityContext.seccompProfile.localhostProfile|string|||
 |global.glooMtls.istioProxy.securityContext.mergePolicy|string||How to combine the defined security policy with the default security policy. Valid values are "", "no-merge", and "helm-merge". If defined as an empty string or "no-merge", use the defined security context as is.  If "helm-merge", merge this security context with the default security context according to the logic of [the helm 'merge' function](https://helm.sh/docs/chart_template_guide/function_list/#merge-mustmerge). This is intended to be used to modify a field in a security context, while using all other default values. Please note that due to how helm's 'merge' function works, you can not override a 'true' value with a 'false' value, and for that case you will need to define the entire security context and set this values to false. Default value is "".|
+|global.glooMtls.istioProxy.logLevel|string|warning|Log level for istio-proxy. Options include "info", "debug", "warning", and "error". Default level is info Default is 'warning'.|
 |global.glooMtls.envoySidecarResources.limits.memory|string||amount of memory|
 |global.glooMtls.envoySidecarResources.limits.cpu|string||amount of CPUs|
 |global.glooMtls.envoySidecarResources.requests.memory|string||amount of memory|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -731,6 +731,7 @@ type Mtls struct {
 type SdsContainer struct {
 	Image           *Image           `json:"image,omitempty"`
 	SecurityContext *SecurityContext `json:"securityContext,omitempty" desc:"securityContext for sds gloo deployment container. If this is defined it supercedes any values set in FloatingUserId, RunAsUser, DisableNetBind, RunUnprivileged. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core for details."`
+	LogLevel        *string          `json:"logLevel,omitempty" desc:"Log level for sds.  Options include \"info\", \"debug\", \"warn\", \"error\", \"panic\" and \"fatal\". Default level is info."`
 }
 
 type EnvoySidecarContainer struct {
@@ -741,6 +742,7 @@ type EnvoySidecarContainer struct {
 type IstioProxyContainer struct {
 	Image           *Image           `json:"image,omitempty" desc:"Istio-proxy image to use for mTLS"`
 	SecurityContext *SecurityContext `json:"securityContext,omitempty" desc:"securityContext for istio-proxy deployment container. If this is defined it supercedes any values set in FloatingUserId, RunAsUser, DisableNetBind, RunUnprivileged. See https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.26/#securitycontext-v1-core for details."`
+	LogLevel        *string          `json:"logLevel,omitempty" desc:"Log level for istio-proxy. Options include \"info\", \"debug\", \"warning\", and \"error\". Default level is info Default is 'warning'."`
 }
 
 type IstioSDS struct {

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -77,7 +77,7 @@ spec:
       {{- range $key, $value := $spec.podTemplate.extraAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- if .Values.global.glooStats.setDatadogAnnotations }}
+      {{- if $global.glooStats.setDatadogAnnotations }}
         ad.datadoghq.com/gateway-proxy.check_names: '["envoy"]'
         ad.datadoghq.com/gateway-proxy.init_configs: '[{}]'
         ad.datadoghq.com/gateway-proxy.instances: '[{"stats_url": "http://%%host%%:8081/stats"}]'
@@ -327,6 +327,14 @@ spec:
           - name: ISTIO_MTLS_SDS_ENABLED
             value: "true"
 {{- end }}
+{{- if $global.glooMtls.sds.logLevel }}
+          - name: LOG_LEVEL
+            value: {{ $global.glooMtls.sds.logLevel }}
+{{- end}}
+{{- if $statsConfig.enabled }}
+          - name: START_STATS_SERVER
+            value: "true"
+{{- end}}
         volumeMounts:
 {{- if $global.glooMtls.enabled }}
         - mountPath: /etc/envoy/ssl
@@ -382,7 +390,7 @@ spec:
         - 45s
         - --parentShutdownDuration
         - 1m0s
-        - --proxyLogLevel=warning
+        - --proxyLogLevel={{ $global.glooMtls.istioProxy.logLevel }}
         - --proxyComponentLogLevel=misc:error
         - --connectTimeout
         - 10s

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -226,11 +226,13 @@ global:
     sds:
       image:
         repository: sds
+      logLevel: info
     istioProxy:
       image:
         repository: proxyv2
         registry: docker.io/istio
         tag: 1.18.2
+      logLevel: warning
     envoy:
       image:
         repository: gloo-envoy-wrapper

--- a/projects/sds/pkg/run/run_main.go
+++ b/projects/sds/pkg/run/run_main.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/avast/retry-go"
+	"github.com/kelseyhightower/envconfig"
 	"github.com/solo-io/gloo/pkg/version"
 	"github.com/solo-io/gloo/projects/sds/pkg/server"
 	"github.com/solo-io/go-utils/contextutils"
-
-	"github.com/avast/retry-go"
-	"github.com/kelseyhightower/envconfig"
+	"github.com/solo-io/go-utils/stats"
 	"go.uber.org/zap"
 	v1 "k8s.io/api/core/v1"
 )
@@ -18,6 +18,7 @@ import (
 var (
 	// The NodeID of the envoy server reading from this SDS
 	sdsClientDefault = "sds_client"
+	sdsComponentName = "sds_server"
 )
 
 type Config struct {
@@ -39,9 +40,10 @@ type Config struct {
 }
 
 func RunMain() {
-	ctx := contextutils.WithLogger(context.Background(), "sds_server")
+	ctx := contextutils.WithLogger(context.Background(), sdsComponentName)
+	// Initialize stats server to dynamically change log level. This will also use LOG_LEVEL if set.
+	stats.ConditionallyStartStatsServer()
 	ctx = contextutils.WithLoggerValues(ctx, "version", version.Version)
-
 	contextutils.LoggerFrom(ctx).Info("initializing config")
 
 	var c = setup(ctx)


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/9102/files helm values to set log level. Add helm flags for setting log level on sds container `.Values.global.glooMtls.sds.logLevel` and setting log level on istio-proxy container `global.glooMtls.istioProxy.logLevel`.
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9006