### PR TITLE
Remove glooctl init to not automatically register types to global scheme

### DIFF
--- a/changelog/v1.17.0-rc8/remove-glooctl-init.yaml
+++ b/changelog/v1.17.0-rc8/remove-glooctl-init.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Remove init from glooctl root cmd introduced in https://github.com/solo-io/gloo/pull/9666

--- a/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
@@ -20,7 +20,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -107,8 +106,10 @@ type unstructuredGlooInstanceReader struct {
 }
 
 func getUnstructuredGlooInstanceReader(cfg *rest.Config) (*unstructuredGlooInstanceReader, error) {
+	// because all this client does is list this one object type, we pass our scheme with just
+	// gloo instance api registered.
 	client, err := client.New(cfg, client.Options{
-		Scheme: scheme.Scheme,
+		Scheme: registrar.scheme,
 	})
 	if err != nil {
 		return nil, err

--- a/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
@@ -26,9 +26,8 @@ import (
 )
 
 func CheckMulticlusterResources(ctx context.Context, printer printers.P, opts *options.Options) {
-	if !fedv1Registered {
-		fedv1RegistrationChan <- struct{}{}
-	}
+	registrar.registerFedv1()
+
 	// check if the gloo fed deployment exists
 	client := helpers.MustKubeClientWithKubecontext(opts.Top.KubeContext)
 	_, err := client.AppsV1().Deployments(opts.Metadata.GetNamespace()).Get(ctx, constants.GlooFedDeploymentName, metav1.GetOptions{})

--- a/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
@@ -26,6 +26,9 @@ import (
 )
 
 func CheckMulticlusterResources(ctx context.Context, printer printers.P, opts *options.Options) {
+	if !fedv1Registered {
+		fedv1RegistrationChan <- struct{}{}
+	}
 	// check if the gloo fed deployment exists
 	client := helpers.MustKubeClientWithKubecontext(opts.Top.KubeContext)
 	_, err := client.AppsV1().Deployments(opts.Metadata.GetNamespace()).Get(ctx, constants.GlooFedDeploymentName, metav1.GetOptions{})

--- a/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
+++ b/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
@@ -16,10 +16,8 @@ import (
 type CheckFunc = func(ctx context.Context, printer printers.P, opts *options.Options) error
 
 func CheckKubeGatewayResources(ctx context.Context, printer printers.P, opts *options.Options) error {
+	registrar.registerGatewayv1alpha1()
 
-	if !gatewayv1alpha1Registered {
-		gatewayv1alpha1RegistrationChan <- struct{}{}
-	}
 	var multiErr *multierror.Error
 
 	kubeGatewayEnabled, err := isKubeGatewayEnabled(ctx, opts)

--- a/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
+++ b/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
@@ -16,6 +16,10 @@ import (
 type CheckFunc = func(ctx context.Context, printer printers.P, opts *options.Options) error
 
 func CheckKubeGatewayResources(ctx context.Context, printer printers.P, opts *options.Options) error {
+
+	if !gatewayv1alpha1Registered {
+		gatewayv1alpha1RegistrationChan <- struct{}{}
+	}
 	var multiErr *multierror.Error
 
 	kubeGatewayEnabled, err := isKubeGatewayEnabled(ctx, opts)

--- a/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
+++ b/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
@@ -16,10 +16,6 @@ import (
 type CheckFunc = func(ctx context.Context, printer printers.P, opts *options.Options) error
 
 func CheckKubeGatewayResources(ctx context.Context, printer printers.P, opts *options.Options) error {
-	// I don't think we even need to register these in the scheme because we use a gwapi client directly
-	// ref ./internal/checks.go
-	// registrar.registerGatewayv1alpha1()
-
 	var multiErr *multierror.Error
 
 	kubeGatewayEnabled, err := isKubeGatewayEnabled(ctx, opts)

--- a/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
+++ b/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
@@ -16,7 +16,9 @@ import (
 type CheckFunc = func(ctx context.Context, printer printers.P, opts *options.Options) error
 
 func CheckKubeGatewayResources(ctx context.Context, printer printers.P, opts *options.Options) error {
-	registrar.registerGatewayv1alpha1()
+	// I don't think we even need to register these in the scheme because we use a gwapi client directly
+	// ref ./internal/checks.go
+	// registrar.registerGatewayv1alpha1()
 
 	var multiErr *multierror.Error
 

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 
@@ -22,7 +21,6 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	rlopts "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
 	"github.com/solo-io/go-utils/cliutils"
-	fedv1 "github.com/solo-io/solo-apis/pkg/api/fed.solo.io/v1"
 	rlv1alpha1 "github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd"
@@ -32,19 +30,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 )
 
 var (
 	CrdNotFoundErr = func(crdName string) error {
 		return eris.Errorf("%s CRD has not been registered", crdName)
-	}
-
-	registrar = &schemeRegistrar{
-		Mutex:                     &sync.Mutex{},
-		scheme:                    runtime.NewScheme(),
-		gatewayv1alpha1Registered: false,
-		fedv1Registered:           false,
 	}
 )
 
@@ -1011,32 +1001,4 @@ func isCrdNotFoundErr(crd crd.Crd, err error) bool {
 		}
 		return false
 	}
-}
-
-// since the following line is the impl for scheme, we will maintain a local scheme
-// var Scheme = runtime.NewScheme()
-type schemeRegistrar struct {
-	*sync.Mutex
-	scheme                                     *runtime.Scheme
-	gatewayv1alpha1Registered, fedv1Registered bool
-}
-
-// func (r *schemeRegistrar) registerGatewayv1alpha1() {
-// 	r.Lock()
-// 	defer r.Unlock()
-// 	if err := gatewayv1alpha1.AddToScheme(r.scheme); err != nil {
-// 		panic(err)
-// 	}
-// 	r.gatewayv1alpha1Registered = true
-
-// }
-
-func (r *schemeRegistrar) registerFedv1() {
-	r.Lock()
-	defer r.Unlock()
-	if err := fedv1.AddToScheme(r.scheme); err != nil {
-		panic(err)
-	}
-	r.fedv1Registered = true
-
 }

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -41,7 +41,11 @@ var (
 		return eris.Errorf("%s CRD has not been registered", crdName)
 	}
 
-	registrar = &schemeRegistrar{}
+	registrar = &schemeRegistrar{
+		Mutex:                     &sync.Mutex{},
+		gatewayv1alpha1Registered: false,
+		fedv1Registered:           false,
+	}
 )
 
 // contains method


### PR DESCRIPTION
# Description

Having the scheme registration for gloo fed APIs in the init causes issues when importing since importing code requires registering the same APIs from a different source. 

In this PR we revert registration to just before needed for an actual call. We also use a local scheme for the client that requires it, and remove the registration of kube gw APIs since we use the library client directly instead of controller-runtime.

## Code changes
- Do not register Kube GW APIs in scheme
- Do not use global scheme

# Context

See internal slack conversation [here](https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1719415728479849)

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

I manually verified behavior by importing this into the location in solo-projects where it was previously failing ([link](https://github.com/solo-io/solo-projects/pull/6453))

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works