### PR TITLE
Fix GGv2 RBAC Permissions To Allow Mesh Side-by-side Deployment 

### DIFF
--- a/changelog/v1.18.0-beta2/add-ggv2-rbac-roles-for-gp-deployment.yaml
+++ b/changelog/v1.18.0-beta2/add-ggv2-rbac-roles-for-gp-deployment.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6449
+    resolvesIssue: false
+    description: Fix a bug where installing GGv2 alongside Gloo Mesh doesn't have the right permissions, due to missing ClusterRole rules.

--- a/install/helm/gloo/templates/44-rbac.yaml
+++ b/install/helm/gloo/templates/44-rbac.yaml
@@ -44,6 +44,11 @@ rules:
   - gateways/status
   - httproutes/status
   verbs: ["update", "patch"]
+- apiGroups:
+  - "apiextensions.k8s.io"
+  resources:
+  - customresourcedefinitions
+  verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/install/helm/gloo/templates/44-rbac.yaml
+++ b/install/helm/gloo/templates/44-rbac.yaml
@@ -48,7 +48,7 @@ rules:
   - "apiextensions.k8s.io"
   resources:
   - customresourcedefinitions
-  verbs: ["get", "list", "watch"]
+  verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
# Description

Added permissions for the gloo gateway cluster role to fix issues hit regarding inability to list `customresourcedefinitions`.

## Code changes
- Add permissions for `customresourcedefinitions` for the gloo gateway cluster role.

# Context

When deploying Gloo Mesh alongside GGv2, users hit issues regarding missing resource permissions.

`User "system:serviceaccount:gloo-system:gloo`

According to [this](https://solo-io-corp.slack.com/archives/C07077NS0NP/p1719343266086899?thread_ts=1719341283.194989&cid=C07077NS0NP) (as I haven't been able to set this up locally yet), this is because we do not have the right permissions unless enabling GGv2 Portal. Therefore I brought the `customresourcedefinitions` policies from the Portal role onto the gloo gateway cluster role.

See slack conversation [here](https://solo-io-corp.slack.com/archives/C07077NS0NP/p1719341283194989).

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

I will be sending a dev release/build to others to verify. 

I will also look into how to deploy Gloo Mesh, as well as Gloo Edge alongside it to verify it myself. That may take a while since I haven't worked with either; this is a release blocker, so primarily relying on others with more expertise on this subject.

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->