### PR TITLE
Lambda non-string header tests 1.16

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.27.4-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.27.5-patch2
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/changelog/v1.16.13/envoy-bump-and-test-multivalueheader-fix.yaml
+++ b/changelog/v1.16.13/envoy-bump-and-test-multivalueheader-fix.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: v1.29.3-patch2
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8867
+    resolvesIssue: false
+    description: >-
+      Fix a bug where Lambdas returning multiValueHeaders with non-string type with `unwrapAsApiGateway` enabled 
+      would result in a 500 response to the caller

--- a/changelog/v1.16.13/envoy-bump-and-test-multivalueheader-fix.yaml
+++ b/changelog/v1.16.13/envoy-bump-and-test-multivalueheader-fix.yaml
@@ -2,7 +2,7 @@ changelog:
   - type: DEPENDENCY_BUMP
     dependencyOwner: solo-io
     dependencyRepo: envoy-gloo
-    dependencyTag: v1.29.3-patch2
+    dependencyTag: v1.27.5-patch2
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/8867
     resolvesIssue: false

--- a/devel/testing/aws-tests.md
+++ b/devel/testing/aws-tests.md
@@ -9,11 +9,9 @@ See [e2e-tests](./e2e-tests.md) for more details about e2e tests in general
 You will need to do the following to run the [AWS Lambda Tests](/test/e2e/aws_test.go) locally:
 1. Obtain an AWS IAM User account that is part of the Solo.io organization
 2. Create an AWS access key
