### PR TITLE
Enhance debug info for failed kubernetes e2e tests

### DIFF
--- a/changelog/v1.18.0-beta7/debug-info.yaml
+++ b/changelog/v1.18.0-beta7/debug-info.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update test fail handler to output information about the cluster. Also creates a separate dir for each
+      tested namespace such that multiple failures don't overwrite previous failures' output

--- a/test/kubernetes/e2e/example/debug_logging_test.go
+++ b/test/kubernetes/e2e/example/debug_logging_test.go
@@ -35,7 +35,7 @@ func TestInstallationWithDebugLogLevel(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 		}
 
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {

--- a/test/kubernetes/e2e/tests/automtls_istio_edge_api_test.go
+++ b/test/kubernetes/e2e/tests/automtls_istio_edge_api_test.go
@@ -37,7 +37,7 @@ func TestAutomtlsIstioEdgeApisGateway(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 
 			// Generate istioctl bug report
 			testInstallation.CreateIstioBugReport(ctx)

--- a/test/kubernetes/e2e/tests/automtls_istio_test.go
+++ b/test/kubernetes/e2e/tests/automtls_istio_test.go
@@ -36,7 +36,7 @@ func TestK8sGatewayIstioAutoMtls(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 
 			// Generate istioctl bug report
 			testInstallation.CreateIstioBugReport(ctx)

--- a/test/kubernetes/e2e/tests/edge_gw_test.go
+++ b/test/kubernetes/e2e/tests/edge_gw_test.go
@@ -31,7 +31,7 @@ func TestGlooGatewayEdgeGateway(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 		}
 
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {

--- a/test/kubernetes/e2e/tests/glooctl_istio_inject_test.go
+++ b/test/kubernetes/e2e/tests/glooctl_istio_inject_test.go
@@ -36,7 +36,7 @@ func TestGlooctlIstioInjectEdgeApiGateway(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 
 			// Generate istioctl bug report
 			testInstallation.CreateIstioBugReport(ctx)

--- a/test/kubernetes/e2e/tests/gloomtls_edge_api_test.go
+++ b/test/kubernetes/e2e/tests/gloomtls_edge_api_test.go
@@ -31,7 +31,7 @@ func TestGloomtlsGatewayEdgeGateway(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 		}
 
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {

--- a/test/kubernetes/e2e/tests/istio_edge_api_test.go
+++ b/test/kubernetes/e2e/tests/istio_edge_api_test.go
@@ -39,7 +39,7 @@ func TestIstioEdgeApiGateway(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 
 			// Generate istioctl bug report
 			testInstallation.CreateIstioBugReport(ctx)

--- a/test/kubernetes/e2e/tests/istio_regression_test.go
+++ b/test/kubernetes/e2e/tests/istio_regression_test.go
@@ -39,7 +39,7 @@ func TestIstioRegression(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 
 			// Generate istioctl bug report
 			testInstallation.CreateIstioBugReport(ctx)

--- a/test/kubernetes/e2e/tests/k8s_gw_istio_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_istio_test.go
@@ -34,7 +34,7 @@ func TestK8sGatewayIstio(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 
 			// Generate istioctl bug report
 			testInstallation.CreateIstioBugReport(ctx)

--- a/test/kubernetes/e2e/tests/k8s_gw_minimal_default_gatewayparameters_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_minimal_default_gatewayparameters_test.go
@@ -34,7 +34,7 @@ func TestK8sGatewayMinimalDefaultGatewayParameters(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 		}
 
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {

--- a/test/kubernetes/e2e/tests/k8s_gw_no_validation_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_no_validation_test.go
@@ -32,7 +32,7 @@ func TestK8sGatewayNoValidation(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 		}
 
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {

--- a/test/kubernetes/e2e/tests/k8s_gw_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_test.go
@@ -33,7 +33,7 @@ func TestK8sGateway(t *testing.T) {
 	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
 	t.Cleanup(func() {
 		if t.Failed() {
-			testInstallation.PreFailHandler(ctx)
+			testInstallation.PreFailHandler(ctx, testInstallation.Metadata.InstallNamespace)
 		}
 
 		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {


### PR DESCRIPTION
# Description

Currently we output only logs from the gloo pod on failure, and subsequent failures can overwrite the prior logs.

Here we hope to expand this failure logging