### PR TITLE
CVE fix bump bitnami/kubectl image

### DIFF
--- a/changelog/v1.17.0-beta26/cve-kubctl-update.yaml
+++ b/changelog/v1.17.0-beta26/cve-kubctl-update.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: bitnami
+  dependencyRepo: kubectl
+  dependencyTag: 1.28.9
+  issueLink: https://github.com/solo-io/gloo/issues/9440
+  description: Upgrade image used to build kubectl to pick up CVE fixes.

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM bitnami/kubectl:1.28.4 as kubectl
+FROM bitnami/kubectl:1.28.9 as kubectl
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
# Description

Updated bitnami/kubectl in the [kubectl Dockerfile](https://github.com/solo-io/gloo/blob/e05a5a0c1196fc770307738e117a13818fb4a606/jobs/kubectl/Dockerfile) from 1.28.4 to 1.28.9 to address [CVE-2023-45288](https://github.com/advisories/GHSA-4v7x-pqxf-cx7m)

The [changelog for the image](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md) was reviewed and nothing of concern was found, though it may be notable that the go version used to build Kubernetes went up a minor version from 1.20.13 to 1.21.7 at version 1.28.6.

# Context

Addressing a CVE

## Testing steps

Existing versions:
```
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.17.0-beta25-9448"; done
```
<details>
<summary>
Results:
</summary>

```
2024-05-07T11:54:42-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:54:42-04:00	INFO	Secret scanning is enabled
2024-05-07T11:54:42-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:54:42-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:54:45-04:00	INFO	Detected OS	family="ubuntu" version="20.04"
2024-05-07T11:54:45-04:00	INFO	[ubuntu] Detecting vulnerabilities...	os_version="20.04" pkg_num=98
2024-05-07T11:54:45-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:54:45-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.17.0-beta25-9448 (ubuntu 20.04)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T11:54:45-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:54:45-04:00	INFO	Secret scanning is enabled
2024-05-07T11:54:45-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:54:45-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:54:47-04:00	INFO	Detected OS	family="ubuntu" version="20.04"
2024-05-07T11:54:47-04:00	INFO	[ubuntu] Detecting vulnerabilities...	os_version="20.04" pkg_num=98
2024-05-07T11:54:47-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:54:47-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.17.0-beta25-9448 (ubuntu 20.04)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T11:54:47-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:54:47-04:00	INFO	Secret scanning is enabled
2024-05-07T11:54:47-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:54:47-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:54:53-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T11:54:53-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-07T11:54:53-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:54:53-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.17.0-beta25-9448 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T11:54:54-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:54:54-04:00	INFO	Secret scanning is enabled
2024-05-07T11:54:54-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:54:54-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:54:56-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T11:54:56-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-07T11:54:56-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:54:56-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.17.0-beta25-9448 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T11:54:57-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:54:57-04:00	INFO	Secret scanning is enabled
2024-05-07T11:54:57-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:54:57-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:54:59-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T11:54:59-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-07T11:54:59-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:54:59-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.17.0-beta25-9448 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T11:54:59-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:54:59-04:00	INFO	Secret scanning is enabled
2024-05-07T11:54:59-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:54:59-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:55:01-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T11:55:01-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-07T11:55:01-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:55:01-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.17.0-beta25-9448 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T11:55:01-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:55:01-04:00	INFO	Secret scanning is enabled
2024-05-07T11:55:01-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:55:01-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:55:03-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T11:55:03-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-07T11:55:03-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:55:03-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.17.0-beta25-9448 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T11:55:04-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T11:55:04-04:00	INFO	Secret scanning is enabled
2024-05-07T11:55:04-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T11:55:04-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T11:55:05-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T11:55:05-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-07T11:55:05-04:00	INFO	Number of language-specific files	num=1
2024-05-07T11:55:05-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.17.0-beta25-9448 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/kubectl (gobinary)

Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                       Title                        │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2023-45288 │ HIGH     │ fixed  │ 1.20.11           │ 1.21.9, 1.22.2 │ golang: net/http, x/net/http2: unlimited number of │
│         │                │          │        │                   │                │ CONTINUATION frames causes DoS                     │
│         │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2023-45288         │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────────┘

```
</details>



New versions:
```
VERSION=1.17.0-cve make docker -B
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.17.0-cve"; done
```

<details>
<summary>
Results of scan:
</summary>

```
View build details: docker-desktop://dashboard/build/desktop-linux/desktop-linux/srgs5zkgn20nlfkdyyabm3xvd
2024-05-07T12:02:35-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:35-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:35-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:35-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:39-04:00	INFO	Detected OS	family="ubuntu" version="20.04"
2024-05-07T12:02:39-04:00	INFO	[ubuntu] Detecting vulnerabilities...	os_version="20.04" pkg_num=98
2024-05-07T12:02:39-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:39-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.17.0-cve (ubuntu 20.04)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T12:02:40-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:40-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:40-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:40-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:43-04:00	INFO	Detected OS	family="ubuntu" version="20.04"
2024-05-07T12:02:43-04:00	INFO	[ubuntu] Detecting vulnerabilities...	os_version="20.04" pkg_num=98
2024-05-07T12:02:43-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:43-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.17.0-cve (ubuntu 20.04)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T12:02:43-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:43-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:43-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:43-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:45-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T12:02:45-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-07T12:02:45-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:45-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.17.0-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T12:02:45-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:45-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:45-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:45-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:47-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T12:02:47-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-07T12:02:47-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:47-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.17.0-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T12:02:47-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:47-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:47-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:47-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:48-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T12:02:48-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-07T12:02:48-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:48-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.17.0-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T12:02:48-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:48-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:48-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:48-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:50-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T12:02:50-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-07T12:02:50-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:50-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.17.0-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T12:02:50-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:50-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:50-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:50-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:51-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T12:02:51-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-05-07T12:02:51-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:51-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.17.0-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-05-07T12:02:51-04:00	INFO	Vulnerability scanning is enabled
2024-05-07T12:02:51-04:00	INFO	Secret scanning is enabled
2024-05-07T12:02:51-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-05-07T12:02:51-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.51/docs/scanner/secret/#recommendation for faster secret detection
2024-05-07T12:02:51-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-05-07T12:02:51-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-05-07T12:02:51-04:00	INFO	Number of language-specific files	num=1
2024-05-07T12:02:51-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.17.0-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)
```
</details>

Scan images built for this PR:

```
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.15.25-9453"; done
```


<details>
<summary>
Results of scan (pending):
</summary>

```

```
</details>


