### PR TITLE
allow deploying other GatewayClasses

### DIFF
--- a/changelog/v1.18.0-beta1/custom-gwclass-deploy.yaml
+++ b/changelog/v1.18.0-beta1/custom-gwclass-deploy.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Allow GME to configure additional GatewayClasses that are deployed by our controller.

--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +42,7 @@ const (
 
 type GatewayConfig struct {
 	Mgr            manager.Manager
-	GWClass        apiv1.ObjectName
+	GWClasses      sets.Set[string]
 	Dev            bool
 	ControllerName string
 	AutoProvision  bool
@@ -55,7 +56,7 @@ type GatewayConfig struct {
 
 func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 	log := log.FromContext(ctx)
-	log.V(5).Info("starting controller", "controllerName", cfg.ControllerName, "gwclass", cfg.GWClass)
+	log.V(5).Info("starting controller", "controllerName", cfg.ControllerName, "gwclass", sets.List(cfg.GWClasses))
 
 	controllerBuilder := &controllerBuilder{
 		cfg: cfg,
@@ -85,7 +86,6 @@ func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 		controllerBuilder.addVhOptIndexes,
 		controllerBuilder.addGwParamsIndexes,
 	)
-
 }
 
 func run(ctx context.Context, funcs ...func(ctx context.Context) error) error {
@@ -179,7 +179,7 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 		// Don't use WithEventFilter here as it also filters events for Owned objects.
 		For(&apiv1.Gateway{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
 			if gw, ok := object.(*apiv1.Gateway); ok {
-				return gw.Spec.GatewayClassName == c.cfg.GWClass
+				return c.cfg.GWClasses.Has(string(gw.Spec.GatewayClassName))
 			}
 			return false
 		}), predicate.GenerationChangedPredicate{}))
@@ -226,7 +226,6 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 	gwReconciler := &gatewayReconciler{
 		cli:           c.cfg.Mgr.GetClient(),
 		scheme:        c.cfg.Mgr.GetScheme(),
-		className:     c.cfg.GWClass,
 		autoProvision: c.cfg.AutoProvision,
 		deployer:      d,
 		kick:          c.cfg.Kick,
@@ -408,7 +407,6 @@ func (r *controllerReconciler) ReconcileHttpRoutes(ctx context.Context, req ctrl
 }
 
 func (r *controllerReconciler) ReconcileReferenceGrants(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
 	// reconcile all things?!
 	r.kick(ctx)
 	return ctrl.Result{}, nil

--- a/projects/gateway2/controller/controller_suite_test.go
+++ b/projects/gateway2/controller/controller_suite_test.go
@@ -116,22 +116,24 @@ var _ = BeforeSuite(func() {
 	err = controller.NewBaseGatewayController(ctx, cfg)
 	Expect(err).ToNot(HaveOccurred())
 
-	err = k8sClient.Create(ctx, &api.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: gatewayClassName,
-		},
-		Spec: api.GatewayClassSpec{
-			ControllerName: api.GatewayController(gatewayControllerName),
-			ParametersRef: &api.ParametersReference{
-				Group:     api.Group(v1alpha1.GatewayParametersGVK.Group),
-				Kind:      api.Kind(v1alpha1.GatewayParametersGVK.Kind),
-				Name:      wellknown.DefaultGatewayParametersName,
-				Namespace: ptr.To(api.Namespace("default")),
+	for _, gwclass := range []string{gatewayClassName, altGatewayClassName} {
+		err = k8sClient.Create(ctx, &api.GatewayClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: gwclass,
 			},
-		},
-	})
-	Expect(err).NotTo(HaveOccurred())
+			Spec: api.GatewayClassSpec{
+				ControllerName: api.GatewayController(gatewayControllerName),
+				ParametersRef: &api.ParametersReference{
+					Group:     api.Group(v1alpha1.GatewayParametersGVK.Group),
+					Kind:      api.Kind(v1alpha1.GatewayParametersGVK.Kind),
+					Name:      wellknown.DefaultGatewayParametersName,
+					Namespace: ptr.To(api.Namespace("default")),
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
 
+	}
 	err = k8sClient.Create(ctx, &v1alpha1.GatewayParameters{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      wellknown.DefaultGatewayParametersName,

--- a/projects/gateway2/controller/gw_controller.go
+++ b/projects/gateway2/controller/gw_controller.go
@@ -20,7 +20,6 @@ const (
 
 type gatewayReconciler struct {
 	cli           client.Client
-	className     api.ObjectName
 	autoProvision bool
 
 	scheme   *runtime.Scheme

--- a/projects/gateway2/controller/gw_controller_test.go
+++ b/projects/gateway2/controller/gw_controller_test.go
@@ -20,7 +20,6 @@ var _ = Describe("GwController", func() {
 	DescribeTable(
 		"should add status to gateway",
 		func(gwClass string) {
-			print(gwClass)
 			same := api.NamespacesFromSame
 			gwName := "gw-" + gwClass
 			gw := api.Gateway{

--- a/projects/gateway2/controller/gw_controller_test.go
+++ b/projects/gateway2/controller/gw_controller_test.go
@@ -17,70 +17,75 @@ var _ = Describe("GwController", func() {
 		interval = time.Millisecond * 250
 	)
 
-	It("should add status to gateway", func() {
-		same := api.NamespacesFromSame
-		gw := api.Gateway{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gw",
-				Namespace: "default",
-			},
-			Spec: api.GatewaySpec{
-				GatewayClassName: api.ObjectName(gatewayClassName),
-				Listeners: []api.Listener{{
-					Protocol: "HTTP",
-					Port:     80,
-					AllowedRoutes: &api.AllowedRoutes{
-						Namespaces: &api.RouteNamespaces{
-							From: &same,
+	DescribeTable(
+		"should add status to gateway",
+		func(gwClass string) {
+			print(gwClass)
+			same := api.NamespacesFromSame
+			gwName := "gw-" + gwClass
+			gw := api.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      gwName,
+					Namespace: "default",
+				},
+				Spec: api.GatewaySpec{
+					GatewayClassName: api.ObjectName(gwClass),
+					Listeners: []api.Listener{{
+						Protocol: "HTTP",
+						Port:     80,
+						AllowedRoutes: &api.AllowedRoutes{
+							Namespaces: &api.RouteNamespaces{
+								From: &same,
+							},
 						},
-					},
-					Name: "listener",
-				}},
-			},
-		}
-		err := k8sClient.Create(ctx, &gw)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Wait for service to be created
-		var svc corev1.Service
-		Eventually(func() bool {
-			var createdServices corev1.ServiceList
-			err := k8sClient.List(ctx, &createdServices)
-			if err != nil {
-				return false
+						Name: "listener",
+					}},
+				},
 			}
-			for _, svc = range createdServices.Items {
-				if len(svc.ObjectMeta.OwnerReferences) == 1 && svc.ObjectMeta.OwnerReferences[0].UID == gw.UID {
-					return true
+			err := k8sClient.Create(ctx, &gw)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Wait for service to be created
+			var svc corev1.Service
+			Eventually(func() bool {
+				var createdServices corev1.ServiceList
+				err := k8sClient.List(ctx, &createdServices)
+				if err != nil {
+					return false
 				}
-			}
-			return false
-		}, timeout, interval).Should(BeTrue(), "service not created")
-		Expect(svc.Spec.ClusterIP).NotTo(BeEmpty())
-
-		// Need to update the status of the service
-		svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
-			Ingress: []corev1.LoadBalancerIngress{{
-				IP: "127.0.0.1",
-			}},
-		}
-		Expect(k8sClient.Status().Update(ctx, &svc)).NotTo(HaveOccurred())
-
-		Eventually(func() bool {
-			err := k8sClient.Get(ctx, client.ObjectKey{Name: "gw", Namespace: "default"}, &gw)
-			if err != nil {
+				for _, svc = range createdServices.Items {
+					if len(svc.ObjectMeta.OwnerReferences) == 1 && svc.ObjectMeta.OwnerReferences[0].UID == gw.UID {
+						return true
+					}
+				}
 				return false
+			}, timeout, interval).Should(BeTrue(), "service not created")
+			Expect(svc.Spec.ClusterIP).NotTo(BeEmpty())
+
+			// Need to update the status of the service
+			svc.Status.LoadBalancer = corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{{
+					IP: "127.0.0.1",
+				}},
 			}
-			if len(gw.Status.Addresses) == 0 {
-				return false
-			}
-			return true
-		}, timeout, interval).Should(BeTrue())
+			Expect(k8sClient.Status().Update(ctx, &svc)).NotTo(HaveOccurred())
 
-		Expect(gw.Status.Addresses).To(HaveLen(1))
-		Expect(*gw.Status.Addresses[0].Type).To(Equal(api.IPAddressType))
-		Expect(gw.Status.Addresses[0].Value).To(Equal("127.0.0.1"))
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKey{Name: gwName, Namespace: "default"}, &gw)
+				if err != nil {
+					return false
+				}
+				if len(gw.Status.Addresses) == 0 {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
 
-	})
-
+			Expect(gw.Status.Addresses).To(HaveLen(1))
+			Expect(*gw.Status.Addresses[0].Type).To(Equal(api.IPAddressType))
+			Expect(gw.Status.Addresses[0].Value).To(Equal("127.0.0.1"))
+		},
+		Entry("default gateway class", gatewayClassName),
+		Entry("alternative gateway class", altGatewayClassName),
+	)
 })

--- a/projects/gateway2/controller/start.go
+++ b/projects/gateway2/controller/start.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/servers/iosnapshot"
 
+	"k8s.io/apimachinery/pkg/util/sets"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	apiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gateway2/controller/scheme"
@@ -30,11 +30,7 @@ const (
 	AutoProvision = true
 )
 
-var (
-	gatewayClass = apiv1.ObjectName(wellknown.GatewayClassName)
-
-	setupLog = ctrl.Log.WithName("setup")
-)
+var setupLog = ctrl.Log.WithName("setup")
 
 type StartConfig struct {
 	Dev  bool
@@ -137,7 +133,7 @@ func Start(ctx context.Context, cfg StartConfig) error {
 
 	gwCfg := GatewayConfig{
 		Mgr:            mgr,
-		GWClass:        gatewayClass,
+		GWClasses:      sets.New(append(cfg.Opts.ExtraGatewayClasses, wellknown.GatewayClassName)...),
 		ControllerName: wellknown.GatewayControllerName,
 		AutoProvision:  AutoProvision,
 		ControlPlane:   cfg.Opts.ControlPlane,

--- a/projects/gateway2/deployer/values_helpers.go
+++ b/projects/gateway2/deployer/values_helpers.go
@@ -18,11 +18,9 @@ import (
 // This file contains helper functions that generate helm values in the format needed
 // by the deployer.
 
-var (
-	ComponentLogLevelEmptyError = func(key string, value string) error {
-		return eris.Errorf("an empty key or value was provided in componentLogLevels: key=%s, value=%s", key, value)
-	}
-)
+var ComponentLogLevelEmptyError = func(key string, value string) error {
+	return eris.Errorf("an empty key or value was provided in componentLogLevels: key=%s, value=%s", key, value)
+}
 
 // Extract the listener ports from a Gateway. These will be used to populate:
 // 1. the ports exposed on the envoy container
@@ -108,7 +106,7 @@ func getSdsContainerValues(sdsContainerConfig *v1alpha1.SdsContainer) *helmSdsCo
 		Repository: ptr.To(sdsConfigImage.GetRepository().GetValue()),
 		Tag:        ptr.To(sdsConfigImage.GetTag().GetValue()),
 		Digest:     ptr.To(sdsConfigImage.GetDigest().GetValue()),
-		PullPolicy: ptr.To(sdsConfigImage.GetPullPolicy().String()),
+		PullPolicy: pullPolicyOrDefault(sdsConfigImage.GetPullPolicy().String()),
 	}
 	return &helmSdsContainer{
 		Image:           sdsImage,
@@ -131,7 +129,7 @@ func getIstioContainerValues(istioContainerConfig *v1alpha1.IstioContainer) *hel
 		Repository: ptr.To(istioConfigImage.GetRepository().GetValue()),
 		Tag:        ptr.To(istioConfigImage.GetTag().GetValue()),
 		Digest:     ptr.To(istioConfigImage.GetDigest().GetValue()),
-		PullPolicy: ptr.To(istioConfigImage.GetPullPolicy().String()),
+		PullPolicy: pullPolicyOrDefault(istioConfigImage.GetPullPolicy().String()),
 	}
 
 	return &helmIstioContainer{
@@ -168,7 +166,7 @@ func getEnvoyImageValues(envoyImage *v1alpha1kube.Image) *helmImage {
 		Repository: ptr.To(envoyImage.GetRepository().GetValue()),
 		Tag:        ptr.To(envoyImage.GetTag().GetValue()),
 		Digest:     ptr.To(envoyImage.GetDigest().GetValue()),
-		PullPolicy: ptr.To(envoyImage.GetPullPolicy().String()),
+		PullPolicy: pullPolicyOrDefault(envoyImage.GetPullPolicy().String()),
 	}
 }
 
@@ -191,4 +189,19 @@ func ComponentLogLevelsToString(vals map[string]string) (string, error) {
 	}
 	sort.Strings(parts)
 	return strings.Join(parts, ","), nil
+}
+
+func orDefault[T comparable](value T, fallback T) T {
+	var empty T
+	if value == empty {
+		return fallback
+	}
+	return value
+}
+
+const defaultPullPolicy = "IfNotPresent"
+
+func pullPolicyOrDefault(policy string) *string {
+	value := orDefault(policy, defaultPullPolicy)
+	return ptr.To(value)
 }

--- a/projects/gateway2/translator/gateway_translator.go
+++ b/projects/gateway2/translator/gateway_translator.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/registry"
+	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 
 	"github.com/solo-io/gloo/projects/gateway2/query"
 	"github.com/solo-io/gloo/projects/gateway2/reports"
@@ -47,6 +48,9 @@ func (t *translator) TranslateProxy(
 	writeNamespace string,
 	reporter reports.Reporter,
 ) *v1.Proxy {
+	if gateway.Spec.GatewayClassName != wellknown.GatewayClassName {
+		return nil
+	}
 
 	routesForGw, err := t.queries.GetRoutesForGw(ctx, gateway)
 	if err != nil {

--- a/projects/gateway2/translator/testutils/inputs/delegation/basic.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/basic.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/basic_invalid_hostname.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/basic_invalid_hostname.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/basic_parentref_match.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/basic_parentref_match.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/basic_parentref_mismatch.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/basic_parentref_mismatch.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/child_rule_matcher.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/child_rule_matcher.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/cyclic1.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/cyclic1.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/cyclic2.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/cyclic2.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/invalid_child_valid_standalone.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/invalid_child_valid_standalone.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/multiple_children.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/multiple_children.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/multiple_parents.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/multiple_parents.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/nested_absolute_relative.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/nested_absolute_relative.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/recursive.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/recursive.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/relative_paths.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/relative_paths.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_filter.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_filter.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_filter_override_merge.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_filter_override_merge.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_child_override_ignore.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_child_override_ignore.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_child_override_ok.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_child_override_ok.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_filter_override.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_filter_override.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_multi_level_inheritance_override_ok.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_multi_level_inheritance_override_ok.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/http-routing/gateway.yaml
+++ b/projects/gateway2/translator/testutils/inputs/http-routing/gateway.yaml
@@ -5,7 +5,7 @@ kind: Gateway
 metadata:
   name: example-gateway
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/https-routing/gateway.yaml
+++ b/projects/gateway2/translator/testutils/inputs/https-routing/gateway.yaml
@@ -5,7 +5,7 @@ kind: Gateway
 metadata:
   name: example-gateway
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: https
     protocol: HTTPS

--- a/projects/gateway2/translator/testutils/inputs/route-sort.yaml
+++ b/projects/gateway2/translator/testutils/inputs/route-sort.yaml
@@ -4,7 +4,7 @@ metadata:
   name: example-gateway
   namespace: infra
 spec:
-  gatewayClassName: example-gateway-class
+  gatewayClassName: gloo-gateway
   listeners:
   - name: http
     protocol: HTTP

--- a/projects/gloo/pkg/bootstrap/opts.go
+++ b/projects/gloo/pkg/bootstrap/opts.go
@@ -56,6 +56,7 @@ type Opts struct {
 	ValidationOpts               *gwtranslator.ValidationOpts
 	ReadGatwaysFromAllNamespaces bool
 	GatewayControllerEnabled     bool
+	ExtraGatewayClasses          []string
 	ProxyCleanup                 func()
 
 	Identity leaderelector.Identity


### PR DESCRIPTION
# Description

Allows configuring the our gateway controller to deploy gateways with additional classes. 
Reduced-scope version of https://github.com/solo-io/gloo/pull/9471

## API changes

The only API is an internal Go API to allow GME to take control of the Gateway translation. 

```go
// bootstrap opts
ExtraGatewayClasses []string
```

## Code Changes

The translator will now ignore other non `gloo-gateway` gateways (separate translation should be added for them, this PR just allows these classes to be deployed)

Also, fixed an issue where not fully specifying pull-policy breaks the deployer

```
{"controller": "gateway", "controllerGroup": "gateway.networking.k8s.io", "controllerKind": "Gateway", "Gateway": {"name":"gw-clsname","namespace":"default"}, "namespace": "default", "name": "gw-clsname", "reconcileID": "29e3d9fe-2821-424c-a4b0-1ee4f2d855db", "error": "failed to apply object apps/v1, Kind=Deployment gloo-proxy-gw-clsname: Deployment.apps \"gloo-proxy-gw-clsname\" is invalid: spec.template.spec.containers[0].imagePullPolicy: Unsupported value: \"Unspecified\": supported values: \"Always\", \"IfNotPresent\", \"Never\""}
```

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