-    - Sign into the AWS console with the account created during step 1
-    - Hover over your username at the top right of the page. Click on "My Security Credentials"
-      - If you are unable to view or create security credentials, see [Temporary credentials](#temporary-credentials).
-    - In the section titled "AWS IAM credentials", click "Create access key" to create an access key
-    - Save the Access key ID and the associated secret key
+    - Under IAM > Users in the AWS console, select the User from step 1
+    - Under Summary click "Create access key" to create an access key
+    - Save the Access key ID and the associated secret key to be used later
 3. Install AWS CLI v2
     - You can check whether you have AWS CLI installed by running `aws --version`
     - Installation guides for various operating systems can be found [here](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
@@ -21,13 +19,7 @@ You will need to do the following to run the [AWS Lambda Tests](/test/e2e/aws_te
     - You can do this by running `aws configure`
     - You will be asked to provide your Access Key ID and Secret Key from step 2, as well as the default region name and default output format
         - It is critical that you set the default region to `us-east-1`
-    - This will create a credentials file at `~/.aws/credentials` on Linux or macOS, or at `C:\Users\USERNAME\.aws\credentials` on Windows. The tests read this file in order to interact with lambdas that have been created in the Solo.io organization
-
-## Temporary credentials
-Solo's AWS security has been tightened, so it _may_ not be possible to generate personal AIM credentials anymore - at least without the proper permissions.
-
-You can configure your local credentials using the temporary credentials found in our [AWS start page](https://soloio.awsapps.com/start#/) by:
-1. Selecting the `developers` AWS account
-2. Click on the "Command line or programmatic access" option
-3. Use the credentials shown, _including_ the Session Token
-   - _Note: From experience, these credentials update every 12 hours, so you'll need to update the credentials as necessary._
+    - This will create a credentials file at `~/.aws/credentials` on Linux or macOS, or at `C:\Users\USERNAME\.aws\credentials` on Windows. 
+    - Copy the credentials file to a location in the `gloo` directory, for example at `/test/e2e/aws_credentials/credentials` and set the `AWS_SHARED_CREDENTIALS_FILE` var to that location, relative to `/test/e2e`
+      - The tests read this file in order to interact with lambdas that have been created in the Solo.io organization
+    - Set the `AWS_PROFILE` env var to the name of the IAM User 

--- a/test/e2e/aws_test.go
+++ b/test/e2e/aws_test.go
@@ -96,6 +96,7 @@ var _ = Describe("AWS Lambda", func() {
 		requestBody                     string
 		expectedSubstrings              []string
 		requestHeaders, expectedHeaders http.Header
+		exactExpectedHeaderKeys         []string
 		requestUrl                      *url.URL
 		expectedStatus                  *int
 	}
@@ -144,7 +145,7 @@ var _ = Describe("AWS Lambda", func() {
 			g.Expect(res).Should(testmatchers.HaveHttpResponse(&testmatchers.HttpResponse{
 				StatusCode: expectedStatus,
 				Body:       testmatchers.ContainSubstrings(params.expectedSubstrings),
-				Custom:     testmatchers.ContainHeaders(params.expectedHeaders),
+				Custom:     And(testmatchers.ContainHeaders(params.expectedHeaders), testmatchers.ContainHeaderKeysExact(params.exactExpectedHeaderKeys)),
 			}))
 
 		}, "30s", "1s").Should(Succeed())
@@ -342,6 +343,59 @@ var _ = Describe("AWS Lambda", func() {
 			offset:             1,
 			envoyPort:          envoyInstance.HttpPort,
 			expectedSubstrings: []string{`"\"solo.io\""`},
+		})
+	}
+
+	// this tests the case where a lambda returns non-string values in multiValueHeaders, a case which previously caused
+	// Envoy to return a 500 response
+	// lambda: https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/non-string-headers-test
+	// expected response:
+	//        'body': json.dumps('test body'),
+	//        'multiValueHeaders': {
+	//            'foo': [
+	//                None,
+	//                "bar",
+	//                123
+	//            ]
+	//        }
+	testProxyWithUnwrapAsApiGatewayNonStringHeaderResponse := func() {
+		err := envoyInstance.RunWithRole(envoy.DefaultProxyName, testClients.GlooPort)
+		Expect(err).NotTo(HaveOccurred())
+
+		createProxy(true, false, false, "non-string-headers-test")
+		validateLambda(lambdaValidationParams{
+			offset:             1,
+			envoyPort:          envoyInstance.HttpPort,
+			expectedSubstrings: []string{`"test body"`},
+			expectedHeaders:    http.Header{"Foo": []string{"null,bar,123"}},
+		})
+	}
+
+	// this tests the case where a lambda returns malformed multiValueHeaders, a case which previously caused Envoy to
+	// return a 500 response
+	// we now expect a 200 response with no body and no headers
+	// the headers are malformed because multiValueHeaders is an object and not an array
+	// lambda: https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/malformed-headers-test
+	// expected response:
+	//        'body': json.dumps('test body'),
+	//        'multiValueHeaders': {
+	//            'foo': {
+	//                None,
+	//                "bar",
+	//                123
+	//            }
+	//        }
+	testProxyWithUnwrapAsApiGatewayMalformedHeaderResponse := func() {
+		err := envoyInstance.RunWithRole(envoy.DefaultProxyName, testClients.GlooPort)
+		Expect(err).NotTo(HaveOccurred())
+
+		createProxy(true, false, false, "malformed-headers-test")
+		validateLambda(lambdaValidationParams{
+			offset:                  1,
+			envoyPort:               envoyInstance.HttpPort,
+			expectedSubstrings:      []string{"{}"},
+			expectedHeaders:         map[string][]string{},
+			exactExpectedHeaderKeys: []string{"Date", "Server", "Content-Length"},
 		})
 	}
 
@@ -570,6 +624,10 @@ var _ = Describe("AWS Lambda", func() {
 			It("should be able to call lambda with response transform", testProxyWithResponseTransform)
 
 			It("should be able to call lambda with unwrapAsApiGateway", testProxyWithUnwrapAsApiGateway)
+
+			It("should be able to call lambda with unwrapAsApiGateway with non-string headers in response", testProxyWithUnwrapAsApiGatewayNonStringHeaderResponse)
+
+			It("should be able to call lambda with unwrapAsApiGateway with malformed headers in response", testProxyWithUnwrapAsApiGatewayMalformedHeaderResponse)
 
 			It("should be able to call lambda with request transform", testProxyWithRequestTransform)
 

--- a/test/gomega/matchers/contain_headers.go
+++ b/test/gomega/matchers/contain_headers.go
@@ -53,3 +53,19 @@ func ContainHeaderKeys(keys []string) types.GomegaMatcher {
 	matcher := gomega.WithTransform(transforms.WithHeaderKeys(), gomega.ContainElements(keys))
 	return gomega.And(matcher)
 }
+
+// ContainHeaderKeysExact produces a matcher that will only match if all provided header keys exist and no others.
+func ContainHeaderKeysExact(keys []string) types.GomegaMatcher {
+	if len(keys) == 0 {
+		// If no keys are defined, we create a matcher that always succeeds
+		return gstruct.Ignore()
+	}
+	for i, key := range keys {
+		keys[i] = textproto.CanonicalMIMEHeaderKey(key)
+	}
+	//nolint:bodyclose // The caller of this matcher constructor should be responsible for ensuring the body close
+	lenMatcher := gomega.WithTransform(transforms.WithHeaderKeys(), gomega.HaveLen(len(keys)))
+	//nolint:bodyclose // The caller of this matcher constructor should be responsible for ensuring the body close
+	keyMatcher := gomega.WithTransform(transforms.WithHeaderKeys(), gomega.ContainElements(keys))
+	return gomega.And(lenMatcher, keyMatcher)
+}


### PR DESCRIPTION
Backport #9455 using the appropriate Envoy version