### PR TITLE
Fix virtualhostoptions rbac for k8s gateway

### DIFF
--- a/changelog/v1.17.0-beta22/vhopts-rbac.yaml
+++ b/changelog/v1.17.0-beta22/vhopts-rbac.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix an rbac oversight in original implementation of virtualhostoptions plugin for k8s gateway

--- a/changelog/v1.17.1/virtualhostoption-rbac.yaml.yaml
+++ b/changelog/v1.17.1/virtualhostoption-rbac.yaml.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix an rbac oversight in original implementation of virtualhostoptions plugin for k8s gateway

--- a/changelog/v1.17.1/virtualhostoption-rbac.yaml.yaml
+++ b/changelog/v1.17.1/virtualhostoption-rbac.yaml.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: >-
-      Fix an rbac oversight in original implementation of virtualhostoptions plugin for k8s gateway

--- a/install/helm/gloo/templates/44-rbac.yaml
+++ b/install/helm/gloo/templates/44-rbac.yaml
@@ -33,6 +33,7 @@ rules:
   - "gateway.solo.io"
   resources:
   - routeoptions
+  - virtualhostoptions
   verbs: ["get", "list", "watch"]
 - apiGroups:
   - "gateway.networking.k8s.io"


### PR DESCRIPTION
# Description

The original virtualhostoptions plugin for k8s gateway implementation missed adding the resource to rbac for the ClusterRole defined for K8s Gateway API. 