### PR TITLE
gateway2/route-delegation: report child ref status and add more tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ data
 
 # The istio binary downloaded for the kube2e tests
 istio-*/*
+
+# Bin directory created by e2e test
+.bin/

--- a/Makefile
+++ b/Makefile
@@ -271,8 +271,8 @@ run-kube-e2e-tests: test
 GO_TEST_ENV ?= GOLANG_PROTOBUF_REGISTRATION_CONFLICT=ignore
 # Testings flags: https://pkg.go.dev/cmd/go#hdr-Testing_flags
 # The default timeout for a suite is 10 minutes, but this can be overridden by setting the -timeout flag. Currently set
-# to 20 minutes based on the time it takes to run the longest test setup (k8s_gw_test).
-GO_TEST_ARGS ?= -timeout=20m -cpu=4 -race
+# to 25 minutes based on the time it takes to run the longest test setup (k8s_gw_test).
+GO_TEST_ARGS ?= -timeout=25m -cpu=4 -race
 
 # This is a way for a user executing `make go-test` to be able to provide args which we do not include by default
 # For example, you may want to run tests multiple times, or with various timeouts

--- a/changelog/v1.17.0-beta26/deleg-test-1.yaml
+++ b/changelog/v1.17.0-beta26/deleg-test-1.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6121
+    resolvesIssue: false
+    description: |
+      - Report unresolved reference in status when parent route can't resolve to a child route.
+      - Add tests for unresolved reference status reporting and scenario where a child route is invalid in the context of a parent route delegating to it but is valid when it attaches to a Gateway.

--- a/projects/gateway2/translator/backendref/types.go
+++ b/projects/gateway2/translator/backendref/types.go
@@ -1,6 +1,8 @@
 package backendref
 
 import (
+	"fmt"
+
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
@@ -23,4 +25,19 @@ func RefIsUpstream(ref gwv1.BackendObjectReference) bool {
 // Parent routes may delegate to child routes using an HTTPRoute backend reference.
 func RefIsHTTPRoute(ref gwv1.BackendObjectReference) bool {
 	return (ref.Kind != nil && *ref.Kind == wellknown.HTTPRouteKind) && (ref.Group != nil && *ref.Group == gwv1.GroupName)
+}
+
+// ToString returns a string representation of the BackendObjectReference
+func ToString(ref gwv1.BackendObjectReference) string {
+	var group, kind, namespace string
+	if ref.Group != nil {
+		group = string(*ref.Group)
+	}
+	if ref.Kind != nil {
+		kind = string(*ref.Kind)
+	}
+	if ref.Namespace != nil {
+		namespace = string(*ref.Namespace)
+	}
+	return fmt.Sprintf("%s.%s %s/%s", kind, group, namespace, ref.Name)
 }

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -360,5 +360,32 @@ var _ = Describe("GatewayTranslator", func() {
 				Name:      "example-gateway",
 			}]).To(BeTrue())
 		})
+
+		It("should translate a route that is valid standalone but invalid as a delegatee", func() {
+			results, err := TestCase{
+				Name:       "delegation-invalid-child-valid-standalone",
+				InputFiles: []string{dir + "/testutils/inputs/delegation/invalid_child_valid_standalone.yaml"},
+				ResultsByGateway: map[types.NamespacedName]ExpectedTestResult{
+					{
+						Namespace: "infra",
+						Name:      "example-gateway",
+					}: {
+						Proxy: dir + "/testutils/outputs/delegation/invalid_child_valid_standalone.yaml",
+						// Reports:     nil,
+					},
+				},
+			}.Run(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(results).To(HaveLen(1))
+			Expect(results).To(HaveKey(types.NamespacedName{
+				Namespace: "infra",
+				Name:      "example-gateway",
+			}))
+			Expect(results[types.NamespacedName{
+				Namespace: "infra",
+				Name:      "example-gateway",
+			}]).To(BeTrue())
+		})
 	})
 })

--- a/projects/gateway2/translator/testutils/inputs/delegation/invalid_child_valid_standalone.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/invalid_child_valid_standalone.yaml
@@ -1,0 +1,86 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+spec:
+  hostnames:
+  - "foo.com" # hostname must not be set on delegatee but it can be set for a standalone attachment to a Gateway
+  parentRefs:
+  - name: example-gateway
+    namespace: infra
+    group: gateway.networking.k8s.io
+    kind: Gateway
+  - name: example-route
+    namespace: infra
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/invalid_child_valid_standalone.yaml
@@ -1,0 +1,49 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+      - http~foo_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - prefix: /
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: example-svc
+                    namespace: infra
+        http~foo_com:
+          domains:
+          - foo.com
+          name: http~foo_com
+          routes:
+          - matchers:
+            - prefix: /a/1
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system

--- a/test/kubernetes/e2e/debugging.md
+++ b/test/kubernetes/e2e/debugging.md
@@ -33,7 +33,7 @@ Alternatively, you can use a custom debugger launch config that sets the `test.r
   "program": "${workspaceFolder}/test/kubernetes/e2e/k8sgateway/k8s_gw_test.go",
   "args": [
     "-test.run",
-    "TestK8sGateway/Deployer",
+    "TestK8sGateway$/Deployer",
     "-test.v",
   ],
   "env": {
@@ -76,7 +76,7 @@ Alternatively, with VSCode you can use a custom debugger launch config that sets
 
 #### Goland
 
-In Goland, you can run a single test feature by right-clicking on the test function and selecting `Run 'TestXyz'` or 
+In Goland, you can run a single test feature by right-clicking on the test function and selecting `Run 'TestXyz'` or
 `Debug 'TestXyz'`.
 
 You will need to set the env variable `SKIP_INSTALL` to `true` in the run configuration to skip the installation of Gloo. This

--- a/test/kubernetes/e2e/features/route_delegation/inputs/invalid_child_valid_standalone.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/invalid_child_valid_standalone.yaml
@@ -1,0 +1,105 @@
+# Configuration:
+#
+# Gateway http-gateway-test:
+#  - HTTP listener on port 8090
+#
+# Parent infra/root:
+#   - Delegate /anything/team1 to team1 namespace
+#   - Delegate /anything/team2 to team2 namespace
+#
+# Child team1/svc1:
+#   - Route /anything/team1/foo to team1/svc1
+#   - No parentRefs
+#
+# Child team2/svc2:
+#   - Route /anything/team2/foo to team2/svc2
+#   - Parent infra/root route and infra/http-gateway-test gateway
+#   - Invalid delegatee as route specifies hostname!
+#   - Valid standalone route as it also attaches to a Gateway
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: http-gateway-test
+  namespace: infra
+spec:
+  gatewayClassName: gloo-gateway
+  listeners:
+  - protocol: HTTP
+    port: 8090
+    name: http
+    allowedRoutes:
+      namespaces:
+        from: All
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: root
+  namespace: infra
+spec:
+  parentRefs:
+  - name: http-gateway-test
+  hostnames:
+  - "parent.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: team1
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team2
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: team2
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc1
+  namespace: team1
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1/foo
+    backendRefs:
+    - name: svc1
+      port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc2
+  namespace: team2
+spec:
+  hostnames:
+  - team2.com
+  parentRefs:
+  - name: http-gateway-test
+    namespace: infra
+    group: gateway.networking.k8s.io
+    kind: Gateway
+  - name: root
+    namespace: infra
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /anything/team2/foo
+    backendRefs:
+    - name: svc2
+      port: 8000
+---

--- a/test/kubernetes/e2e/features/route_delegation/inputs/unresolved_child.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/inputs/unresolved_child.yaml
@@ -1,0 +1,25 @@
+# Configuration:
+#
+# Parent infra/root:
+#   - Delegate /anything/team1 to team1 namespace
+#     Unresolved reference
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: root
+  namespace: infra
+spec:
+  parentRefs:
+  - name: http-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: team1
+---

--- a/test/kubernetes/e2e/features/route_delegation/types.go
+++ b/test/kubernetes/e2e/features/route_delegation/types.go
@@ -85,11 +85,30 @@ var (
 	pathTeam2 = "anything/team2/foo"
 )
 
+// ref: test/kubernetes/e2e/features/route_delegation/inputs/invalid_child_valid_standalone.yaml
 var (
-	basicRoutesManifest            = filepath.Join(util.MustGetThisDir(), "inputs/basic.yaml")
-	recursiveRoutesManifest        = filepath.Join(util.MustGetThisDir(), "inputs/recursive.yaml")
-	cyclicRoutesManifest           = filepath.Join(util.MustGetThisDir(), "inputs/cyclic.yaml")
-	invalidChildRoutesManifest     = filepath.Join(util.MustGetThisDir(), "inputs/invalid_child.yaml")
-	headerQueryMatchRoutesManifest = filepath.Join(util.MustGetThisDir(), "inputs/header_query_match.yaml")
-	multipleParentsManifest        = filepath.Join(util.MustGetThisDir(), "inputs/multiple_parents.yaml")
+	gatewayTestPort = 8090
+
+	proxyTestMeta = metav1.ObjectMeta{
+		Name:      "gloo-proxy-http-gateway-test",
+		Namespace: "infra",
+	}
+	proxyTestDeployment = &appsv1.Deployment{ObjectMeta: proxyTestMeta}
+	proxyTestService    = &corev1.Service{ObjectMeta: proxyTestMeta}
+
+	proxyTestHostPort = fmt.Sprintf("%s.%s.svc:%d", proxyTestService.Name, proxyTestService.Namespace, gatewayTestPort)
+
+	routeParentHost = "parent.com"
+	routeTeam2Host  = "team2.com"
+)
+
+var (
+	basicRoutesManifest                 = filepath.Join(util.MustGetThisDir(), "inputs/basic.yaml")
+	recursiveRoutesManifest             = filepath.Join(util.MustGetThisDir(), "inputs/recursive.yaml")
+	cyclicRoutesManifest                = filepath.Join(util.MustGetThisDir(), "inputs/cyclic.yaml")
+	invalidChildRoutesManifest          = filepath.Join(util.MustGetThisDir(), "inputs/invalid_child.yaml")
+	headerQueryMatchRoutesManifest      = filepath.Join(util.MustGetThisDir(), "inputs/header_query_match.yaml")
+	multipleParentsManifest             = filepath.Join(util.MustGetThisDir(), "inputs/multiple_parents.yaml")
+	invalidChildValidStandaloneManifest = filepath.Join(util.MustGetThisDir(), "inputs/invalid_child_valid_standalone.yaml")
+	unresolvedChildManifest             = filepath.Join(util.MustGetThisDir(), "inputs/unresolved_child.yaml")
 )


### PR DESCRIPTION
# Description
- Reports an unresolved ref status when a parent route does not resolve to any child routes.

- Adds a test to confirm that a child route can work as a standalone route even if it is invalid in the context of route delegation from a parent.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

