### PR TITLE
[1.14] cli: Infer gloo deploy name

### DIFF
--- a/changelog/v1.14.32/infer-gloo-deploy-name-114.yaml
+++ b/changelog/v1.14.32/infer-gloo-deploy-name-114.yaml
@@ -3,3 +3,7 @@ changelog:
   issueLink: https://github.com/solo-io/gloo/issues/9163
   resolvesIssue: false
   description: Infer the gloo deployment name in cases where the deployment name is not the default `gloo`. The gloo deployment is identified by the `gloo=gloo` label.
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/9644
+  resolvesIssue: false
+  description: Fix a bug where the service and function names of a discovered gRPC service are not printed when running glooctl get upstreams

--- a/changelog/v1.14.32/infer-gloo-deploy-name-114.yaml
+++ b/changelog/v1.14.32/infer-gloo-deploy-name-114.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/9163
+  resolvesIssue: false
+  description: Infer the gloo deployment name in cases where the deployment name is not the default `gloo`. The gloo deployment is identified by the `gloo=gloo` label.

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
@@ -29,7 +29,7 @@ var (
 			"Gloo will not be able to process any other configuration updates until these errors are resolved.", resourceNames)
 	}
 
-	// Initialize the custom deployment name that is overwritten later on
+	// Initialize the custom deployment name that is overwritten later on in the `CheckResources` function
 	customGlooDeploymentName = helpers.GlooDeploymentName
 )
 

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
@@ -8,12 +8,12 @@ import (
 
 	"github.com/solo-io/gloo/pkg/cliutil"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
 	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
 	v1 "k8s.io/api/apps/v1"
 )
 
 const (
-	glooDeployment      = "gloo"
 	rateLimitDeployment = "rate-limit"
 	glooStatsPath       = "/metrics"
 
@@ -28,6 +28,9 @@ var (
 		return fmt.Sprintf("Gloo has detected that the data plane is out of sync. The following types of resources have not been accepted: %v. "+
 			"Gloo will not be able to process any other configuration updates until these errors are resolved.", resourceNames)
 	}
+
+	// Initialize the custom deployment name that is overwritten later on
+	customGlooDeploymentName = helpers.GlooDeploymentName
 )
 
 func ResourcesSyncedOverXds(stats, deploymentName string) bool {
@@ -83,7 +86,7 @@ func checkXdsMetrics(ctx context.Context, opts *options.Options, deployments *v1
 		printer.AppendCheck("Warning: checking xds with port forwarding is disabled\n")
 		return nil
 	}
-	stats, portFwdCmd, err := cliutil.PortForwardGet(ctx, opts.Metadata.GetNamespace(), "deploy/"+glooDeployment,
+	stats, portFwdCmd, err := cliutil.PortForwardGet(ctx, opts.Metadata.GetNamespace(), "deploy/"+customGlooDeploymentName,
 		localPort, adminPort, false, glooStatsPath)
 	if err != nil {
 		return err
@@ -94,12 +97,12 @@ func checkXdsMetrics(ctx context.Context, opts *options.Options, deployments *v1
 	}
 
 	if strings.TrimSpace(stats) == "" {
-		err := fmt.Sprint(errMessage+": could not find any metrics at", glooStatsPath, "endpoint of the "+glooDeployment+" deployment")
+		err := fmt.Sprint(errMessage+": could not find any metrics at", glooStatsPath, "endpoint of the "+customGlooDeploymentName+" deployment")
 		fmt.Println(err)
 		return fmt.Errorf(err)
 	}
 
-	if !ResourcesSyncedOverXds(stats, glooDeployment) {
+	if !ResourcesSyncedOverXds(stats, customGlooDeploymentName) {
 		fmt.Println(errMessage)
 		return fmt.Errorf(errMessage)
 	}

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -115,6 +115,11 @@ func CheckResources(opts *options.Options) error {
 			multiErr = multierror.Append(multiErr, err)
 		}
 	}
+	// Fetch the gloo deployment name even if check deployments is disabled as it is used in other checks
+	customGlooDeploymentName, err = helpers.GetGlooDeploymentName(opts.Top.Ctx, opts.Metadata.GetNamespace())
+	if err != nil {
+		multiErr = multierror.Append(multiErr, err)
+	}
 
 	if included := doesNotContain(opts.Top.CheckName, "pods"); included {
 		err := checkPods(ctx, opts)

--- a/projects/gloo/cli/pkg/common/get.go
+++ b/projects/gloo/cli/pkg/common/get.go
@@ -186,6 +186,11 @@ func getProxiesFromK8s(name string, opts *options.Options) (gloov1.ProxyList, er
 // if name is empty, return all proxies
 func getProxiesFromGrpc(name string, namespace string, opts *options.Options, proxyEndpointPort string) (gloov1.ProxyList, error) {
 
+	glooDeploymentName, err := helpers.GetGlooDeploymentName(opts.Top.Ctx, opts.Metadata.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+
 	options := []grpc.CallOption{
 		// Some proxies can become very large and exceed the default 100Mb limit
 		// For this reason we want remove the limit but will settle for a limit of MaxInt32
@@ -198,7 +203,7 @@ func getProxiesFromGrpc(name string, namespace string, opts *options.Options, pr
 		return nil, err
 	}
 	localPort := strconv.Itoa(freePort)
-	portFwdCmd, err := cliutil.PortForward(opts.Metadata.GetNamespace(), "deployment/gloo",
+	portFwdCmd, err := cliutil.PortForward(opts.Metadata.GetNamespace(), "deployment/"+glooDeploymentName,
 		localPort, proxyEndpointPort, opts.Top.Verbose)
 	if portFwdCmd.Process != nil {
 		defer portFwdCmd.Process.Release()

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -47,6 +47,10 @@ var (
 	lock sync.Mutex
 )
 
+const (
+	GlooDeploymentName = "gloo"
+)
+
 // iterates over all the factory overrides, returning the first non-nil
 // mem > consul
 // if none set, return nil (callers will default to Kube CRD)
@@ -147,6 +151,44 @@ func KubeClientWithKubecontext(kubecontext string) (kubernetes.Interface, error)
 	}
 
 	return clientset, nil
+}
+
+func GetGlooDeploymentName(ctx context.Context, namespace string) (string, error) {
+	client, err := KubeClient()
+	if err != nil {
+		errMessage := "error getting KubeClient"
+		fmt.Println(errMessage)
+		return "", fmt.Errorf(errMessage+": %v", err)
+	}
+	_, err = client.CoreV1().Namespaces().Get(ctx, namespace, metav1.GetOptions{})
+	if err != nil {
+		errMessage := "Gloo namespace does not exist"
+		fmt.Println(errMessage)
+		return "", fmt.Errorf(errMessage+": %v", err)
+	}
+	deployments, err := client.AppsV1().Deployments(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: "gloo=gloo",
+	})
+	if err != nil {
+		return "", err
+	}
+	if len(deployments.Items) == 1 {
+		return deployments.Items[0].Name, nil
+	}
+	errMessage := "Unable to find the gloo deployment"
+	// if there are multiple we can reasonably use the default variant
+	for _, d := range deployments.Items {
+		if d.Name != GlooDeploymentName {
+			// At least 1 deployment exists, in case we dont find default update our error message
+			errMessage = "too many app=gloo deployments, cannot decide which to target"
+			continue
+		}
+		// TODO: (nfuden) Remove this, while we should generally avoid println in our formatted output we already have alot of these
+		fmt.Println("multiple gloo labeled apps found, defaulting to", GlooDeploymentName)
+		return GlooDeploymentName, nil
+	}
+	fmt.Println(errMessage)
+	return "", fmt.Errorf(errMessage+": %v", err)
 }
 
 func MustGetNamespaces(ctx context.Context) []string {

--- a/projects/gloo/cli/pkg/helpers/clients.go
+++ b/projects/gloo/cli/pkg/helpers/clients.go
@@ -180,7 +180,7 @@ func GetGlooDeploymentName(ctx context.Context, namespace string) (string, error
 	for _, d := range deployments.Items {
 		if d.Name != GlooDeploymentName {
 			// At least 1 deployment exists, in case we dont find default update our error message
-			errMessage = "too many app=gloo deployments, cannot decide which to target"
+			errMessage = "too many deployments labeled gloo=gloo; cannot decide which to target"
 			continue
 		}
 		// TODO: (nfuden) Remove this, while we should generally avoid println in our formatted output we already have alot of these

--- a/projects/gloo/cli/pkg/printers/upstream.go
+++ b/projects/gloo/cli/pkg/printers/upstream.go
@@ -6,6 +6,11 @@ import (
 	"os"
 	"sort"
 
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/xdsinspection"
 	plugins "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/aws/ec2"
@@ -50,7 +55,6 @@ func UpstreamTable(xdsDump *xdsinspection.XdsDump, upstreams []*v1.Upstream, w i
 				table.Append([]string{"", "", "", line})
 			}
 		}
-
 	}
 
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
@@ -216,13 +220,47 @@ func linesForServiceSpec(serviceSpec *plugins.ServiceSpec) []string {
 				add(fmt.Sprintf("  - %v", fn))
 			}
 		}
+	case *plugins.ServiceSpec_GrpcJsonTranscoder:
+		add("gRPC service:")
+		descriptorBin := plug.GrpcJsonTranscoder.GetProtoDescriptorBin()
+		for _, grpcService := range plug.GrpcJsonTranscoder.GetServices() {
+			add(fmt.Sprintf("  %v", grpcService))
+			methodDescriptors := getMethodDescriptors(grpcService, descriptorBin)
+			for i := 0; i < methodDescriptors.Len(); i++ {
+				add(fmt.Sprintf("  - %v", methodDescriptors.Get(i).Name()))
+			}
+		}
 	}
-
 	return spec
 }
 
+func getMethodDescriptors(service string, descriptorSet []byte) protoreflect.MethodDescriptors {
+	fds := &descriptor.FileDescriptorSet{}
+	err := proto.Unmarshal(descriptorSet, fds)
+	if err != nil {
+		fmt.Println("unable to unmarshal descriptor")
+		return nil
+	}
+	files, err := protodesc.NewFiles(fds)
+	if err != nil {
+		fmt.Println("unable to create proto registry files")
+		return nil
+	}
+	descriptor, err := files.FindDescriptorByName(protoreflect.FullName(service))
+	if err != nil {
+		fmt.Println("unable to fin descriptor")
+		return nil
+	}
+	serviceDescriptor, ok := descriptor.(protoreflect.ServiceDescriptor)
+	if !ok {
+		fmt.Println("unable to decode service descriptor")
+		return nil
+	}
+	return serviceDescriptor.Methods()
+}
+
 // stringifyKey for a resource likely could be done more nicely with spew
-// or a better accessor but minimall this avoids panicing on nested references to nils
+// or a better accessor but minimal this avoids panicing on nested references to nils
 func stringifyKey(plausiblyNilRef *core.ResourceRef) string {
 
 	if plausiblyNilRef == nil {

--- a/projects/gloo/cli/pkg/printers/upstream_test.go
+++ b/projects/gloo/cli/pkg/printers/upstream_test.go
@@ -1,9 +1,15 @@
 package printers
 
 import (
+	"bytes"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc_json"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/kubernetes"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 var _ = Describe("UpstreamTable", func() {
@@ -12,5 +18,35 @@ var _ = Describe("UpstreamTable", func() {
 			us := &v1.Upstream{}
 			UpstreamTable(nil, []*v1.Upstream{us}, GinkgoWriter)
 		}).NotTo(Panic())
+	})
+
+	It("prints grpc upstream function names", func() {
+		us := &v1.Upstream{
+			Metadata: &core.Metadata{
+				Name: "test-us",
+			},
+			UpstreamType: &v1.Upstream_Kube{
+				Kube: &kubernetes.UpstreamSpec{
+					ServiceName:      "test",
+					ServiceNamespace: "gloo-system",
+					ServiceSpec: &options.ServiceSpec{
+						PluginType: &options.ServiceSpec_GrpcJsonTranscoder{
+							GrpcJsonTranscoder: &grpc_json.GrpcJsonTranscoder{
+								DescriptorSet: &grpc_json.GrpcJsonTranscoder_ProtoDescriptorBin{
+									ProtoDescriptorBin: []byte{10, 230, 1, 10, 16, 104, 101, 108, 108, 111, 119, 111, 114, 108, 100, 46, 112, 114, 111, 116, 111, 18, 10, 104, 101, 108, 108, 111, 119, 111, 114, 108, 100, 34, 28, 10, 12, 72, 101, 108, 108, 111, 82, 101, 113, 117, 101, 115, 116, 18, 12, 10, 4, 110, 97, 109, 101, 24, 1, 32, 1, 40, 9, 34, 29, 10, 10, 72, 101, 108, 108, 111, 82, 101, 112, 108, 121, 18, 15, 10, 7, 109, 101, 115, 115, 97, 103, 101, 24, 1, 32, 1, 40, 9, 50, 73, 10, 7, 71, 114, 101, 101, 116, 101, 114, 18, 62, 10, 8, 83, 97, 121, 72, 101, 108, 108, 111, 18, 24, 46, 104, 101, 108, 108, 111, 119, 111, 114, 108, 100, 46, 72, 101, 108, 108, 111, 82, 101, 113, 117, 101, 115, 116, 26, 22, 46, 104, 101, 108, 108, 111, 119, 111, 114, 108, 100, 46, 72, 101, 108, 108, 111, 82, 101, 112, 108, 121, 34, 0, 66, 54, 10, 27, 105, 111, 46, 103, 114, 112, 99, 46, 101, 120, 97, 109, 112, 108, 101, 115, 46, 104, 101, 108, 108, 111, 119, 111, 114, 108, 100, 66, 15, 72, 101, 108, 108, 111, 87, 111, 114, 108, 100, 80, 114, 111, 116, 111, 80, 1, 162, 2, 3, 72, 76, 87, 98, 6, 112, 114, 111, 116, 111, 51},
+								},
+								Services: []string{"helloworld.Greeter"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		var out bytes.Buffer
+		UpstreamTable(nil, []*v1.Upstream{us}, &out)
+		// The `SayHello` method exists in the ProtoDescriptorBin. This should be printed when listing upstreams.
+		// Since there is only one service, it is safe to assume that this method belongs to it
+		Expect(out.String()).To(ContainSubstring("- SayHello"))
 	})
 })


### PR DESCRIPTION
# Description
Infer the gloo deployment name in cases where the deployment name is not the default `gloo`. The gloo deployment is identified by the `gloo=gloo` label.

Forward port of https://github.com/solo-io/gloo/pull/9719

# Context
https://github.com/solo-io/gloo/issues/9163

## Interesting decisions
Rather than adding another flag for the gloo deployment name which can soon ballon into a flag for the name of each deployment, I've decided to identify the deployment via the labels.

## Testing steps
The following commands depend on the gloo deployment name :
- `glooctl check`
```
$ kg get deploy
NAME             READY   UP-TO-DATE   AVAILABLE   AGE
discovery        1/1     1            1           5h33m
gateway-proxy    1/1     1            1           5h33m
gloo-deploy-v2   1/1     1            1           9m9s

$ ./_output/glooctl-darwin-amd64 check
Checking deployments... OK
Checking pods... OK
Checking upstreams... OK
Checking upstream groups... OK
Checking auth configs... OK
Checking rate limit configs... OK
Checking VirtualHostOptions... OK
Checking RouteOptions... OK
Checking secrets... OK
Checking virtual services... OK
Checking gateways... OK
Checking proxies... OK
No problems detected.
Skipping Gloo Instance check -- Gloo Federation not detected
```
- `glooctl get proxy`
```
$ ./_output/glooctl-darwin-amd64 get proxy
+---------------+-----------+---------------+----------+
|     PROXY     | LISTENERS | VIRTUAL HOSTS |  STATUS  |
+---------------+-----------+---------------+----------+
| gateway-proxy | :::8080   | 1             | Accepted |
+---------------+-----------+---------------+----------+
```
- `glooctl proxy served-config`
```
$ ./_output/glooctl-darwin-amd64 proxy served-config

#role: gloo-system~gateway-proxy

#clusters
connectTimeout: 5s
edsClusterConfig:
  edsConfig:
    ads: {}
    resourceApiVersion: V3
....................
```
- `glooctl get upstream -o wide`
```
$ ./_output/glooctl-darwin-amd64 -o wide get upstream 

+-------------------------------+------------+----------+------------------------------+
|           UPSTREAM            |    TYPE    |  STATUS  |           DETAILS            |
+-------------------------------+------------+----------+------------------------------+
| default-kubernetes-443        | Kubernetes | Accepted | svc name:      kubernetes    |
|                               |            |          | svc namespace: default       |
|                               |            |          | port:          443           |
|                               |            |          |                              |
| gloo-system-gateway-proxy-443 | Kubernetes | Accepted | svc name:      gateway-proxy |
|                               |            |          | svc namespace: gloo-system   |
|                               |            |          | port:          443           |
.............

```


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->