### PR TITLE
.github/workflows: update nightly tests to include 1.17

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -114,7 +114,7 @@ jobs:
 
   end_to_end_tests_main:
     name: End-to-End (branch=main, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'main') || github.event.schedule == '0 5 * * 1-5' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'main') || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     strategy:
@@ -251,7 +251,7 @@ jobs:
 
   regression_tests_main:
     name: main regression tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'main') || github.event.schedule == '0 5 * * 1-5' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'main') || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     # Previously, there was an environment variable, RELEASED_VERSION="LATEST" set.  This made use of some internal code:
@@ -343,7 +343,7 @@ jobs:
 
   performance_tests_main:
     name: main performance tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'main') || github.event.schedule == '0 5 * * 1-5' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'main') || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
@@ -391,7 +391,7 @@ jobs:
 
   kube_gateway_api_conformance_tests_main:
     name: Conformance (branch=main, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'main') || github.event.schedule == '0 5 * * 1-5' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'main') || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -457,7 +457,7 @@ jobs:
             trigger="Gloo OSS Manual run"
             branch=${{ inputs.branch }}
             echo "SLACK_CHANNEL=C0314KESVNV" >> $GITHUB_ENV   #slack-integration-testing if manually run
-          elif [[ ${{github.event.schedule == '0 5 * * 1-5'}} = true ]]; then
+          elif [[ ${{github.event.schedule == '0 5 * * *'}} = true ]]; then
             trigger="Gloo OSS nightlies"
             branch="main"
           elif [[ ${{github.event.schedule == '0 6 * * 1'}} = true ]]; then

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -11,9 +11,10 @@ on:
   # Month of the year [1,12]
   # Day of the week ([0,6] with 0=Sunday)
   schedule:
-    - cron: "0 5 * * 1-5" # weekdays @ 05:00 UTC, run tests against latest main
-    - cron: "0 6 * * 1"   # monday   @ 06:00 UTC, run expanded tests against v1.16.x
-    - cron: "0 7 * * 1"   # monday   @ 07:00 UTC, run expanded tests against v1.15.x
+    - cron: "0 5 * * *" # every day @ 05:00 UTC, run tests against latest main
+    - cron: "0 6 * * 1" # monday    @ 06:00 UTC, run expanded tests against v1.17.x
+    - cron: "0 7 * * 1" # monday    @ 07:00 UTC, run expanded tests against v1.16.x
+    - cron: "0 8 * * 1" # monday    @ 08:00 UTC, run expanded tests against v1.15.x
   workflow_dispatch:
     inputs:
       branch:
@@ -21,6 +22,7 @@ on:
         type: choice
         options:
           - main
+          - v1.17.x
           - v1.16.x
           - v1.15.x
           - workflow_initiating_branch
@@ -30,6 +32,10 @@ on:
         default: false
       run-performance:
         description: "Run performance tests"
+        type: boolean
+        default: false
+      run-conformance:
+        description: "Run conformance tests"
         type: boolean
         default: false
       run-kubernetes-end-to-end:
@@ -165,6 +171,65 @@ jobs:
           run-regex: ${{ matrix.test.go-test-run-regex }}
           istio-version: ${{ steps.dotenv.outputs.istio_version }}
 
