### PR TITLE
gateway2: simplify how plugins handle delegated routes

### DIFF
--- a/changelog/v1.17.0-beta29/deleg-plugin.yaml
+++ b/changelog/v1.17.0-beta29/deleg-plugin.yaml
@@ -1,0 +1,17 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6204
+    resolvesIssue: true
+    description: |
+      gateway2: simplify how plugins handle delegated routes
+
+      This change simplifies how plugins may perform merging
+      of policies in a delegation chain, particularly in the
+      case of RouteOptions. It performs an in-place merge
+      such that the policy on a child route may be overridden
+      by by a subsequent call to the plugin with a different
+      route context.
+
+      Further, it accurately tracks the source RouteOptions
+      involved in the merge so that the statuses on them
+      can be correctly reported.

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -1,0 +1,12 @@
+package env
+
+import "os"
+
+// GetOrDefault returns the value of the environment variable for the given key,
+// or the default value if the environment variable is not set.
+func GetOrDefault(key, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value
+	}
+	return fallback
+}

--- a/projects/gateway/pkg/translator/converter.go
+++ b/projects/gateway/pkg/translator/converter.go
@@ -209,7 +209,7 @@ func (rv *routeVisitor) visit(
 				routeClone.Options = routeOpts.GetOptions()
 				continue
 			}
-			routeClone.Options = utils.ShallowMergeRouteOptions(routeClone.GetOptions(), routeOpts.GetOptions())
+			routeClone.Options, _ = utils.ShallowMergeRouteOptions(routeClone.GetOptions(), routeOpts.GetOptions())
 		}
 
 		// If the parent route is not nil, this route has been delegated to and we need to perform additional operations
@@ -524,7 +524,7 @@ func validateAndMergeParentRoute(child *gatewayv1.Route, parent *routeInfo) (*ga
 
 	// Merge options from parent routes
 	// If an option is defined on a parent route, it will override the child route's option
-	child.Options = utils.ShallowMergeRouteOptions(child.GetOptions(), parent.options)
+	child.Options, _ = utils.ShallowMergeRouteOptions(child.GetOptions(), parent.options)
 
 	return child, nil
 }

