### PR TITLE
Remove glooctl init to not automatically register types to global scheme

### DIFF
--- a/changelog/v1.18.0-beta2/remove-glooctl-init.yaml
+++ b/changelog/v1.18.0-beta2/remove-glooctl-init.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Remove init from glooctl root cmd introduced in https://github.com/solo-io/gloo/pull/9666

--- a/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_instances.go
@@ -19,8 +19,8 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -105,8 +105,12 @@ type unstructuredGlooInstanceReader struct {
 }
 
 func getUnstructuredGlooInstanceReader(cfg *rest.Config) (*unstructuredGlooInstanceReader, error) {
+	scheme := runtime.NewScheme()
+	if err := glooinstancev1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
 	client, err := client.New(cfg, client.Options{
-		Scheme: scheme.Scheme,
+		Scheme: scheme,
 	})
 	if err != nil {
 		return nil, err

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -11,7 +11,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/rotisserie/eris"
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
-	gatewayv1alpha1 "github.com/solo-io/gloo/projects/gateway2/pkg/api/gateway.gloo.solo.io/v1alpha1"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/common"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/constants"
@@ -22,7 +21,6 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	rlopts "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/ratelimit"
 	"github.com/solo-io/go-utils/cliutils"
-	fedv1 "github.com/solo-io/solo-apis/pkg/api/fed.solo.io/v1"
 	rlv1alpha1 "github.com/solo-io/solo-apis/pkg/api/ratelimit.solo.io/v1alpha1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients/kube/crd"
@@ -32,7 +30,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes/scheme"
 )
 
 var (
@@ -40,16 +37,6 @@ var (
 		return eris.Errorf("%s CRD has not been registered", crdName)
 	}
 )
-
-func init() {
-	scheme := scheme.Scheme
-	if err := gatewayv1alpha1.AddToScheme(scheme); err != nil {
-		panic(err)
-	}
-	if err := fedv1.AddToScheme(scheme); err != nil {
-		panic(err)
-	}
-}
 
 // contains method
 func doesNotContain(arr []string, str string) bool {


### PR DESCRIPTION
Forward-port of https://github.com/solo-io/gloo/pull/9692

# Description

Having the scheme registration for gloo fed APIs in the init causes issues when importing since importing code requires registering the same APIs from a different source. 

In this PR we revert registration to just before needed for an actual call. We also use a local scheme for the client that requires it, and remove the registration of kube gw APIs since we use the library client directly instead of controller-runtime.

## Code changes
- Do not register Kube GW APIs in scheme
- Do not use global scheme

# Context

See internal slack conversation [here](https://solo-io-corp.slack.com/archives/G01EERAK3KJ/p1719415728479849)

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

I manually verified behavior by importing this into the location in solo-projects where it was previously failing ([link](https://github.com/solo-io/solo-projects/pull/6453))

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works