### PR TITLE
fix github asset publish script, add dry run for PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -741,7 +741,11 @@ publish-docker-retag: docker-retag docker-push
 
 # publish glooctl
 publish-glooctl: build-cli
-	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go true
+	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go true false # assets only, not dry run
+else
+# dry run publish glooctl
+publish-glooctl: build-cli
+	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go true true # assets only, dry run
 endif # RELEASE exclusive make targets
 
 

--- a/changelog/v1.17.0-beta15/fix-github-release-script.yaml
+++ b/changelog/v1.17.0-beta15/fix-github-release-script.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/9288
+  resolvesIssue: true
+  description: >-
+    Fixes Github asset release action broken by updates to https://github.com/solo-io/gloo/pull/9212. 
+    Also adds a dry_run option to the script that broke so we can catch these errors on PRs
+    

--- a/changelog/v1.17.0-beta15/fix-github-release-script.yaml
+++ b/changelog/v1.17.0-beta15/fix-github-release-script.yaml
@@ -5,4 +5,6 @@ changelog:
   description: >-
     Fixes Github asset release action broken by updates to https://github.com/solo-io/gloo/pull/9212. 
     Also adds a dry_run option to the script that broke so we can catch these errors on PRs
-    
+
+    skipCI-kube-tests:true
+    skipCI-docs-build:true

