### PR TITLE
reconcile upstreams in gateway controller

### DIFF
--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -12,6 +12,7 @@ import (
 	rtoptquery "github.com/solo-io/gloo/projects/gateway2/translator/plugins/routeoptions/query"
 	vhoptquery "github.com/solo-io/gloo/projects/gateway2/translator/plugins/virtualhostoptions/query"
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/bootstrap"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -71,6 +72,7 @@ func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 		controllerBuilder.watchNamespaces,
 		controllerBuilder.watchRouteOptions,
 		controllerBuilder.watchVirtualHostOptions,
+		controllerBuilder.watchUpstreams,
 		controllerBuilder.addIndexes,
 		controllerBuilder.addRtOptIndexes,
 		controllerBuilder.addVhOptIndexes,
@@ -281,6 +283,17 @@ func (c *controllerBuilder) watchVirtualHostOptions(ctx context.Context) error {
 	return nil
 }
 
+func (c *controllerBuilder) watchUpstreams(ctx context.Context) error {
+	err := ctrl.NewControllerManagedBy(c.cfg.Mgr).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		For(&gloov1.Upstream{}).
+		Complete(reconcile.Func(c.reconciler.ReconcileUpstreams))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 type controllerReconciler struct {
 	cli    client.Client
 	scheme *runtime.Scheme
@@ -294,6 +307,12 @@ func (r *controllerReconciler) ReconcileRouteOptions(ctx context.Context, req ct
 }
 
 func (r *controllerReconciler) ReconcileVirtualHostOptions(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// eventually reconcile only effected listeners etc
+	r.kick(ctx)
+	return ctrl.Result{}, nil
+}
+
+func (r *controllerReconciler) ReconcileUpstreams(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	// eventually reconcile only effected listeners etc
 	r.kick(ctx)
 	return ctrl.Result{}, nil


### PR DESCRIPTION
# Description

currently a change to a k8s upstream might not get reconciled because the gateway controller is not set to resync on an Upstream change

this PR fixes that