### PR TITLE
ggv2: allow extra gateway classes

### DIFF
--- a/changelog/v1.17.0-beta28/extra-gwclass.yaml
+++ b/changelog/v1.17.0-beta28/extra-gwclass.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >- 
+      Allow configuring additional gatewayclasses for controller

--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +39,7 @@ const (
 
 type GatewayConfig struct {
 	Mgr            manager.Manager
-	GWClass        apiv1.ObjectName
+	GWClasses      sets.Set[string]
 	Dev            bool
 	ControllerName string
 	AutoProvision  bool
@@ -52,7 +53,7 @@ type GatewayConfig struct {
 
 func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 	log := log.FromContext(ctx)
-	log.V(5).Info("starting controller", "controllerName", cfg.ControllerName, "gwclass", cfg.GWClass)
+	log.V(5).Info("starting controller", "controllerName", cfg.ControllerName, "gwclass", sets.List(cfg.GWClasses))
 
 	controllerBuilder := &controllerBuilder{
 		cfg: cfg,
@@ -76,7 +77,6 @@ func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 		controllerBuilder.addVhOptIndexes,
 		controllerBuilder.addGwParamsIndexes,
 	)
-
 }
 
 func run(ctx context.Context, funcs ...func(ctx context.Context) error) error {
@@ -156,7 +156,7 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 		// Don't use WithEventFilter here as it also filters events for Owned objects.
 		For(&apiv1.Gateway{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			if gw, ok := object.(*apiv1.Gateway); ok {
-				return gw.Spec.GatewayClassName == c.cfg.GWClass
+				return c.cfg.GWClasses.Has(string(gw.Spec.GatewayClassName))
 			}
 			return false
 		}), predicate.GenerationChangedPredicate{}))
@@ -203,7 +203,6 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 	gwReconciler := &gatewayReconciler{
 		cli:           c.cfg.Mgr.GetClient(),
 		scheme:        c.cfg.Mgr.GetScheme(),
-		className:     c.cfg.GWClass,
 		autoProvision: c.cfg.AutoProvision,
 		deployer:      d,
 		kick:          c.cfg.Kick,
@@ -321,7 +320,6 @@ func (r *controllerReconciler) ReconcileHttpRoutes(ctx context.Context, req ctrl
 }
 
 func (r *controllerReconciler) ReconcileReferenceGrants(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
 	// reconcile all things?!
 	r.kick(ctx)
 	return ctrl.Result{}, nil

--- a/projects/gateway2/controller/controller_suite_test.go
+++ b/projects/gateway2/controller/controller_suite_test.go
@@ -36,6 +36,7 @@ var (
 	cancel    context.CancelFunc
 
 	gatewayClassName      string
+	altGatewayClassName   string
 	gatewayControllerName string
 	kubeconfig            string
 )
@@ -58,6 +59,7 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.TODO())
 
 	gatewayClassName = "clsname"
+	altGatewayClassName = "clsname-alt"
 	gatewayControllerName = "controller/name"
 
 	By("bootstrapping test environment")
@@ -103,7 +105,7 @@ var _ = BeforeSuite(func() {
 	cfg := controller.GatewayConfig{
 		Mgr:            mgr,
 		ControllerName: gatewayControllerName,
-		GWClasses:      sets.New(gatewayClassName),
+		GWClasses:      sets.New(gatewayClassName, altGatewayClassName),
 		AutoProvision:  true,
 		Kick:           func(ctx context.Context) { return },
 		Extensions:     exts,

--- a/projects/gateway2/controller/controller_suite_test.go
+++ b/projects/gateway2/controller/controller_suite_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/solo-io/gloo/projects/gateway2/controller/scheme"
 	"github.com/solo-io/gloo/projects/gateway2/extensions"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
@@ -40,7 +41,6 @@ var (
 )
 
 func getAssetsDir() string {
-
 	assets := ""
 	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
 		// set default if not user provided
@@ -96,8 +96,6 @@ var _ = BeforeSuite(func() {
 	kubeconfig = generateKubeConfiguration(cfg)
 	mgr.GetLogger().Info("starting manager", "kubeconfig", kubeconfig)
 
-	var gatewayClassObjName api.ObjectName = api.ObjectName(gatewayClassName)
-
 	exts, err := extensions.NewK8sGatewayExtensions(ctx, extensions.K8sGatewayExtensionsFactoryParameters{
 		Mgr: mgr,
 	})
@@ -105,7 +103,7 @@ var _ = BeforeSuite(func() {
 	cfg := controller.GatewayConfig{
 		Mgr:            mgr,
 		ControllerName: gatewayControllerName,
-		GWClass:        gatewayClassObjName,
+		GWClasses:      sets.New(gatewayClassName),
 		AutoProvision:  true,
 		Kick:           func(ctx context.Context) { return },
 		Extensions:     exts,
@@ -144,6 +142,7 @@ func TestController(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Controller Suite")
 }
+
 func generateKubeConfiguration(restconfig *rest.Config) string {
 	clusters := make(map[string]*clientcmdapi.Cluster)
 	authinfos := make(map[string]*clientcmdapi.AuthInfo)

--- a/projects/gateway2/controller/gw_controller.go
+++ b/projects/gateway2/controller/gw_controller.go
@@ -20,7 +20,6 @@ const (
 
 type gatewayReconciler struct {
 	cli           client.Client
-	className     api.ObjectName
 	autoProvision bool
 
 	scheme   *runtime.Scheme

--- a/projects/gateway2/controller/gw_controller_test.go
+++ b/projects/gateway2/controller/gw_controller_test.go
@@ -17,70 +17,75 @@ var _ = Describe("GwController", func() {
 		interval = time.Millisecond * 250
 	)
 
-	It("should add status to gateway", func() {
-		same := api.NamespacesFromSame
-		gw := api.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gw",
-				Namespace: "default",
-			},
-			Spec: api.GatewaySpec{
-				GatewayClassName: api.ObjectName(gatewayClassName),
-				Listeners: []api.Listener{{
-					Protocol: "HTTP",
-					Port:     80,
-					AllowedRoutes: &api.AllowedRoutes{
-						Namespaces: &api.RouteNamespaces{
-							From: &same,
-						},
+	DescribeTable(
+		"gatewayclass",
+		func(gwClass string) {
+			It("should add status to gateway", func() {
+				same := api.NamespacesFromSame
+				gw := api.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gw",
+						Namespace: "default",
 					},
-					Name: "listener",
-				}},
-			},
-		}
-		err := k8sClient.Create(ctx, &gw)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Wait for service to be created
-		var svc corev1.Service
-		Eventually(func() bool {
-			var createdServices corev1.ServiceList
-			err := k8sClient.List(ctx, &createdServices)
-			if err != nil {
-				return false
-			}
-			for _, svc = range createdServices.Items {
-				if len(svc.ObjectMeta.OwnerReferences) == 1 && svc.ObjectMeta.OwnerReferences[0].UID == gw.UID {
-					return true
+					Spec: api.GatewaySpec{
+						GatewayClassName: api.ObjectName(gwClass),
+						Listeners: []api.Listener{{
+							Protocol: "HTTP",
+							Port:     80,
+							AllowedRoutes: &api.AllowedRoutes{
+								Namespaces: &api.RouteNamespaces{
+									From: &same,
+								},
+							},
+							Name: "listener",
+						}},
+					},
 				}
-			}
-			return false
-		}, timeout, interval).Should(BeTrue(), "service not created")
-		Expect(svc.Spec.ClusterIP).NotTo(BeEmpty())
+				err := k8sClient.Create(ctx, &gw)
+				Expect(err).NotTo(HaveOccurred())
 
-		// Need to update the status of the service
-		svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{{
-				IP: "127.0.0.1",
-			}},
-		}
-		Expect(k8sClient.Status().Update(ctx, &svc)).NotTo(HaveOccurred())
+				// Wait for service to be created
+				var svc corev1.Service
+				Eventually(func() bool {
+					var createdServices corev1.ServiceList
+					err := k8sClient.List(ctx, &createdServices)
+					if err != nil {
+						return false
+					}
+					for _, svc = range createdServices.Items {
+						if len(svc.ObjectMeta.OwnerReferences) == 1 && svc.ObjectMeta.OwnerReferences[0].UID == gw.UID {
+							return true
+						}
+					}
+					return false
+				}, timeout, interval).Should(BeTrue(), "service not created")
+				Expect(svc.Spec.ClusterIP).NotTo(BeEmpty())
 
-		Eventually(func() bool {
-			err := k8sClient.Get(ctx, client.ObjectKey{Name: "gw", Namespace: "default"}, &gw)
-			if err != nil {
-				return false
-			}
-			if len(gw.Status.Addresses) == 0 {
-				return false
-			}
-			return true
-		}, timeout, interval).Should(BeTrue())
+				// Need to update the status of the service
+				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+					Ingress: []corev1.LoadBalancerIngress{{
+						IP: "127.0.0.1",
+					}},
+				}
+				Expect(k8sClient.Status().Update(ctx, &svc)).NotTo(HaveOccurred())
 
-		Expect(gw.Status.Addresses).To(HaveLen(1))
-		Expect(*gw.Status.Addresses[0].Type).To(Equal(api.IPAddressType))
-		Expect(gw.Status.Addresses[0].Value).To(Equal("127.0.0.1"))
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKey{Name: "gw", Namespace: "default"}, &gw)
+					if err != nil {
+						return false
+					}
+					if len(gw.Status.Addresses) == 0 {
+						return false
+					}
+					return true
+				}, timeout, interval).Should(BeTrue())
 
-	})
-
+				Expect(gw.Status.Addresses).To(HaveLen(1))
+				Expect(*gw.Status.Addresses[0].Type).To(Equal(api.IPAddressType))
+				Expect(gw.Status.Addresses[0].Value).To(Equal("127.0.0.1"))
+			})
+		},
+		Entry("default gateway class", gatewayClassName),
+		Entry("alternative gateway class", altGatewayClassName),
+	)
 })

--- a/projects/gateway2/controller/gw_controller_test.go
+++ b/projects/gateway2/controller/gw_controller_test.go
@@ -18,72 +18,70 @@ var _ = Describe("GwController", func() {
 	)
 
 	DescribeTable(
-		"gatewayclass",
+		"should add status to gateway",
 		func(gwClass string) {
-			It("should add status to gateway", func() {
-				same := api.NamespacesFromSame
-				gw := api.Gateway{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "gw",
-						Namespace: "default",
-					},
-					Spec: api.GatewaySpec{
-						GatewayClassName: api.ObjectName(gwClass),
-						Listeners: []api.Listener{{
-							Protocol: "HTTP",
-							Port:     80,
-							AllowedRoutes: &api.AllowedRoutes{
-								Namespaces: &api.RouteNamespaces{
-									From: &same,
-								},
+			same := api.NamespacesFromSame
+			gw := api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw",
+					Namespace: "default",
+				},
+				Spec: api.GatewaySpec{
+					GatewayClassName: api.ObjectName(gwClass),
+					Listeners: []api.Listener{{
+						Protocol: "HTTP",
+						Port:     80,
+						AllowedRoutes: &api.AllowedRoutes{
+							Namespaces: &api.RouteNamespaces{
+								From: &same,
 							},
-							Name: "listener",
-						}},
-					},
-				}
-				err := k8sClient.Create(ctx, &gw)
-				Expect(err).NotTo(HaveOccurred())
-
-				// Wait for service to be created
-				var svc corev1.Service
-				Eventually(func() bool {
-					var createdServices corev1.ServiceList
-					err := k8sClient.List(ctx, &createdServices)
-					if err != nil {
-						return false
-					}
-					for _, svc = range createdServices.Items {
-						if len(svc.ObjectMeta.OwnerReferences) == 1 && svc.ObjectMeta.OwnerReferences[0].UID == gw.UID {
-							return true
-						}
-					}
-					return false
-				}, timeout, interval).Should(BeTrue(), "service not created")
-				Expect(svc.Spec.ClusterIP).NotTo(BeEmpty())
-
-				// Need to update the status of the service
-				svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-					Ingress: []corev1.LoadBalancerIngress{{
-						IP: "127.0.0.1",
+						},
+						Name: "listener",
 					}},
+				},
+			}
+			err := k8sClient.Create(ctx, &gw)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for service to be created
+			var svc corev1.Service
+			Eventually(func() bool {
+				var createdServices corev1.ServiceList
+				err := k8sClient.List(ctx, &createdServices)
+				if err != nil {
+					return false
 				}
-				Expect(k8sClient.Status().Update(ctx, &svc)).NotTo(HaveOccurred())
-
-				Eventually(func() bool {
-					err := k8sClient.Get(ctx, client.ObjectKey{Name: "gw", Namespace: "default"}, &gw)
-					if err != nil {
-						return false
+				for _, svc = range createdServices.Items {
+					if len(svc.ObjectMeta.OwnerReferences) == 1 && svc.ObjectMeta.OwnerReferences[0].UID == gw.UID {
+						return true
 					}
-					if len(gw.Status.Addresses) == 0 {
-						return false
-					}
-					return true
-				}, timeout, interval).Should(BeTrue())
+				}
+				return false
+			}, timeout, interval).Should(BeTrue(), "service not created")
+			Expect(svc.Spec.ClusterIP).NotTo(BeEmpty())
 
-				Expect(gw.Status.Addresses).To(HaveLen(1))
-				Expect(*gw.Status.Addresses[0].Type).To(Equal(api.IPAddressType))
-				Expect(gw.Status.Addresses[0].Value).To(Equal("127.0.0.1"))
-			})
+			// Need to update the status of the service
+			svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{
+					IP: "127.0.0.1",
+				}},
+			}
+			Expect(k8sClient.Status().Update(ctx, &svc)).NotTo(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: "gw", Namespace: "default"}, &gw)
+				if err != nil {
+					return false
+				}
+				if len(gw.Status.Addresses) == 0 {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			Expect(gw.Status.Addresses).To(HaveLen(1))
+			Expect(*gw.Status.Addresses[0].Type).To(Equal(api.IPAddressType))
+			Expect(gw.Status.Addresses[0].Value).To(Equal("127.0.0.1"))
 		},
 		Entry("default gateway class", gatewayClassName),
 		Entry("alternative gateway class", altGatewayClassName),

--- a/projects/gateway2/controller/start.go
+++ b/projects/gateway2/controller/start.go
@@ -3,11 +3,11 @@ package controller
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gateway2/controller/scheme"
@@ -29,11 +29,7 @@ const (
 	AutoProvision = true
 )
 
-var (
-	gatewayClass = apiv1.ObjectName(wellknown.GatewayClassName)
-
-	setupLog = ctrl.Log.WithName("setup")
-)
+var setupLog = ctrl.Log.WithName("setup")
 
 type StartConfig struct {
 	Dev  bool
@@ -135,7 +131,7 @@ func Start(ctx context.Context, cfg StartConfig) error {
 
 	gwCfg := GatewayConfig{
 		Mgr:            mgr,
-		GWClass:        gatewayClass,
+		GWClasses:      sets.New(append(cfg.Opts.ExtraGatewayClasses, wellknown.GatewayClassName)...),
 		ControllerName: wellknown.GatewayControllerName,
 		AutoProvision:  AutoProvision,
 		ControlPlane:   cfg.Opts.ControlPlane,

--- a/projects/gloo/pkg/bootstrap/opts.go
+++ b/projects/gloo/pkg/bootstrap/opts.go
@@ -55,6 +55,7 @@ type Opts struct {
 	ValidationOpts               *gwtranslator.ValidationOpts
 	ReadGatwaysFromAllNamespaces bool
 	GatewayControllerEnabled     bool
+	ExtraGatewayClasses          []string
 	ProxyCleanup                 func()
 
 	Identity leaderelector.Identity


### PR DESCRIPTION
# Description

When using gloo as a module, an additional list of gateway classes can be passed via `bootstrap.Opts`. 
These gateway classes will get deployed using the same logic as `gloo-gateway`. 

Used in conjunction with https://github.com/solo-io/gloo/pull/9471 and GatewayParameters, it's possible to have very custom types of gateways that still use gloo plugins and partially re-use gloo logic. 

## API changes

Code/Internal API: Added `ExtraGatewayClasses` to bootstrap opts.

## Code changes
- `GWClass` is now a set `GWClasses`

# Context

Gloo waypoints. 

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

I manually verified behavior by hardcoding an entry in the list. 

# Checklist:

- [X] I have performed a self-review of my own code
- [  I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
