### PR TITLE
[1.13] cli: Infer gloo deploy name

### DIFF
--- a/changelog/v1.13.39/infer-gloo-deploy-name.yaml
+++ b/changelog/v1.13.39/infer-gloo-deploy-name.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/9163
+  resolvesIssue: false
+  description: Infer the gloo deployment name in cases where the deployment name is not the default `gloo`. The gloo deployment is identified by the `gloo=gloo` label.

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
@@ -27,6 +27,9 @@ var (
 		return fmt.Sprintf("Gloo has detected that the data plane is out of sync. The following types of resources have not been accepted: %v. "+
 			"Gloo will not be able to process any other configuration updates until these errors are resolved.", resourceNames)
 	}
+
+	// Initialize the custom deployment name that is overwritten later on
+	customGlooDeploymentName = glooDeployment
 )
 
 func ResourcesSyncedOverXds(stats, deploymentName string) bool {
@@ -78,7 +81,7 @@ func checkXdsMetrics(opts *options.Options, glooNamespace string, deployments *v
 	localPort := strconv.Itoa(freePort)
 	adminPort := strconv.Itoa(int(defaults.GlooAdminPort))
 	// stats is the string containing all stats from /stats/prometheus
-	stats, portFwdCmd, err := cliutil.PortForwardGet(opts.Top.Ctx, glooNamespace, "deploy/"+glooDeployment,
+	stats, portFwdCmd, err := cliutil.PortForwardGet(opts.Top.Ctx, glooNamespace, "deploy/"+customGlooDeploymentName,
 		localPort, adminPort, false, glooStatsPath)
 	if err != nil {
 		return err
@@ -89,12 +92,12 @@ func checkXdsMetrics(opts *options.Options, glooNamespace string, deployments *v
 	}
 
 	if strings.TrimSpace(stats) == "" {
-		err := fmt.Sprint(errMessage+": could not find any metrics at", glooStatsPath, "endpoint of the "+glooDeployment+" deployment")
+		err := fmt.Sprint(errMessage+": could not find any metrics at", glooStatsPath, "endpoint of the "+customGlooDeploymentName+" deployment")
 		fmt.Println(err)
 		return fmt.Errorf(err)
 	}
 
-	if !ResourcesSyncedOverXds(stats, glooDeployment) {
+	if !ResourcesSyncedOverXds(stats, customGlooDeploymentName) {
 		fmt.Println(errMessage)
 		return fmt.Errorf(errMessage)
 	}

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/solo-io/gloo/pkg/cliutil"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	v1 "k8s.io/api/apps/v1"
 )
 
 const (
-	glooDeployment      = "gloo"
 	rateLimitDeployment = "rate-limit"
 	glooStatsPath       = "/metrics"
 
@@ -29,7 +29,7 @@ var (
 	}
 
 	// Initialize the custom deployment name that is overwritten later on
-	customGlooDeploymentName = glooDeployment
+	customGlooDeploymentName = helpers.GlooDeploymentName
 )
 
 func ResourcesSyncedOverXds(stats, deploymentName string) bool {

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -113,6 +113,13 @@ func CheckResources(opts *options.Options) error {
 			multiErr = multierror.Append(multiErr, err)
 		}
 	}
+	// Fetch the gloo deployment name even if check deployments is disabled as it is used in other checks
+	customGlooDeploymentName, err = helpers.GetGlooDeploymentName(opts.Top.Ctx, opts.Metadata.GetNamespace())
+	if err != nil {
+		multiErr = multierror.Append(multiErr, err)
+		// Fallback to the default deployment name if unable to fetch the custom one
+		customGlooDeploymentName = glooDeployment
+	}
 
 	if included := doesNotContain(opts.Top.CheckName, "pods"); included {
 		err := checkPods(ctx, opts)

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -117,8 +117,6 @@ func CheckResources(opts *options.Options) error {
 	customGlooDeploymentName, err = helpers.GetGlooDeploymentName(opts.Top.Ctx, opts.Metadata.GetNamespace())
 	if err != nil {
 		multiErr = multierror.Append(multiErr, err)
-		// Fallback to the default deployment name if unable to fetch the custom one
-		customGlooDeploymentName = glooDeployment
 	}
 
 	if included := doesNotContain(opts.Top.CheckName, "pods"); included {

--- a/projects/gloo/cli/pkg/cmd/check/root_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/root_test.go
@@ -56,6 +56,9 @@ var _ = Describe("Root", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      appName,
 					Namespace: "gloo-system",
+					Labels: map[string]string{
+						"gloo": "gloo",
+					},
 				},
 				Spec: appsv1.DeploymentSpec{},
 			}, metav1.CreateOptions{})
@@ -95,6 +98,9 @@ var _ = Describe("Root", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      appName,
 					Namespace: "gloo-system",
+					Labels: map[string]string{
+						"gloo": "gloo",
+					},
 				},
 				Spec: appsv1.DeploymentSpec{},
 			}, metav1.CreateOptions{})
@@ -176,6 +182,9 @@ var _ = Describe("Root", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      appName,
 					Namespace: myNs,
+					Labels: map[string]string{
+						"gloo": "gloo",
+					},
 				},
 				Spec: appsv1.DeploymentSpec{},
 			}, metav1.CreateOptions{})
@@ -221,6 +230,9 @@ var _ = Describe("Root", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      appName,
 					Namespace: "gloo-system",
+					Labels: map[string]string{
+						"gloo": "gloo",
+					},
 				},
 				Spec: appsv1.DeploymentSpec{},
 			}, metav1.CreateOptions{})

