### PR TITLE
feat: no compiler inlining

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
 ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.29.2-patch2
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
-GCFLAGS := all="-N -l"
+GCFLAGS ?=
 
 UNAME_M := $(shell uname -m)
 # if `GO_ARCH` is set, then it will keep its value. Else, it will be changed based off the machine's host architecture.

--- a/changelog/v1.17.0-beta17/compiler-inlining.yaml
+++ b/changelog/v1.17.0-beta17/compiler-inlining.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: "Turn on compiler optimizations by not alwyas passing gc flags. If needed these flags can be used with delve."


### PR DESCRIPTION
# Description

Remove GCflags by default. This should remove compiler inlining which will allow us to run faster. For debug builds that need to dive more deeply these can always be passed in to a build.