### PR TITLE
hardcode envoy's runtime flag for sanitize TE to false

### DIFF
--- a/changelog/v1.17.0-beta16/envoy-sanitize-te-false.yaml
+++ b/changelog/v1.17.0-beta16/envoy-sanitize-te-false.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/9232
+  resolvesIssue: false
+  description: >-
+    Hardcode Envoy's reloadable feature for TE header sanitization to false. This feature as it
+    exists in 1.29.2 breaks gRPC upstreams whose client library expects `TE: trailers`. This hardcode 
+    will be removed when Gloo Edge depends upon 1.29.3, which has a fix for the gRPC case but is currently
+    unreleased.

--- a/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
+++ b/install/helm/gloo/templates/9-gateway-proxy-configmap.yaml
@@ -35,6 +35,9 @@ data:
           upstream:
             healthy_panic_threshold:
               value: {{ $spec.healthyPanicThreshold }}
+          envoy:
+            reloadable_features:
+              sanitize_te: false
       - name: admin_layer
         admin_layer: {}
     node:

--- a/install/test/fixtures.go
+++ b/install/test/fixtures.go
@@ -10,6 +10,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:
@@ -192,6 +195,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:
@@ -335,6 +341,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:
@@ -492,6 +501,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:
@@ -686,6 +698,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:

--- a/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
+++ b/install/test/fixtures/envoy_config/bootstrap_extensions.yaml
@@ -7,6 +7,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:

--- a/install/test/fixtures/envoy_config/custom_static_bootstrap.yaml
+++ b/install/test/fixtures/envoy_config/custom_static_bootstrap.yaml
@@ -9,6 +9,9 @@ layered_runtime:
         upstream:
           healthy_panic_threshold:
             value: 50
+        envoy:
+          reloadable_features:
+            sanitize_te: false
     - name: admin_layer
       admin_layer: {}
 node:

--- a/install/test/fixtures/envoy_config/overload_manager.yaml
+++ b/install/test/fixtures/envoy_config/overload_manager.yaml
@@ -7,6 +7,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:

--- a/install/test/fixtures/envoy_config/static_clusters.yaml
+++ b/install/test/fixtures/envoy_config/static_clusters.yaml
@@ -7,6 +7,9 @@ layered_runtime:
       upstream:
         healthy_panic_threshold:
           value: 50
+      envoy:
+        reloadable_features:
+          sanitize_te: false
   - name: admin_layer
     admin_layer: {}
 node:

--- a/install/test/fixtures/envoy_config/tcp_keepalive.yaml
+++ b/install/test/fixtures/envoy_config/tcp_keepalive.yaml
@@ -7,6 +7,9 @@ layered_runtime:
         upstream:
           healthy_panic_threshold:
             value: 50
+        envoy:
+          reloadable_features:
+            sanitize_te: false
     - name: admin_layer
       admin_layer: {}
 node:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -2865,7 +2865,7 @@ spec:
 							// This annotation was introduced to resolve https://github.com/solo-io/gloo/issues/8392
 							// It triggers a new rollout of the gateway proxy if the config map it uses changes
 							// As of PR 8733, changing the values of the deployment spec doesn't change the gateway-proxy config map, so it is safe to hardcode the checksum in the tests
-							"checksum/gateway-proxy-envoy-config": "27068cd033014d38f6c77522484e957ab25fa1be34a900a1f5241b8f7d62f525",
+							"checksum/gateway-proxy-envoy-config": "a67d1fe8cd3e4daa680a6d4a8aac54b4d191c00bd3089739888f22bfa508563a",
 						}
 						deploy.Spec.Template.Spec.Volumes = []corev1.Volume{{
 							Name: "envoy-config",
@@ -3501,7 +3501,7 @@ spec:
 						})
 						// Since changing the value of gatewayProxies.gatewayProxy.readConfig changes the gateway-proxy-envoy-config configmap, we need to update the checksum on the deployment as well.
 						// This also doubles as a check to validate that changes in the configmap change the checksum annotation on the deployment which will trigger a rollout.
-						gatewayProxyDeployment.Spec.Template.Annotations["checksum/gateway-proxy-envoy-config"] = "3e431b3dbb3fa7e31cedf9594474ad19e6ecc0e5a7bba59b99cf044d51546eaa"
+						gatewayProxyDeployment.Spec.Template.Annotations["checksum/gateway-proxy-envoy-config"] = "17409698f10666d68e6ef4a719b8143f4f07406c15b807c4902cbc4de6376a74"
 
 						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
 					})


### PR DESCRIPTION
# Description

Envoy's change to remove hop-by-hop TE headers broke upstreams whose gRPC client libraries expect a `TE: trailers` header. This is fixed in Envoy 1.29.3, which is not yet released. In the interim we will disable the sanitization.


# Context


Implementation: https://github.com/envoyproxy/envoy/pull/30535
Upstream Fix: https://github.com/envoyproxy/envoy/pull/32255
Upstream Fix backport: https://github.com/envoyproxy/envoy/pull/33018 

See slack conversation [here](https://solo-io-corp.slack.com/archives/C03MFATU265/p1712070803092839)

## Interesting decisions
 
We chose to do things this way in case 1.29.3 is not released at the time 1.17 goes GA or in case the bump is not made

## Testing steps

Helm tests upgraded, could stand to test that before/after a grpc upstream did or did not receive the headers

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
