### PR TITLE
[1.16.x] Gateway validation flake fix (#9119)

### DIFF
--- a/changelog/v1.16.11/validation-test-flake-fix.yaml
+++ b/changelog/v1.16.11/validation-test-flake-fix.yaml
@@ -1,5 +1,5 @@
 changelog:
   - type: NON_USER_FACING
     issueLink: https://github.com/solo-io/gloo/issues/9118
-    resolvesIssue: true
+    resolvesIssue: false
     description: Fix flake in secret validation tests

--- a/changelog/v1.17.0-beta6/validation-test-flake-fix.yaml
+++ b/changelog/v1.17.0-beta6/validation-test-flake-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/9118
+    resolvesIssue: true
+    description: Fix flake in secret validation tests

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -2148,8 +2148,9 @@ spec:
 					})
 
 					// Although these tests delete the secret handled by our SnapshotWriter, because we set `IgnoreNotFound` when deleting snapshot resources, this won't cause an issue.
-					err = resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
-					Expect(err).NotTo(HaveOccurred())
+					Eventually(func() error {
+						return resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})
+					}).WithPolling(500 * time.Millisecond).WithTimeout(30 * time.Second).ShouldNot(HaveOccurred())
 				})
 
 				It("can delete a secret that is not in use", func() {


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/9119
