### PR TITLE
[1.15.x] Gateway validation flake fix (#9119)

### DIFF
--- a/changelog/v1.15.26/validation-test-flake-fix.yaml
+++ b/changelog/v1.15.26/validation-test-flake-fix.yaml
@@ -1,5 +1,5 @@
 changelog:
   - type: NON_USER_FACING
     issueLink: https://github.com/solo-io/gloo/issues/9118
-    resolvesIssue: true
+    resolvesIssue: false
     description: Fix flake in secret validation tests

--- a/changelog/v1.17.0-beta6/validation-test-flake-fix.yaml
+++ b/changelog/v1.17.0-beta6/validation-test-flake-fix.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/9118
+    resolvesIssue: true
+    description: Fix flake in secret validation tests


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/9119
