### PR TITLE
tests/kube/e2e: Expand utilities, run tests multiple times on PRs

### DIFF
--- a/.github/workflows/composite-actions/kubernetes-e2e-tests/action.yaml
+++ b/.github/workflows/composite-actions/kubernetes-e2e-tests/action.yaml
@@ -24,15 +24,16 @@ runs:
     shell: bash
     env:
       CLUSTER_NAME: 'kind'
-      CLUSTER_NODE_VERSION: ${{ matrix.tool-versions.cluster_node }}
+      CLUSTER_NODE_VERSION: ${{ matrix.tool-versions.cluster-node }}
     run: ./ci/kind/setup-kind.sh
   - name: Install test tools
     shell: bash
     run: make install-test-tools
   - name: Execute tests
     env:
+      GINKGO_USER_FLAGS: ${{ matrix.test-suites.ginkgo-args }}
       CLUSTER_NAME: 'kind'
-      TEST_PKG: test/kubernetes/e2e/${{ matrix.kubernetes-e2e-suite }}
+      TEST_PKG: test/kubernetes/e2e/${{ matrix.test-suites.package }}
     shell: bash
     run: make test
   # TODO: Emit artifacts to shared location on failure

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         fi
 
   end_to_end_tests:
-    name: End-to-End (${{matrix.kubernetes-e2e-suite}})
+    name: End-to-End (${{ matrix.test-suites.package }})
     needs: prepare_env
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -46,10 +46,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-e2e-suite:
-        - 'k8sgateway'
+        test-suites:
+        - package: 'k8sgateway'
+          # https://onsi.github.io/ginkgo/#repeating-spec-runs-and-managing-flaky-specs
+          # --flake-attempts: We want to error on flakes loudly, so we do not repeat any of them
+          # --repeat: We are introducing new tests, and want to increase the confidence that new tests aren't flaky
+          ginkgo-args: '--flake-attempts=0 --repeat=1'
         tool-versions:
-        - cluster_node: 'v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31'
+        - cluster-node: 'v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31'
           kubectl: 'v1.28.4'
           kind: 'v0.20.0'
           helm: 'v3.13.2'

--- a/changelog/v1.17.0-beta23/cmd-data-race.yaml
+++ b/changelog/v1.17.0-beta23/cmd-data-race.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/9390
+    resolvesIssue: false
+    description: >-
+      Attempt to resolve a data race, by re-using the same client (and output receiver)
+      instead of recreating it each time

