### PR TITLE
[1.17] ci: Disable ingress suite on regression tests

### DIFF
--- a/.github/workflows/regression-tests.yaml
+++ b/.github/workflows/regression-tests.yaml
@@ -49,7 +49,7 @@ jobs:
         # upgrade tests are run on LTS but not on main branch, for main they are run nightly
         # ingress is deprecated from 1.17. Ref: https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1716389614777799
         # this is the github action version of ternary op
-        kube-e2e-test-type: [ 'gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade' ]
+        kube-e2e-test-type: [ 'gateway', 'gloo', 'helm', 'gloomtls', 'glooctl', 'upgrade' ]
         kube-version: [ { node: 'v1.29.2@sha256:51a1434a5397193442f0be2a297b488b6c919ce8a3931be0ce822606ea5ca245', kubectl: 'v1.29.2', kind: 'v0.20.0', helm: 'v3.14.4' } ]
         image-variant:
           - distroless

--- a/changelog/v1.17.0-rc6/disable-ingress.yaml
+++ b/changelog/v1.17.0-rc6/disable-ingress.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Disable ingress tests in v1.17 regression suite
+    skipCI-kube-tests:true
+    skipCI-docs-build:true


### PR DESCRIPTION
# Description

Disables the ingress suite on 1.17 regression tests as it has been deprecated
Ref: https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1716389614777799