--- a/projects/gloo/cli/pkg/common/get.go
+++ b/projects/gloo/cli/pkg/common/get.go
@@ -186,6 +186,11 @@ func getProxiesFromK8s(name string, opts *options.Options) (gloov1.ProxyList, er
 // if name is empty, return all proxies
 func getProxiesFromGrpc(name string, namespace string, opts *options.Options, proxyEndpointPort string) (gloov1.ProxyList, error) {
 
+	glooDeploymentName, err := helpers.GetGlooDeploymentName(opts.Top.Ctx, opts.Metadata.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+
 	options := []grpc.CallOption{
 		// Some proxies can become very large and exceed the default 100Mb limit
 		// For this reason we want remove the limit but will settle for a limit of MaxInt32
@@ -198,7 +203,7 @@ func getProxiesFromGrpc(name string, namespace string, opts *options.Options, pr
 		return nil, err
 	}
 	localPort := strconv.Itoa(freePort)
-	portFwdCmd, err := cliutil.PortForward(opts.Metadata.GetNamespace(), "deployment/gloo",
+	portFwdCmd, err := cliutil.PortForward(opts.Metadata.GetNamespace(), "deployment/"+glooDeploymentName,
 		localPort, proxyEndpointPort, opts.Top.Verbose)
 	if portFwdCmd.Process != nil {
 		defer portFwdCmd.Process.Release()

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -158,12 +158,25 @@ func GetGlooDeploymentName(ctx context.Context, namespace string) (string, error
 	if err != nil {
 		return "", err
 	}
-	if len(deployments.Items) != 1 {
-		errMessage := "Unable to find the gloo deployment"
-		fmt.Println(errMessage)
-		return "", fmt.Errorf(errMessage+": %v", err)
+	if len(deployments.Items) == 1 {
+		return deployments.Items[0].Name, nil
 	}
-	return deployments.Items[0].Name, nil
+	errMessage := "Unable to find the gloo deployment"
+	// if there are multiple we can reasonably use the default variant
+	for _, d := range deployment.Items{
+		if d.Name != glooDeployment{
+			// At least 1 deployment exists, in case we dont find default update our error message
+			errMessage = "too many app=gloo deployments, cannot decide which to target"
+			continue
+		}
+		// TODO: (nfuden) Remove this, while we should generally avoid println in our formatted output we already have alot of these
+		fmt.Println("multiple gloo labeled apps found, defaulting to", glooDeployment)
+		return glooDeployment, nil
+	}
+	fmt.Println(errMessage)
+	return "", fmt.Errorf(errMessage+": %v", err)
+	}
+	
 }
 
 func MustGetNamespaces(ctx context.Context) []string {

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -45,6 +45,10 @@ var (
 	lock sync.Mutex
 )
 
+const (
+	GlooDeploymentName = "gloo"
+)
+
 // iterates over all the factory overrides, returning the first non-nil
 // mem > consul
 // if none set, return nil (callers will default to Kube CRD)
@@ -163,20 +167,18 @@ func GetGlooDeploymentName(ctx context.Context, namespace string) (string, error
 	}
 	errMessage := "Unable to find the gloo deployment"
 	// if there are multiple we can reasonably use the default variant
-	for _, d := range deployment.Items{
-		if d.Name != glooDeployment{
+	for _, d := range deployments.Items {
+		if d.Name != GlooDeploymentName {
 			// At least 1 deployment exists, in case we dont find default update our error message
 			errMessage = "too many app=gloo deployments, cannot decide which to target"
 			continue
 		}
 		// TODO: (nfuden) Remove this, while we should generally avoid println in our formatted output we already have alot of these
-		fmt.Println("multiple gloo labeled apps found, defaulting to", glooDeployment)
-		return glooDeployment, nil
+		fmt.Println("multiple gloo labeled apps found, defaulting to", GlooDeploymentName)
+		return GlooDeploymentName, nil
 	}
 	fmt.Println(errMessage)
 	return "", fmt.Errorf(errMessage+": %v", err)
-	}
-	
 }
 
 func MustGetNamespaces(ctx context.Context) []string {

--- a/projects/gloo/cli/pkg/xdsinspection/get_last_config.go
+++ b/projects/gloo/cli/pkg/xdsinspection/get_last_config.go
@@ -25,6 +25,7 @@ import (
 	structpb "github.com/golang/protobuf/ptypes/struct"
 	"github.com/rotisserie/eris"
 	_ "github.com/solo-io/gloo/projects/envoyinit/hack/filter_types"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	"github.com/solo-io/go-utils/contextutils"
 	"go.uber.org/zap"
@@ -38,6 +39,11 @@ const (
 
 func GetGlooXdsDump(ctx context.Context, proxyName, namespace string, verboseErrors bool) (*XdsDump, error) {
 
+	glooDeploymentName, err := helpers.GetGlooDeploymentName(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	xdsPort := strconv.Itoa(int(defaults.GlooXdsPort))
 	// If gloo is in MTLS mode
 	glooMtlsCheck := exec.Command("kubectl", "get", "configmap", envoySidecarConfig, "-n", namespace)
@@ -45,7 +51,7 @@ func GetGlooXdsDump(ctx context.Context, proxyName, namespace string, verboseErr
 		xdsPort = strconv.Itoa(int(defaults.GlooMtlsModeXdsPort))
 	}
 	portFwd := exec.Command("kubectl", "port-forward", "-n", namespace,
-		"deployment/gloo", xdsPort)
+		"deployment/"+glooDeploymentName, xdsPort)
 	mergedPortForwardOutput := bytes.NewBuffer([]byte{})
 	portFwd.Stdout = mergedPortForwardOutput
 	portFwd.Stderr = mergedPortForwardOutput


### PR DESCRIPTION
# Description
Infer the gloo deployment name in cases where the deployment name is not the default `gloo`. The gloo deployment is identified by the `gloo=gloo` label.

This will be forward ported

# Context
https://github.com/solo-io/gloo/issues/9163

## Interesting decisions
Rather than adding another flag for the gloo deployment name which can soon ballon into a flag for the name of each deployment, I've decided to identify the deployment via the labels.

## Testing steps
The following commands depend on the gloo deployment name :
- `glooctl check`
```
$ kg get deploy
NAME             READY   UP-TO-DATE   AVAILABLE   AGE
discovery        1/1     1            1           5h33m
gateway-proxy    1/1     1            1           5h33m
gloo-deploy-v2   1/1     1            1           9m9s

$ ./_output/glooctl-darwin-amd64 check
Checking deployments... OK
Checking pods... OK
Checking upstreams... OK
Checking upstream groups... OK
Checking auth configs... OK
Checking rate limit configs... OK
Checking VirtualHostOptions... OK
Checking RouteOptions... OK
Checking secrets... OK
Checking virtual services... OK
Checking gateways... OK
Checking proxies... OK
No problems detected.
Skipping Gloo Instance check -- Gloo Federation not detected
```
- `glooctl get proxy`
```
$ ./_output/glooctl-darwin-amd64 get proxy
+---------------+-----------+---------------+----------+
|     PROXY     | LISTENERS | VIRTUAL HOSTS |  STATUS  |
+---------------+-----------+---------------+----------+
| gateway-proxy | :::8080   | 1             | Accepted |
+---------------+-----------+---------------+----------+
```
- `glooctl proxy served-config`
```
$ ./_output/glooctl-darwin-amd64 proxy served-config

#role: gloo-system~gateway-proxy

#clusters
connectTimeout: 5s
edsClusterConfig:
  edsConfig:
    ads: {}
    resourceApiVersion: V3
....................
```
- `glooctl get upstream -o wide`
```
$ ./_output/glooctl-darwin-amd64 -o wide get upstream 

+-------------------------------+------------+----------+------------------------------+
|           UPSTREAM            |    TYPE    |  STATUS  |           DETAILS            |
+-------------------------------+------------+----------+------------------------------+
| default-kubernetes-443        | Kubernetes | Accepted | svc name:      kubernetes    |
|                               |            |          | svc namespace: default       |
|                               |            |          | port:          443           |
|                               |            |          |                              |
| gloo-system-gateway-proxy-443 | Kubernetes | Accepted | svc name:      gateway-proxy |
|                               |            |          | svc namespace: gloo-system   |
|                               |            |          | port:          443           |
.............

```


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->