### PR TITLE
gateway v2: set hostnames in RouteContext for plugins

### DIFF
--- a/changelog/v1.17.0-beta24/delegate-host.yaml
+++ b/changelog/v1.17.0-beta24/delegate-host.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/6121
+    resolvesIssue: false
+    description: |
+      Route delegation: explicitly pass route's hostnames to plugins so that delegatee (child) routes without hostnames can be associated with their corresponding hostnames.

--- a/projects/gateway2/translator/httproute/delegation.go
+++ b/projects/gateway2/translator/httproute/delegation.go
@@ -45,6 +45,10 @@ func flattenDelegatedRoutes(
 		return err
 	}
 
+	// Child routes inherit the hostnames from the parent route
+	hostnames := make([]gwv1.Hostname, len(parent.Spec.Hostnames))
+	copy(hostnames, parent.Spec.Hostnames)
+
 	// For these child routes, recursively flatten them
 	for _, child := range children {
 		childRef := types.NamespacedName{Namespace: child.Namespace, Name: child.Name}
@@ -80,7 +84,8 @@ func flattenDelegatedRoutes(
 			continue
 		}
 
-		translateGatewayHTTPRouteRulesUtil(ctx, pluginRegistry, queries, gwListener, child, reporter, baseReporter, outputs, routesVisited)
+		translateGatewayHTTPRouteRulesUtil(
+			ctx, pluginRegistry, queries, gwListener, child, reporter, baseReporter, outputs, routesVisited, hostnames)
 	}
 
 	routesVisited.Delete(parentRef)

--- a/projects/gateway2/translator/plugins/plugins.go
+++ b/projects/gateway2/translator/plugins/plugins.go
@@ -18,6 +18,10 @@ type RouteContext struct {
 	Listener *gwv1.Listener
 	// top-level HTTPRoute
 	Route *gwv1.HTTPRoute
+	// Hostnames associated with the Route.
+	// Note: this should be used over Route.spec.Hostnames as
+	// delegatee (child) routes of delegated routes will not have spec.Hostnames set.
+	Hostnames []gwv1.Hostname
 	// specific HTTPRouteRule of the HTTPRoute being processed, nil if the entire HTTPRoute is being processed
 	// rather than just a specific Rule
 	Rule *gwv1.HTTPRouteRule


### PR DESCRIPTION
# Description
Sets Hostnames are explicitly in the RouteContext for plugins that handle delegatee (child) routes to associate them with their hostnames, as the hostnames are not set on these routes.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
