### PR TITLE
[1.17] Rename GGv2 env vars to remove `experimental` phrasing

### DIFF
--- a/changelog/v1.17.0-rc10/rename-ggv2-enablement-var.yaml
+++ b/changelog/v1.17.0-rc10/rename-ggv2-enablement-var.yaml
@@ -1,3 +1,5 @@
 changelog:
   - type: NON_USER_FACING
-    description: Rename the k8s gateway api enablement variable from `GG_EXPERIMENTAL_K8S_GW_CONTROLLER` to `GG_K8S_GW_CONTROLLER`.
+    description: >-
+      Rename the k8s gateway api enablement variable from `GG_EXPERIMENTAL_K8S_GW_CONTROLLER` to `GG_K8S_GW_CONTROLLER`.
+      Remove unreferenced `GG_EXPERIMENTAL_ISTIO_MTLS_SDS_ENABLED` variable.

--- a/changelog/v1.17.0-rc10/rename-ggv2-enablement-var.yaml
+++ b/changelog/v1.17.0-rc10/rename-ggv2-enablement-var.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Rename the k8s gateway api enablement variable from `GG_EXPERIMENTAL_K8S_GW_CONTROLLER` to `GG_K8S_GW_CONTROLLER`.

--- a/install/helm/gloo/templates/1-gloo-deployment.yaml
+++ b/install/helm/gloo/templates/1-gloo-deployment.yaml
@@ -220,7 +220,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
         {{- if .Values.kubeGateway.enabled }}
-          - name: GG_EXPERIMENTAL_K8S_GW_CONTROLLER
+          - name: GG_K8S_GW_CONTROLLER
             value: "true"
         {{- end }}{{/* if .Values.kubeGateway.enabled */}}
         {{- if .Values.gloo.splitLogOutput }}

--- a/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
+++ b/projects/gloo/cli/pkg/cmd/check/kube_gateway.go
@@ -55,7 +55,7 @@ func CheckKubeGatewayResources(ctx context.Context, printer printers.P, opts *op
 }
 
 // check if Kubernetes Gateway integration is enabled by checking if the Gateway API CRDs are installed and
-// whether the GG_EXPERIMENTAL_K8S_GW_CONTROLLER env var is true in the gloo deployment.
+// whether the GG_K8S_GW_CONTROLLER env var is true in the gloo deployment.
 func isKubeGatewayEnabled(ctx context.Context, opts *options.Options) (bool, error) {
 	cfg, err := kubeutils.GetRestConfigWithKubeContext(opts.Top.KubeContext)
 	if err != nil {

--- a/projects/gloo/cli/pkg/kubegatewayutils/detect.go
+++ b/projects/gloo/cli/pkg/kubegatewayutils/detect.go
@@ -40,7 +40,7 @@ func DetectKubeGatewayCrds(cfg *rest.Config) (bool, error) {
 	return false, nil
 }
 
-// Returns true if the GG_EXPERIMENTAL_K8S_GW_CONTROLLER env var is true in the gloo deployment.
+// Returns true if the GG_K8S_GW_CONTROLLER env var is true in the gloo deployment.
 // Note: This is tied up with the GG implementation and will need to be updated if it changes
 func DetectKubeGatewayEnabled(ctx context.Context, opts *options.Options) (bool, error) {
 	// check if Kubernetes Gateway integration is enabled by checking if the controller env variable is set in the

--- a/projects/gloo/constants/gloo_gateway.go
+++ b/projects/gloo/constants/gloo_gateway.go
@@ -1,5 +1,5 @@
 package constants
 
 const (
-	GlooGatewayEnableK8sGwControllerEnv = "GG_EXPERIMENTAL_K8S_GW_CONTROLLER"
+	GlooGatewayEnableK8sGwControllerEnv = "GG_K8S_GW_CONTROLLER"
 )

--- a/projects/gloo/constants/istio.go
+++ b/projects/gloo/constants/istio.go
@@ -1,12 +1,6 @@
 package constants
 
 const (
-	// Env variable that indicates the Istio mtls integration is enabled via istioSDS.enabled on the helm chart.
-	// If enabled, an istio-proxy container is assumed to exist alongside the gateway proxy.
-	// Note: This value should be inherited at installation time, to determine if the istio sidecar is injected.
-	// In the interim, we use an env variable to control the value
-	IstioMtlsEnabled = "GG_EXPERIMENTAL_ISTIO_MTLS_SDS_ENABLED"
-
 	// Env variable that indicates the Istio sidecar injection is enabled via istioIntegration.enableIstioSidecarOnGateway
 	// on the helm chart. If enabled, the gateway proxy is assumed to have an istio sidecar injected.
 	IstioInjectionEnabled = "ENABLE_ISTIO_SIDECAR_ON_GATEWAY"


### PR DESCRIPTION
_backport of https://github.com/solo-io/gloo/pull/9708_

# Description

Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
## API changes
- Rename ggv2 enablement variable to remove `EXPERIMENTAL`.

# Context

As this is reaching GA, this is no longer an experimental feature.

## Interesting decisions
 
## Testing steps

Relying on CI (specifically gateway tests), as this just changes the envVar naming used to install ggv2 controller.

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->