### PR TITLE
Kube2e artifact generation

### DIFF
--- a/changelog/v1.17.0-beta13/kube2e-test-artifacts.yaml
+++ b/changelog/v1.17.0-beta13/kube2e-test-artifacts.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Update to get the kube2e artifacts dumping again

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -25,8 +25,8 @@ var (
 // Look at `KubeDumpOnFail` && `EnvoyDumpOnFail` for more details
 func StandardGlooDumpOnFail(out io.Writer, namespaces ...string) func() {
 	return func() {
-		KubeDumpOnFail(out, namespaces...)
-		EnvoyDumpOnFail(out, namespaces...)
+		KubeDumpOnFail(out, namespaces...)()
+		EnvoyDumpOnFail(out, namespaces...)()
 	}
 }
 


### PR DESCRIPTION
# Description
The `StandardGlooDumpOnFail` was not dumping configurations. Updated to start doing so again.

Example of a current artifact archive: https://github.com/solo-io/gloo/actions/runs/8321982247/artifacts/1334181049
## Testing steps
- Introduce a failure to a kube2e2 test
- Run it
- Validate the configuration is dumped into `_output/kube2e-artifacts/`

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
