### PR TITLE
gateway2/route-options: merge ExtensionRef override with targetRef attachment

### DIFF
--- a/changelog/v1.17.0-beta28/deleg-extref.yaml
+++ b/changelog/v1.17.0-beta28/deleg-extref.yaml
@@ -1,0 +1,22 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6161
+    resolvesIssue: false
+    description: |
+      gateway2/route-options: merge ExtensionRef override with targetRef attachment
+
+      Implements merging of RouteOptions attached via ExtensionRef filter
+      and targetRef based policy attachment. ExtensionRef based options
+      have higher priority than targetRef based options, such that if
+      the ExtensionRef based option sets a field, it cannot be overridden
+      by a policy using targetRef. However, unset fields on a policy
+      selected by ExtensionRef may be overridden by targetRef based options.
+
+      The merging semantics is already followed when policies are merged
+      along a delegation chain, so this change is required for consistency.
+
+      The core of this change to merge policies in order of their priority
+      within the query resolver itself because the resolver is responsible
+      for recursively resolving the policies for delegated routes. Hence,
+      existing lookup of ExtensionRef based options are moved into the
+      query API that also handles the merge.

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -157,5 +157,5 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("RouteOptions ignore child override on conflict", "route_options_inheritance_child_override_ignore.yaml"),
 	Entry("RouteOptions merge child override on no conflict", "route_options_inheritance_child_override_ok.yaml"),
 	Entry("RouteOptions multi level inheritance with child override", "route_options_multi_level_inheritance_override_ok.yaml"),
-	Entry("RouteOptions filter override on child should be ignored", "route_options_filter_override_ignore.yaml"),
+	Entry("RouteOptions filter override merge", "route_options_filter_override_merge.yaml"),
 )

