### PR TITLE
Cleanup assets upload script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -741,11 +741,11 @@ publish-docker-retag: docker-retag docker-push
 
 # publish glooctl
 publish-glooctl: build-cli
-	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go true false # assets only, not dry run
+	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go false
 else
 # dry run publish glooctl
 publish-glooctl: build-cli
-	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go true true # assets only, dry run
+	VERSION=$(VERSION) GO111MODULE=on go run ci/upload_github_release_assets.go true
 endif # RELEASE exclusive make targets
 
 

--- a/changelog/v1.17.0-beta16/remove-pkgmgmt.yaml
+++ b/changelog/v1.17.0-beta16/remove-pkgmgmt.yaml
@@ -4,3 +4,6 @@ changelog:
   resolvesIssue: false
   description: >-
     Remove misleading package management code in ci/upload_github_release_assets.go
+
+    skipCI-kube-tests: true
+    skipCI-docs-build: true

--- a/changelog/v1.17.0-beta16/remove-pkgmgmt.yaml
+++ b/changelog/v1.17.0-beta16/remove-pkgmgmt.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/9301
+  resolvesIssue: false
+  description: >-
+    Remove misleading package management code in ci/upload_github_release_assets.go

--- a/ci/README.md
+++ b/ci/README.md
@@ -44,3 +44,9 @@ This is enabled as a GitHub App on the project, and if changes are required, ple
 **Skip Docs Build**: Include `skipCI-docs-build:true` in the changelog entry of the PR.
 
 **Skip Kubernetes E2E Tests**: Include `skipCI-kube-tests:true` in the changelog entry of the PR.