+  end_to_end_tests_17:
+    name: End-to-End (branch=v1.17.x, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1-5' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 90
+    strategy:
+      # Since we are running these on a schedule, there is no value in failing fast
+      # In fact, we want to ensure that all tests run, so that we have a clearer picture of which tests are prone to flaking
+      fail-fast: false
+      matrix:
+        test:
+          # When running the tests at night, there is no value in splitting the tests across multiple clusters and running them in parallel.
+          # As a result, we increase the threshold for the tests, since they all run serially on a single cluster
+          - cluster-name: 'cluster-one'
+            go-test-args: '-v -timeout=90m'
+            go-test-run-regex: ""
+        # In our nightly tests, we run the suite of tests using the lower and upper ends of versions that we claim to support
+        # The versions should mirror: https://docs.solo.io/gloo-edge/latest/reference/support/
+        version-files:
+          - label: 'min'
+            file: './.github/workflows/.env/nightly-tests/min_versions.env'
+          - label: 'max'
+            file: './.github/workflows/.env/nightly-tests/max_versions.env'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v1.17.x
+      # The dotenv action is used to load key-value pairs from files.
+      # In this case, the file is specified in the matrix and will contain the versions of the tools to use
+      - name: Dotenv Action
+        uses: falti/dotenv-action@v1.1.2
+        id: dotenv
+        with:
+          path: ${{ matrix.version-files.file }}
+          log-variables: true
+      - name: Prep Go Runner
+        uses: ./.github/workflows/composite-actions/prep-go-runner
+      # Set up the KinD cluster that the tests will use
+      - id: setup-kind-cluster
+        name: Setup KinD Cluster
+        uses: ./.github/workflows/composite-actions/setup-kind-cluster
+        with:
+          cluster-name: ${{ matrix.test.cluster-name }}
+          kind-node-version: ${{ steps.dotenv.outputs.node_version }}
+          kind-version: ${{ steps.dotenv.outputs.kind_version }}
+          kubectl-version: ${{ steps.dotenv.outputs.kubectl_version }}
+          helm-version: ${{ steps.dotenv.outputs.helm_version }}
+          istio-version: ${{ steps.dotenv.outputs.istio_version }}
+      # Run the tests
+      - id: run-tests
+        name: Run Kubernetes e2e Tests
+        uses: ./.github/workflows/composite-actions/kubernetes-e2e-tests
+        with:
+          cluster-name: ${{ matrix.test.cluster-name }}
+          test-args: ${{ matrix.test.go-test-args }}
+          run-regex: ${{ matrix.test.go-test-run-regex }}
+          istio-version: ${{ steps.dotenv.outputs.istio_version }}
+
   regression_tests_on_demand:
     name: on demand regression tests
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'workflow_initiating_branch' }}
@@ -213,9 +278,26 @@ jobs:
         ref: main
     - uses: ./.github/workflows/composite-actions/regression-tests
 
+  regression_tests_17:
+    name: v1.17.x regression tests
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade' ]
+        kube-version: [ { node: 'v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b', kubectl: 'v1.25.16', kind: 'v0.20.0', helm: 'v3.13.2' },
+                        { node: 'v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245', kubectl: 'v1.29.2', kind: 'v0.20.0', helm: 'v3.14.4' } ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v1.17.x
+      - uses: ./.github/workflows/composite-actions/regression-tests
+
   regression_tests_16:
     name: v1.16.x regression tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.16.x') || github.event.schedule == '0 6 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.16.x') || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -232,7 +314,7 @@ jobs:
 
   regression_tests_15:
     name: v1.15.x regression tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.15.x') || github.event.schedule == '0 7 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.15.x') || github.event.schedule == '0 8 * * 1' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -271,21 +353,33 @@ jobs:
       - uses: ./.github/workflows/composite-actions/prep-go-runner
       - uses: ./.github/workflows/composite-actions/performance-tests
 
-  performance_tests_16:
-    name: v1.16.x performance tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.16.x') || github.event.schedule == '0 6 * * 1' }}
+  performance_tests_17:
+    name: v1.17.x performance tests
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.15.x
+          ref: v1.17.x
+      - uses: ./.github/workflows/composite-actions/prep-go-runner
+      - uses: ./.github/workflows/composite-actions/performance-tests
+
+  performance_tests_16:
+    name: v1.16.x performance tests
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.16.x') || github.event.schedule == '0 7 * * 1' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v1.16.x
       - uses: ./.github/workflows/composite-actions/prep-go-runner
       - uses: ./.github/workflows/composite-actions/performance-tests
 
   performance_tests_15:
     name: v1.15.x performance tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.15.x') || github.event.schedule == '0 7 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.15.x') || github.event.schedule == '0 8 * * 1' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
@@ -296,8 +390,8 @@ jobs:
       - uses: ./.github/workflows/composite-actions/performance-tests
 
   kube_gateway_api_conformance_tests_main:
-    name: kubernetes gateway api conformance tests@k8s-${{matrix.kube-version.node}})
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'main') || github.event.schedule == '0 5 * * 1-5' }}
+    name: Conformance (branch=main, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'main') || github.event.schedule == '0 5 * * 1-5' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:
@@ -313,19 +407,42 @@ jobs:
         ref: main
     - uses: ./.github/workflows/composite-actions/kube-gateway-api-conformance-tests
 
