### PR TITLE
GGv2: Name output routes

### DIFF
--- a/changelog/v1.17.0-beta34/name-output-routes.yaml
+++ b/changelog/v1.17.0-beta34/name-output-routes.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Name output routes in the Gateway translator.
+     

--- a/projects/gateway2/translator/httproute/gateway_http_route_translator.go
+++ b/projects/gateway2/translator/httproute/gateway_http_route_translator.go
@@ -3,6 +3,7 @@ package httproute
 import (
 	"container/list"
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/golang/protobuf/ptypes/wrappers"
@@ -62,7 +63,7 @@ func translateGatewayHTTPRouteRulesUtil(
 	hostnames []gwv1.Hostname,
 	delegationChain *list.List,
 ) {
-	for _, rule := range route.Spec.Rules {
+	for idx, rule := range route.Spec.Rules {
 		rule := rule
 		if rule.Matches == nil {
 			// from the spec:
@@ -76,6 +77,7 @@ func translateGatewayHTTPRouteRulesUtil(
 			queries,
 			gwListener,
 			&route,
+			idx,
 			rule,
 			reporter,
 			baseReporter,
@@ -102,6 +104,7 @@ func translateGatewayHTTPRouteRule(
 	queries query.GatewayQueries,
 	gwListener gwv1.Listener,
 	gwroute *gwv1.HTTPRoute,
+	ruleIndex int,
 	rule gwv1.HTTPRouteRule,
 	reporter reports.ParentRefReporter,
 	baseReporter reports.Reporter,
@@ -117,6 +120,7 @@ func translateGatewayHTTPRouteRule(
 			Matchers: []*matchers.Matcher{translateGlooMatcher(match)},
 			Action:   nil,
 			Options:  &v1.RouteOptions{},
+			Name:     fmt.Sprintf("%s-%s-%d-%d", gwroute.Name, gwroute.Namespace, ruleIndex, idx),
 		}
 
 		var delegatedRoutes []*v1.Route


### PR DESCRIPTION
just adds names to output routes sent to envoy. this enables plugins with caches to be aware when they are operating on the same route