### PR TITLE
[1.17] Retry on leader lease renewal failure

### DIFF
--- a/changelog/v1.17.0-rc5/dont-crash-on-failed-lease-renewal.yaml
+++ b/changelog/v1.17.0-rc5/dont-crash-on-failed-lease-renewal.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NEW_FEATURE
+  issueLink: https://github.com/solo-io/gloo/issues/8107
+  description: Adds the ability to recover if the Kubernetes API server is unreachable once the gloo pod comes up. The `MAX_RECOVERY_DURATION_WITHOUT_KUBE_API_SERVER` environment variable defines the maximum duration the gloo pod can run and attempt to reconnect to the kube apiserver if it is unreachable. Exceeding this duration will lead to the pod quitting. To enable this feature, set the `MAX_RECOVERY_DURATION_WITHOUT_KUBE_API_SERVER` environment variable to the desired duration in the gloo container. This can be done either by modifying the gloo deployment or by specifying the `gloo.deployment.customEnv[0].Name=MAX_RECOVERY_DURATION_WITHOUT_KUBE_API_SERVER` and `gloo.deployment.customEnv[0].Value=60s` helm values.

--- a/ci/kind/cluster.yaml
+++ b/ci/kind/cluster.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+# Do not use the default CNI as kindnet does not support custom network policies.
+# Instead, cilium is installed as CNI as we need to test Kube API server unavailability in the kube2e tests
+networking:
+  disableDefaultCNI: true
 kubeadmConfigPatches:
   - |
     apiVersion: kubeadm.k8s.io/v1beta3

--- a/ci/kind/setup-kind.sh
+++ b/ci/kind/setup-kind.sh
@@ -21,6 +21,7 @@ ISTIO_VERSION="${ISTIO_VERSION:-1.22.0}"
 IMAGE_VARIANT="${IMAGE_VARIANT:-standard}"
 # If true, run extra steps to set up k8s gateway api conformance test environment
 CONFORMANCE="${CONFORMANCE:-false}"
