### PR TITLE
[1.15.x] Delete secret flake mititgation

### DIFF
--- a/changelog/v1.15.25/secret-delete-flake.yaml
+++ b/changelog/v1.15.25/secret-delete-flake.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    issueLink: https://github.com/solo-io/gloo/issues/8826
+    description: >-
+      - Added `verifyGlooValidationWorks` to the beginning of flaky secret delete test to validate that validation is ready before starting the test
+      - Removed the `FlakeAttempts` on the test to expose the errors if they occur

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -2107,7 +2107,8 @@ spec:
 				// There are times when the VirtualService + Proxy do not update Status with the error when deleting the referenced Secret, therefore the validation error doesn't occur.
 				// It isn't until later - either a few minutes and/or after forcing an update by updating the VS - that the error status appears.
 				// The reason is still unknown, so we retry on flakes in the meantime.
-				It("should act as expected with secret validation", FlakeAttempts(3), func() {
+				It("should act as expected with secret validation", func() {
+					verifyGlooValidationWorks()
 					By("failing to delete a secret that is in use")
 					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
 					Expect(err).To(HaveOccurred())


### PR DESCRIPTION
# Description
Partial backport of https://github.com/solo-io/gloo/pull/9250

Added the call to `verifyGlooValidationWorks` and removed `FlakeAttempts`, but did not need the changes to restore the kube artifact dump as the changes that broke it did not get backported to 1.15. For the same reason, the robustness test fixes were not backported.

"spammed" CI run of gateway tests: https://github.com/solo-io/gloo/actions/runs/8392439465