### PR TITLE
1.13 - CVE Go bump

### DIFF
--- a/changelog/v1.13.38/cve-24790.yaml
+++ b/changelog/v1.13.38/cve-24790.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: cloud-builders
+    dependencyTag: v0.7.7
+    issueLink: https://github.com/solo-io/gloo/issues/9672
+    description: Upgrade cloud-builders images to pick up CVE fixes

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ steps:
 
 # $COMMIT_SHA is a default gcloud env var, to run via cloudbuild submit use:
 # gcloud builds submit --substitutions COMMIT_SHA=<commit sha>,REPO_NAME=solo-io/gloo,_PR_NUM=<<insert PR Number here>> --project solo-public
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.7.7'
   args:
     - "--repo-name"
     - "$REPO_NAME"
@@ -35,7 +35,7 @@ steps:
 # Run all the tests with ginkgo -r -failFast -trace -progress --noColor
 # This requires setting up envoy, AWS, helm, and docker
 # The e2e-go-mod-ginkgo container provides everything else needed for running tests
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.7'
   entrypoint: 'bash'
   args:
   - '-c'
@@ -47,7 +47,7 @@ steps:
   waitFor: ['prepare-workspace']
   id: 'get-envoy'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.7'
   entrypoint: 'bash'
   args: ['-c', 'make proxycontroller']
   dir: '/workspace/gloo/example/proxycontroller'
@@ -68,7 +68,7 @@ steps:
 
 # Docker related setup
 # grab this container immediately in parallel
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.7'
   entrypoint: ls
   waitFor: ['-']
   id: 'grab-ginkgo-container'
@@ -82,12 +82,12 @@ steps:
   waitFor: ['set-gcr-zone']
   id: 'get-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.7'
   args: ['install-go-tools']
   dir: *dir
   id: 'install-go-tools'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.7.7'
   entrypoint: make
   env:
   - 'ACK_GINKGO_RC=true'
@@ -117,7 +117,7 @@ steps:
   id: 'docker-login'
 
   # 1) Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.7'
   args: ['docker-push-extended']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -138,7 +138,7 @@ steps:
   waitFor: ['docker-push-extended']
   id: 'gcr-auth'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.7'
   args: ['fetch-package-and-save-helm', 'render-manifests', 'upload-github-release-assets', 'push-chart-to-registry', '-B']
   env:
     - 'DOCKER_CONFIG=/workspace/docker-config'
@@ -152,7 +152,7 @@ steps:
   id: 'release-chart'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.6'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.7.7'
   args: ['docker-push-retag']
   env:
   - 'DOCKER_CONFIG=/workspace/docker-config'

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.24.16 as kubectl
+FROM bitnami/kubectl:1.27.15 as kubectl
 
 FROM alpine:3.17.6
 

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/kubectl:1.27.15 as kubectl
+FROM bitnami/kubectl:1.24.16 as kubectl
 
 FROM alpine:3.17.6
 


### PR DESCRIPTION
# Description

Bump cloud-builders to use latest go1.21

# Context

Routine Trivy scans identified CVE-2024-24790 in our images, with issues opened including #9672

The CVE is also present in bitnami/kubectl however there is not a version of that image available with the CVE that is compatible with Gloo 1.13
An entry for the CVE is being added to the trivyignore in `main` explaining this
 
## Testing steps

I manually tested the latest released images as follows:
```
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.13.37"; done
```
<details>
<summary>
Results:
</summary>

```
2024-06-26T17:00:33-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:33-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:33-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:33-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:34-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-06-26T17:00:34-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-06-26T17:00:34-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:34-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.13.37 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:00:34-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/gloo (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.9            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
2024-06-26T17:00:35-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:35-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:35-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:35-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:35-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-06-26T17:00:35-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-06-26T17:00:35-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:35-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.13.37 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/envoyinit (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.9            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
2024-06-26T17:00:36-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:36-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:36-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:36-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:36-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:00:36-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-26T17:00:36-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:36-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.13.37 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:00:36-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/discovery (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.9            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
2024-06-26T17:00:37-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:37-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:37-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:37-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:37-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:00:37-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-26T17:00:37-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:37-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.13.37 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:00:37-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/ingress (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.9            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
2024-06-26T17:00:38-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:38-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:38-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:38-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:38-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:00:38-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-26T17:00:38-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:38-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.13.37 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:00:38-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/sds (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.9            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
2024-06-26T17:00:39-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:39-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:39-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:39-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:39-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:00:39-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-26T17:00:39-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:39-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.13.37 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/certgen (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.9            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
2024-06-26T17:00:40-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:40-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:40-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:40-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:41-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:00:41-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-26T17:00:41-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:41-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.13.37 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)


usr/local/bin/access-logger (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.21.9            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
2024-06-26T17:00:41-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:00:41-04:00	INFO	Secret scanning is enabled
2024-06-26T17:00:41-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:00:41-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:00:42-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:00:42-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-26T17:00:42-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:00:42-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.13.37 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:00:42-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/kubectl (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.20.6            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```
</details>

I then rebuilt images locally from this branch and scanned them:

```
VERSION=1.13.37-cve make docker -B
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.13.37-cve"; done
```
<details>
<summary>
Results:
</summary>

