### PR TITLE
test/kube/e2e: improved dependency injection

### DIFF
--- a/changelog/v1.17.0-beta26/test-framework-for-portal.yaml
+++ b/changelog/v1.17.0-beta26/test-framework-for-portal.yaml
@@ -1,6 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/solo-projects/issues/6029
-    resolvesIssue: false
-    description: >-
-      Refactor our TestInstallation to make it more re-usable with Portal E2E tests.

--- a/changelog/v1.17.0-beta26/test-framework-for-portal.yaml
+++ b/changelog/v1.17.0-beta26/test-framework-for-portal.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6029
+    resolvesIssue: false
+    description: >-
+      Refactor our TestInstallation to make it more re-usable with Portal E2E tests.

--- a/changelog/v1.17.0-beta27/test-framework-for-portal.yaml
+++ b/changelog/v1.17.0-beta27/test-framework-for-portal.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6029
+    resolvesIssue: false
+    description: >-
+      Refactor our TestInstallation to make it more re-usable with Portal E2E tests.

--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -69,7 +69,7 @@ func (s *testingSuite) TestConfigureProxiesFromGatewayParameters() {
 	s.testInstallation.Assertions.EventuallyRunningReplicas(s.ctx, proxyDeployment.ObjectMeta, Equal(1))
 
 	// We assert that we can port-forward requests to the proxy deployment, and then execute requests against the server
-	if s.testInstallation.TestCluster.RuntimeContext.RunSource == runtime.LocalDevelopment {
+	if s.testInstallation.RuntimeContext.RunSource == runtime.LocalDevelopment {
 		// There are failures when opening port-forwards to the Envoy Admin API in CI
 		// Those are currently being investigated
 		s.testInstallation.Assertions.AssertEnvoyAdminApi(

--- a/test/kubernetes/e2e/features/glooctl/check_suite.go
+++ b/test/kubernetes/e2e/features/glooctl/check_suite.go
@@ -67,6 +67,6 @@ func (s *checkSuite) TestCheckKubeContext() {
 
 	// When passing the kube-context of the running cluster, `glooctl check` should succeed
 	_, err = s.testInstallation.Actions.Glooctl().Check(s.ctx,
-		"-n", s.testInstallation.Metadata.InstallNamespace, "--kube-context", s.testInstallation.TestCluster.ClusterContext.KubeContext)
+		"-n", s.testInstallation.Metadata.InstallNamespace, "--kube-context", s.testInstallation.ClusterContext.KubeContext)
 	s.NoError(err)
 }

--- a/test/kubernetes/e2e/features/route_delegation/suite.go
+++ b/test/kubernetes/e2e/features/route_delegation/suite.go
@@ -65,7 +65,7 @@ func (s *tsuite) SetupSuite() {
 		invalidChildValidStandaloneManifest: {proxyTestService, proxyTestDeployment, routeRoot, routeTeam1, routeTeam2},
 		unresolvedChildManifest:             {routeRoot},
 	}
-	clients, err := gloogateway.NewResourceClients(s.ctx, s.ti.TestCluster.ClusterContext)
+	clients, err := gloogateway.NewResourceClients(s.ctx, s.ti.ClusterContext)
 	s.Require().NoError(err)
 	s.ti.ResourceClients = clients
 }
@@ -122,7 +122,7 @@ func (s *tsuite) TestCyclic() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
 
 	cyclicRoute := &gwv1.HTTPRoute{}
-	err := s.ti.TestCluster.ClusterContext.Client.Get(s.ctx,
+	err := s.ti.ClusterContext.Client.Get(s.ctx,
 		types.NamespacedName{Name: routeTeam2.Name, Namespace: routeTeam2.Namespace},
 		cyclicRoute)
 	s.Require().NoError(err)
@@ -139,7 +139,7 @@ func (s *tsuite) TestInvalidChild() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusNotFound})
 
 	invalidRoute := &gwv1.HTTPRoute{}
-	err := s.ti.TestCluster.ClusterContext.Client.Get(s.ctx,
+	err := s.ti.ClusterContext.Client.Get(s.ctx,
 		types.NamespacedName{Name: routeTeam2.Name, Namespace: routeTeam2.Namespace},
 		invalidRoute)
 	s.Require().NoError(err)
@@ -234,7 +234,7 @@ func (s *tsuite) TestInvalidChildValidStandalone() {
 		&testmatchers.HttpResponse{StatusCode: http.StatusOK, Body: ContainSubstring(pathTeam2)})
 
 	invalidRoute := &gwv1.HTTPRoute{}
-	err := s.ti.TestCluster.ClusterContext.Client.Get(s.ctx,
+	err := s.ti.ClusterContext.Client.Get(s.ctx,
 		types.NamespacedName{Name: routeTeam2.Name, Namespace: routeTeam2.Namespace},
 		invalidRoute)
 	s.Require().NoError(err)
@@ -244,7 +244,7 @@ func (s *tsuite) TestInvalidChildValidStandalone() {
 func (s *tsuite) TestUnresolvedChild() {
 	s.Require().EventuallyWithT(func(c *assert.CollectT) {
 		route := &gwv1.HTTPRoute{}
-		err := s.ti.TestCluster.ClusterContext.Client.Get(s.ctx,
+		err := s.ti.ClusterContext.Client.Get(s.ctx,
 			types.NamespacedName{Name: routeRoot.Name, Namespace: routeRoot.Namespace},
 			route)
 		assert.NoError(c, err, "route not found")

--- a/test/kubernetes/e2e/gloo_gateway_edge/gloo_gateway_api_test.go
+++ b/test/kubernetes/e2e/gloo_gateway_edge/gloo_gateway_api_test.go
@@ -21,8 +21,9 @@ import (
 func TestGlooGatewayEdgeGateway(t *testing.T) {
 	ctx := context.Background()
 	testCluster := e2e.MustTestCluster()
-	testInstallation := testCluster.RegisterTestInstallation(
+	testInstallation := e2e.CreateTestInstallation(
 		t,
+		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "gloo-gateway-edge-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "gloo-gateway-test-helm.yaml"),
@@ -41,7 +42,6 @@ func TestGlooGatewayEdgeGateway(t *testing.T) {
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {
 			return testHelper.UninstallGlooAll()
 		})
-		testCluster.UnregisterTestInstallation(testInstallation)
 	})
 
 	// Install Gloo Gateway with only Gloo Edge Gateway APIs enabled

--- a/test/kubernetes/e2e/gloo_gateway_edge/gloo_gateway_api_test.go
+++ b/test/kubernetes/e2e/gloo_gateway_edge/gloo_gateway_api_test.go
@@ -20,10 +20,8 @@ import (
 // the k8s Gateway controller is disabled
 func TestGlooGatewayEdgeGateway(t *testing.T) {
 	ctx := context.Background()
-	testCluster := e2e.MustTestCluster()
 	testInstallation := e2e.CreateTestInstallation(
 		t,
-		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "gloo-gateway-edge-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "gloo-gateway-test-helm.yaml"),

--- a/test/kubernetes/e2e/k8sgateway/automtls_istio_test.go
+++ b/test/kubernetes/e2e/k8sgateway/automtls_istio_test.go
@@ -20,10 +20,8 @@ import (
 // TestK8sGatewayIstioAutoMtls is the function which executes a series of tests against a given installation
 func TestK8sGatewayIstioAutoMtls(t *testing.T) {
 	ctx := context.Background()
-	testCluster := e2e.MustTestCluster()
 	testInstallation := e2e.CreateTestInstallation(
 		t,
-		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "automtls-istio-k8s-gw-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "istio-automtls-k8s-gateway-test-helm.yaml"),

--- a/test/kubernetes/e2e/k8sgateway/automtls_istio_test.go
+++ b/test/kubernetes/e2e/k8sgateway/automtls_istio_test.go
@@ -21,8 +21,9 @@ import (
 func TestK8sGatewayIstioAutoMtls(t *testing.T) {
 	ctx := context.Background()
 	testCluster := e2e.MustTestCluster()
-	testInstallation := testCluster.RegisterTestInstallation(
+	testInstallation := e2e.CreateTestInstallation(
 		t,
+		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "automtls-istio-k8s-gw-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "istio-automtls-k8s-gateway-test-helm.yaml"),
@@ -51,8 +52,6 @@ func TestK8sGatewayIstioAutoMtls(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to uninstall istio: %v", err)
 		}
-
-		testCluster.UnregisterTestInstallation(testInstallation)
 	})
 
 	// Install Istio before Gloo Gateway to make sure istiod is present before istio-proxy

--- a/test/kubernetes/e2e/k8sgateway/istio_test.go
+++ b/test/kubernetes/e2e/k8sgateway/istio_test.go
@@ -21,8 +21,9 @@ import (
 func TestK8sGatewayIstio(t *testing.T) {
 	ctx := context.Background()
 	testCluster := e2e.MustTestCluster()
-	testInstallation := testCluster.RegisterTestInstallation(
+	testInstallation := e2e.CreateTestInstallation(
 		t,
+		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "istio-k8s-gw-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "istio-k8s-gateway-test-helm.yaml"),
@@ -51,8 +52,6 @@ func TestK8sGatewayIstio(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to uninstall istio: %v", err)
 		}
-
-		testCluster.UnregisterTestInstallation(testInstallation)
 	})
 
 	// Install Istio before Gloo Gateway to make sure istiod is present before istio-proxy

--- a/test/kubernetes/e2e/k8sgateway/istio_test.go
+++ b/test/kubernetes/e2e/k8sgateway/istio_test.go
@@ -20,10 +20,8 @@ import (
 // TestK8sGatewayIstio is the function which executes a series of tests against a given installation
 func TestK8sGatewayIstio(t *testing.T) {
 	ctx := context.Background()
-	testCluster := e2e.MustTestCluster()
 	testInstallation := e2e.CreateTestInstallation(
 		t,
-		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "istio-k8s-gw-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "istio-k8s-gateway-test-helm.yaml"),

--- a/test/kubernetes/e2e/k8sgateway/k8s_gw_test.go
+++ b/test/kubernetes/e2e/k8sgateway/k8s_gw_test.go
@@ -27,10 +27,8 @@ import (
 // TestK8sGateway is the function which executes a series of tests against a given installation
 func TestK8sGateway(t *testing.T) {
 	ctx := context.Background()
-	testCluster := e2e.MustTestCluster()
 	testInstallation := e2e.CreateTestInstallation(
 		t,
-		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "k8s-gw-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "k8s-gateway-test-helm.yaml"),

--- a/test/kubernetes/e2e/k8sgateway/k8s_gw_test.go
+++ b/test/kubernetes/e2e/k8sgateway/k8s_gw_test.go
@@ -28,8 +28,9 @@ import (
 func TestK8sGateway(t *testing.T) {
 	ctx := context.Background()
 	testCluster := e2e.MustTestCluster()
-	testInstallation := testCluster.RegisterTestInstallation(
+	testInstallation := e2e.CreateTestInstallation(
 		t,
+		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "k8s-gw-test",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "k8s-gateway-test-helm.yaml"),
@@ -48,7 +49,6 @@ func TestK8sGateway(t *testing.T) {
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {
 			return testHelper.UninstallGlooAll()
 		})
-		testCluster.UnregisterTestInstallation(testInstallation)
 	})
 
 	// Install Gloo Gateway

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/solo-io/gloo/test/kube2e"

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -39,7 +39,7 @@ func CreateTestInstallation(
 	glooGatewayContext *gloogateway.Context,
 ) *TestInstallation {
 	runtimeContext := testruntime.NewContext()
-	clusterContext := cluster.MustKindContext(runtimeContext.ClusterName, nil)
+	clusterContext := cluster.MustKindContext(runtimeContext.ClusterName)
 
 	return CreateTestInstallationForCluster(t, runtimeContext, clusterContext, glooGatewayContext)
 }
@@ -98,15 +98,15 @@ func (i *TestInstallation) AddIstioctl(ctx context.Context) error {
 }
 
 func (i *TestInstallation) InstallMinimalIstio(ctx context.Context) error {
-	return cluster.InstallMinimalIstio(ctx, i.IstioctlBinary, i.TestCluster.ClusterContext.KubeContext)
+	return cluster.InstallMinimalIstio(ctx, i.IstioctlBinary, i.ClusterContext.KubeContext)
 }
 
 func (i *TestInstallation) UninstallIstio() error {
-	return cluster.UninstallIstio(i.IstioctlBinary, i.TestCluster.ClusterContext.KubeContext)
+	return cluster.UninstallIstio(i.IstioctlBinary, i.ClusterContext.KubeContext)
 }
 
 func (i *TestInstallation) CreateIstioBugReport(ctx context.Context) {
-	cluster.CreateIstioBugReport(ctx, i.IstioctlBinary, i.TestCluster.ClusterContext.KubeContext, i.GeneratedFiles.FailureDir)
+	cluster.CreateIstioBugReport(ctx, i.IstioctlBinary, i.ClusterContext.KubeContext, i.GeneratedFiles.FailureDir)
 }
 
 // TestInstallation is the structure around a set of tests that validate behavior for an installation

--- a/test/kubernetes/e2e/tests/debug_logging_test.go
+++ b/test/kubernetes/e2e/tests/debug_logging_test.go
@@ -23,8 +23,9 @@ import (
 func TestInstallationWithDebugLogLevel(t *testing.T) {
 	ctx := context.Background()
 	testCluster := e2e.MustTestCluster()
-	testInstallation := testCluster.RegisterTestInstallation(
+	testInstallation := e2e.CreateTestInstallation(
 		t,
+		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "debug-example",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "debug-example.yaml"),
@@ -43,7 +44,6 @@ func TestInstallationWithDebugLogLevel(t *testing.T) {
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {
 			return testHelper.UninstallGlooAll()
 		})
-		testCluster.UnregisterTestInstallation(testInstallation)
 	})
 
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {

--- a/test/kubernetes/e2e/tests/debug_logging_test.go
+++ b/test/kubernetes/e2e/tests/debug_logging_test.go
@@ -22,10 +22,8 @@ import (
 // TestInstallationWithDebugLogLevel is the function which executes a series of tests against a given installation
 func TestInstallationWithDebugLogLevel(t *testing.T) {
 	ctx := context.Background()
-	testCluster := e2e.MustTestCluster()
 	testInstallation := e2e.CreateTestInstallation(
 		t,
-		testCluster,
 		&gloogateway.Context{
 			InstallNamespace:   "debug-example",
 			ValuesManifestFile: filepath.Join(util.MustGetThisDir(), "manifests", "debug-example.yaml"),

--- a/test/kubernetes/testutils/clients/clients.go
+++ b/test/kubernetes/testutils/clients/clients.go
@@ -25,7 +25,7 @@ func MustClientset() *kubernetes.Clientset {
 	return clientset
 }
 
-func MustClientScheme(registerAdditionalSchemes func(scheme *runtime.Scheme) error) *runtime.Scheme {
+func MustClientScheme() *runtime.Scheme {
 	clientScheme := runtime.NewScheme()
 
 	// K8s API resources
@@ -51,11 +51,6 @@ func MustClientScheme(registerAdditionalSchemes func(scheme *runtime.Scheme) err
 
 	err = v1.AddToScheme(clientScheme)
 	mustNotError(err)
-
-	if registerAdditionalSchemes != nil {
-		err = registerAdditionalSchemes(clientScheme)
-		mustNotError(err)
-	}
 
 	return clientScheme
 }

--- a/test/kubernetes/testutils/cluster/kind.go
+++ b/test/kubernetes/testutils/cluster/kind.go
@@ -2,8 +2,9 @@ package cluster
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
 	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/test/kubernetes/testutils/cluster/kind.go
+++ b/test/kubernetes/testutils/cluster/kind.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 
 	"k8s.io/client-go/kubernetes"
@@ -16,6 +17,11 @@ import (
 
 // MustKindContext returns the Context for a KinD cluster with the given name
 func MustKindContext(clusterName string) *Context {
+	return MustKindContextWithScheme(clusterName, kubetestclients.MustClientScheme())
+}
+
+// MustKindContextWithScheme returns the Context for a KinD cluster with the given name and scheme
+func MustKindContextWithScheme(clusterName string, scheme *runtime.Scheme) *Context {
 	if len(clusterName) == 0 {
 		// We fall back to the cluster named `kind` if no cluster name was provided
 		clusterName = "kind"
@@ -36,7 +42,7 @@ func MustKindContext(clusterName string) *Context {
 	// This line prevents controller-runtime from complaining about log.SetLogger never being called
 	log.SetLogger(zap.New(zap.WriteTo(os.Stdout), zap.UseDevMode(true)))
 	clt, err := client.New(restCfg, client.Options{
-		Scheme: kubetestclients.MustClientScheme(),
+		Scheme: scheme,
 	})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
# Description
Simplify our test framework further, and enable more dependency injection so we can re-use more of it in our Enterprise Portal e2e tests

# Context
## Background
After speaking with @jmhbh we decided to try to merge https://github.com/solo-io/gloo/pull/9448 first, as it will unblock portal efforts. That work will require some code duplication in Enterprise, and this PR will allow us to delete that duplication in a follow-up.

## Remove TestCluster
Originally our `TestCluster` had state on it, and it "managed" the TestInstallations running on it. We have inverted this relationship and TestInstallations just select a cluster and run against it. This means that we do not need an object that tracks the active installations on a cluster.

A side effect of this is that we remove the register/unregister functions. These were in essence constructors and destructors for a TestInstallation. We now expose two constructors (one simple one for oss, and a generic one that enterprise will use), and we build the destructor into the TestInstallation as a finalizer.

## Collapse `RuntimeContext` and `ClusterContext` on TestInstallation
These properties always existed on a TestInstallation. However, they lived on the TestCluster object which has now been removed.

To support this, we also needed to update the few references in the feature suites.


## Testing steps
- CI continues to pass

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works