### PR TITLE
Secret Delete Flake Fix

### DIFF
--- a/changelog/v1.17.0-beta26/secret-delete-flake-fix-attempt.yaml
+++ b/changelog/v1.17.0-beta26/secret-delete-flake-fix-attempt.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/8826
+    resolvesIssue: false
+    description: >-
+      Attempting to fix a flake in the secret deletion gateway test by moving validation of webhook validation to immediately before the delete.

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -2130,12 +2130,12 @@ spec:
 				// It isn't until later - either a few minutes and/or after forcing an update by updating the VS - that the error status appears.
 				// The reason is still unknown, so we retry on flakes in the meantime.
 				It("should act as expected with secret validation", func() {
-					verifyGlooValidationWorks()
-
 					By("waiting for the modified VS to be accepted")
 					helpers.EventuallyResourceAccepted(func() (resources.InputResource, error) {
 						return resourceClientset.VirtualServiceClient().Read(testHelper.InstallNamespace, testServerVs.GetMetadata().GetName(), clients.ReadOpts{Ctx: ctx})
 					})
+
+					verifyGlooValidationWorks()
 
 					By("failing to delete a secret that is in use")
 					err := resourceClientset.KubeClients().CoreV1().Secrets(testHelper.InstallNamespace).Delete(ctx, secretName, metav1.DeleteOptions{})


### PR DESCRIPTION
# Description
Moving the `verifyGlooValidationWorks` call immediately before the secret is attempted to be deleted.

There are two validation steps at the beginning of the test, `EventuallyResourceAccepted` and `verifyGlooValidationWorks`

I don't have a good explanation of why this works, but here is the empirical evidence:
Before the update I was able to reproduce the error locally by focusing the context and running the tests with `-until-it-fails`

The tests failed on attempts 21, 111, 18 and 68, which amount to 4 failures in 218 tests, with a mean time to failure of ~55 runs.

After updating and re-running the tests, I was unable to replicate with runs of 84, 173, and 150 tests (all manually stopped), for a total of X runs without failure. If the MTF is 55 runs, it is extremely unlikely to have over 400 runs succeed without a flake.