--- a/pkg/utils/kubeutils/dns.go
+++ b/pkg/utils/kubeutils/dns.go
@@ -1,0 +1,18 @@
+package kubeutils
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	// ClusterInternalDomainName is the internal domain for a Kubernetes Cluster
+	ClusterInternalDomainName = "cluster.local"
+)
+
+// ServiceFQDN returns the FQDN for the Service, assuming it is being accessed from within the Cluster
+// https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#services
+func ServiceFQDN(serviceMeta metav1.ObjectMeta) string {
+	return fmt.Sprintf("%s.%s.svc.%s", serviceMeta.GetName(), serviceMeta.GetNamespace(), ClusterInternalDomainName)
+}

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -8,11 +8,11 @@ import (
 	"os"
 	"time"
 
-	"github.com/solo-io/gloo/pkg/utils/requestutils/curl"
-	"github.com/solo-io/k8s-utils/testutils/kube"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/solo-io/gloo/pkg/utils/cmdutils"
+	"github.com/solo-io/gloo/pkg/utils/requestutils/curl"
+	"github.com/solo-io/k8s-utils/testutils/kube"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/solo-io/gloo/pkg/utils/kubeutils/portforward"
@@ -159,7 +159,7 @@ func (c *Cli) StartPortForward(ctx context.Context, options ...portforward.Optio
 }
 
 // CurlFromEphemeralPod executes a curl from a pod, using an ephemeral container
-func (c *Cli) CurlFromEphemeralPod(ctx context.Context, podMeta metav1.ObjectMeta, options ...curl.Option) string {
+func (c *Cli) CurlFromEphemeralPod(ctx context.Context, podMeta types.NamespacedName, options ...curl.Option) string {
 	appendOption := func(option curl.Option) {
 		options = append(options, option)
 	}
@@ -175,7 +175,7 @@ func (c *Cli) CurlFromEphemeralPod(ctx context.Context, podMeta metav1.ObjectMet
 		ctx,
 		c.receiver,
 		c.kubeContext,
-		podMeta.GetNamespace(),
-		podMeta.GetName(),
+		podMeta.Namespace,
+		podMeta.Name,
 		curlArgs...)
 }

--- a/pkg/utils/kubeutils/names.go
+++ b/pkg/utils/kubeutils/names.go
@@ -4,6 +4,7 @@ const (
 	GlooDeploymentName = "gloo"
 	GlooServiceName    = "gloo"
 
-	// The name of the port in the gloo control plane Kubernetes Service that serves xDS config.
+	// GlooXdsPortName is the name of the port in the Gloo Gateway control plane Kubernetes Service that serves xDS config.
+	// See: install/helm/gloo/templates/2-gloo-service.yaml
 	GlooXdsPortName = "grpc-xds"
 )

--- a/projects/gloo/pkg/syncer/setup/controlplane.go
+++ b/projects/gloo/pkg/syncer/setup/controlplane.go
@@ -2,7 +2,8 @@ package setup
 
 import (
 	"context"
-	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/pkg/utils"
@@ -47,5 +48,8 @@ func GetControlPlaneXdsPort(ctx context.Context, svcClient skkube.ServiceClient)
 
 // GetControlPlaneXdsHost gets the xDS address from the gloo Service.
 func GetControlPlaneXdsHost() string {
-	return fmt.Sprintf("%s.%s.svc.%s", kubeutils.GlooServiceName, utils.GetPodNamespace(), "cluster.local")
+	return kubeutils.ServiceFQDN(metav1.ObjectMeta{
+		Name:      kubeutils.GlooServiceName,
+		Namespace: utils.GetPodNamespace(),
+	})
 }

--- a/test/kubernetes/e2e/features/route_options/route_options.go
+++ b/test/kubernetes/e2e/features/route_options/route_options.go
@@ -56,10 +56,10 @@ var ConfigureRouteOptionsWithTargetRef = e2e.Test{
 				OpAction: installation.Actions.Kubectl().NewApplyManifestAction(targetRefManifest),
 				OpAssertions: []assertions.ClusterAssertion{
 					// First check resources are created for Gateway
-					installation.Assertions.ObjectsExist(proxyService, proxyDeployment, curlPod),
+					installation.Assertions.ObjectsExist(proxyService, proxyDeployment),
 
 					installation.Assertions.EphemeralCurlEventuallyResponds(
-						curlPod.ObjectMeta,
+						curlPod,
 						[]curl.Option{
 							curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
 							curl.WithHostHeader("example.com"),
@@ -94,11 +94,11 @@ var ConfigureRouteOptionsWithFilterExtenstion = e2e.Test{
 				OpAction: installation.Actions.Kubectl().NewApplyManifestAction(filterExtensioManifest),
 				OpAssertions: []assertions.ClusterAssertion{
 					// First check resources are created for Gateway
-					installation.Assertions.ObjectsExist(proxyService, proxyDeployment, curlPod),
+					installation.Assertions.ObjectsExist(proxyService, proxyDeployment),
 
 					// Check fault injection is applied
 					installation.Assertions.EphemeralCurlEventuallyResponds(
-						curlPod.ObjectMeta,
+						curlPod,
 						[]curl.Option{
 							curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
 							curl.WithHostHeader("example.com"),

--- a/test/kubernetes/e2e/features/route_options/route_options.go
+++ b/test/kubernetes/e2e/features/route_options/route_options.go
@@ -57,8 +57,8 @@ var ConfigureRouteOptionsWithTargetRef = e2e.Test{
 				OpName:   fmt.Sprintf("apply-manifest-%s", filepath.Base(targetRefManifest)),
 				OpAction: installation.Actions.Kubectl().NewApplyManifestAction(targetRefManifest),
 				OpAssertions: []assertions.ClusterAssertion{
-					// First check resources are created for Gateay
-					installation.Assertions.ObjectsExist(proxyService, proxyDeployment),
+					// First check resources are created for Gateway
+					installation.Assertions.ObjectsExist(proxyService, proxyDeployment, curlPod),
 
 					installation.Assertions.EphemeralCurlEventuallyResponds(
 						curlPod.ObjectMeta,

--- a/test/kubernetes/e2e/features/route_options/route_options.go
+++ b/test/kubernetes/e2e/features/route_options/route_options.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"path/filepath"
 
-	v1 "k8s.io/apiserver/pkg/apis/example/v1"
-
 	"github.com/solo-io/gloo/pkg/utils/kubeutils"
 
 	. "github.com/onsi/gomega"
@@ -35,7 +33,7 @@ var (
 	proxyService    = &corev1.Service{ObjectMeta: glooProxyObjectMeta}
 
 	// curlPod is the Pod that will be used to execute curl requests, and is defined in the fault injection manifest files
-	curlPod = &v1.Pod{
+	curlPod = &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "curl",
 			Namespace: "curl",

--- a/test/kubernetes/testutils/assertions/curl.go
+++ b/test/kubernetes/testutils/assertions/curl.go
@@ -23,7 +23,7 @@ func (p *Provider) EphemeralCurlEventuallyResponds(curlPodMeta metav1.ObjectMeta
 		currentTimeout, pollingInterval := helper.GetTimeouts(timeout...)
 
 		// for some useful-ish output
-		tick := time.Tick(currentTimeout / 8)
+		tick := time.Tick(pollingInterval)
 
 		Eventually(func(g Gomega) {
 			res := p.clusterContext.Cli.CurlFromEphemeralPod(ctx, curlPodMeta, curlOptions...)
@@ -47,14 +47,14 @@ func (p *Provider) EphemeralCurlEventuallyResponds(curlPodMeta metav1.ObjectMeta
 
 // CurlFnEventuallyResponds returns a ClusterAssertion that behaves similarly to EphemeralCurlEventuallyResponds
 // The difference is that it accepts a generic function to execute the curl, instead of requiring the caller to pass explicit curl.Option
-// We recommend that developers rely on the typed EphemeralCurlEventuallyResponds but we want to provide the flexibility of other solutions as well
+// Not all curl requests should be done from an ephemeral container, and this function allows for that to occur
 func (p *Provider) CurlFnEventuallyResponds(curlFn func() string, expectedResponse *matchers.HttpResponse, timeout ...time.Duration) ClusterAssertion {
 	return func(ctx context.Context) {
 		ginkgo.GinkgoHelper()
 		currentTimeout, pollingInterval := helper.GetTimeouts(timeout...)
 
 		// for some useful-ish output
-		tick := time.Tick(currentTimeout / 8)
+		tick := time.Tick(pollingInterval)
 
 		Eventually(func(g Gomega) {
 			res := curlFn()

--- a/test/kubernetes/testutils/assertions/curl.go
+++ b/test/kubernetes/testutils/assertions/curl.go
@@ -16,13 +16,13 @@ import (
 
 var (
 	// curlPodObjectMeta contains the ObjectMeta for the Pod that will be used to execute curl requests
-	// The `curl` pod (referenced here)
 	curlPodObjectMeta = metav1.ObjectMeta{
 		Name:      "curl",
 		Namespace: "curl",
 	}
 )
 
+// CurlEventuallyResponds returns a ClusterAssertion to assert that a set of curl.Option will return the expected matchers.HttpResponse
 func (p *Provider) CurlEventuallyResponds(curlOptions []curl.Option, expectedResponse *matchers.HttpResponse, timeout ...time.Duration) ClusterAssertion {
 	return func(ctx context.Context) {
 		ginkgo.GinkgoHelper()
@@ -33,6 +33,37 @@ func (p *Provider) CurlEventuallyResponds(curlOptions []curl.Option, expectedRes
 
 		Eventually(func(g Gomega) {
 			res := p.clusterContext.Cli.CurlFromEphemeralPod(ctx, curlPodObjectMeta, curlOptions...)
+			select {
+			default:
+				break
+			case <-tick:
+				ginkgo.GinkgoWriter.Printf("want %v\nhave: %s", expectedResponse, res)
+			}
+
+			expectedResponseMatcher := WithTransform(transforms.WithCurlHttpResponse, matchers.HaveHttpResponse(expectedResponse))
+			g.Expect(res).To(expectedResponseMatcher)
+			ginkgo.GinkgoWriter.Printf("success: %v", res)
+		}).
+			WithTimeout(currentTimeout).
+			WithPolling(pollingInterval).
+			WithContext(ctx).
+			Should(Succeed())
+	}
+}
+
+// CurlFnEventuallyResponds returns a ClusterAssertion that behaves similarly to CurlEventuallyResponds
+// The difference is that it accepts a generic function to execute the curl, instead of requiring the caller to pass explicit curl.Option
+// We recommend that developers rely on the typed CurlEventuallyResponds but we want to provide the flexibility of other solutions as well
+func (p *Provider) CurlFnEventuallyResponds(curlFn func() string, expectedResponse *matchers.HttpResponse, timeout ...time.Duration) ClusterAssertion {
+	return func(ctx context.Context) {
+		ginkgo.GinkgoHelper()
+		currentTimeout, pollingInterval := helper.GetTimeouts(timeout...)
+
+		// for some useful-ish output
+		tick := time.Tick(currentTimeout / 8)
+
+		Eventually(func(g Gomega) {
+			res := curlFn()
 			select {
 			default:
 				break

--- a/test/kubernetes/testutils/assertions/curl.go
+++ b/test/kubernetes/testutils/assertions/curl.go
@@ -4,34 +4,49 @@ import (
 	"context"
 	"time"
 
+	"github.com/solo-io/gloo/pkg/utils/requestutils/curl"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/test/gomega/matchers"
 	"github.com/solo-io/gloo/test/gomega/transforms"
 	"github.com/solo-io/gloo/test/kube2e/helper"
-	"github.com/solo-io/go-utils/log"
 )
 
-func CurlEventuallyRespondsAssertion(curlFunc func() string, expectedResponse *matchers.HttpResponse, timeout ...time.Duration) ClusterAssertion {
+var (
+	// curlPodObjectMeta contains the ObjectMeta for the Pod that will be used to execute curl requests
+	// The `curl` pod (referenced here)
+	curlPodObjectMeta = metav1.ObjectMeta{
+		Name:      "curl",
+		Namespace: "curl",
+	}
+)
+
+func (p *Provider) CurlEventuallyResponds(curlOptions []curl.Option, expectedResponse *matchers.HttpResponse, timeout ...time.Duration) ClusterAssertion {
 	return func(ctx context.Context) {
 		ginkgo.GinkgoHelper()
 		currentTimeout, pollingInterval := helper.GetTimeouts(timeout...)
+
 		// for some useful-ish output
 		tick := time.Tick(currentTimeout / 8)
 
 		Eventually(func(g Gomega) {
-			res := curlFunc()
+			res := p.clusterContext.Cli.CurlFromEphemeralPod(ctx, curlPodObjectMeta, curlOptions...)
 			select {
 			default:
 				break
 			case <-tick:
-				log.GreyPrintf("want %v\nhave: %s", expectedResponse, res)
+				ginkgo.GinkgoWriter.Printf("want %v\nhave: %s", expectedResponse, res)
 			}
 
 			expectedResponseMatcher := WithTransform(transforms.WithCurlHttpResponse, matchers.HaveHttpResponse(expectedResponse))
 			g.Expect(res).To(expectedResponseMatcher)
-			log.GreyPrintf("success: %v", res)
-
-		}, currentTimeout, pollingInterval).Should(Succeed())
+			ginkgo.GinkgoWriter.Printf("success: %v", res)
+		}).
+			WithTimeout(currentTimeout).
+			WithPolling(pollingInterval).
+			WithContext(ctx).
+			Should(Succeed())
 	}
 }


### PR DESCRIPTION
# Description

Expand the utilities for the new kubernetes e2e tests



# Context

## Ginkgo Flags
- I set the value of `--repeat` to 1 so that on PRs we run tests twice. The hope here is we are more aggressive about flakes, and thus can act on them more quickly
- I set the value of `--flake-attempts` to 0 to ensure that we do not retry flakes. My hope is that in other suites that are flakier we could increase that number, and so I'd rather be explicit in this suite.

## Cmd Data Race
I don't actually know if this will be resolved, which is why I set it to `resolvesIssue=false`. My hope is that by increasing the number of runs on a PR, we will see more frequently how problematic this is.

## Assertion Utilities 
Instead of requiring callers to construct their own Kube CLI, we can rely on the one in the assertions provider

## Kube DNS
We have a number of places in code that construct the FQDN for a service. I opted to define the mechanism in a shared utility, and call it from the places that use it.

## Interesting decisions
 -

## Testing steps
- Rely on existing CI

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works