+CILIUM_VERSION="${CILIUM_VERSION:-1.15.5}"
 
 function create_kind_cluster_or_skip() {
   activeClusters=$(kind get clusters)
@@ -36,6 +37,14 @@ function create_kind_cluster_or_skip() {
     --name "$CLUSTER_NAME" \
     --image "kindest/node:$CLUSTER_NODE_VERSION" \
     --config="$SCRIPT_DIR/cluster.yaml"
+
+  # Install cilium as we need to define custom network policies to simulate kube api server unavailability
+  # in some of our kube2e tests
+  helm repo add cilium https://helm.cilium.io/
+  helm install cilium cilium/cilium --version $CILIUM_VERSION \
+   --namespace kube-system \
+   --set image.pullPolicy=IfNotPresent \
+   --set ipam.mode=kubernetes
   echo "Finished setting up cluster $CLUSTER_NAME"
 
   # so that you can just build the kind image alone if needed

--- a/pkg/bootstrap/leaderelector/identity.go
+++ b/pkg/bootstrap/leaderelector/identity.go
@@ -37,3 +37,8 @@ func (i identityImpl) IsLeader() bool {
 func (i identityImpl) Elected() <-chan struct{} {
 	return i.elected
 }
+
+// Reset updates the current identity to a follower. It can be promoted to a leader by closing the elected channel
+func (i identityImpl) Reset(elected <-chan struct{}) {
+	i.elected = elected
+}

--- a/pkg/bootstrap/leaderelector/kube/factory.go
+++ b/pkg/bootstrap/leaderelector/kube/factory.go
@@ -3,9 +3,11 @@ package kube
 import (
 	"context"
 	"os"
+	"sync/atomic"
 	"time"
 
 	"github.com/solo-io/gloo/pkg/bootstrap/leaderelector"
+	"github.com/solo-io/gloo/pkg/utils/envutils"
 	"github.com/solo-io/go-utils/contextutils"
 	"k8s.io/client-go/rest"
 	k8sleaderelection "k8s.io/client-go/tools/leaderelection"
@@ -21,9 +23,12 @@ const (
 	defaultRetryPeriod   = 2 * time.Second
 	defaultRenewPeriod   = 10 * time.Second
 
-	leaseDurationEnvName = "LEADER_ELECTION_LEASE_DURATION"
-	retryPeriodEnvName   = "LEADER_ELECTION_RETRY_PERIOD"
-	renewPeriodEnvName   = "LEADER_ELECTION_RENEW_PERIOD"
+	defaultRecoveryTimeout = 60 * time.Second
+
+	leaseDurationEnvName                    = "LEADER_ELECTION_LEASE_DURATION"
+	retryPeriodEnvName                      = "LEADER_ELECTION_RETRY_PERIOD"
+	renewPeriodEnvName                      = "LEADER_ELECTION_RENEW_PERIOD"
+	MaxRecoveryDurationWithoutKubeAPIServer = "MAX_RECOVERY_DURATION_WITHOUT_KUBE_API_SERVER"
 )
 
 // kubeElectionFactory is the implementation for coordinating leader election using
@@ -39,6 +44,20 @@ func NewElectionFactory(config *rest.Config) *kubeElectionFactory {
 }
 
 func (f *kubeElectionFactory) StartElection(ctx context.Context, config *leaderelector.ElectionConfig) (leaderelector.Identity, error) {
+	var recoveryTimeoutIfKubeAPIServerIsUnreachable time.Duration
+	var recoverIfKubeAPIServerIsUnreachable bool
+	var err error
+	if envutils.IsEnvDefined(MaxRecoveryDurationWithoutKubeAPIServer) {
+		recoveryTimeoutIfKubeAPIServerIsUnreachable, err = time.ParseDuration(os.Getenv(MaxRecoveryDurationWithoutKubeAPIServer))
+		if err != nil {
+			contextutils.LoggerFrom(ctx).Errorf("%s is not a valid duration. Defaulting to 60s", MaxRecoveryDurationWithoutKubeAPIServer)
+			recoveryTimeoutIfKubeAPIServerIsUnreachable = defaultRecoveryTimeout
+		} else {
+			contextutils.LoggerFrom(ctx).Infof("max recovery from kube apiserver unavailability set to %s", recoveryTimeoutIfKubeAPIServerIsUnreachable)
+		}
+		recoverIfKubeAPIServerIsUnreachable = true
+	}
+
 	elected := make(chan struct{})
 	identity := leaderelector.NewIdentity(elected)
 
@@ -55,39 +74,99 @@ func (f *kubeElectionFactory) StartElection(ctx context.Context, config *leadere
 		return identity, err
 	}
 
-	l, err := k8sleaderelection.NewLeaderElector(
-		k8sleaderelection.LeaderElectionConfig{
-			Lock:          resourceLock,
-			LeaseDuration: getLeaseDuration(),
-			RenewDeadline: getRenewPeriod(),
-			RetryPeriod:   getRetryPeriod(),
-			Callbacks: k8sleaderelection.LeaderCallbacks{
-				OnStartedLeading: func(callbackCtx context.Context) {
-					contextutils.LoggerFrom(callbackCtx).Debug("Started Leading")
-					close(elected)
-					config.OnStartedLeading(callbackCtx)
+	var justFailed = false
+	var dontDie func()
+
+	// dieIfUnrecoverable causes gloo to exit after the recoveryTimeout (default 60s) if the context is not cancelled.
+	// This function is called when this container is a leader but unable to renew the leader lease (caused by an unreachable kube api server).
+	// The context is cancelled if it is able to participate in leader election again, irrespective if it becomes a leader or follower.
+	dieIfUnrecoverable := func(ctx context.Context) {
+		timer := time.NewTimer(recoveryTimeoutIfKubeAPIServerIsUnreachable)
+		select {
+		case <-timer.C:
+			contextutils.LoggerFrom(ctx).Fatalf("unable to recover from failed leader election, quitting app")
+		case <-ctx.Done():
+			contextutils.LoggerFrom(ctx).Infof("recovered from lease renewal failure")
+		}
+	}
+
+	newLeaderElector := func() (*k8sleaderelection.LeaderElector, error) {
+		recoveryCtx, cancel := context.WithCancel(ctx)
+
+		return k8sleaderelection.NewLeaderElector(
+			k8sleaderelection.LeaderElectionConfig{
+				Lock:          resourceLock,
+				LeaseDuration: getLeaseDuration(),
+				RenewDeadline: getRenewPeriod(),
+				RetryPeriod:   getRetryPeriod(),
+				Callbacks: k8sleaderelection.LeaderCallbacks{
+					OnStartedLeading: func(callbackCtx context.Context) {
+						contextutils.LoggerFrom(callbackCtx).Debug("Started Leading")
+						close(elected)
+						config.OnStartedLeading(callbackCtx)
+					},
+					OnStoppedLeading: func() {
+						contextutils.LoggerFrom(ctx).Error("Stopped Leading")
+						config.OnStoppedLeading()
+						if recoverIfKubeAPIServerIsUnreachable {
+							// Recreate the elected channel and reset the identity to a follower
+							// Ref: https://github.com/solo-io/gloo/issues/7346
+							elected = make(chan struct{})
+							identity.Reset(elected)
+							// Die if we are unable to recover from this within the recoveryTimeout
+							go dieIfUnrecoverable(recoveryCtx)
+							// Set recover to cancel the context to be used the next time `OnNewLeader` is called
+							dontDie = cancel
+							justFailed = true
+						}
+					},
+					OnNewLeader: func(identity string) {
+						contextutils.LoggerFrom(ctx).Debugf("New Leader Elected with Identity: %s", identity)
+						config.OnNewLeader(identity)
+						// Recover since we were able to re-negotiate leader election
+						// Do this only when we just failed and not when someone becomes a leader
+						if recoverIfKubeAPIServerIsUnreachable && justFailed {
+							dontDie()
+							justFailed = false
+						}
+					},
 				},
-				OnStoppedLeading: func() {
-					contextutils.LoggerFrom(ctx).Error("Stopped Leading")
-					config.OnStoppedLeading()
-				},
-				OnNewLeader: func(identity string) {
-					contextutils.LoggerFrom(ctx).Debugf("New Leader Elected with Identity: %s", identity)
-					config.OnNewLeader(identity)
-				},
+				Name:            config.Id,
+				ReleaseOnCancel: true,
 			},
-			Name:            config.Id,
-			ReleaseOnCancel: true,
-		},
-	)
+		)
+	}
+
+	// The error returned is just validating the config passed. If it passes validation once, it will again
+	_, err = newLeaderElector()
 	if err != nil {
 		return identity, err
 	}
 
-	// Start the leader elector process in a goroutine
-	contextutils.LoggerFrom(ctx).Debug("Starting Kube Leader Election")
-	go l.Run(ctx)
+	// leaderElector.Run() is a blocking method but we need to return the identity of this container to sub-components so they can
+	// perform their respective tasks, hence it runs within a go routine.
+	// It runs within an infinite loop so that we can recover if this container is a leader but fails to renew the lease and renegotiate leader election if possible.
+	// This can be caused when there is a failure to connect to the kube api server
+	go func() {
+		var counter atomic.Uint32
 
+		for {
+			l, _ := newLeaderElector()
+			// Start the leader elector process
+			contextutils.LoggerFrom(ctx).Debug("Starting Kube Leader Election")
+			l.Run(ctx)
+
+			if !recoverIfKubeAPIServerIsUnreachable {
+				contextutils.LoggerFrom(ctx).Fatalf("lost leadership, quitting app")
+			}
+
+			contextutils.LoggerFrom(ctx).Errorf("Leader election cycle %v lost. Trying again", counter.Load())
+			counter.Add(1)
+			// Sleep for the lease duration so another container has a chance to become the leader rather than try to renew
+			// in when the kube api server is unreachable by this container
+			time.Sleep(getLeaseDuration())
+		}
+	}()
 	return identity, nil
 }
 

--- a/projects/gloo/pkg/setup/setup.go
+++ b/projects/gloo/pkg/setup/setup.go
@@ -41,11 +41,9 @@ func startSetupLoop(ctx context.Context) error {
 				contextutils.LoggerFrom(ctx).Infof("new leader elected with ID: %s", leaderId)
 			},
 			OnStoppedLeading: func() {
-				// Kill app if we lose leadership, we need to be VERY sure we don't continue
-				// any leader election processes.
-				// https://github.com/solo-io/gloo/issues/7346
-				// There is follow-up work to handle lost leadership more gracefully
-				contextutils.LoggerFrom(ctx).Fatalf("lost leadership, quitting app")
+				// Don't die if we fall from grace. Instead we can retry leader election
+				// Ref: https://github.com/solo-io/gloo/issues/7346
+				contextutils.LoggerFrom(ctx).Errorf("lost leadership")
 			},
 		},
 	})

--- a/test/kube2e/gloo/artifacts/block-gloo-apiserver.yaml
+++ b/test/kube2e/gloo/artifacts/block-gloo-apiserver.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-gloo-to-kube-apiserver
+  namespace: gloo-system
+spec:
+  endpointSelector:
+    matchLabels:
+      gloo: gloo
+  egressDeny:
+  - toEntities:
+    - kube-apiserver

--- a/test/kube2e/gloo/artifacts/block-labels.yaml
+++ b/test/kube2e/gloo/artifacts/block-labels.yaml
@@ -1,0 +1,12 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: deny-gloo-to-kube-apiserver
+  namespace: gloo-system
+spec:
+  endpointSelector:
+    matchLabels:
+      block: this
+  egressDeny:
+  - toEntities:
+    - kube-apiserver

--- a/test/kube2e/gloo/artifacts/helm.yaml
+++ b/test/kube2e/gloo/artifacts/helm.yaml
@@ -17,7 +17,7 @@ gateway:
     alwaysAcceptResources: false
 gloo:
   logLevel: info
-  disableLeaderElection: true
+  disableLeaderElection: false
 gatewayProxies:
   gatewayProxy:
     healthyPanicThreshold: 0

--- a/test/kube2e/gloo/gloo_suite_test.go
+++ b/test/kube2e/gloo/gloo_suite_test.go
@@ -52,8 +52,6 @@ var (
 
 	envoyFactory envoy.Factory
 	vaultFactory *services.VaultFactory
-
-	kubeCli *kubectl.Cli
 )
 
 var _ = BeforeSuite(func() {
@@ -64,9 +62,8 @@ var _ = BeforeSuite(func() {
 	ctx, cancel = context.WithCancel(context.Background())
 	testHelper, err = kube2e.GetTestHelper(ctx, namespace)
 	Expect(err).NotTo(HaveOccurred())
+	testHelper.SetKubeCli(kubectl.NewCli().WithReceiver(GinkgoWriter))
 	skhelpers.RegisterPreFailHandler(helpers.StandardGlooDumpOnFail(GinkgoWriter, metav1.ObjectMeta{Namespace: testHelper.InstallNamespace}))
-
-	kubeCli = kubectl.NewCli().WithReceiver(GinkgoWriter)
 
 	// Allow skipping of install step for running multiple times
 	if !glootestutils.ShouldSkipInstall() {

--- a/test/kube2e/gloo/setup_syncer_test.go
+++ b/test/kube2e/gloo/setup_syncer_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Setup Syncer", func() {
 		})
 
 		It("restarts validation grpc server when settings change", func() {
-			portForwarder, err := kubeCli.StartPortForward(ctx,
+			portForwarder, err := testHelper.StartPortForward(ctx,
 				portforward.WithDeployment(kubeutils.GlooDeploymentName, testHelper.InstallNamespace),
 				portforward.WithRemotePort(defaults.GlooValidationPort),
 			)

--- a/test/kube2e/helper/install.go
+++ b/test/kube2e/helper/install.go
@@ -15,6 +15,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/rotisserie/eris"
+	"github.com/solo-io/gloo/pkg/utils/kubeutils/kubectl"
 	"github.com/solo-io/go-utils/log"
 	"github.com/solo-io/go-utils/testutils/exec"
 	"github.com/solo-io/k8s-utils/testutils/kube"
@@ -88,6 +89,8 @@ type TestConfig struct {
 type SoloTestHelper struct {
 	*TestConfig
 	TestUpstreamServer
+	// The kubernetes helper
+	*kubectl.Cli
 }
 
 // NewSoloTestHelper is meant to provide a standard way of deploying Gloo/GlooE to a k8s cluster during tests.
@@ -149,6 +152,10 @@ func NewSoloTestHelper(configFunc TestConfigFunc) (*SoloTestHelper, error) {
 	}
 
 	return testHelper, nil
+}
+
+func (h *SoloTestHelper) SetKubeCli(cli *kubectl.Cli) {
+	h.Cli = cli
 }
 
 // Return the version of the Helm chart

--- a/test/kube2e/helper/kube.go
+++ b/test/kube2e/helper/kube.go
@@ -1,0 +1,60 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientsv1 "k8s.io/client-go/kubernetes/typed/apps/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func (h *SoloTestHelper) ModifyDeploymentEnv(ctx context.Context, deploymentClient clientsv1.DeploymentInterface, namespace string, deploymentName string, containerIndex int, envVar corev1.EnvVar) {
+	GinkgoHelper()
+
+	d, err := deploymentClient.Get(ctx, deploymentName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	// make sure we are referencing a valid container
+	Expect(len(d.Spec.Template.Spec.Containers)).To(BeNumerically(">", containerIndex))
+
+	// if an env var with the given name already exists, modify it
+	exists := false
+	for i, env := range d.Spec.Template.Spec.Containers[containerIndex].Env {
+		if env.Name == envVar.Name {
+			d.Spec.Template.Spec.Containers[containerIndex].Env[i].Value = envVar.Value
+			exists = true
+			break
+		}
+	}
+	// otherwise add a new env var
+	if !exists {
+		d.Spec.Template.Spec.Containers[containerIndex].Env = append(d.Spec.Template.Spec.Containers[containerIndex].Env, envVar)
+	}
+	_, err = deploymentClient.Update(ctx, d, metav1.UpdateOptions{})
+	Expect(err).NotTo(HaveOccurred())
+
+	h.WaitForRollout(ctx, deploymentName, namespace, "60s", "1s")
+}
+
+// WaitForRollout waits for the specified deployment to be rolled out successfully.
+func (h *SoloTestHelper) WaitForRollout(ctx context.Context, deploymentName string, deploymentNamespace string, intervals ...interface{}) {
+	GinkgoHelper()
+
+	Eventually(func() (bool, error) {
+		out, _, err := h.Cli.Execute(ctx, "rollout", "status", "-n", deploymentNamespace, fmt.Sprintf("deployment/%s", deploymentName))
+		return strings.Contains(out, "successfully rolled out"), err
+	}, "30s", "1s").Should(BeTrue())
+}
+
+func (h *SoloTestHelper) GetContainerLogs(ctx context.Context, namespace string, name string) string {
+	GinkgoHelper()
+
+	out, _, err := h.Cli.Execute(ctx, "-n", namespace, "logs", name)
+	Expect(err).ToNot(HaveOccurred())
+	return out
+}


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/9563

After a container has become a leader, any Kube API server unavailability results in the container crashing. This happens as the leader is unable to renew the lease. This is by design as outlined [here](https://github.com/solo-io/gloo/issues/8107#issuecomment-1516250478)
> if we allowed gloo to continue to function as a leader during kube apiserver outage, we risk having two leaders in other failure modes. we should remove the panic and allow gloo to continue to serve last-known xds as a follower (effectively having two followers until kube apiserver recovers). this idea is similar to the role xds relay could play for gloo edge

However, crashing the gloo pods can also lead to an outage during scaling as the gateway-proxy pods that come up cannot fetch any configs and all routes result in 404s.

Now instead of crashing, the gloo pod falls back to a follower. This prevents an outage and any other pod can take over as leader if possible
This is fine as a leader only writes reports / statuses over [here](https://github.com/solo-io/gloo/blob/0637825838c285e978c51d6a00f68f4e1d5d08d6/pkg/bootstrap/leaderelector/leader.go#L35) and [here](https://github.com/solo-io/gloo/blob/0637825838c285e978c51d6a00f68f4e1d5d08d6/projects/gloo/pkg/syncer/translator_syncer.go#L231). On any failure, the pod becomes a follower and if elected back as a leader will continue to write reports.

## Code changes
- Introduce a new `Reset` method on the identity implementation that allows an identity to fall back to a follower

## CI changes
- Kind clusters that run in CI now do not come up with their own CNI as kindnet does not support custom network policies.
Instead, cilium is installed as CNI as we need to test Kube API server unavailability

# Context
[Kube API unavailability results in a gloo container crash](https://github.com/solo-io/gloo/issues/8107)
[When leader election fails, gloo crashes](https://github.com/solo-io/gloo/issues/7346#top)
[Design Doc](https://soloio.slab.com/posts/dont-crash-on-failure-to-renew-leader-lease-kjkqn0ry)

## Interesting decisions


## Testing steps
Kube2e tests to verify the following :
- It can recover from a Kube APIServer unavailability
- It falls back to a follower
- Another leader can get elected

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/8107