### PR TITLE
glooctl: Improve performance of the check command by optimizing the creation of clients 

### DIFF
--- a/changelog/v1.18.0-beta2/optimize-glooctl-check.yaml
+++ b/changelog/v1.18.0-beta2/optimize-glooctl-check.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/9673
+  resolvesIssue: true
+  description: Optimizes the `glooctl check` command by reducing the time taken to check resources by almost half in large environments consisting of over 500 namespaces

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -425,8 +425,8 @@ func checkUpstreams(ctx context.Context, printer printers.P, _ *options.Options,
 	printer.AppendCheck("Checking Upstreams... ")
 	var knownUpstreams []string
 	var multiErr *multierror.Error
+	client, err := helpers.UpstreamClient(ctx, namespaces)
 	for _, ns := range namespaces {
-		client, err := helpers.UpstreamClient(ctx, []string{ns})
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 			continue
@@ -469,8 +469,8 @@ func checkUpstreams(ctx context.Context, printer printers.P, _ *options.Options,
 func checkUpstreamGroups(ctx context.Context, printer printers.P, _ *options.Options, namespaces []string) error {
 	printer.AppendCheck("Checking UpstreamGroups... ")
 	var multiErr *multierror.Error
+	upstreamGroupClient, err := helpers.UpstreamGroupClient(ctx, namespaces)
 	for _, ns := range namespaces {
-		upstreamGroupClient, err := helpers.UpstreamGroupClient(ctx, []string{ns})
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 			continue
@@ -516,8 +516,8 @@ func checkAuthConfigs(ctx context.Context, printer printers.P, _ *options.Option
 	printer.AppendCheck("Checking AuthConfigs... ")
 	var knownAuthConfigs []string
 	var multiErr *multierror.Error
+	authConfigClient, err := helpers.AuthConfigClient(ctx, namespaces)
 	for _, ns := range namespaces {
-		authConfigClient, err := helpers.AuthConfigClient(ctx, []string{ns})
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 			continue
@@ -561,9 +561,8 @@ func checkRateLimitConfigs(ctx context.Context, printer printers.P, _ *options.O
 	printer.AppendCheck("Checking RateLimitConfigs... ")
 	var knownConfigs []string
 	var multiErr *multierror.Error
+	rlcClient, err := helpers.RateLimitConfigClient(ctx, namespaces)
 	for _, ns := range namespaces {
-
-		rlcClient, err := helpers.RateLimitConfigClient(ctx, []string{ns})
 		if err != nil {
 			if isCrdNotFoundErr(ratelimit.RateLimitConfigCrd, err) {
 				// Just warn. If the CRD is required, the check would have failed on the crashing gloo/gloo-ee pod.
@@ -601,8 +600,8 @@ func checkVirtualHostOptions(ctx context.Context, printer printers.P, _ *options
 	printer.AppendCheck("Checking VirtualHostOptions... ")
 	var knownVhOpts []string
 	var multiErr *multierror.Error
+	vhoptClient, err := helpers.VirtualHostOptionClient(ctx, namespaces)
 	for _, ns := range namespaces {
-		vhoptClient, err := helpers.VirtualHostOptionClient(ctx, []string{ns})
 		if err != nil {
 			if isCrdNotFoundErr(gatewayv1.VirtualHostOptionCrd, err) {
 				// Just warn. If the CRD is required, the check would have failed on the crashing gloo/gloo-ee pod.
@@ -649,8 +648,8 @@ func checkRouteOptions(ctx context.Context, printer printers.P, _ *options.Optio
 	printer.AppendCheck("Checking RouteOptions... ")
 	var knownRouteOpts []string
 	var multiErr *multierror.Error
+	routeOptionClient, err := helpers.RouteOptionClient(ctx, namespaces)
 	for _, ns := range namespaces {
-		routeOptionClient, err := helpers.RouteOptionClient(ctx, []string{ns})
 		if err != nil {
 			if isCrdNotFoundErr(gatewayv1.RouteOptionCrd, err) {
 				// Just warn. If the CRD is required, the check would have failed on the crashing gloo/gloo-ee pod.
@@ -697,8 +696,8 @@ func checkVirtualServices(ctx context.Context, printer printers.P, _ *options.Op
 	printer.AppendCheck("Checking VirtualServices... ")
 	var multiErr *multierror.Error
 
+	virtualServiceClient, err := helpers.VirtualServiceClient(ctx, namespaces)
 	for _, ns := range namespaces {
-		virtualServiceClient, err := helpers.VirtualServiceClient(ctx, []string{ns})
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 			continue
@@ -837,8 +836,8 @@ func checkVirtualServices(ctx context.Context, printer printers.P, _ *options.Op
 func checkGateways(ctx context.Context, printer printers.P, _ *options.Options, namespaces []string) error {
 	printer.AppendCheck("Checking Gateways... ")
 	var multiErr *multierror.Error
+	gatewayClient, err := helpers.GatewayClient(ctx, namespaces)
 	for _, ns := range namespaces {
-		gatewayClient, err := helpers.GatewayClient(ctx, []string{ns})
 		if err != nil {
 			multiErr = multierror.Append(multiErr, err)
 			continue

--- a/test/kube2e/glooctl/check_test.go
+++ b/test/kube2e/glooctl/check_test.go
@@ -393,15 +393,17 @@ var _ = Describe("Check", func() {
 			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "apply", "-f", testHelper.RootDir+"/test/kube2e/glooctl/reject-me-too.yaml")
 			Expect(err).NotTo(HaveOccurred())
 
-			_, err = GlooctlOut("check")
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("* Found rejected virtual service by 'gloo-system': default reject-me-too (Reason: 2 errors occurred:"))
-			Expect(err.Error()).To(ContainSubstring("* domain conflict: other virtual services that belong to the same Gateway as this one don't specify a domain (and thus default to '*'): [gloo-system.reject-me]"))
-			Expect(err.Error()).To(ContainSubstring("* VirtualHost Error: DomainsNotUniqueError. Reason: domain * is shared by the following virtual hosts: [default.reject-me-too gloo-system.reject-me]"))
+			Eventually(func(g Gomega) {
+				_, err = GlooctlOut("check")
+				g.Expect(err).To(HaveOccurred())
+				g.Expect(err.Error()).To(ContainSubstring("* Found rejected virtual service by 'gloo-system': default reject-me-too (Reason: 2 errors occurred:"))
+				g.Expect(err.Error()).To(ContainSubstring("* domain conflict: other virtual services that belong to the same Gateway as this one don't specify a domain (and thus default to '*'): [gloo-system.reject-me]"))
+				g.Expect(err.Error()).To(ContainSubstring("* VirtualHost Error: DomainsNotUniqueError. Reason: domain * is shared by the following virtual hosts: [default.reject-me-too gloo-system.reject-me]"))
 
-			Expect(err.Error()).To(ContainSubstring("* Found rejected virtual service by 'gloo-system': gloo-system reject-me (Reason: 2 errors occurred:"))
-			Expect(err.Error()).To(ContainSubstring("* domain conflict: other virtual services that belong to the same Gateway as this one don't specify a domain (and thus default to '*'): [default.reject-me-too]"))
-			Expect(err.Error()).To(ContainSubstring("* VirtualHost Error: DomainsNotUniqueError. Reason: domain * is shared by the following virtual hosts: [default.reject-me-too gloo-system.reject-me]"))
+				g.Expect(err.Error()).To(ContainSubstring("* Found rejected virtual service by 'gloo-system': gloo-system reject-me (Reason: 2 errors occurred:"))
+				g.Expect(err.Error()).To(ContainSubstring("* domain conflict: other virtual services that belong to the same Gateway as this one don't specify a domain (and thus default to '*'): [default.reject-me-too]"))
+				g.Expect(err.Error()).To(ContainSubstring("* VirtualHost Error: DomainsNotUniqueError. Reason: domain * is shared by the following virtual hosts: [default.reject-me-too gloo-system.reject-me]"))
+			}, "10s", "2s").Should(Succeed())
 
 			err = exec.RunCommand(testHelper.RootDir, false, "kubectl", "delete", "-n", "gloo-system", "virtualservice", "reject-me")
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
# Description

Optimize `glooctl check` by creating the resource client prior to iterating over namespaces.
This saves a considerable amount of time in large envs consisting of over 700 ns and cuts time by ~50%

# Context

See slack conversation [here](https://solo-io-corp.slack.com/archives/CEDCS8TAP/p1718935489580349)

## Testing steps
In an env of 700+ ns

glooctl version: `1.17.0-beta34(latest version)`
```
glooctl check  251.22s user 266.20s system 37% cpu 22:48.24 total
```
glooctl version: `1.0.0-ci1 (This PR)`
```
glooctl-darwin-arm64-david check  81.22s user 74.02s system 24% cpu 10:28.20 total
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9673