### PR TITLE
gateway2/delegation: add test for multiple parents scenario

### DIFF
--- a/changelog/v1.17.0-beta25/deleg-mulitple-parents.yaml
+++ b/changelog/v1.17.0-beta25/deleg-mulitple-parents.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6121
+    resolvesIssue: false
+    description: >-
+      "Route delegation: add test for the scenario where multiple parent routes select the same child route."

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -333,5 +333,32 @@ var _ = Describe("GatewayTranslator", func() {
 				Name:      "example-gateway",
 			}]).To(BeTrue())
 		})
+
+		It("should translate delegatee routes with multiple parents", func() {
+			results, err := TestCase{
+				Name:       "delegation-basic",
+				InputFiles: []string{dir + "/testutils/inputs/delegation/multiple_parents.yaml"},
+				ResultsByGateway: map[types.NamespacedName]ExpectedTestResult{
+					{
+						Namespace: "infra",
+						Name:      "example-gateway",
+					}: {
+						Proxy: dir + "/testutils/outputs/delegation/multiple_parents.yaml",
+						// Reports:     nil,
+					},
+				},
+			}.Run(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results).To(HaveKey(types.NamespacedName{
+				Namespace: "infra",
+				Name:      "example-gateway",
+			}))
+			Expect(results[types.NamespacedName{
+				Namespace: "infra",
+				Name:      "example-gateway",
+			}]).To(BeTrue())
+		})
 	})
 })

--- a/projects/gateway2/translator/testutils/inputs/delegation/multiple_parents.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/multiple_parents.yaml
@@ -1,0 +1,141 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /b
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: b
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: foo-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "foo.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /b
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: b
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-b
+  namespace: b
+spec:
+  parentRefs:
+  - name: example-route
+    namespace: infra
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: /b/.*
+    backendRefs:
+    - name: svc-b
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-b
+  namespace: b
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/outputs/delegation/multiple_parents.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/multiple_parents.yaml
@@ -1,0 +1,69 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+      - http~foo_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - exact: /a/1
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - prefix: /
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: example-svc
+                    namespace: infra
+          - matchers:
+            - regex: /b/.*
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-b
+                    namespace: b
+        http~foo_com:
+          domains:
+          - foo.com
+          name: http~foo_com
+          routes:
+          - matchers:
+            - exact: /a/1
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system

--- a/test/kubernetes/e2e/features/route_delegation/inputs/multiple_parents.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/multiple_parents.yaml
@@ -1,0 +1,123 @@
+# Configuration:
+#
+# Parent infra/parent1 (parent1.com):
+#   - Delegate /anything/team1 to team1 namespace
+#   - Delegate /anything/team2 to team2 namespace
+#
+# Parent infra/parent2 (parent2.com):
+#   - Delegate /anything/team1 to team1 namespace
+#   - Delegate /anything/team2 to team2 namespace
+#
+# Child team1/svc1:
+#   - Route /anything/team1/foo to team1/svc1
+#   - No parentRefs
+#
+# Child team2/svc2:
+#   - Route /anything/team2/foo to team2/svc2
+#   - Parent infra/parent1: request to parent2.com/anything/team2/foo should fail!
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: parent1
+  namespace: infra
+spec:
+  parentRefs:
+  - name: http-gateway
+  hostnames:
+  - "parent1.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: team1
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team2
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: team2
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: parent2
+  namespace: infra
+spec:
+  parentRefs:
+  - name: http-gateway
+  hostnames:
+  - "parent2.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: team1
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team2
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: team2
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team1
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc1
+  namespace: team1
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1/foo
+    backendRefs:
+    - name: svc1
+      port: 8000
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: team2
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc2
+  namespace: team2
+spec:
+  parentRefs:
+  - name: parent1
+    namespace: infra
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /anything/team2/foo
+    backendRefs:
+    - name: svc2
+      port: 8000
+---

--- a/test/kubernetes/e2e/features/route_delegation/types.go
+++ b/test/kubernetes/e2e/features/route_delegation/types.go
@@ -67,6 +67,20 @@ var (
 			Namespace: "team2",
 		},
 	}
+	routeParent1 = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent1",
+			Namespace: "infra",
+		},
+	}
+	routeParent1Host = "parent1.com"
+	routeParent2Host = "parent2.com"
+	routeParent2     = &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "parent2",
+			Namespace: "infra",
+		},
+	}
 	pathTeam1 = "anything/team1/foo"
 	pathTeam2 = "anything/team2/foo"
 )
@@ -77,4 +91,5 @@ var (
 	cyclicRoutesManifest           = filepath.Join(util.MustGetThisDir(), "inputs/cyclic.yaml")
 	invalidChildRoutesManifest     = filepath.Join(util.MustGetThisDir(), "inputs/invalid_child.yaml")
 	headerQueryMatchRoutesManifest = filepath.Join(util.MustGetThisDir(), "inputs/header_query_match.yaml")
+	multipleParentsManifest        = filepath.Join(util.MustGetThisDir(), "inputs/multiple_parents.yaml")
 )


### PR DESCRIPTION
# Description
Adds translator and e2e tests for the scenario where a child route is selected by multiple parents with different hostnames.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works