### PR TITLE
fix `glooctl check` when default gateway proxy is disabled

### DIFF
--- a/changelog/v1.17.0-rc4/glooctl-check-fix-prom-stats.yaml
+++ b/changelog/v1.17.0-rc4/glooctl-check-fix-prom-stats.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/5741
+    resolvesIssue: false
+    description: >-
+      Fix `glooctl check` to not rely on existence of proxy deployments when checking proxies.


### PR DESCRIPTION
# Description

During `glooctl check` we check prom stats for the gateway proxies. Currently if the default gateway proxy is disabled (which might be the case if you only want to use the kube gw api integration), glooctl check results in an error. Change it to a warning instead.

Manual testing steps:

```
helm install -n gloo-system gloo gloo/gloo --create-namespace --version 1.17.0-rc3 --set gatewayProxies.gatewayProxy.disabled=true
```

Before fix:
```
> glooctl check

Checking deployments... OK
Checking pods... OK
Checking upstreams... OK
Checking upstream groups... OK
Checking auth configs... OK
Checking rate limit configs... OK
Checking VirtualHostOptions... OK
Checking RouteOptions... OK
Checking secrets... OK
Checking virtual services... OK
Checking gateways... OK
Checking proxies... 1 Errors!
Error: 1 error occurred:
	* Gloo installation is incomplete: no active gateway-proxy pods exist in cluster
```

After fix:
```
> glooctl check

Checking deployments... OK
Checking pods... OK
Checking upstreams... OK
Checking upstream groups... OK
Checking auth configs... OK
Checking rate limit configs... OK
Checking VirtualHostOptions... OK
Checking RouteOptions... OK
Checking secrets... OK
Checking virtual services... OK
Checking gateways... OK
Checking proxies... OK
No active gateway-proxy pods exist in cluster
No problems detected.
Skipping Gloo Instance check -- Gloo Federation not detected
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
