### PR TITLE
gateway2/delegation: update cyclic reference status message and tweak…

### DIFF
--- a/changelog/v1.17.0-beta25/delegation-misc.yaml
+++ b/changelog/v1.17.0-beta25/delegation-misc.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6121
+    resolvesIssue: false
+    description: >-
+      "Route delegation: update status message for cyclic references and tweak test manifests so that they do not cleanup resources referenced in the common manifest."

--- a/projects/gateway2/translator/httproute/delegation.go
+++ b/projects/gateway2/translator/httproute/delegation.go
@@ -54,7 +54,7 @@ func flattenDelegatedRoutes(
 		childRef := types.NamespacedName{Namespace: child.Namespace, Name: child.Name}
 		if routesVisited.Has(childRef) {
 			// Loop detected, ignore child route
-			msg := fmt.Sprintf("cyclic loop detected while evaluating delegated routes for parent: %s; child route %s will be ignored",
+			msg := fmt.Sprintf("cyclic reference detected while evaluating delegated routes for parent: %s; child route %s will be ignored",
 				parentRef, childRef)
 			contextutils.LoggerFrom(ctx).Warn(msg)
 			parentReporter.SetCondition(reports.HTTPRouteCondition{

--- a/test/kubernetes/e2e/features/route_delegation/inputs/basic.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/basic.yaml
@@ -12,11 +12,6 @@
 #   - Route /anything/team2/foo to team2/svc2
 #   - Parent infra/root
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: infra
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/route_delegation/inputs/cyclic.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/cyclic.yaml
@@ -16,11 +16,6 @@
 #     - Delegate /anything/team2/foo to routes in team2 namespace
 #     - Cyclic delegation as it selects itself!
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: infra
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/route_delegation/inputs/header_query_match.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/header_query_match.yaml
@@ -13,11 +13,6 @@
 #   - Parent infra/root
 #   - Routes does not match headers and queries required by parent!
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: infra
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/route_delegation/inputs/invalid_child.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/invalid_child.yaml
@@ -13,11 +13,6 @@
 #   - Parent infra/root
 #   - Invalid as route specifies hostname!
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: infra
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/route_delegation/inputs/recursive.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/recursive.yaml
@@ -15,11 +15,6 @@
 #   Child team2/svc2:
 #     - Route /anything/team2/.* to team2/svc2
 ---
-apiVersion: v1
-kind: Namespace
-metadata:
-  name: infra
----
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -118,7 +118,7 @@ func (s *tsuite) TestCyclic() {
 		types.NamespacedName{Name: routeTeam2.Name, Namespace: routeTeam2.Namespace},
 		cyclicRoute)
 	s.Require().NoError(err)
-	s.Require().Truef(utils.HTTPRouteStatusContainsMsg(cyclicRoute, "cyclic loop detected"), "missing status on cyclic route")
+	s.Require().Truef(utils.HTTPRouteStatusContainsMsg(cyclicRoute, "cyclic reference detected"), "missing status on cyclic route")
 }
 
 func (s *tsuite) TestInvalidChild() {


### PR DESCRIPTION
# Description

Updates the message reported on the route's status for cyclic references and tweaks the test manifests to not delete the infra namespace which is referenced in common.yaml.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