--- a/projects/gateway2/translator/httproute/delegation.go
+++ b/projects/gateway2/translator/httproute/delegation.go
@@ -47,8 +47,7 @@ func flattenDelegatedRoutes(
 	defer routesVisited.Delete(parentRef)
 
 	delegationCtx := plugins.DelegationCtx{
-		Ref:  parentRef,
-		Rule: &rule,
+		Ref: parentRef,
 	}
 	lRef := delegationChain.PushFront(delegationCtx)
 	defer delegationChain.Remove(lRef)

--- a/projects/gateway2/translator/plugins/plugins.go
+++ b/projects/gateway2/translator/plugins/plugins.go
@@ -38,14 +38,19 @@ type RouteContext struct {
 }
 
 type DelegationCtx struct {
-	Ref  types.NamespacedName
-	Rule *gwv1.HTTPRouteRule
+	Ref types.NamespacedName
 }
 
 type RoutePlugin interface {
 	Plugin
 
 	// ApplyRoutePlugin is called for each Match in a given Rule
+	//
+	// For delegatee/child routes, this will be called multiple times for
+	// each route in the delegation chain starting from the child to the parent
+	// up the chain. Plugins may choose to override the existing configuration
+	// associated with a route when the plugin is invoked multiple times on the
+	// same route but with different configuration.
 	ApplyRoutePlugin(
 		ctx context.Context,
 		routeCtx *RouteContext,

--- a/projects/gateway2/translator/routeutils/utils.go
+++ b/projects/gateway2/translator/routeutils/utils.go
@@ -1,27 +1,22 @@
 package routeutils
 
 import (
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
-	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func AppendSourceToRoute(route *v1.Route, source client.Object) {
+func AppendSourceToRoute(route *v1.Route, newSources []*gloov1.SourceMetadata_SourceRef, preserveExisting bool) {
 	meta := route.GetMetadataStatic()
 	if meta == nil {
-		meta = &v1.SourceMetadata{}
+		meta = &gloov1.SourceMetadata{}
 	}
 	sources := meta.GetSources()
-	sources = append(sources, &v1.SourceMetadata_SourceRef{
-		ResourceRef: &core.ResourceRef{
-			Name:      source.GetName(),
-			Namespace: source.GetNamespace(),
-		},
-		ResourceKind:       source.GetObjectKind().GroupVersionKind().Kind,
-		ObservedGeneration: source.GetGeneration(),
-	})
-	route.OpaqueMetadata = &v1.Route_MetadataStatic{
-		MetadataStatic: &v1.SourceMetadata{
+	if !preserveExisting {
+		sources = nil
+	}
+	sources = append(sources, newSources...)
+	route.OpaqueMetadata = &gloov1.Route_MetadataStatic{
+		MetadataStatic: &gloov1.SourceMetadata{
 			Sources: sources,
 		},
 	}

--- a/projects/gateway2/translator/testutils/outputs/delegation/route_options_filter_override_merge.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/route_options_filter_override_merge.yaml
@@ -14,6 +14,20 @@ listeners:
           routes:
           - matchers:
             - prefix: /a/1
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: route-a-opt-1
+                  namespace: a
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: route-a-opt-2
+                  namespace: a
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: example-opt
+                  namespace: infra
             options:
               cors:
                 allowOrigin:

--- a/projects/gateway2/translator/testutils/outputs/delegation/route_options_inheritance_child_override_ok.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/route_options_inheritance_child_override_ok.yaml
@@ -18,6 +18,10 @@ listeners:
               sources:
               - resourceKind: RouteOption
                 resourceRef:
+                  name: route-a-opt
+                  namespace: a
+              - resourceKind: RouteOption
+                resourceRef:
                   name: example-opt
                   namespace: infra
             options:

--- a/projects/gateway2/translator/testutils/outputs/delegation/route_options_multi_level_inheritance_override_ok.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/route_options_multi_level_inheritance_override_ok.yaml
@@ -18,6 +18,14 @@ listeners:
               sources:
               - resourceKind: RouteOption
                 resourceRef:
+                  name: route-a-opt
+                  namespace: a
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: route-a-root-opt
+                  namespace: a-root
+              - resourceKind: RouteOption
+                resourceRef:
                   name: example-opt
                   namespace: infra
             options:

--- a/projects/gloo/pkg/utils/merge_test.go
+++ b/projects/gloo/pkg/utils/merge_test.go
@@ -54,7 +54,8 @@ var _ = Describe("Merge", func() {
 			},
 		}
 
-		actual := ShallowMergeRouteOptions(dst, src)
+		actual, overwrote := ShallowMergeRouteOptions(dst, src)
 		Expect(actual).To(Equal(expected))
+		Expect(overwrote).To(BeTrue())
 	})
 })

--- a/test/kubernetes/e2e/tests/k8s_gw_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/solo-io/gloo/pkg/utils/env"
 	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	"github.com/solo-io/gloo/test/kubernetes/e2e/features/deployer"
@@ -17,6 +18,7 @@ import (
 	"github.com/solo-io/gloo/test/kubernetes/e2e/features/upstreams"
 	"github.com/solo-io/gloo/test/kubernetes/e2e/features/virtualhost_options"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/testutils"
 	"github.com/solo-io/skv2/codegen/util"
 	"github.com/stretchr/testify/suite"
 )
@@ -27,7 +29,7 @@ func TestK8sGateway(t *testing.T) {
 	testInstallation := e2e.CreateTestInstallation(
 		t,
 		&gloogateway.Context{
-			InstallNamespace:       "k8s-gw-test",
+			InstallNamespace:       env.GetOrDefault(testutils.InstallNamespace, "k8s-gw-test"),
 			ValuesManifestFile:     filepath.Join(util.MustGetThisDir(), "manifests", "k8s-gateway-test-helm.yaml"),
 			ValidationAlwaysAccept: false,
 		},
@@ -81,7 +83,6 @@ func TestK8sGateway(t *testing.T) {
 	})
 
 	t.Run("Glooctl", func(t *testing.T) {
-
 		t.Run("Check", func(t *testing.T) {
 			suite.Run(t, glooctl.NewCheckSuite(ctx, testInstallation))
 		})

--- a/test/testutils/env.go
+++ b/test/testutils/env.go
@@ -13,6 +13,9 @@ const (
 	// installation from a previous run
 	SkipInstall = "SKIP_INSTALL"
 
+	// InstallNamespace is the namespace in which Gloo is installed
+	InstallNamespace = "INSTALL_NAMESPACE"
+
 	// SkipIstioInstall is a flag that indicates whether to skip the install of Istio.
 	// This is used to test against an existing installation of Istio so that the
 	// test framework does not need to install/uninstall Istio.


### PR DESCRIPTION
# Description
This change simplifies how plugins may perform merging of policies in a delegation chain, particularly in the case of RouteOptions. It performs an in-place merge such that the policy on a child route may be overridden by by a subsequent call to the plugin with a different route context.

Further, it accurately tracks the source RouteOptions involved in the merge so that the statuses on them can be correctly reported.

## Testing steps

Apply RouteOptions to routes similar to the configs in `projects/gateway2/translator/testutils/inputs/delegation/route_options*` and confirm the merging of policies works as expected.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/6204