### PR TITLE
xds/hash: support non-proxy workload key generation

### DIFF
--- a/changelog/v1.17.0-beta10/fix-xds-cache-key.yaml
+++ b/changelog/v1.17.0-beta10/fix-xds-cache-key.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix the node_hash implementation so that non-proxy workloads (such as ext-auth-service and rate-limit-service)
+      ask for a cache key that is not prefixed with the custom proxy prefix. Without this fix, Enterprise services
+      could not communicate with the Control Plane to pick up configuration.

--- a/projects/gloo/pkg/xds/node_hash.go
+++ b/projects/gloo/pkg/xds/node_hash.go
@@ -1,7 +1,7 @@
 package xds
 
 import (
-	"fmt"
+	"strings"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
@@ -16,13 +16,16 @@ var _ cache.NodeHash = new(aggregateNodeHash)
 // we assign a "fix me" snapshot for bad nodes
 const FallbackNodeCacheKey = "misconfigured-node"
 
+// KeyDelimiter is the character used to join segments of a cache key
+const KeyDelimiter = "~"
+
 // OwnerNamespaceNameID returns the string identifier for an Envoy node in a provided namespace.
 // Envoy proxies are assigned their configuration by Gloo based on their Node ID.
 // Therefore, proxies must identify themselves using the same naming
 // convention that we use to persist the Proxy resource in the snapshot cache.
 // The naming convention that we follow is "OWNER~NAMESPACE~NAME"
 func OwnerNamespaceNameID(owner, namespace, name string) string {
-	return fmt.Sprintf("%s~%s~%s", owner, namespace, name)
+	return strings.Join([]string{owner, namespace, name}, KeyDelimiter)
 }
 
 func NewClassicEdgeNodeHash() *classicEdgeNodeHash {
@@ -36,11 +39,32 @@ func (c classicEdgeNodeHash) ID(node *envoy_config_core_v3.Node) string {
 	if node.GetMetadata() != nil {
 		roleValue := node.GetMetadata().GetFields()["role"]
 		if roleValue != nil {
-			return fmt.Sprintf("%s~%s", utils.GlooEdgeTranslatorValue, roleValue.GetStringValue())
+			roleString := roleValue.GetStringValue()
+			if c.isProxyWorkloadRole(roleString) {
+				// Proxy workloads us a key that is prefixed by the translator that produced the xDS Snapshot
+				return strings.Join([]string{utils.GlooEdgeTranslatorValue, roleString}, KeyDelimiter)
+			} else {
+				// Non-Proxy workloads are used the exact key as the role
+				return roleString
+			}
+
 		}
 	}
 
 	return FallbackNodeCacheKey
+}
+
+// isProxyWorkloadRole returns true if the provided role fits the format that is used by Proxy workloads
+// This format is: "NAMESPACE~NAME".
+// In classic Edge, nodes could also identify themselves with a node.metadata.role that do not fit this structure
+// This is useful in the case of additional services (like Enterprise ext-auth-service, and rate-limit-service)
+// who follow a format of "NAME".
+func (c classicEdgeNodeHash) isProxyWorkloadRole(role string) bool {
+	if strings.Contains(role, KeyDelimiter) {
+		// We assume that this will only occur if a role is NAMESPACE~NAME
+		return true
+	}
+	return false
 }
 
 func NewGlooGatewayNodeHash() *glooGatewayNodeHash {

--- a/projects/gloo/pkg/xds/node_hash.go
+++ b/projects/gloo/pkg/xds/node_hash.go
@@ -41,10 +41,10 @@ func (c classicEdgeNodeHash) ID(node *envoy_config_core_v3.Node) string {
 		if roleValue != nil {
 			roleString := roleValue.GetStringValue()
 			if c.isProxyWorkloadRole(roleString) {
-				// Proxy workloads us a key that is prefixed by the translator that produced the xDS Snapshot
+				// Proxy workloads use a key that is prefixed by the translator that produced the xDS Snapshot
 				return strings.Join([]string{utils.GlooEdgeTranslatorValue, roleString}, KeyDelimiter)
 			} else {
-				// Non-Proxy workloads are used the exact key as the role
+				// Non-Proxy workloads use the exact key as the role
 				return roleString
 			}
 
@@ -61,7 +61,6 @@ func (c classicEdgeNodeHash) ID(node *envoy_config_core_v3.Node) string {
 // who follow a format of "NAME".
 func (c classicEdgeNodeHash) isProxyWorkloadRole(role string) bool {
 	if strings.Contains(role, KeyDelimiter) {
-		// We assume that this will only occur if a role is NAMESPACE~NAME
 		return true
 	}
 	return false

--- a/projects/gloo/pkg/xds/node_hash_test.go
+++ b/projects/gloo/pkg/xds/node_hash_test.go
@@ -28,11 +28,16 @@ var _ = Describe("NodeHash", func() {
 				"non-role-field": structpb.NewStringValue("non-role-value"),
 			},
 		}, Equal(xds.FallbackNodeCacheKey)),
-		Entry("metadata with role", &structpb.Struct{
+		Entry("metadata with proxy workload", &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"role": structpb.NewStringValue("role-value"),
+				"role": structpb.NewStringValue("proxy-namespace~proxy-name"),
 			},
-		}, Equal("gloo-gateway-translator~role-value")),
+		}, Equal("gloo-gateway-translator~proxy-namespace~proxy-name")),
+		Entry("metadata with non-proxy workload", &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"role": structpb.NewStringValue("no-tilde-in-role"),
+			},
+		}, Equal("no-tilde-in-role")),
 	)
 
 	DescribeTable("GlooGatewayNodeHash",
@@ -89,11 +94,16 @@ var _ = Describe("NodeHash", func() {
 				}),
 			},
 		}, Equal("gloo-kube-gateway-api-translator~namespace~name")),
