### PR TITLE
Fix GatewayParameters selfManaged

### DIFF
--- a/changelog/v1.18.0-beta7/fix-self-managed.yaml
+++ b/changelog/v1.18.0-beta7/fix-self-managed.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/9740
+    resolvesIssue: false
+    description: >-
+      Allow GatewayParameters with selfManaged to be applied successfully on k8s versions below 1.29.

--- a/install/helm/gloo/crds/gateway.gloo.solo.io_gatewayparameters.yaml
+++ b/install/helm/gloo/crds/gateway.gloo.solo.io_gatewayparameters.yaml
@@ -1757,6 +1757,7 @@ spec:
                 type: object
               selfManaged:
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
             type: object
             x-kubernetes-validations:
             - message: only one of 'kube' or 'selfManaged' may be set

--- a/projects/gateway2/api/v1alpha1/gateway_parameters_types.go
+++ b/projects/gateway2/api/v1alpha1/gateway_parameters_types.go
@@ -41,6 +41,7 @@ type GatewayParametersSpec struct {
 	// The proxy will be self-managed and not auto-provisioned.
 	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:pruning:PreserveUnknownFields
 	SelfManaged *SelfManagedGateway `json:"selfManaged,omitempty"`
 }
 


### PR DESCRIPTION
# Description

There was an [issue](https://github.com/solo-io/gloo/issues/9740) with creating GatewayParameters that had selfManaged set, when using Kubernetes versions older than 1.29.

We use an empty struct to indicate that the proxies will be self-managed (rather than auto-provisioned):
```
apiVersion: gateway.gloo.solo.io/v1alpha1
kind: GatewayParameters
metadata:
  name: gw-params
spec:
  selfManaged: {}
```

This worked fine in Kubernetes 1.29+ due to [this fix](https://github.com/kubernetes/kubernetes/pull/121459), but on older Kubernetes versions it was complaining with an error like `The GatewayParameters "gw-params" is invalid: spec: Invalid value: "object": invalid object type, expected either Properties or AdditionalProperties with Allows=true and non-empty Schema evaluating rule: only one of 'kube' or 'selfManaged' may be set`. This error was only caught in our nightly tests which run on older Kubernetes versions (PRs on main run on 1.29 so don't encounter this error).

To get around this issue on older k8s versions, we ensure IsXPreserveUnknownFields is set so that the k8s apiserver will treat the selfManaged field as an [empty object](https://github.com/kubernetes/kubernetes/blob/41a539be8bbd3936a969e5d70b547acd179f137a/staging/src/k8s.io/apiserver/pkg/cel/common/values.go#L89) instead of throwing an error.

## Testing steps

### Local manual testing steps:
```
kind create cluster --image "kindest/node:v1.28.0"
kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.0.0/standard-install.yaml
helm install -n gloo-system gloo gloo/gloo --create-namespace --version 1.18.0-beta6 --set kubeGateway.enabled=true

kubectl apply -f - <<EOF
apiVersion: gateway.gloo.solo.io/v1alpha1
kind: GatewayParameters
metadata:
  name: gw-params
spec:
  selfManaged: {}
EOF
```
This should fail with the error mentioned above.

Apply the updated CRD from this PR:
```
kubectl apply -f install/helm/gloo/crds/gateway.gloo.solo.io_gatewayparameters.yaml
```
Now try creating the same GatewayParameters again, and it should succeed.


### Local e2e testing steps
```
kind delete cluster --name kind
rm -rf _test _output
ci/kind/setup-kind.sh  # this currently uses v1.28.0 so we should see the tests fail without the fix, and pass with the fix
make install-test-tools -B

go test -v -timeout 600s ./test/kubernetes/e2e/tests -run ^TestK8sGateway$/^Deployer$
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
