### PR TITLE
V1.14.x CVE 2023 45288

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -31,3 +31,13 @@ CVE-2022-41721
 # affect us as kubernetes does not use the affected code path (see description in
 # https://github.com/kubernetes/kubernetes/pull/118036).
 CVE-2023-2253
+
+# These CVEs only impacts install of Gloo-Edge from Glooctl CLI.
+# It only leads to a panic if there is a misconfigured / malicious helm plugin installed
+# and can be easily resolved by removing the misconfigured / malicious plugin
+# The helm bump will require bumping the k8s dependencies by +2 minor versions that can cause issues.
+# https://github.com/advisories/GHSA-r53h-jv2g-vpx6
+# https://github.com/solo-io/gloo/issues/9186
+# https://github.com/solo-io/gloo/issues/9187
+# https://github.com/solo-io/gloo/issues/9189
+CVE-2024-26147

--- a/changelog/v1.14.30/cve-kubctl-update.yaml
+++ b/changelog/v1.14.30/cve-kubctl-update.yaml
@@ -5,3 +5,9 @@ changelog:
   dependencyTag: 1.27.13
   issueLink: https://github.com/solo-io/gloo/issues/9442
   description: Upgrade image used to build kubectl to pick up CVE fixes.
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: cloud-builders
+  dependencyTag: 0.7.1
+  issueLink: https://github.com/solo-io/gloo/issues/9442
+  description: Update clouderbuilder image to use updated version of Go to pick up CVE fixes.

--- a/changelog/v1.14.30/cve-kubctl-update.yaml
+++ b/changelog/v1.14.30/cve-kubctl-update.yaml
@@ -8,6 +8,6 @@ changelog:
 - type: DEPENDENCY_BUMP
   dependencyOwner: solo-io
   dependencyRepo: cloud-builders
-  dependencyTag: 0.7.1
+  dependencyTag: 0.7.6
   issueLink: https://github.com/solo-io/gloo/issues/9442
   description: Update clouderbuilder image to use updated version of Go to pick up CVE fixes.

--- a/changelog/v1.14.30/cve-kubctl-update.yaml
+++ b/changelog/v1.14.30/cve-kubctl-update.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: bitnami
+  dependencyRepo: kubectl
+  dependencyTag: 1.27.13
+  issueLink: https://github.com/solo-io/gloo/issues/9442
+  description: Upgrade image used to build kubectl to pick up CVE fixes.

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.7.1'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.7.6'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -44,7 +44,7 @@ steps:
   - 'us-central1-a'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
   id: 'docker-push-extended'
   args:
   - 'docker-push-extended'
@@ -65,7 +65,7 @@ steps:
   waitFor:
   - 'docker-push-extended'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
   id: 'release-chart'
   dir: *dir
   args:
@@ -82,7 +82,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.25.15 as kubectl
+FROM bitnami/kubectl:1.27.13 as kubectl
 
 FROM alpine:3.17.6
 


### PR DESCRIPTION
# Description

