### PR TITLE
add authconfigclient to gw extension params

### DIFF
--- a/projects/gateway2/controller/start.go
+++ b/projects/gateway2/controller/start.go
@@ -16,6 +16,7 @@ import (
 	"github.com/solo-io/gloo/projects/gateway2/secrets"
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	api "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/bootstrap"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/projects/gloo/pkg/translator"
@@ -49,6 +50,10 @@ type StartConfig struct {
 	// ProxyClient is the client that writes Proxy resources into an in-memory cache
 	// This cache is utilized by the debug.ProxyEndpointServer
 	ProxyClient v1.ProxyClient
+
+	// AuthConfigClient is the client used for retrieving AuthConfig objects within the Portal Plugin
+	AuthConfigClient api.AuthConfigClient
+
 	// RouteOptionClient is the client used for retrieving RouteOption objects within the RouteOptionsPlugin
 	// NOTE: We may be able to move this entirely to the RouteOptionsPlugin
 	RouteOptionClient gatewayv1.RouteOptionClient
@@ -93,6 +98,7 @@ func Start(ctx context.Context, cfg StartConfig) error {
 
 	k8sGwExtensions, err := cfg.ExtensionsFactory(ctx, extensions.K8sGatewayExtensionsFactoryParameters{
 		Mgr:               mgr,
+		AuthConfigClient:  cfg.AuthConfigClient,
 		RouteOptionClient: cfg.RouteOptionClient,
 		StatusReporter:    cfg.StatusReporter,
 		KickXds:           inputChannels.Kick,

--- a/projects/gateway2/extensions/extensions.go
+++ b/projects/gateway2/extensions/extensions.go
@@ -2,6 +2,7 @@ package extensions
 
 import (
 	"context"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 
 	"github.com/solo-io/gloo/pkg/version"
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
@@ -24,6 +25,7 @@ type K8sGatewayExtensions interface {
 // K8sGatewayExtensionsFactoryParameters contains the parameters required to start Gloo K8s Gateway Extensions (including Translator Plugins)
 type K8sGatewayExtensionsFactoryParameters struct {
 	Mgr               controllerruntime.Manager
+	AuthConfigClient  v1.AuthConfigClient
 	RouteOptionClient gatewayv1.RouteOptionClient
 	StatusReporter    reporter.StatusReporter
 	KickXds           func(ctx context.Context)

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -927,7 +927,7 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 
 	if opts.GlooGateway.EnableK8sGatewayController {
 		// Share proxyClient with the gateway controller
-		startFuncs["k8s-gateway-controller"] = K8sGatewayControllerStartFunc(proxyClient)
+		startFuncs["k8s-gateway-controller"] = K8sGatewayControllerStartFunc(proxyClient, authConfigClient)
 	}
 
 	validationMustStart := os.Getenv("VALIDATION_MUST_START")

--- a/projects/gloo/pkg/syncer/setup/start_func.go
+++ b/projects/gloo/pkg/syncer/setup/start_func.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"context"
+	api "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1"
 
 	"golang.org/x/sync/errgroup"
 
@@ -49,7 +50,7 @@ func ExecuteAsynchronousStartFuncs(
 }
 
 // K8sGatewayControllerStartFunc returns a StartFunc to run the k8s Gateway controller
-func K8sGatewayControllerStartFunc(proxyClient v1.ProxyClient) StartFunc {
+func K8sGatewayControllerStartFunc(proxyClient v1.ProxyClient, authConfigClient api.AuthConfigClient) StartFunc {
 	return func(ctx context.Context, opts bootstrap.Opts, extensions Extensions) error {
 		if opts.ProxyDebugServer.Server != nil {
 			// If we have a debug server running, let's register the proxy client used by
@@ -71,6 +72,7 @@ func K8sGatewayControllerStartFunc(proxyClient v1.ProxyClient) StartFunc {
 			Opts:                      opts,
 
 			ProxyClient:       proxyClient,
+			AuthConfigClient:  authConfigClient,
 			RouteOptionClient: routeOptionClient,
 			StatusReporter:    statusReporter,
 


### PR DESCRIPTION
this enables reading authconfigs from the portal plugin, which is necessary to generate SecurityRequirements in OpenAPI Docs https://github.com/solo-io/solo-projects/issues/6050