### PR TITLE
Fix MetalLB setup for Kube GW API conformance tests

### DIFF
--- a/changelog/v1.17.0-rc3/fix-conformance-setup.yaml
+++ b/changelog/v1.17.0-rc3/fix-conformance-setup.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink:
+    resolvesIssue: false
+    description: >-
+      Select more specifically for determining pod subnet when setting up MetalLB for conformance tests
+      
+      skipCI-docs-build:true

--- a/ci/kind/setup-kind.sh
+++ b/ci/kind/setup-kind.sh
@@ -76,7 +76,7 @@ if [[ $CONFORMANCE == "true" ]]; then
   kubectl rollout status -n metallb-system daemonset/speaker --timeout 2m
   kubectl wait -n metallb-system  pod -l app=metallb --for=condition=Ready --timeout=10s
 
-  SUBNET=$(docker network inspect  kind -f '{{(index .IPAM.Config 0).Subnet}}'| cut -d '.' -f1,2)
+  SUBNET=$(docker network inspect kind | jq -r '.[].IPAM.Config[].Subnet | select(contains(":") | not)' | cut -d '.' -f1,2)
   MIN=${SUBNET}.255.0
   MAX=${SUBNET}.255.231
 


### PR DESCRIPTION
# Description

Uses jq to select specifically non-ipv6 ipam config when setting up MetalLB for kube gateway api conformance tests

error seen previously:
```log
Error from server (parsing address pool address-pool: invalid CIDR "fc00:f853:ccd:e793::/64.255.0-fc00:f853:ccd:e793::/64.255.231" in pool "address-pool": invalid IP range "fc00:f853:ccd:e793::/64.255.0-fc00:f853:ccd:e793::/64.255.231": invalid start IP "fc00:f853:ccd:e793::/64.255.0"): error when creating "STDIN": admission webhook "ipaddresspoolvalidationwebhook.metallb.io" denied the request: parsing address pool address-pool: invalid CIDR "fc00:f853:ccd:e793::/64.255.0-fc00:f853:ccd:e793::/64.255.231" in pool "address-pool": invalid IP range "fc00:f853:ccd:e793::/64.255.0-fc00:f853:ccd:e793::/64.255.231": invalid start IP "fc00:f853:ccd:e793::/64.255.0"
```

[internal slack thread context](https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1718205317385649)