### PR TITLE
setup kind fix for installing cilium

### DIFF
--- a/changelog/v1.18.0-beta2/helm-repo-update-cilium.yaml
+++ b/changelog/v1.18.0-beta2/helm-repo-update-cilium.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix helm error with outdated cache in helm when installing cilium for kube2e tests

--- a/ci/kind/setup-kind.sh
+++ b/ci/kind/setup-kind.sh
@@ -36,12 +36,14 @@ function create_kind_cluster_or_skip() {
 
   # Install cilium as we need to define custom network policies to simulate kube api server unavailability
   # in some of our kube2e tests
-  helm repo add cilium https://helm.cilium.io/
+  helm repo add cilium-setup-kind https://helm.cilium.io/
   helm repo update
-  helm install cilium cilium/cilium --version $CILIUM_VERSION \
+  helm install cilium cilium-setup-kind/cilium --version $CILIUM_VERSION \
    --namespace kube-system \
    --set image.pullPolicy=IfNotPresent \
-   --set ipam.mode=kubernetes
+   --set ipam.mode=kubernetes \
+   --set operator.replicas=1
+  helm repo remove cilium-setup-kind
   echo "Finished setting up cluster $CLUSTER_NAME"
 
   # so that you can just build the kind image alone if needed

--- a/ci/kind/setup-kind.sh
+++ b/ci/kind/setup-kind.sh
@@ -37,6 +37,7 @@ function create_kind_cluster_or_skip() {
   # Install cilium as we need to define custom network policies to simulate kube api server unavailability
   # in some of our kube2e tests
   helm repo add cilium https://helm.cilium.io/
+  helm repo update
   helm install cilium cilium/cilium --version $CILIUM_VERSION \
    --namespace kube-system \
    --set image.pullPolicy=IfNotPresent \


### PR DESCRIPTION
# Description
In order to avert helm caching issues with folks who may have already had cilium repo on their machines, we add the repo under a separate name, make sure to update it, then delete the repo when we're done.

Additionally, since the affinity for the operator is set to disallow scheduling multiple pods on the same node, set our replica count to 1 ([ref](https://github.com/cilium/cilium/blob/v1.15.5/install/kubernetes/cilium/values.yaml#L2536))