### PR TITLE
[DNM] Testing AWS credentials in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,7 +166,7 @@ analyze:
 
 GINKGO_VERSION ?= $(shell echo $(shell go list -m github.com/onsi/ginkgo/v2) | cut -d' ' -f2)
 GINKGO_ENV ?= GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore ACK_GINKGO_RC=true ACK_GINKGO_DEPRECATIONS=$(GINKGO_VERSION)
-GINKGO_FLAGS ?= -tags=purego --trace -progress -race --fail-fast -fail-on-pending --randomize-all --compilers=5
+GINKGO_FLAGS ?= -tags=purego --trace -progress -race -fail-on-pending --randomize-all --compilers=5
 GINKGO_REPORT_FLAGS ?= --json-report=test-report.json --junit-report=junit.xml -output-dir=$(OUTPUT_DIR)
 GINKGO_COVERAGE_FLAGS ?= --cover --covermode=count --coverprofile=coverage.cov
 TEST_PKG ?= ./... # Default to run all tests
@@ -228,6 +228,8 @@ run-performance-tests: test
 
 .PHONY: run-e2e-tests
 run-e2e-tests: TEST_PKG = ./test/e2e/ ## Run all in-memory E2E tests
+run-e2e-tests: GINKGO_FLAGS += -focus="AWS Lambda" ## only run AWS Lambda tests
+run-e2e-tests: GINKGO_FLAGS += --keepGoing ## continue running tests after a failure
 run-e2e-tests: GINKGO_FLAGS += --label-filter="end-to-end && !performance"
 run-e2e-tests: test
 


### PR DESCRIPTION
# Description
 - do not merge
 - we have been experiencing issues with AWS e2e tests -- I suspect it's a credentials issue
 - this PR updates ginkgo settings to run only AWS e2e tests, and to run all of them, regardless of which ones fail