### PR TITLE
Fix missing listener data for HTTPS listeners during proxy translation

### DIFF
--- a/changelog/v1.17.0-beta31/append-missing-https-listener-data.yaml
+++ b/changelog/v1.17.0-beta31/append-missing-https-listener-data.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6201
+    resolvesIssue: false
+    description: Set the previously-missing HTTPS listener data when the listeners are translated.

--- a/projects/gateway2/translator/listener/gateway_listener_translator.go
+++ b/projects/gateway2/translator/listener/gateway_listener_translator.go
@@ -169,6 +169,7 @@ func (ml *mergedListeners) appendHttpsListener(
 		port:              gwv1.PortNumber(ports.TranslatePort(uint16(listener.Port))),
 		httpsFilterChains: []httpsFilterChain{mfc},
 		listenerReporter:  reporter,
+		listener:          listener, // TODO(infocus7): ask jenny/ggv2-team why we aren't passing the listener here, but we are for http. was it just accidentally forgotten?
 	})
 }
 

--- a/projects/gateway2/translator/listener/gateway_listener_translator.go
+++ b/projects/gateway2/translator/listener/gateway_listener_translator.go
@@ -169,7 +169,7 @@ func (ml *mergedListeners) appendHttpsListener(
 		port:              gwv1.PortNumber(ports.TranslatePort(uint16(listener.Port))),
 		httpsFilterChains: []httpsFilterChain{mfc},
 		listenerReporter:  reporter,
-		listener:          listener, // TODO(infocus7): ask jenny/ggv2-team why we aren't passing the listener here, but we are for http. was it just accidentally forgotten?
+		listener:          listener,
 	})
 }
 


### PR DESCRIPTION
# Description

Fixes issue seen (in portal) where the passed **routeCtx** to ApplyRoutePlugin had zero-valued listener information for HTTPS listeners.

## Code changes
- Pass missing HTTPS `listener` data to listener merger.

# Context

When using https gateway listener, in Portal the `listener` during the **ApplyRoutePlugin** was missing information.

## Testing steps

Only verified [here](https://github.com/solo-io/solo-projects/pull/6229) with a Portal integration.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works