--- a/ci/upload_github_release_assets.go
+++ b/ci/upload_github_release_assets.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,8 +10,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/solo-io/gloo/pkg/utils/protoutils"
-	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/version"
+	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/githubutils"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/pkgmgmtutils"
@@ -20,8 +20,8 @@ import (
 
 func main() {
 	ctx := context.Background()
-	versionBeingReleased := getReleaseVersionOrExitGracefully()
 	assetsOnly := false
+	dryRun := false
 	if len(os.Args) > 1 {
 		var err error
 		assetsOnly, err = strconv.ParseBool(os.Args[1])
@@ -29,11 +29,20 @@ func main() {
 			log.Fatalf("Unable to parse `assets_only` boolean argument, was provided %v", os.Args[1])
 		}
 	}
+	if len(os.Args) > 2 {
+		var err error
+		dryRun, err = strconv.ParseBool(os.Args[2])
+		if err != nil {
+			log.Fatalf("Unable to parse `dry_run` boolean argument, was provided %v", os.Args[2])
+		}
+	}
 	const buildDir = "_output"
 	const repoOwner = "solo-io"
 	const repoName = "gloo"
 
-	validateReleaseVersionOfCli()
+	versionBeingReleased := getReleaseVersionOrExitGracefully(dryRun)
+
+	validateReleaseVersionOfCli(dryRun)
 
 	assets := []githubutils.ReleaseAssetSpec{
 		{
@@ -63,13 +72,15 @@ func main() {
 		},
 	}
 
-	spec := githubutils.UploadReleaseAssetSpec{
-		Owner:             repoOwner,
-		Repo:              repoName,
-		Assets:            assets,
-		SkipAlreadyExists: true,
+	if !dryRun {
+		spec := githubutils.UploadReleaseAssetSpec{
+			Owner:             repoOwner,
+			Repo:              repoName,
+			Assets:            assets,
+			SkipAlreadyExists: true,
+		}
+		githubutils.UploadReleaseAssetCli(&spec)
 	}
-	githubutils.UploadReleaseAssetCli(&spec)
 
 	if assetsOnly {
 		log.Warnf("Not creating PRs to update homebrew formulas or fish food because this was an assets_only release")
@@ -157,38 +168,57 @@ func mustUpdateFormulas(ctx context.Context, versionBeingReleased *versionutils.
 	}
 }
 
-func validateReleaseVersionOfCli() {
-	releaseVersion := getReleaseVersionOrExitGracefully().String()[1:]
+func validateReleaseVersionOfCli(dryRun bool) {
+	releaseVersion := getReleaseVersionOrExitGracefully(dryRun).String()[1:]
 	name := fmt.Sprintf("_output/glooctl-%s-amd64", runtime.GOOS)
 	cmd := exec.Command(name, "version")
 	bytes, err := cmd.Output()
 	if err != nil {
 		log.Fatalf("Error while trying to validate artifact version. Error was: %s", err.Error())
 	}
-	if !strings.HasPrefix(string(bytes), "Client: ") {
+	if !strings.Contains(string(bytes), `"client": `) {
 		log.Fatalf("Unexpected version output for glooctl: %s", string(bytes))
 	}
-	clientVersionStr := strings.TrimPrefix(string(bytes), "Client: ")
+	clientVersionStr := strings.TrimPrefix(string(bytes), "Server: version undefined, could not find any version of gloo running\n\n")
 
-	expectedVersion := version.ClientVersion{Version: releaseVersion}
-	var foundVersion version.ClientVersion
-	err = protoutils.UnmarshalBytes([]byte(clientVersionStr), &foundVersion)
-	if err != nil {
-		log.Fatalf("Failed to unmarshal version output from glooctl into `ClientVersion` struct: %s", string(bytes))
+	m := map[string]interface{}{}
+	err = json.Unmarshal([]byte(clientVersionStr), &m)
+	cl, ok := m["client"]
+	if !ok {
+		log.Fatalf("no client field")
 	}
-	if !expectedVersion.Equal(foundVersion) {
-		log.Fatalf("Expected to release artifacts for version %s, glooctl binary reported version %s", expectedVersion, foundVersion)
+	clM, ok := cl.(map[string]interface{})
+	if !ok {
+		log.Fatalf("failed to cast client field")
+	}
+	clVer, ok := clM["version"]
+	if !ok {
+		log.Fatalf("no client.version field")
+	}
+	clVerStr, ok := clVer.(string)
+	if !ok {
+		log.Fatalf("failed to cast client.version field")
+	}
+
+	if releaseVersion != clVerStr {
+		log.Fatalf("Expected to release artifacts for version %s, glooctl binary reported version %s", releaseVersion, clVerStr)
 	}
 }
 
 // stolen from "github.com/solo-io/go-utils/versionutils", but changed the hardcoding of "TAGGED_VERSION" to "VERSION"
-func getReleaseVersionOrExitGracefully() *versionutils.Version {
+func getReleaseVersionOrExitGracefully(dryRun bool) *versionutils.Version {
 	versionStr, present := os.LookupEnv("VERSION")
 	if !present || versionStr == "" {
 		fmt.Printf("VERSION not found in environment.\n")
 		os.Exit(1)
 	}
-
+	if dryRun {
+		var err error
+		versionStr, err = validVersionFromPrVersion(versionStr)
+		if err != nil {
+			log.Fatalf("unable to parse valid semver from PR version: %v", err)
+		}
+	}
 	tag := "v" + versionStr
 
 	version, err := versionutils.ParseVersion(tag)
@@ -197,4 +227,19 @@ func getReleaseVersionOrExitGracefully() *versionutils.Version {
 		os.Exit(1)
 	}
 	return version
+}
+
+// we have to force the version into semver in order to test this. We do this by chopping the PR designation off
+// when running as dry_run
+func validVersionFromPrVersion(ver string) (string, error) {
+	expectedLen := 2
+	if strings.Contains(ver, "beta") || strings.Contains(ver, "rc") {
+		expectedLen = 3
+	}
+	splitVer := strings.Split(ver, "-")
+	if len(splitVer) != expectedLen {
+		return "", eris.New("invalid format for PR version; expected v<MAJOR>.<MINOR>.<PATCH>-(beta|rc)<N>-<PR> for beta or rc and v<MAJOR>.<MINOR>.<PATCH>-<PR> for LTS")
+	}
+	return strings.Join(splitVer[:expectedLen-1], "-"), nil
+
 }

--- a/ci/upload_github_release_assets.go
+++ b/ci/upload_github_release_assets.go
@@ -200,6 +200,14 @@ func validateReleaseVersionOfCli(dryRun bool) {
 		log.Fatalf("failed to cast client.version field")
 	}
 
+	if dryRun {
+		clVerStr, err = validVersionFromPrVersion(clVerStr)
+		if err != nil {
+			log.Fatalf(err.Error())
+		}
+
+	}
+
 	if releaseVersion != clVerStr {
 		log.Fatalf("Expected to release artifacts for version %s, glooctl binary reported version %s", releaseVersion, clVerStr)
 	}

--- a/ci/upload_github_release_assets.go
+++ b/ci/upload_github_release_assets.go
@@ -72,15 +72,17 @@ func main() {
 		},
 	}
 
-	if !dryRun {
-		spec := githubutils.UploadReleaseAssetSpec{
-			Owner:             repoOwner,
-			Repo:              repoName,
-			Assets:            assets,
-			SkipAlreadyExists: true,
-		}
-		githubutils.UploadReleaseAssetCli(&spec)
+	if dryRun {
+		return
 	}
+
+	spec := githubutils.UploadReleaseAssetSpec{
+		Owner:             repoOwner,
+		Repo:              repoName,
+		Assets:            assets,
+		SkipAlreadyExists: true,
+	}
+	githubutils.UploadReleaseAssetCli(&spec)
 
 	if assetsOnly {
 		log.Warnf("Not creating PRs to update homebrew formulas or fish food because this was an assets_only release")


### PR DESCRIPTION
# Description

Publishing glooctl assets to github depends on fragile output of `glooctl version`. This was broken in https://github.com/solo-io/gloo/pull/9212. A more holistic fix to `glooctl version` is in progress in https://github.com/solo-io/gloo/pull/9285, but this PR should unblock releases


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9288