Updated bitnami/kubectl in the [kubectl Dockerfile](https://github.com/solo-io/gloo/blob/67d2bbfb8e5bb1018799bf8f2240972fae5a98b1/jobs/kubectl/Dockerfile) from 1.25.15 to 1.27.13 to address [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m). This jump in minor versions was necessary to use images that no longer has CVEs. Kubectl is backwards-compatible 2 versions, so this should be compatible.

Updated CloudBuilder version form `0.7.1` to `0.7.6`. This version is already in use in the EE 1.13 branch, added [here](https://github.com/solo-io/solo-projects/pull/6043)

"Urgent" changelogs:
* https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#urgent-upgrade-notes
* https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#urgent-upgrade-notes-1
  * `autoscaling/v2beta2` [is no longer served](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#horizontalpodautoscaler-v126) and is [referenced in our code](https://github.com/search?q=org%3Asolo-io+autoscaling%2Fv2beta2+repo%3Asolo-io%2Fgloo&type=code), although it is present in `main`, which is using `1.28`
  *
CVE-2024-26147 has been added to the `.trivyignore` file.  It is being ignored in later versions but had not yet surfaced in this one.


# Context

Addressing a CVE

## Testing steps
These local scans do not seem to respect the trivyignore file, which was [updated to include CVE-2024-26147](https://github.com/solo-io/gloo/pull/9216/files) and should be ignored. That CVE is present in the current image and the local build, but does not appear in the images built through CI.

### Existing versions:
```
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.14.29"; done
```
<details>
<summary>
Results:
</summary>

```
2024-05-08T12:01:24-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:24-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:24-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:24-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:25-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-05-08T12:01:25-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-05-08T12:01:25-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:25-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.14.29 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:01:25-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/gloo (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.5            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘
2024-05-08T12:01:26-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:26-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:26-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:26-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:27-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-05-08T12:01:27-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-05-08T12:01:27-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:27-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.14.29 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/envoyinit (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.5            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘
2024-05-08T12:01:27-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:27-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:27-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:27-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:28-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:01:28-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:01:28-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:28-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.14.29 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:01:28-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/discovery (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.5            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘
2024-05-08T12:01:28-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:28-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:28-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:28-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:31-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:01:31-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:01:31-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:31-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.14.29 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:01:31-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/ingress (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.5            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘
2024-05-08T12:01:31-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:31-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:31-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:31-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:32-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:01:32-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:01:32-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:32-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.14.29 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:01:32-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/sds (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.5            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘
2024-05-08T12:01:33-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:33-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:33-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:33-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:34-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:01:34-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:01:34-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:34-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.14.29 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/certgen (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.5            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘
2024-05-08T12:01:34-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:34-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:34-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:34-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:35-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:01:35-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:01:35-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:35-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.14.29 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/access-logger (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.21.5            │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘
2024-05-08T12:01:35-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:01:35-04:00	INFO	Secret scanning is enabled
2024-05-08T12:01:35-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:01:35-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:01:36-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:01:36-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:01:36-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:01:36-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.14.29 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:01:36-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/kubectl (gobinary)

Total: 3 (HIGH: 3, CRITICAL: 0)

┌───────────────────┬────────────────┬──────────┬────────┬───────────────────┬──────────────────────────────────┬───────────────────────────────────────────────────────────┐
│      Library      │ Vulnerability  │ Severity │ Status │ Installed Version │          Fixed Version           │                           Title                           │
├───────────────────┼────────────────┼──────────┼────────┼───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ k8s.io/kubernetes │ CVE-2023-5528  │ HIGH     │ fixed  │ v1.25.15          │ 1.28.4, 1.27.8, 1.26.11, 1.25.16 │ kubernetes: Insufficient input sanitization in in-tree    │
│                   │                │          │        │                   │                                  │ storage plugin leads to privilege escalation...           │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-5528                 │
├───────────────────┼────────────────┤          │        ├───────────────────┼──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│ stdlib            │ CVE-2023-45283 │          │        │ 1.20.10           │ 1.20.11, 1.21.4, 1.20.12, 1.21.5 │ The filepath package does not recognize paths with a \??\ │
│                   │                │          │        │                   │                                  │ prefix as...                                              │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45283                │
│                   ├────────────────┤          │        │                   ├──────────────────────────────────┼───────────────────────────────────────────────────────────┤
│                   │ CVE-2023-45288 │          │        │                   │ 1.21.9, 1.22.2                   │ golang: net/http, x/net/http2: unlimited number of        │
│                   │                │          │        │                   │                                  │ CONTINUATION frames causes DoS                            │
│                   │                │          │        │                   │                                  │ https://avd.aquasec.com/nvd/cve-2023-45288                │
└───────────────────┴────────────────┴──────────┴────────┴───────────────────┴──────────────────────────────────┴───────────────────────────────────────────────────────────┘
```
</details>

### New versions (local)
```
VERSION=1.14.29-cve make docker -B
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.14.29-cve"; done
```
<details>
<summary>
Results of scan
</summary>

```
View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/xwa8hg1zqzpbnbk2169cht9uw
touch docker-local
2024-05-08T12:03:31-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:31-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:31-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:31-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:31-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-05-08T12:03:31-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-05-08T12:03:31-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:31-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.14.29-cve (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:31-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/gloo (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:32-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:32-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:32-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:32-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:32-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-05-08T12:03:32-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-05-08T12:03:32-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:32-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.14.29-cve (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:32-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:32-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:32-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:32-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:32-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:03:32-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:03:32-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:32-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.14.29-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:32-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/discovery (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:32-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:32-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:32-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:32-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:32-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:03:32-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:03:32-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:32-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.14.29-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:32-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/ingress (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:33-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:33-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:33-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:33-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:33-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:03:33-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:03:33-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:33-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.14.29-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:33-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/sds (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:33-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:33-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:33-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:33-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:33-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:03:33-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:03:33-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:33-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.14.29-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:33-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:33-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:33-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:33-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:33-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:03:33-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:03:33-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:33-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.14.29-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:34-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:03:34-04:00	INFO	Secret scanning is enabled
2024-05-08T12:03:34-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:03:34-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:03:34-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:03:34-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:03:34-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:03:34-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.14.29-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:03:34-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/kubectl (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)
```
</details>

### Scan images built for this PR0 

```
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.14.29-9451"; done
```

<details>
<summary>
Results of scan
</summary>

```
2024-05-08T12:04:40-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:40-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:40-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:40-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:41-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-05-08T12:04:41-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-05-08T12:04:41-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:41-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.14.29-9451 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:41-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/gloo (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:41-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:41-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:41-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:41-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:42-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-05-08T12:04:42-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-05-08T12:04:42-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:42-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.14.29-9451 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:42-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:42-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:42-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:42-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:43-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:04:43-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:04:43-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:43-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.14.29-9451 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:43-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/discovery (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:44-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:44-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:44-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:44-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:45-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:04:45-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:04:45-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:45-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.14.29-9451 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:45-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/ingress (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:45-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:45-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:45-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:45-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:46-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:04:46-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:04:46-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:46-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.14.29-9451 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:46-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/sds (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:46-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:46-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:46-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:46-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:47-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:04:47-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:04:47-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:47-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.14.29-9451 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:48-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:48-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:48-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:48-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:48-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:04:48-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-08T12:04:48-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:48-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.14.29-9451 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:49-04:00	INFO	Vulnerability scanning is enabled
2024-05-08T12:04:49-04:00	INFO	Secret scanning is enabled
2024-05-08T12:04:49-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-08T12:04:49-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-08T12:04:49-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-08T12:04:49-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-08T12:04:49-04:00	INFO	Number of language-specific files	num=1
2024-05-08T12:04:49-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.14.29-9451 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-08T12:04:49-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/kubectl (gobinary)

Total: 0 (HIGH: 0, CRITICAL: 0)
```
</details>



BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9442