### PR TITLE
prevent Proxy namespace being from modified

### DIFF
--- a/projects/gloo/pkg/syncer/envoy_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/envoy_translator_syncer.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/go-utils/hashutils"
-	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
 	envoycache "github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
 	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/types"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
@@ -24,11 +23,9 @@ import (
 
 	"github.com/solo-io/gloo/pkg/utils/syncutil"
 	"github.com/solo-io/gloo/projects/gateway2/translator/translatorutils"
-	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	v1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	syncerstats "github.com/solo-io/gloo/projects/gloo/pkg/syncer/stats"
-	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 )
 
@@ -58,7 +55,7 @@ func init() {
 const emptyVersionKey = "empty"
 
 var (
-	emptyResource = cache.Resources{
+	emptyResource = envoycache.Resources{
 		Version: emptyVersionKey,
 		Items:   map[string]envoycache.Resource{},
 	}
@@ -128,7 +125,7 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1snap.ApiSnapsh
 	var proxiesWithReports []translatorutils.ProxyWithReports
 	for _, proxy := range snap.Proxies {
 		proxyCtx := ctx
-		metaKey := GetKeyFromProxyMeta(proxy)
+		metaKey := xds.SnapshotCacheKey(proxy)
 		if ctxWithTags, err := tag.New(proxyCtx, tag.Insert(syncerstats.ProxyNameKey, metaKey)); err == nil {
 			proxyCtx = ctxWithTags
 		}
@@ -233,18 +230,4 @@ func prettify(original interface{}) string {
 	}
 
 	return string(b)
-}
-
-func GetKeyFromProxyMeta(proxy *gloov1.Proxy) string {
-	meta := proxy.GetMetadata()
-	metaKey := meta.Ref().Key()
-	labels := proxy.GetMetadata().GetLabels()
-	if labels != nil && labels[utils.ProxyTypeKey] == utils.GatewayApiProxyValue {
-		proxyNamespace := labels[utils.GatewayNamespaceKey]
-		if proxyNamespace != "" {
-			meta.Namespace = proxyNamespace
-			metaKey = meta.Ref().Key()
-		}
-	}
-	return metaKey
 }

--- a/projects/gloo/pkg/syncer/translator_syncer_test.go
+++ b/projects/gloo/pkg/syncer/translator_syncer_test.go
@@ -7,8 +7,6 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/servers/iosnapshot"
 
 	"github.com/solo-io/gloo/pkg/bootstrap/leaderelector/singlereplica"
-	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
-	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 
 	gloo_translator "github.com/solo-io/gloo/projects/gloo/pkg/translator"
 
@@ -343,68 +341,6 @@ var _ = Describe("Translate multiple proxies with errors", func() {
 		}))
 
 		Expect(xdsCache.Called).To(BeTrue())
-	})
-
-	Describe("correctl returns metaKey for proxies", func() {
-		It("returns the correct key", func() {
-			// Create a proxy with metadata and labels
-			proxy := &gloov1.Proxy{
-				Metadata: &core.Metadata{
-					Name:      "test-proxy",
-					Namespace: "test-namespace",
-					Labels: map[string]string{
-						utils.ProxyTypeKey:        utils.GatewayApiProxyValue,
-						utils.GatewayNamespaceKey: "custom-namespace",
-					},
-				},
-			}
-
-			key := GetKeyFromProxyMeta(proxy)
-
-			// Assert that the returned key matches the expected value
-			expectedKey := "custom-namespace.test-proxy"
-			Expect(key).To(Equal(expectedKey))
-		})
-
-		It("returns the correct key when proxy has no custom namespace label", func() {
-
-			// Create a proxy with metadata and labels
-			proxy := &gloov1.Proxy{
-				Metadata: &core.Metadata{
-					Name:      "test-proxy",
-					Namespace: "test-namespace",
-					Labels: map[string]string{
-						utils.ProxyTypeKey: utils.GatewayApiProxyValue,
-					},
-				},
-			}
-
-			key := GetKeyFromProxyMeta(proxy)
-
-			// Assert that the returned key matches the expected value
-			expectedKey := "test-namespace.test-proxy"
-			Expect(key).To(Equal(expectedKey))
-		})
-
-		It("returns the correct key when proxy is not a Gloo gateway proxy", func() {
-			// Create a proxy with metadata and labels
-			proxy := &gloov1.Proxy{
-				Metadata: &core.Metadata{
-					Name:      "test-proxy",
-					Namespace: "test-namespace",
-					Labels: map[string]string{
-						utils.ProxyTypeKey:        "some-other-value",
-						utils.GatewayNamespaceKey: "custom-namespace",
-					},
-				},
-			}
-
-			key := GetKeyFromProxyMeta(proxy)
-
-			// Assert that the returned key matches the expected value
-			expectedKey := "test-namespace.test-proxy"
-			Expect(key).To(Equal(expectedKey))
-		})
 	})
 })
 


### PR DESCRIPTION
# Description

Previously, a 'metaKey' was generated for each Proxy being translated and synced to envoy.
This key was used as a 'tag' for tracing of the
translation/sync prcoess. It used a custom function that was almost exactly
matched how the SnapshotCacheKey used for xDS was generated; this function
also modified the actual Proxy's namespace, which broke assumptions of where
the proxy lives in the in-memory client.

By removing the namespace modification we fix various status error logs as
now the Proxy is located where the rest of the system expects (the write
namespace). Also, we can simply use the SnapshotCacheKey(...) to generate
a key with the same logic used for xds.

## Testing steps

I manually verified behavior by ...

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->