+
+  kube_gateway_api_conformance_tests_17:
+    name: Conformance (branch=v1.17.x, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1-5' }}
+    runs-on: ubuntu-22.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-version: [ { node: 'v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b', kubectl: 'v1.25.16', kind: 'v0.20.0', helm: 'v3.13.2' },
+                        { node: 'v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245', kubectl: 'v1.29.2', kind: 'v0.20.0', helm: 'v3.14.4' } ]
+        image-variant:
+          - standard
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: v1.17.x
+      - uses: ./.github/workflows/composite-actions/kube-gateway-api-conformance-tests
+
   publish_results:
     runs-on: ubuntu-22.04
     timeout-minutes: 5
     if: ${{ always() }}
     needs:
       - end_to_end_tests_main
+      - end_to_end_tests_17
       - regression_tests_main
-      - regression_tests_15
+      - regression_tests_17
       - regression_tests_16
+      - regression_tests_15
       - performance_tests_main
-      - performance_tests_15
+      - performance_tests_17
       - performance_tests_16
+      - performance_tests_15
       - kube_gateway_api_conformance_tests_main
+      - kube_gateway_api_conformance_tests_17
       - end_to_end_tests_on_demand
       - regression_tests_on_demand
       - performance_tests_on_demand
@@ -340,15 +457,18 @@ jobs:
             trigger="Gloo OSS Manual run"
             branch=${{ inputs.branch }}
             echo "SLACK_CHANNEL=C0314KESVNV" >> $GITHUB_ENV   #slack-integration-testing if manually run
-          elif [[ ${{github.event.schedule == '0 7 * * 1'}} = true ]]; then
-            trigger="Gloo OSS weeklies"
-            branch="v1.15.x"
-          elif [[ ${{github.event.schedule == '0 6 * * 1'}} = true ]]; then
-            trigger="Gloo OSS weeklies"
-            branch="v1.16.x"
           elif [[ ${{github.event.schedule == '0 5 * * 1-5'}} = true ]]; then
             trigger="Gloo OSS nightlies"
             branch="main"
+          elif [[ ${{github.event.schedule == '0 6 * * 1'}} = true ]]; then
+            trigger="Gloo OSS weeklies"
+            branch="v1.17.x"
+          elif [[ ${{github.event.schedule == '0 7 * * 1'}} = true ]]; then
+            trigger="Gloo OSS weeklies"
+            branch="v1.16.x"
+          elif [[ ${{github.event.schedule == '0 8 * * 1-5'}} = true ]]; then
+            trigger="Gloo OSS nightlies"
+            branch="v1.15.x"
           fi
           preamble="$trigger ($branch)"
           echo "Setting PREAMBLE as $preamble"

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -173,7 +173,7 @@ jobs:
 
   end_to_end_tests_17:
     name: End-to-End (branch=v1.17.x, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1-5' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 90
     strategy:
@@ -410,7 +410,7 @@ jobs:
 
   kube_gateway_api_conformance_tests_17:
     name: Conformance (branch=v1.17.x, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1-5' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -466,7 +466,7 @@ jobs:
           elif [[ ${{github.event.schedule == '0 7 * * 1'}} = true ]]; then
             trigger="Gloo OSS weeklies"
             branch="v1.16.x"
-          elif [[ ${{github.event.schedule == '0 8 * * 1-5'}} = true ]]; then
+          elif [[ ${{github.event.schedule == '0 8 * * 1'}} = true ]]; then
             trigger="Gloo OSS nightlies"
             branch="v1.15.x"
           fi

--- a/changelog/v1.18.0-beta1/update-lts.yaml
+++ b/changelog/v1.18.0-beta1/update-lts.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6264
+    resolvesIssue: false
+    description: >-
+      Update the set of LTS branches that run tests at night


### PR DESCRIPTION
# Description

Update our nightly tests to run against the newly created v1.17.x branch

# Context

We want to test our most recent stable branches 

- Change the frequency of our nightly tests from every weekday, to everyday: https://github.com/solo-io/gloo/pull/9620/files#r1638945969
- Allow the conformance tests to be run without the regression tests: https://github.com/solo-io/gloo/pull/9620/files#r1638943927
- Fix a bug in our 1.16 performance tests, which were actually running the 1.15 branch: https://github.com/solo-io/gloo/pull/9620/files#r1638944250

## Interesting decisions
 -

## Testing steps
I invoked the nightly tests from this branch.
Logs: https://github.com/solo-io/gloo/actions/runs/9506754249
Slack result: https://solo-io-corp.slack.com/archives/C0314KESVNV/p1718315762628899
```
[Gloo OSS Manual run (v1.17.x)](https://github.com/solo-io/gloo/actions/runs/9506754249) have failed some jobs: FAILURE: regression_tests_17,end_to_end_tests_17
```

The test failure isn't actually relevant to me. What's important is that all the tests were able to run against the 1.17.x branch. The failures are flakes that the team will need to triage/address.

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works