### PR TITLE
1.16 bump: envoy-gloo and go (via cbuild) for http2 cont cve

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.27.3-patch2
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.27.4-patch1
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/changelog/v1.16.10/envoy-gloo-cves.yaml
+++ b/changelog/v1.16.10/envoy-gloo-cves.yaml
@@ -1,0 +1,20 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: envoy-gloo
+  dependencyTag: v1.27.4-patch1
+  issueLink: https://github.com/solo-io/solo-projects/issues/6008
+  resolvesIssue: false
+  description: >-
+    Bump envoy-gloo for fixes Envoy CVEs with HTTP2 continuation
+    https://github.com/envoyproxy/envoy/security/advisories/GHSA-j654-3ccm-vfmm
+- type: DEPENDENCY_BUMP
+  dependencyOwner: golang
+  dependencyRepo: go
+  dependencyTag: v1.21.9
+  description: >-
+    Bump go via cloud builders for HTTP2 continuation
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: cloud-builders
+  dependencyTag: v0.8.4

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.8.4'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -44,7 +44,7 @@ steps:
   - 'us-central1-a'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.4'
   id: 'publish-docker'
   args:
   - 'publish-docker'
@@ -65,7 +65,7 @@ steps:
   waitFor:
   - 'publish-docker'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.4'
   id: 'release-chart'
   dir: *dir
   args:
@@ -80,7 +80,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.4'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.8.4'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -23,7 +23,7 @@ steps:
     cd /go/pkg
     gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.4'
   id: 'prepare-envoy'
   dir: *dir
   entrypoint: 'bash'
@@ -74,7 +74,7 @@ steps:
   waitFor:
   - 'prepare-gcr-zone'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.8.4'
   id: 'prepare-test-tools'
   dir: *dir
   args:
@@ -85,7 +85,7 @@ steps:
   - 'prepare-gcr-zone'
   - 'prepare-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.8.4'
   id: 'run-tests'
   dir: *dir
   entrypoint: 'make'
@@ -96,7 +96,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.8.4'
   id: 'run-e2e-tests'
   dir: *dir
   entrypoint: 'make'
@@ -107,7 +107,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.8.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.8.4'
   id: 'run-hashicorp-e2e-tests'
   dir: *dir
   entrypoint: 'make'


### PR DESCRIPTION
# Description

Bumps cloud builders for golang and envoy for envoy upstream changes.

Deals with http2 cve cont in both places.
