### PR TITLE
Set persistProxySpec to false in kubernetes e2e tests

### DIFF
--- a/changelog/v1.17.0-beta34/persistproxy-false.yaml
+++ b/changelog/v1.17.0-beta34/persistproxy-false.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Set persistProxySpec to false in kubernetes e2e tests.
+      skipCI-docs-build:true

--- a/test/kubernetes/e2e/tests/manifests/edge-gateway-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/edge-gateway-test-helm.yaml
@@ -9,7 +9,7 @@ settings:
     invalidRouteResponseBody: Gloo Gateway has invalid configuration.
 gateway:
   enabled: true
-  persistProxySpec: true
+  persistProxySpec: false
   logLevel: info
   validation:
     allowWarnings: true

--- a/test/kubernetes/e2e/tests/manifests/istio-automtls-edge-gateway-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/istio-automtls-edge-gateway-test-helm.yaml
@@ -14,7 +14,7 @@ settings:
     invalidRouteResponseBody: Gloo Gateway has invalid configuration.
 gateway:
   enabled: true
-  persistProxySpec: true
+  persistProxySpec: false
   logLevel: info
   validation:
     allowWarnings: true

--- a/test/kubernetes/e2e/tests/manifests/istio-automtls-k8s-gateway-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/istio-automtls-k8s-gateway-test-helm.yaml
@@ -21,7 +21,7 @@ settings:
     invalidRouteResponseCode: 404
     invalidRouteResponseBody: Gloo Gateway has invalid configuration.
 gateway:
-  persistProxySpec: true
+  persistProxySpec: false
   logLevel: info
   validation:
     allowWarnings: true

--- a/test/kubernetes/e2e/tests/manifests/istio-edge-gateway-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/istio-edge-gateway-test-helm.yaml
@@ -14,7 +14,7 @@ settings:
     invalidRouteResponseBody: Gloo Gateway has invalid configuration.
 gateway:
   enabled: true
-  persistProxySpec: true
+  persistProxySpec: false
   logLevel: info
   validation:
     allowWarnings: true

--- a/test/kubernetes/e2e/tests/manifests/istio-k8s-gateway-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/istio-k8s-gateway-test-helm.yaml
@@ -21,7 +21,7 @@ settings:
     invalidRouteResponseCode: 404
     invalidRouteResponseBody: Gloo Gateway has invalid configuration.
 gateway:
-  persistProxySpec: true
+  persistProxySpec: false
   logLevel: info
   validation:
     allowWarnings: true

--- a/test/kubernetes/e2e/tests/manifests/k8s-gateway-no-webhook-validation-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/k8s-gateway-no-webhook-validation-test-helm.yaml
@@ -16,7 +16,7 @@ settings:
     invalidRouteResponseCode: 404
     invalidRouteResponseBody: Gloo Gateway has invalid configuration.
 gateway:
-  persistProxySpec: true
+  persistProxySpec: false
   logLevel: info
   validation:
     # this is not relevant for k8s GW

--- a/test/kubernetes/e2e/tests/manifests/k8s-gateway-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/k8s-gateway-test-helm.yaml
@@ -16,7 +16,7 @@ settings:
     invalidRouteResponseCode: 404
     invalidRouteResponseBody: Gloo Gateway has invalid configuration.
 gateway:
-  persistProxySpec: true
+  persistProxySpec: false
   logLevel: info
   validation:
     allowWarnings: true


### PR DESCRIPTION
# Description

Change `persistProxySpec` to false (which is the default) in the kubernetes e2e tests.

Keeping the proxies in memory rather than persisting to etcd is generally recommended for performance reasons.



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
