### PR TITLE
Bernie/kube dump logs

### DIFF
--- a/changelog/v1.17.0-beta23/fix-kube-dumps-on-fail.yaml
+++ b/changelog/v1.17.0-beta23/fix-kube-dumps-on-fail.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix a bug that prevented kube dumps on failure from being populated as intended.

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -150,7 +150,7 @@ func recordKubeDump(namespaces ...string) {
 
 // recordPods records logs from each pod to _output/kube2e-artifacts/$namespace/pods/$pod.log
 func recordPods(podDir, namespace string) error {
-	pods, err := kubeList(namespace, "pod")
+	pods, _, err := kubeList(namespace, "pod")
 	if err != nil {
 		return err
 	}
@@ -161,19 +161,26 @@ func recordPods(podDir, namespace string) error {
 		}
 
 		f := fileAtPath(filepath.Join(podDir, pod+".log"))
-		logs, err := kubeLogs(namespace, pod)
-		if err != nil {
-			return err
+		errF := fileAtPath(filepath.Join(podDir, pod+"-error.log"))
+		logs, errOutput, err := kubeLogs(namespace, pod)
+
+		if logs != "" {
+			f.WriteString(logs)
+			f.Close()
 		}
-		f.WriteString(logs)
-		f.Close()
+		if errOutput != "" {
+			errF.WriteString(errOutput)
+			errF.Close()
+		}
+
+		return err
 	}
 	return nil
 }
 
 // recordCRs records all unique CRs floating about to _output/kube2e-artifacts/$namespace/$crd/$cr.yaml
 func recordCRs(namespaceDir string, namespace string) error {
-	crds, err := kubeList(namespace, "crd")
+	crds, _, err := kubeList(namespace, "crd")
 	if err != nil {
 		return err
 	}
@@ -186,7 +193,7 @@ func recordCRs(namespaceDir string, namespace string) error {
 		}
 
 		// if there are any existing CRs corresponding to this CRD
-		crs, err := kubeList(namespace, crd)
+		crs, _, err := kubeList(namespace, crd)
 		if err != nil {
 			return err
 		}
@@ -201,12 +208,20 @@ func recordCRs(namespaceDir string, namespace string) error {
 		// we record each one in its own .yaml representation
 		for _, cr := range crs {
 			f := fileAtPath(filepath.Join(crdDir, cr+".yaml"))
-			crDetails, err := kubeGet(namespace, crd, cr)
-			if err != nil {
-				return err
+			errF := fileAtPath(filepath.Join(crdDir, cr+"-error.log"))
+
+			crDetails, errOutput, err := kubeGet(namespace, crd, cr)
+
+			if crDetails != "" {
+				f.WriteString(crDetails)
+				f.Close()
 			}
-			f.WriteString(crDetails)
-			f.Close()
+			if errOutput != "" {
+				errF.WriteString(errOutput)
+				errF.Close()
+			}
+
+			return err
 		}
 	}
 
@@ -214,39 +229,39 @@ func recordCRs(namespaceDir string, namespace string) error {
 }
 
 // kubeLogs runs $(kubectl -n $namespace logs $pod --all-containers) and returns the string result
-func kubeLogs(namespace string, pod string) (string, error) {
+func kubeLogs(namespace string, pod string) (string, string, error) {
 	args := []string{"-n", namespace, "logs", pod, "--all-containers"}
 	return kubeExecute(args)
 }
 
 // kubeGet runs $(kubectl -n $namespace get $kubeType $name -oyaml) and returns the string result
-func kubeGet(namespace string, kubeType string, name string) (string, error) {
+func kubeGet(namespace string, kubeType string, name string) (string, string, error) {
 	args := []string{"-n", namespace, "get", kubeType, name, "-oyaml"}
 	return kubeExecute(args)
 }
 
-func kubeExecute(args []string) (string, error) {
+func kubeExecute(args []string) (string, string, error) {
 	cli := kubectl.NewCli().WithReceiver(ginkgo.GinkgoWriter)
 
 	var outLocation threadsafe.Buffer
 	runError := cli.Command(context.Background(), args...).WithStdout(&outLocation).Run()
 	if runError != nil {
-		return runError.OutputString(), runError.Cause()
+		return outLocation.String(), runError.OutputString(), runError.Cause()
 	}
 
-	return outLocation.String(), nil
+	return outLocation.String(), "", nil
 }
 
 // kubeList runs $(kubectl -n $namespace $target) and returns a slice of kubernetes object names
-func kubeList(namespace string, target string) ([]string, error) {
+func kubeList(namespace string, target string) ([]string, string, error) {
 	args := []string{"-n", namespace, "get", target}
-	line, err := kubeExecute(args)
+	lines, errContent, err := kubeExecute(args)
 	if err != nil {
-		return nil, err
+		return nil, errContent, err
 	}
 
 	var toReturn []string
-	for _, line := range strings.Split(strings.TrimSuffix(line, "\n"), "\n") {
+	for _, line := range strings.Split(strings.TrimSuffix(lines, "\n"), "\n") {
 		if strings.HasPrefix(line, "NAME") || strings.HasPrefix(line, "No resources found") {
 			continue // skip header line and cases where there are no resources
 		}
@@ -254,7 +269,7 @@ func kubeList(namespace string, target string) ([]string, error) {
 			toReturn = append(toReturn, split[0])
 		}
 	}
-	return toReturn, nil
+	return toReturn, "", nil
 }
 
 // EnvoyDumpOnFail creates a small dump of the envoy admin interface when a test fails.

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -56,10 +56,11 @@ func KubeDumpOnFail(out io.Writer, namespaces ...string) func() {
 	return func() {
 		setupOutDir(kubeOutDir)
 
-		recordDockerState(fileAtPath(filepath.Join(kubeOutDir, "docker-state.log")))
-		recordProcessState(fileAtPath(filepath.Join(kubeOutDir, "process-state.log")))
-		recordKubeState(fileAtPath(filepath.Join(kubeOutDir, "kube-state.log")))
+		//recordDockerState(fileAtPath(filepath.Join(kubeOutDir, "docker-state.log")))
+		//recordProcessState(fileAtPath(filepath.Join(kubeOutDir, "process-state.log")))
+		//recordKubeState(fileAtPath(filepath.Join(kubeOutDir, "kube-state.log")))
 
+		fmt.Printf("ABOUT TO DUMP LOGS FOR NAMESPACES %v\n", namespaces)
 		recordKubeDump(namespaces...)
 	}
 }
@@ -134,6 +135,7 @@ func recordKubeState(f *os.File) {
 func recordKubeDump(namespaces ...string) {
 	// for each namespace, create a namespace directory that contains...
 	for _, ns := range namespaces {
+		fmt.Printf("ABOUT TO RECORD PODS FOR %s\n", ns)
 		// ...a pod logs subdirectoy
 		if err := recordPods(filepath.Join(kubeOutDir, ns, "_pods"), ns); err != nil {
 			fmt.Printf("error recording pod logs: %f, \n", err)
@@ -152,6 +154,7 @@ func recordPods(podDir, namespace string) error {
 	if err != nil {
 		return err
 	}
+	fmt.Printf("HAVE PODS: %v\n", pods)
 
 	for _, pod := range pods {
 		if err := os.MkdirAll(podDir, os.ModePerm); err != nil {
@@ -163,6 +166,7 @@ func recordPods(podDir, namespace string) error {
 		if err != nil {
 			return err
 		}
+		fmt.Printf("WRITING LOGS FOR %s\n%s\n", pod, logs)
 		f.WriteString(logs)
 		f.Close()
 	}

--- a/test/helpers/kube_dump.go
+++ b/test/helpers/kube_dump.go
@@ -4,13 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/solo-io/go-utils/threadsafe"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/solo-io/go-utils/threadsafe"
 
 	"github.com/solo-io/gloo/pkg/utils/kubeutils/kubectl"
 


### PR DESCRIPTION
# Description

Fix return from `kubeExecute()` helper so that it returns the actual response from the command instead of only returning error output

_Fill out any of the following sections that are relevant and remove the others_
## CI changes
- `kubeExecute()` writes stdout to a local buffer and returns the contents of that buffer if there is no error
  - This is called as part of `KubeDumpOnFail()` in tests and is not in a production code path

# Context

We intend to dump resources and logs on kube2e test failure, however we haven't actually been getting logs, resources etc. to date
This is because we weren't capturing the output to stdout on k8s commands, only error output, and were throwing away the output we actually care about
With this change we return the output from the k8s commands and ultimately write it to disk (test artifacts in CI) as intended

## Testing steps

This change has been used successfully in solo-io/solo-projects#6018
For example see the dumps on [this action](https://github.com/solo-io/solo-projects/actions/runs/8696156924) populated as intended
Compare with the dump on [this action](https://github.com/solo-io/solo-projects/actions/runs/8634082143) which didn't use this branch and which does not have pod logs, CRs, etc.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works