### PR TITLE
ginkgo/parallel: add tests for AdvancePortSafeListen

### DIFF
--- a/changelog/v1.17.0-beta30/advance-port-safe.yaml
+++ b/changelog/v1.17.0-beta30/advance-port-safe.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Add tests for AdvancePortSafeListen, to demonstrate that the logic to find a free port works as expected

--- a/test/ginkgo/parallel/ports.go
+++ b/test/ginkgo/parallel/ports.go
@@ -66,8 +66,8 @@ func AdvancePort(p *uint32) uint32 {
 
 // AdvancePortSafeListen returns a port that is safe to use in parallel tests
 // It relies on pinging the port to see if it is in use
-func AdvancePortSafeListen(p *uint32) uint32 {
-	return MustAdvancePortSafe(p, portInUseListen)
+func AdvancePortSafeListen(p *uint32, retryOptions ...retry.Option) uint32 {
+	return MustAdvancePortSafe(p, portInUseListen, retryOptions...)
 }
 
 func portInUseListen(proposedPort uint32) error {


### PR DESCRIPTION
# Description

Add a test for the AdvancePortSafeListen logic

# Context

Slack: https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1716309405979209

We still are seeing some flakes with one particular test service that relies on this functionality. I decided to add these tests to verify that the logic works as expected.

## Testing steps
```go
TEST_PKG=test/ginkgo/parallel make test
```

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works