--- a/projects/gateway2/translator/httproute/delegation.go
+++ b/projects/gateway2/translator/httproute/delegation.go
@@ -15,6 +15,7 @@ import (
 	"github.com/solo-io/gloo/projects/gateway2/query"
 	"github.com/solo-io/gloo/projects/gateway2/reports"
 	"github.com/solo-io/gloo/projects/gateway2/translator/backendref"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/registry"
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -30,6 +31,7 @@ func flattenDelegatedRoutes(
 	ctx context.Context,
 	queries query.GatewayQueries,
 	parent *gwv1.HTTPRoute,
+	rule gwv1.HTTPRouteRule,
 	backendRef gwv1.HTTPBackendRef,
 	parentReporter reports.ParentRefReporter,
 	baseReporter reports.Reporter,
@@ -44,7 +46,11 @@ func flattenDelegatedRoutes(
 	routesVisited.Insert(parentRef)
 	defer routesVisited.Delete(parentRef)
 
-	lRef := delegationChain.PushFront(parentRef)
+	delegationCtx := plugins.DelegationCtx{
+		Ref:  parentRef,
+		Rule: &rule,
+	}
+	lRef := delegationChain.PushFront(delegationCtx)
 	defer delegationChain.Remove(lRef)
 
 	children, err := queries.GetDelegatedRoutes(ctx, backendRef.BackendObjectReference, parentMatch, parentRef)

--- a/projects/gateway2/translator/httproute/gateway_http_route_translator.go
+++ b/projects/gateway2/translator/httproute/gateway_http_route_translator.go
@@ -125,7 +125,7 @@ func translateGatewayHTTPRouteRule(
 				ctx,
 				queries,
 				gwroute,
-				rule.BackendRefs,
+				rule,
 				outputRoute,
 				reporter,
 				baseReporter,
@@ -256,7 +256,7 @@ func setRouteAction(
 	ctx context.Context,
 	queries query.GatewayQueries,
 	gwroute *gwv1.HTTPRoute,
-	backendRefs []gwv1.HTTPBackendRef,
+	rule gwv1.HTTPRouteRule,
 	outputRoute *v1.Route,
 	reporter reports.ParentRefReporter,
 	baseReporter reports.Reporter,
@@ -269,6 +269,7 @@ func setRouteAction(
 ) bool {
 	var weightedDestinations []*v1.WeightedDestination
 	hasDelegatedRoute := false
+	backendRefs := rule.BackendRefs
 
 	for _, backendRef := range backendRefs {
 		// If the backend is an HTTPRoute, it implies route delegation
@@ -277,7 +278,7 @@ func setRouteAction(
 			hasDelegatedRoute = true
 			// Flatten delegated HTTPRoute references
 			err := flattenDelegatedRoutes(
-				ctx, queries, gwroute, backendRef, reporter, baseReporter, pluginRegistry, gwListener, match, outputs, routesVisited, delegationChain)
+				ctx, queries, gwroute, rule, backendRef, reporter, baseReporter, pluginRegistry, gwListener, match, outputs, routesVisited, delegationChain)
 			if err != nil {
 				reporter.SetCondition(reports.HTTPRouteCondition{
 					Type:    gwv1.RouteConditionResolvedRefs,

--- a/projects/gateway2/translator/plugins/plugins.go
+++ b/projects/gateway2/translator/plugins/plugins.go
@@ -7,6 +7,7 @@ import (
 	"github.com/solo-io/gloo/projects/gateway2/reports"
 	"github.com/solo-io/gloo/projects/gateway2/translator/translatorutils"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
@@ -24,7 +25,7 @@ type RouteContext struct {
 	// delegatee (child) routes of delegated routes will not have spec.Hostnames set.
 	Hostnames []gwv1.Hostname
 	// DelegationChain is a doubly linked list containing the delegation chain from child to its ancestors
-	// excluding the child itself, where the elements are the NamespacedName type
+	// excluding the child itself, where the elements are the DelegationCtx type
 	DelegationChain *list.List
 	// specific HTTPRouteRule of the HTTPRoute being processed, nil if the entire HTTPRoute is being processed
 	// rather than just a specific Rule
@@ -34,6 +35,11 @@ type RouteContext struct {
 	Match *gwv1.HTTPRouteMatch
 	// Reporter for the correct ParentRef associated with this HTTPRoute
 	Reporter reports.ParentRefReporter
+}
+
+type DelegationCtx struct {
+	Ref  types.NamespacedName
+	Rule *gwv1.HTTPRouteRule
 }
 
 type RoutePlugin interface {

--- a/projects/gateway2/translator/plugins/routeoptions/query/query.go
+++ b/projects/gateway2/translator/plugins/routeoptions/query/query.go
@@ -4,14 +4,27 @@ import (
 	"container/list"
 	"context"
 
-	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
-	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/utils"
+	"github.com/rotisserie/eris"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
-
-	glooutils "github.com/solo-io/gloo/projects/gloo/pkg/utils"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
+	gwquery "github.com/solo-io/gloo/projects/gateway2/query"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins"
+	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/utils"
+	glooutils "github.com/solo-io/gloo/projects/gloo/pkg/utils"
 )
+
+var routeOptionGK = schema.GroupKind{
+	Group: sologatewayv1.RouteOptionGVK.Group,
+	Kind:  sologatewayv1.RouteOptionGVK.Kind,
+}
 
 type RouteOptionQueries interface {
 	// Gets the RouteOption attached to the provided HTTPRoute.
@@ -23,7 +36,13 @@ type RouteOptionQueries interface {
 	// that may be attached to the route itself. The creation timestamp is only considered if multiple RouteOptions
 	// attach to the same route for a route in the delegation chain, in which case the earliest created resource is
 	// picked for the merging process.
-	GetRouteOptionForRoute(ctx context.Context, route types.NamespacedName, delegationChain *list.Element) (*solokubev1.RouteOption, error)
+	GetRouteOptionForRouteRule(
+		ctx context.Context,
+		route types.NamespacedName,
+		rule *gwv1.HTTPRouteRule,
+		parentRef *list.Element,
+		gwQueries gwquery.GatewayQueries,
+	) (*solokubev1.RouteOption, bool, error)
 }
 
 type routeOptionQueries struct {
@@ -34,23 +53,31 @@ func NewQuery(c client.Client) RouteOptionQueries {
 	return &routeOptionQueries{c}
 }
 
-func (r *routeOptionQueries) GetRouteOptionForRoute(
+func (r *routeOptionQueries) GetRouteOptionForRouteRule(
 	ctx context.Context,
 	route types.NamespacedName,
+	rule *gwv1.HTTPRouteRule,
 	parentRef *list.Element,
-) (*solokubev1.RouteOption, error) {
+	gwQueries gwquery.GatewayQueries,
+) (*solokubev1.RouteOption, bool, error) {
 	var err error
 	var mergedOpt *solokubev1.RouteOption
+
 	if parentRef != nil {
-		mergedOpt, err = r.GetRouteOptionForRoute(ctx, parentRef.Value.(types.NamespacedName), parentRef.Next())
+		delegationCtx, ok := parentRef.Value.(plugins.DelegationCtx)
+		if !ok {
+			return nil, false, eris.Errorf("invalid type %T in delegation chain, expected DelegationCtx", parentRef.Value)
+		}
+		mergedOpt, _, err = r.GetRouteOptionForRouteRule(
+			ctx, delegationCtx.Ref, delegationCtx.Rule, parentRef.Next(), gwQueries)
 	}
 
-	routeOpt, err := r.getPreferredRouteOption(ctx, route)
+	routeOpt, filterOverride, err := r.getPreferredRouteOption(ctx, route, rule, gwQueries)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
 	if mergedOpt == nil {
-		return routeOpt, nil
+		return routeOpt, filterOverride, nil
 	}
 
 	// merge scoped RouteOptions with parent giving preference to the parent
@@ -59,7 +86,7 @@ func (r *routeOptionQueries) GetRouteOptionForRoute(
 	}
 	glooutils.ShallowMergeRouteOptions(mergedOpt.Spec.GetOptions(), routeOpt.Spec.GetOptions())
 
-	return mergedOpt, nil
+	return mergedOpt, filterOverride, nil
 }
 
 // getPreferredRouteOption returns the most preferred RouteOption for the given route
@@ -67,7 +94,14 @@ func (r *routeOptionQueries) GetRouteOptionForRoute(
 func (r *routeOptionQueries) getPreferredRouteOption(
 	ctx context.Context,
 	route types.NamespacedName,
-) (*solokubev1.RouteOption, error) {
+	rule *gwv1.HTTPRouteRule,
+	gwQueries gwquery.GatewayQueries,
+) (*solokubev1.RouteOption, bool, error) {
+	merged, err := lookupFilterOverride(ctx, route, rule, gwQueries)
+	if err != nil {
+		return nil, false, err
+	}
+
 	var list solokubev1.RouteOptionList
 	if err := r.c.List(
 		ctx,
@@ -75,11 +109,11 @@ func (r *routeOptionQueries) getPreferredRouteOption(
 		client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(RouteOptionTargetField, route.String())},
 		client.InNamespace(route.Namespace),
 	); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	if len(list.Items) == 0 {
-		return nil, nil
+		return merged, false, nil
 	}
 
 	out := make([]*solokubev1.RouteOption, len(list.Items))
@@ -87,6 +121,66 @@ func (r *routeOptionQueries) getPreferredRouteOption(
 		out[i] = &list.Items[i]
 	}
 	utils.SortByCreationTime(out)
+	attached := out[0]
 
-	return out[0], nil
+	if merged == nil {
+		return attached, false, nil
+	}
+
+	glooutils.ShallowMergeRouteOptions(merged.Spec.GetOptions(), attached.Spec.GetOptions())
+
+	return merged, true, nil
+}
+
+func lookupFilterOverride(
+	ctx context.Context,
+	route types.NamespacedName,
+	rule *gwv1.HTTPRouteRule,
+	gwQueries gwquery.GatewayQueries,
+) (*solokubev1.RouteOption, error) {
+	if rule == nil {
+		return nil, nil
+	}
+
+	filter := utils.FindExtensionRefFilter(rule, routeOptionGK)
+	if filter == nil {
+		return nil, nil
+	}
+
+	extLookup := extensionRefLookup{namespace: route.Namespace}
+	routeOption := &solokubev1.RouteOption{}
+	err := utils.GetExtensionRefObjFrom(ctx, extLookup, gwQueries, filter.ExtensionRef, routeOption)
+
+	// If the filter is not found, report a specific error so that it can reflect more
+	// clearly on the status of the HTTPRoute.
+	if err != nil && apierrors.IsNotFound(err) {
+		return nil, errFilterNotFound(route.Namespace, filter)
+	}
+
+	return routeOption, err
+}
+
+type extensionRefLookup struct {
+	namespace string
+}
+
+func (e extensionRefLookup) GroupKind() (metav1.GroupKind, error) {
+	return metav1.GroupKind{
+		Group: routeOptionGK.Group,
+		Kind:  routeOptionGK.Kind,
+	}, nil
+}
+
+func (e extensionRefLookup) Namespace() string {
+	return e.namespace
+}
+
+func errFilterNotFound(namespace string, filter *gwv1.HTTPRouteFilter) error {
+	return eris.Errorf(
+		"extensionRef '%s' of type %s.%s in namespace '%s' not found",
+		filter.ExtensionRef.Group,
+		filter.ExtensionRef.Kind,
+		filter.ExtensionRef.Name,
+		namespace,
+	)
 }

--- a/projects/gateway2/translator/plugins/utils/plugin_utils.go
+++ b/projects/gateway2/translator/plugins/utils/plugin_utils.go
@@ -54,14 +54,14 @@ func FindAppliedRouteFilter(
 // references the supplied GroupKind in the Rule being processed.
 // Returns nil if the Rule doesn't contain a matching ExtensionRef filter
 func FindExtensionRefFilter(
-	routeCtx *plugins.RouteContext,
+	rule *gwv1.HTTPRouteRule,
 	gk schema.GroupKind,
 ) *gwv1.HTTPRouteFilter {
-	if routeCtx.Rule == nil {
+	if rule == nil {
 		return nil
 	}
 	// TODO: check full Filter list for duplicates and error?
-	for _, filter := range routeCtx.Rule.Filters {
+	for _, filter := range rule.Filters {
 		if filter.Type == gwv1.HTTPRouteFilterExtensionRef {
 			if filter.ExtensionRef.Group == gwv1.Group(gk.Group) && filter.ExtensionRef.Kind == gwv1.Kind(gk.Kind) {
 				return &filter
@@ -83,12 +83,22 @@ var (
 // A nil error indicates success and `obj` should be usable as normal.
 func GetExtensionRefObj(
 	ctx context.Context,
-	routeCtx *plugins.RouteContext,
+	route *gwv1.HTTPRoute,
 	queries query.GatewayQueries,
 	extensionRef *gwv1.LocalObjectReference,
 	obj client.Object,
 ) error {
-	localObj, err := queries.GetLocalObjRef(ctx, queries.ObjToFrom(routeCtx.Route), *extensionRef)
+	return GetExtensionRefObjFrom(ctx, queries.ObjToFrom(route), queries, extensionRef, obj)
+}
+
+func GetExtensionRefObjFrom(
+	ctx context.Context,
+	from query.From,
+	queries query.GatewayQueries,
+	extensionRef *gwv1.LocalObjectReference,
+	obj client.Object,
+) error {
+	localObj, err := queries.GetLocalObjRef(ctx, from, *extensionRef)
 	if err != nil {
 		return err
 	}

--- a/projects/gateway2/translator/plugins/utils/plugin_utils_test.go
+++ b/projects/gateway2/translator/plugins/utils/plugin_utils_test.go
@@ -31,11 +31,11 @@ func TestExtensionRef(t *testing.T) {
 		Group: sologatewayv1.RouteOptionGVK.Group,
 		Kind:  sologatewayv1.RouteOptionGVK.Kind,
 	}
-	filter := utils.FindExtensionRefFilter(&rtCtx, gk)
+	filter := utils.FindExtensionRefFilter(rtCtx.Rule, gk)
 	g.Expect(filter).ToNot(BeNil())
 
 	routeOption := &solokubev1.RouteOption{}
-	err := utils.GetExtensionRefObj(context.Background(), &rtCtx, queries, filter.ExtensionRef, routeOption)
+	err := utils.GetExtensionRefObj(context.Background(), rtCtx.Route, queries, filter.ExtensionRef, routeOption)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(routeOption.Spec.GetOptions().GetFaults().GetAbort().GetPercentage()).To(BeEquivalentTo(1))
 }
@@ -50,11 +50,11 @@ func TestExtensionRefWrongObject(t *testing.T) {
 		Group: sologatewayv1.RouteOptionGVK.Group,
 		Kind:  sologatewayv1.RouteOptionGVK.Kind,
 	}
-	filter := utils.FindExtensionRefFilter(&rtCtx, gk)
+	filter := utils.FindExtensionRefFilter(rtCtx.Rule, gk)
 	g.Expect(filter).ToNot(BeNil())
 
 	vhostOption := &solokubev1.VirtualHostOption{}
-	err := utils.GetExtensionRefObj(context.Background(), &rtCtx, queries, filter.ExtensionRef, vhostOption)
+	err := utils.GetExtensionRefObj(context.Background(), rtCtx.Route, queries, filter.ExtensionRef, vhostOption)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(errors.Is(err, utils.ErrTypesNotEqual)).To(BeTrue())
 }

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_filter_override_merge.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_filter_override_merge.yaml
@@ -81,7 +81,7 @@ spec:
         extensionRef:
           group: gateway.solo.io
           kind: RouteOption
-          name: route-a-opt
+          name: route-a-opt-1
 ---
 apiVersion: v1
 kind: Service
@@ -96,7 +96,21 @@ spec:
 apiVersion: gateway.solo.io/v1
 kind: RouteOption
 metadata:
-  name: route-a-opt
+  name: route-a-opt-1
+  namespace: a
+spec:
+  options:
+    faults:
+      abort:
+        percentage: 80
+        httpStatus: 404
+    headerManipulation:
+      requestHeadersToRemove: ["foo"]
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: route-a-opt-2
   namespace: a
 spec:
   targetRef:
@@ -106,5 +120,12 @@ spec:
   options:
     faults:
       abort:
-        percentage: 80
-        httpStatus: 404
+        percentage: 70
+        httpStatus: 403
+    headerManipulation:
+      requestHeadersToRemove: ["baz"]
+    cors:
+      exposeHeaders:
+        - foo
+      allowOrigin:
+        - baz

--- a/projects/gateway2/translator/testutils/outputs/delegation/route_options_filter_override_merge.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/route_options_filter_override_merge.yaml
@@ -14,17 +14,19 @@ listeners:
           routes:
           - matchers:
             - prefix: /a/1
-            metadataStatic:
-              sources:
-              - resourceKind: RouteOption
-                resourceRef:
-                  name: example-opt
-                  namespace: infra
             options:
+              cors:
+                allowOrigin:
+                - baz
+                exposeHeaders:
+                - foo
               faults:
                 abort:
                   httpStatus: 418
                   percentage: 100
+              headerManipulation:
+                requestHeadersToRemove:
+                - foo
             routeAction:
               single:
                 kube:

--- a/test/gomega/matchers/have_status.go
+++ b/test/gomega/matchers/have_status.go
@@ -34,11 +34,13 @@ func HaveState(state core.Status_State) types.GomegaMatcher {
 		State: &state,
 	})
 }
+
 func HaveReportedBy(reporter string) types.GomegaMatcher {
 	return HaveStatus(&SoloKitStatus{
 		ReportedBy: reporter,
 	})
 }
+
 func HaveAcceptedState() types.GomegaMatcher {
 	st := core.Status_Accepted
 	return HaveStatus(&SoloKitStatus{
@@ -119,7 +121,6 @@ func HaveNamespacedStatuses(expected *SoloKitNamespacedStatuses) types.GomegaMat
 		namespacedStatusesMatchers: namespacedStatusMatchers,
 		evaluated:                  false,
 	}
-
 }
 
 // HaveStatus produces a matcher that will match if the provided status matches the
@@ -231,7 +232,7 @@ func (m *HaveNamespacedStatusesMatcher) Match(actual interface{}) (success bool,
 	for ns, matcher := range m.namespacedStatusesMatchers {
 		actualStatus, ok := val.GetStatuses()[ns]
 		if !ok {
-			return false, eris.New("have matcher for namespace which is not found")
+			return false, eris.Errorf("have matcher for namespace %s which is not found", ns)
 		}
 		if actualStatus == nil {
 			return false, eris.New("got nil status")


### PR DESCRIPTION
# Description

Implements merging of RouteOptions attached via ExtensionRef filter and targetRef based policy attachment. ExtensionRef based options have higher priority than targetRef based options, such that if the ExtensionRef based option sets a field, it cannot be overridden by a policy using targetRef. However, unset fields on a policy selected by ExtensionRef may be overridden by targetRef based options.

The merging semantics is already followed when policies are merged along a delegation chain, so this change is required for consistency.

The core of this change to merge policies in order of their priority within the query resolver itself because the resolver is responsible for recursively resolving the policies for delegated routes. Hence, existing lookup of ExtensionRef based options are moved into the query API that also handles the merge.

## Testing steps

Apply RouteOptions to an HTTPRoute using both ExtensionRef filter and targetRef

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation TODO
- [X] I have added tests that prove my fix is effective or that my feature works 

# Future work
https://github.com/solo-io/solo-projects/issues/6204