-		Entry("metadata with role", &structpb.Struct{
+		Entry("metadata with proxy workload role", &structpb.Struct{
 			Fields: map[string]*structpb.Value{
-				"role": structpb.NewStringValue("role-value"),
+				"role": structpb.NewStringValue("proxy-namespace~proxy-name"),
 			},
-		}, Equal("gloo-gateway-translator~role-value")),
+		}, Equal("gloo-gateway-translator~proxy-namespace~proxy-name")),
+		Entry("metadata with non-proxy workload role", &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"role": structpb.NewStringValue("no-tilde-in-role"),
+			},
+		}, Equal("no-tilde-in-role")),
 		Entry("metadata with gateway and role field", &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"role": structpb.NewStringValue("role-value"),


### PR DESCRIPTION
# Description

Fix the implementation of node_hash to support the assumption that Enterprise services make when communicating with the control plane.

# Context

## Previous Solution
In classic Gloo Edge (1.16 and below), we only supported a single type of Proxy workload (data plane). This meant that when workloads started, they would identify themselves via the `node.metadata.role` property in the Node metadata. Our xDS cache used a node hash to inspect the value of the `node.metadata.role` and use that string value as the exact cache key.

Node Metadata:
```
node:
  metadata:
    role: gloo-system~gateway-proxy
```

In-Memory Cache:
```
gloo-system~gateway-proxy: <xDS Snapshot>
```

We relied on the same functionality for non-proxy workloads (like extauth). Node Metadata:
```
node:
  metadata:
    role: extauth
```
In-Memory Cache:
```
extauth: <xDS Snapshot>
```


## Flawed Existing Solution
As part of work to support the k8s gateway API (https://github.com/solo-io/gloo/pull/9148/) we needed to distinguish between xDS Snapshots that were generated by the classic "Edge" controller, and the new "k8s Gateway" controller. This was because each controller was responsible for garbage collection, and we needed one controller to not clean up cache entries that were populated by the other controller.

To support this, we added a prefix for proxy-workloads in their cache entry:
```
node:
  metadata:
    role: gloo-system~gateway-proxy
```
In-Memory Cache:
```
gloo-gateway-translator~gloo-system~gateway-proxy: <xDS Snapshot>
```

However, this meant that the prefix was also applied to non-proxy workloads
```
node:
  metadata:
    role: extauth
```
In-Memory Cache:
```
gloo-gateway-translator~extauth: <xDS Snapshot>
```
**The problem with this is that the extauth syncer makes an assumption about the cache key, and assumes the key and the node.metadata.role are the same. Therefore, it stores cache entries at the `extauth` key. This means we have a disconnect: `extauth` is the key with the values, but an xds request for the `extauth` role, leads to a lookup at the `gloo-gateway-translator~extauth` key**

## New Solution
We have 3 types of workloads that can ask for configuration from the control plane:
- Classic Edge proxies
- New Gateway proxies dynamically provisioned from the k8s API
- Enterprise services

Unfortunately, when it was originally designed, the mechanism that "classic edge proxies" and "enterprise services" identified themselves was by the same field `node.metadata.role` but with different formats: proxy workloads use `NAMESPACE~NAME` , but enterprise services just use `NAME`.

Ideally, each workload would have a unique way of representing its metadata, so that the node_hash could easily come up with the relevant cache key. To support the legacy proxies, we need to make the node-hash aware of the implementation detail that non-proxy workloads should not be keyed by the gateway translator prefix. It's not ideal, but a necessary solution.

In the future, we should have enterprise services identify themselves using custom metadata, so that we can look for a particular field.

## Interesting decisions
 -

## Testing steps
- [x] Unit tests to validate the changes
- [x] Existing OSS integration tests prove that proxy workloads do work
- [x] [Enterprise PR](https://github.com/solo-io/solo-projects/pull/5854/) to prove that non-proxy workloads can get configuration from control plane

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
