### PR TITLE
glooctl test fixes

### DIFF
--- a/changelog/v1.17.0-beta34/glooctl-test-fixes.yaml
+++ b/changelog/v1.17.0-beta34/glooctl-test-fixes.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Glooctl e2e test: make sure proxies are cleaned up. Use delete file safe to fix test flake.
+      skipCI-docs-build:true

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -65,6 +65,7 @@ func NewGatewayInputChannels() *GatewayInputChannels {
 var (
 	// labels used to uniquely identify Proxies that are managed by the kube gateway controller
 	kubeGatewayProxyLabels = map[string]string{
+		// the proxy type key/value must stay in sync with the one defined in projects/gateway2/translator/gateway_translator.go
 		utils.ProxyTypeKey: utils.GatewayApiProxyValue,
 	}
 )

--- a/projects/gateway2/translator/gateway_translator.go
+++ b/projects/gateway2/translator/gateway_translator.go
@@ -97,6 +97,7 @@ func proxyMetadata(gateway *gwv1.Gateway, writeNamespace string) *core.Metadata 
 		// All proxies are created in the writeNamespace (ie. gloo-system).
 		// We apply a label to maintain a reference to where the originating Gateway was defined
 		Labels: map[string]string{
+			// the proxy type key/value must stay in sync with the one defined in projects/gateway2/proxy_syncer/proxy_syncer.go
 			utils.ProxyTypeKey:        utils.GatewayApiProxyValue,
 			utils.GatewayNamespaceKey: gateway.GetNamespace(),
 		},


### PR DESCRIPTION
# Description

A couple of small updates to the glooctl get proxy test suite:
- Use DeleteFileSafe to fix test flake where VS deletion fails
- Make sure proxies are cleaned up at the end


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
