### PR TITLE
kube2e/glooctl: fix invalid syntax

### DIFF
--- a/changelog/v1.17.0-beta23/skip-glooctl-istio-test-attempt2.yaml
+++ b/changelog/v1.17.0-beta23/skip-glooctl-istio-test-attempt2.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6048
+    resolvesIssue: false
+    description: >-
+      Disable istio tests in the glooctl suite, as they were flaking too frequently.
+      Disabling these tests is a short-term solution. The linked issue describes our long-term approach.
+      
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/test/kube2e/glooctl/istio_test.go
+++ b/test/kube2e/glooctl/istio_test.go
@@ -37,10 +37,12 @@ var (
 
 var _ = Describe("Istio", Ordered, func() {
 
-	// These tests are known to be inconsistent, and cause toil in our CI pipeline
-	// https://github.com/solo-io/solo-projects/issues/6048 tracks the work to re-enable these tests
-	Skip("These tests are inconsistent. Temporarily disabling")
-
+	BeforeEach(func() {
+		// These tests are known to be inconsistent, and cause toil in our CI pipeline
+		// https://github.com/solo-io/solo-projects/issues/6048 tracks the work to re-enable these tests
+		Skip("These tests are inconsistent. Temporarily disabling")
+	})
+	
 	// Tests for: `glooctl istio [..]`
 	// These tests assume that Gloo and Istio are pre-installed in the cluster
 

--- a/test/kube2e/glooctl/istio_test.go
+++ b/test/kube2e/glooctl/istio_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Istio", Ordered, func() {
 		// https://github.com/solo-io/solo-projects/issues/6048 tracks the work to re-enable these tests
 		Skip("These tests are inconsistent. Temporarily disabling")
 	})
-	
+
 	// Tests for: `glooctl istio [..]`
 	// These tests assume that Gloo and Istio are pre-installed in the cluster
 


### PR DESCRIPTION
# Description

Fix for bad syntax I added to: https://github.com/solo-io/gloo/pull/9383


# Context

Fast follow to https://github.com/solo-io/gloo/pull/9383 which has more context

## Interesting decisions
-

## Testing steps
I skipped the tests in CI, but locally you can focus the `Describe` block in the `istio_test` run: 
```
VERSION=1.17.0-beta22 KUBE2E_TESTS=glooctl SKIP_INSTALL=true make run-kube-e2e-tests
```

```
Running Suite: Glooctl Suite - /Users/samheilbron/go/src/github.com/solo-io/gloo/test/kube2e/glooctl
====================================================================================================
Random Seed: 1713470015 - will randomize all specs

Will run 4 of 29 specs
"Thu, 18 Apr 2024 13:53:53 MDT: github.com/solo-io/gloo/test/kube2e/helper/install.go:294"      found Helm index file at: "/Users/samheilbron/go/src/github.com/solo-io/gloo/_test/index.yaml"
"Thu, 18 Apr 2024 13:53:53 MDT: github.com/solo-io/gloo/test/kube2e/helper/install.go:303"      version of ["gloo"] Helm chart is: "1.0.0-ci1"
SSSSSSSSSSSSSSSSSSSSSSSSSSSSS

Ran 0 of 29 Specs in 0.870 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 29 Skipped
PASS | FOCUSED
```

## Notes for reviewers
-


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->