+
+
+### Assets and Package Management
+`glooctl` is built and published to the GitHub release via the script `upload_github_release_assets.go`. This is sensitive to changes to the output of `glooctl version`.
+
+`glooctl` is also available through the package management tool [Homebrew](https://formulae.brew.sh/formula/glooctl). `glooctl` is on the [Autobump list](https://github.com/Homebrew/homebrew-core/blob/8064f66cd04d0f32dc1be25ce8363a7a9e370fae/.github/autobump.txt#L790) which means it is automatically updated within 3 hours of a stable release via [GitHub Actions within Homebrew](https://github.com/Homebrew/homebrew-core/blob/8064f66cd04d0f32dc1be25ce8363a7a9e370fae/.github/workflows/autobump.yml)

--- a/ci/upload_github_release_assets.go
+++ b/ci/upload_github_release_assets.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -13,25 +12,14 @@ import (
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/go-utils/githubutils"
 	"github.com/solo-io/go-utils/log"
-	"github.com/solo-io/go-utils/pkgmgmtutils"
-	"github.com/solo-io/go-utils/pkgmgmtutils/formula_updater_types"
 	"github.com/solo-io/go-utils/versionutils"
 )
 
 func main() {
-	ctx := context.Background()
-	assetsOnly := false
 	dryRun := false
 	if len(os.Args) > 1 {
 		var err error
-		assetsOnly, err = strconv.ParseBool(os.Args[1])
-		if err != nil {
-			log.Fatalf("Unable to parse `assets_only` boolean argument, was provided %v", os.Args[1])
-		}
-	}
-	if len(os.Args) > 2 {
-		var err error
-		dryRun, err = strconv.ParseBool(os.Args[2])
+		dryRun, err = strconv.ParseBool(os.Args[1])
 		if err != nil {
 			log.Fatalf("Unable to parse `dry_run` boolean argument, was provided %v", os.Args[2])
 		}
@@ -42,7 +30,7 @@ func main() {
 
 	versionBeingReleased := getReleaseVersionOrExitGracefully(dryRun)
 
-	validateReleaseVersionOfCli(dryRun)
+	validateReleaseVersionOfCli(dryRun, strings.TrimPrefix(versionBeingReleased.String(), "v"))
 
 	assets := []githubutils.ReleaseAssetSpec{
 		{
@@ -72,106 +60,19 @@ func main() {
 		},
 	}
 
-	if dryRun {
-		return
-	}
-
 	spec := githubutils.UploadReleaseAssetSpec{
 		Owner:             repoOwner,
 		Repo:              repoName,
 		Assets:            assets,
 		SkipAlreadyExists: true,
 	}
-	githubutils.UploadReleaseAssetCli(&spec)
 
-	if assetsOnly {
-		log.Warnf("Not creating PRs to update homebrew formulas or fish food because this was an assets_only release")
-		return
-	}
-	mustUpdateFormulas(ctx, versionBeingReleased, repoOwner, repoName)
-}
-
-func mustUpdateFormulas(ctx context.Context, versionBeingReleased *versionutils.Version, repoOwner, repoName string) {
-	fOpts := []*formula_updater_types.FormulaOptions{
-		{
-			Name:           "homebrew-tap/glooctl",
-			FormulaName:    "glooctl",
-			Path:           "Formula/glooctl.rb",
-			RepoOwner:      repoOwner,      // Make change in this repo
-			RepoName:       "homebrew-tap", // assumes this repo is forked from PRRepoOwner
-			PRRepoOwner:    repoOwner,      // Make PR to this repo
-			PRRepoName:     "homebrew-tap",
-			PRBranch:       "main",
-			PRDescription:  "",
-			PRCommitName:   "Solo-io Bot",
-			PRCommitEmail:  "bot@solo.io",
-			VersionRegex:   `version\s*"([0-9.]+)"`,
-			DarwinShaRegex: `url\s*".*-darwin.*\W*sha256\s*"(.*)"`,
-			LinuxShaRegex:  `url\s*".*-linux.*\W*sha256\s*"(.*)"`,
-		},
-		{
-			Name:            "fish-food/glooctl",
-			FormulaName:     "glooctl",
-			Path:            "Food/glooctl.lua",
-			RepoOwner:       repoOwner,
-			RepoName:        "fish-food",
-			PRRepoOwner:     "fishworks",
-			PRRepoName:      "fish-food",
-			PRBranch:        "main",
-			PRDescription:   "",
-			PRCommitName:    "Solo-io Bot",
-			PRCommitEmail:   "bot@solo.io",
-			VersionRegex:    `version\s*=\s*"([0-9.]+)"`,
-			DarwinShaRegex:  `os\s*=\s*"darwin",\W*.*\W*.*\W*.*\W*sha256\s*=\s*"(.*)",`,
-			LinuxShaRegex:   `os\s*=\s*"linux",\W*.*\W*.*\W*.*\W*sha256\s*=\s*"(.*)",`,
-			WindowsShaRegex: `os\s*=\s*"windows",\W*.*\W*.*\W*.*\W*sha256\s*=\s*"(.*)",`,
-		},
-		{
-			Name:            "homebrew-core/glooctl",
-			FormulaName:     "glooctl",
-			Path:            "Formula/glooctl.rb",
-			RepoOwner:       repoOwner,
-			RepoName:        "homebrew-core",
-			PRRepoOwner:     "homebrew",
-			PRRepoName:      "homebrew-core",
-			PRBranch:        "main",
-			PRDescription:   "Created by Solo-io Bot",
-			PRCommitName:    "Solo-io Bot",
-			PRCommitEmail:   "bot@solo.io",
-			VersionRegex:    `tag:\s*"v([0-9.]+)",`,
-			VersionShaRegex: `revision:\s*"(.*)"`,
-		},
-	}
-
-	formulaUpdater, err := pkgmgmtutils.NewFormulaUpdaterWithDefaults(ctx)
-	if err != nil {
-		log.Fatalf("Error constructing formula updater: %+v", err)
-	}
-
-	status, err := formulaUpdater.Update(ctx, versionBeingReleased, repoOwner, repoName, fOpts)
-	if err != nil {
-		log.Fatalf("Error trying to update package manager formulas. Error was: %s", err.Error())
-	}
-	for _, s := range status {
-		if !s.Updated {
-			if s.Err != nil {
-				log.Fatalf("Error while trying to update formula %s. Error was: %s", s.Name, s.Err.Error())
-			} else {
-				log.Fatalf("Error while trying to update formula %s. Error was nil", s.Name) // Shouldn't happen; really bad if it does
-			}
-		}
-		if s.Err != nil {
-			if s.Err == pkgmgmtutils.ErrAlreadyUpdated {
-				log.Warnf("Formula %s was updated externally, so no updates applied during this release", s.Name)
-			} else {
-				log.Fatalf("Error updating Formula %s. Error was: %s", s.Name, s.Err.Error())
-			}
-		}
+	if !dryRun {
+		githubutils.UploadReleaseAssetCli(&spec)
 	}
 }
 
-func validateReleaseVersionOfCli(dryRun bool) {
-	releaseVersion := getReleaseVersionOrExitGracefully(dryRun).String()[1:]
+func validateReleaseVersionOfCli(dryRun bool, releaseVersion string) {
 	name := fmt.Sprintf("_output/glooctl-%s-amd64", runtime.GOOS)
 	cmd := exec.Command(name, "version")
 	bytes, err := cmd.Output()

--- a/go.mod
+++ b/go.mod
@@ -270,7 +270,6 @@ require (
 	github.com/solo-io/anyvendor v0.0.4 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
-	github.com/src-d/gcfg v1.4.0 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect
 	github.com/subosito/gotenv v1.2.0 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
@@ -297,8 +296,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.62.0 // indirect
 	gopkg.in/square/go-jose.v2 v2.6.0 // indirect
-	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
-	gopkg.in/src-d/go-git.v4 v4.10.0 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -787,7 +787,6 @@ github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b/go.mod h1:1KcenG0jGWcpt8ov532z81sp/kMMUG485J2InIOyADM=
-github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
 github.com/alecthomas/jsonschema v0.0.0-20180308105923-f2c93856175a/go.mod h1:qpebaTNSsyUn5rPSJMsfqEtDw71TTggXM6stUDI16HA=
 github.com/alecthomas/kingpin/v2 v2.3.1/go.mod h1:oYL5vtsvEHZGHxU7DMp32Dvx+qL+ptGn6lWaot2vCNE=
@@ -1988,7 +1987,6 @@ github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/y
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/src-d/gcfg v1.4.0 h1:xXbNR5AlLSA315x2UO+fTSSAXCDf+Ar38/6oyGbDKQ4=
 github.com/src-d/gcfg v1.4.0/go.mod h1:p/UMsR43ujA89BJY9duynAwIpvqEujIH/jFlfL7jWoI=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
@@ -3000,11 +2998,7 @@ gopkg.in/square/go-jose.v2 v2.5.1/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76
 gopkg.in/square/go-jose.v2 v2.6.0 h1:NGk74WTnPKBNUhNzQX7PYcTLUjoq7mzKk2OKbvwk2iI=
 gopkg.in/square/go-jose.v2 v2.6.0/go.mod h1:M9dMgbHiYLoDGQrXy7OpJDJWiKiU//h+vD76mk0e1AI=
 gopkg.in/src-d/go-billy.v4 v4.2.1/go.mod h1:tm33zBoOwxjYHZIE+OV8bxTWFMJLrconzFMd38aARFk=
-gopkg.in/src-d/go-billy.v4 v4.3.2 h1:0SQA1pRztfTFx2miS8sA97XvooFeNOmvUenF4o0EcVg=
-gopkg.in/src-d/go-billy.v4 v4.3.2/go.mod h1:nDjArDMp+XMs1aFAESLRjfGSgfvoYN0hDfzEk0GjC98=
-gopkg.in/src-d/go-git-fixtures.v3 v3.1.1 h1:XWW/s5W18RaJpmo1l0IYGqXKuJITWRFuA45iOf1dKJs=
 gopkg.in/src-d/go-git-fixtures.v3 v3.1.1/go.mod h1:dLBcvytrw/TYZsNTWCnkNF2DSIlzWYqTe3rJR56Ac7g=
-gopkg.in/src-d/go-git.v4 v4.10.0 h1:NWjTJTQnk8UpIGlssuefyDZ6JruEjo5s88vm88uASbw=
 gopkg.in/src-d/go-git.v4 v4.10.0/go.mod h1:Vtut8izDyrM8BUVQnzJ+YvmNcem2J89EmfZYCkLokZk=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=


### PR DESCRIPTION
# Description

Following up the unblock PR for the GitHub release assets upload script, this PR removes confusing and antiquated dead code around updating package management systems homebrew and fishfood (archived). The codepath was never called, and it has been confirmed that `glooctl` is updated via autobump in the homebrew repo.