```
2024-06-26T17:05:16-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:16-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:16-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:16-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:16-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-06-26T17:05:16-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-06-26T17:05:16-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:16-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.13.37-cve (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:16-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-26T17:05:16-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:16-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:16-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:16-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:16-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-06-26T17:05:16-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-06-26T17:05:16-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:16-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.13.37-cve (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:17-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:17-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:17-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:17-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:17-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:05:17-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-26T17:05:17-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:17-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.13.37-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:17-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-26T17:05:17-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:17-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:17-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:17-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:17-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:05:17-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-26T17:05:17-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:17-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.13.37-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:17-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-26T17:05:18-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:18-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:18-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:18-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:18-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:05:18-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-26T17:05:18-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:18-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.13.37-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:18-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-26T17:05:19-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:19-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:19-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:19-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:19-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:05:19-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-26T17:05:19-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:19-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.13.37-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:19-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:19-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:19-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:19-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:19-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:05:19-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-26T17:05:19-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:19-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.13.37-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:20-04:00	INFO	Vulnerability scanning is enabled
2024-06-26T17:05:20-04:00	INFO	Secret scanning is enabled
2024-06-26T17:05:20-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-26T17:05:20-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-26T17:05:22-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-26T17:05:22-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-26T17:05:22-04:00	INFO	Number of language-specific files	num=1
2024-06-26T17:05:22-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.13.37-cve (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-26T17:05:22-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/kubectl (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.20.6            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```
</details>

I also scanned the images published for the PR:
```
for service in gloo gloo-envoy-wrapper discovery ingress sds certgen access-logger kubectl; do trivy image --severity HIGH,CRITICAL "quay.io/solo-io/${service}:1.13.37-9697"; done
```
<details>
<summary>
Results:
</summary>

```
2024-06-27T02:22:38-04:00	INFO	Need to update DB
2024-06-27T02:22:38-04:00	INFO	Downloading DB...	repository="ghcr.io/aquasecurity/trivy-db:2"
49.31 MiB / 49.31 MiB [--------------------------------------------------------------------------] 100.00% 6.33 MiB p/s 8.0s
2024-06-27T02:22:47-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:22:47-04:00	INFO	Secret scanning is enabled
2024-06-27T02:22:47-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:22:47-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:22:53-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-06-27T02:22:53-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-06-27T02:22:53-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:22:53-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo:1.13.37-9697 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:22:53-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-27T02:22:53-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:22:53-04:00	INFO	Secret scanning is enabled
2024-06-27T02:22:53-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:22:53-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:22:57-04:00	INFO	Detected OS	family="alpine" version="3.17.5"
2024-06-27T02:22:57-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=20
2024-06-27T02:22:57-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:22:57-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/gloo-envoy-wrapper:1.13.37-9697 (alpine 3.17.5)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:22:58-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:22:58-04:00	INFO	Secret scanning is enabled
2024-06-27T02:22:58-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:22:58-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:23:03-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-27T02:23:03-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-27T02:23:03-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:23:03-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/discovery:1.13.37-9697 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:23:03-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-27T02:23:04-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:23:04-04:00	INFO	Secret scanning is enabled
2024-06-27T02:23:04-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:23:04-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:23:09-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-27T02:23:09-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-27T02:23:09-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:23:09-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/ingress:1.13.37-9697 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:23:09-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-27T02:23:09-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:23:09-04:00	INFO	Secret scanning is enabled
2024-06-27T02:23:09-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:23:09-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:23:13-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-27T02:23:13-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-27T02:23:13-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:23:13-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/sds:1.13.37-9697 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:23:13-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.
2024-06-27T02:23:14-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:23:14-04:00	INFO	Secret scanning is enabled
2024-06-27T02:23:14-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:23:14-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:23:18-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-27T02:23:18-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-27T02:23:18-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:23:18-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/certgen:1.13.37-9697 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:23:19-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:23:19-04:00	INFO	Secret scanning is enabled
2024-06-27T02:23:19-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:23:19-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:23:23-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-27T02:23:23-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=16
2024-06-27T02:23:23-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:23:23-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/access-logger:1.13.37-9697 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:23:23-04:00	INFO	Vulnerability scanning is enabled
2024-06-27T02:23:23-04:00	INFO	Secret scanning is enabled
2024-06-27T02:23:23-04:00	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2024-06-27T02:23:23-04:00	INFO	Please see also https://aquasecurity.github.io/trivy/v0.52/docs/scanner/secret/#recommendation for faster secret detection
2024-06-27T02:23:27-04:00	INFO	Detected OS	family="alpine" version="3.17.6"
2024-06-27T02:23:27-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.17" repository="3.17" pkg_num=15
2024-06-27T02:23:27-04:00	INFO	Number of language-specific files	num=1
2024-06-27T02:23:27-04:00	INFO	[gobinary] Detecting vulnerabilities...

quay.io/solo-io/kubectl:1.13.37-9697 (alpine 3.17.6)

Total: 0 (HIGH: 0, CRITICAL: 0)

2024-06-27T02:23:27-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

usr/local/bin/kubectl (gobinary)

Total: 1 (HIGH: 0, CRITICAL: 1)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                           Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2024-24790 │ CRITICAL │ fixed  │ 1.20.6            │ 1.21.11, 1.22.4 │ golang: net/netip: Unexpected behavior from Is methods for │
│         │                │          │        │                   │                 │ IPv4-mapped IPv6 addresses                                 │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2024-24790                 │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴────────────────────────────────────────────────────────────┘
```
</details>
 
 Note that the following CVEs from the trivyignore in `main` need to be present in the trivyignore when scanning these images:
 ```
CVE-2024-26147
CVE-2023-2253
CVE-2023-39325
CVE-2023-45283
CVE-2023-45288
```

Also note that the kubectl image still has the CVE as called out above and will be ignored moving forward

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works


BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9672