### PR TITLE
Always build and load sds standard image for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1044,6 +1044,8 @@ kind-build-and-load: # Distroless images
 ifeq ($(IMAGE_VARIANT),$(filter $(IMAGE_VARIANT),all distroless))
 kind-build-and-load: kind-build-and-load-distroless
 endif # distroless images
+kind-build-and-load: # As of now the glooctl istio inject command is not smart enough to determine the variant used, so we always build the standard variant of the sds image.
+kind-build-and-load: kind-build-and-load-sds
 
 define kind_reload_msg
 The kind-reload-% targets exist in order to assist developers with the work cycle of

--- a/changelog/v1.17.0-beta22/fix-glooctl-istio-inject.yaml
+++ b/changelog/v1.17.0-beta22/fix-glooctl-istio-inject.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Always build the sds standard image variant in tests as the `glooctl istio inject` command deploys the standard sds variant irrespective of the variant of edge installed


### PR DESCRIPTION
# Description

The `glooctl istio inject` command always injects the standard sds image variant irrespective of the variant of edge installed. As tests run on the distroless variant, this PR ensures the standard sds image is built and loaded so the glooctl test passes while we fix the underlying issue

# Context
https://github.com/solo-io/gloo/actions/runs/8683582052/job/23826553002?pr=9358
https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1713193713670019
```
 Back-off pulling image "quay.io/solo-io/sds:1.0.0-ci1"
  Warning  Failed     30s (x3 over 56s)  kubelet            Error: ImagePullBackOff
  Warning  Failed     15s (x3 over 59s)  kubelet            Error: ErrImagePull
  Warning  Failed     15s (x3 over 59s)  kubelet            Failed to pull image "quay.io/solo-io/sds:1.0.0-ci1": rpc error: code = NotFound desc = failed to pull and unpack image "quay.io/solo-io/sds:1.0.0-ci1": failed to resolve reference "quay.io/solo-io/sds:1.0.0-ci1": quay.io/solo-io/sds:1.0.0-ci1: not found
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->