### PR TITLE
[1.17] Migrate utils from `test/kube2e` to `test/kubernetes`

### DIFF
--- a/changelog/v1.17.0-rc12/test-utils-debug.yaml
+++ b/changelog/v1.17.0-rc12/test-utils-debug.yaml
@@ -6,3 +6,8 @@ changelog:
       Migrate test utilities from kube2e to facilitate test migration.
 
       skipCI-docs-build:true
+  - type: NON_USER_FACING
+    description: >-
+      Update test fail handler to output information about the cluster. Also creates a separate dir for each
+      tested namespace such that multiple failures don't overwrite previous failures' output
+

--- a/changelog/v1.18.0-beta5/utils.yaml
+++ b/changelog/v1.18.0-beta5/utils.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6303
+    resolvesIssue: false
+    description: >-
+      Migrate test utilities from kube2e to facilitate test migration.
+
+      skipCI-docs-build:true

--- a/changelog/v1.18.0-beta7/debug-info.yaml
+++ b/changelog/v1.18.0-beta7/debug-info.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update test fail handler to output information about the cluster. Also creates a separate dir for each
+      tested namespace such that multiple failures don't overwrite previous failures' output

--- a/changelog/v1.18.0-beta7/debug-info.yaml
+++ b/changelog/v1.18.0-beta7/debug-info.yaml
@@ -1,5 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: >-
-      Update test fail handler to output information about the cluster. Also creates a separate dir for each
-      tested namespace such that multiple failures don't overwrite previous failures' output

--- a/pkg/utils/fsutils/fsutils.go
+++ b/pkg/utils/fsutils/fsutils.go
@@ -1,0 +1,35 @@
+package fsutils
+
+import (
+	"fmt"
+	"os"
+)
+
+// ToTempFile takes a string to write to a temp file. It returns the filename and an error.
+func ToTempFile(content string) (string, error) {
+	f, err := os.CreateTemp("", "")
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	n, err := f.WriteString(content)
+	if err != nil {
+		return "", err
+	}
+
+	if n != len(content) {
+		return "", fmt.Errorf("expected to write %d bytes, actually wrote %d", len(content), n)
+	}
+	return f.Name(), nil
+}
+
+// IsDirectory checks the provided path is a directory by first checking something exists at that path
+// and then checking that it is a directory.
+func IsDirectory(dir string) bool {
+	stat, err := os.Stat(dir)
+	if err != nil {
+		return false
+	}
+	return stat.IsDir()
+}

--- a/pkg/utils/helmutils/client.go
+++ b/pkg/utils/helmutils/client.go
@@ -2,6 +2,7 @@ package helmutils
 
 import (
 	"context"
+	"fmt"
 	"io"
 
 	"github.com/solo-io/gloo/pkg/utils/cmdutils"
@@ -13,6 +14,77 @@ type Client struct {
 	receiver io.Writer
 
 	namespace string
+}
+
+// InstallOpts is a set of typical options for a helm install which can be passed in
+// instead of requiring the caller to remember the helm cli flags. extraArgs should
+// always be accepted and respected when using InstallOpts.
+type InstallOpts struct {
+	// KubeContext is the kubernetes context to use.
+	KubeContext string
+
+	// Namespace is the namespace to which the release will be installed.
+	Namespace string
+	// CreateNamespace controls whether to create the namespace or error if it doesn't exist.
+	CreateNamespace bool
+
+	// ValuesFile is the path to the YAML values for the installation.
+	ValuesFile string
+
+	// ReleaseName is the name of the release to install. Usually will be "gloo".
+	ReleaseName string
+
+	// Repository is the remote repo to use. Usually will be one of the constants exported
+	// from this package. Ignored if LocalChartPath is set.
+	Repository string
+
+	// ChartName is the name of the chart to use. Usually will be "gloo". Ignored if LocalChartPath is set.
+	ChartName string
+
+	// LocalChartPath is the path to a locally built tarballed chart to install
+	LocalChartPath string
+}
+
+func (o InstallOpts) all() []string {
+	return append([]string{o.chart(), o.release()}, o.flags()...)
+}
+
+func (o InstallOpts) flags() []string {
+	args := []string{}
+	appendIfNonEmpty := func(fld, flag string) {
+		if fld != "" {
+			args = append(args, flag, fld)
+		}
+	}
+
+	appendIfNonEmpty(o.KubeContext, "--kube-context")
+	appendIfNonEmpty(o.Namespace, "--namespace")
+	if o.CreateNamespace {
+		args = append(args, "--create-namespace")
+	}
+	appendIfNonEmpty(o.ValuesFile, "--values")
+
+	return args
+}
+
+func (o InstallOpts) chart() string {
+	if o.LocalChartPath != "" {
+		return o.LocalChartPath
+	}
+
+	if o.Repository == "" || o.ChartName == "" {
+		return RemoteChartName
+	}
+
+	return fmt.Sprintf("%s/%s", o.Repository, o.ChartName)
+}
+
+func (o InstallOpts) release() string {
+	if o.ReleaseName != "" {
+		return o.ReleaseName
+	}
+
+	return ChartName
 }
 
 // NewClient returns an implementation of the helmutils.Client
@@ -62,6 +134,14 @@ func (c *Client) Install(ctx context.Context, extraArgs ...string) error {
 	return c.RunCommand(ctx, args...)
 }
 
+func (c *Client) Delete(ctx context.Context, extraArgs ...string) error {
+	args := append([]string{
+		"delete",
+	}, extraArgs...)
+
+	return c.RunCommand(ctx, args...)
+}
+
 func (c *Client) AddRepository(ctx context.Context, chartName string, chartUrl string, extraArgs ...string) error {
 	args := append([]string{
 		"repo",
@@ -74,4 +154,13 @@ func (c *Client) AddRepository(ctx context.Context, chartName string, chartUrl s
 
 func (c *Client) AddGlooRepository(ctx context.Context, extraArgs ...string) error {
 	return c.AddRepository(ctx, ChartName, ChartRepositoryUrl, extraArgs...)
+}
+
+func (c *Client) AddPrGlooRepository(ctx context.Context, extraArgs ...string) error {
+	return c.AddRepository(ctx, ChartName, PrChartRepositoryUrl, extraArgs...)
+}
+
+func (c *Client) InstallGloo(ctx context.Context, installOpts InstallOpts, extraArgs ...string) error {
+	args := append(installOpts.all(), extraArgs...)
+	return c.Install(ctx, args...)
 }

--- a/pkg/utils/helmutils/constants.go
+++ b/pkg/utils/helmutils/constants.go
@@ -6,6 +6,7 @@ const (
 	ChartName = "gloo"
 
 	ChartRepositoryUrl     = "https://storage.googleapis.com/solo-public-helm"
+	PrChartRepositoryUrl   = "https://storage.googleapis.com/solo-public-tagged-helm"
 	RemoteChartUriTemplate = "https://storage.googleapis.com/solo-public-helm/charts/gloo-%s.tgz"
 	RemoteChartName        = "gloo/gloo"
 )

--- a/pkg/utils/kubeutils/kubectl/cli.go
+++ b/pkg/utils/kubeutils/kubectl/cli.go
@@ -83,6 +83,15 @@ func (c *Cli) RunCommand(ctx context.Context, args ...string) error {
 	return c.Command(ctx, args...).Run().Cause()
 }
 
+// Namespaces returns a sorted list of namespaces or an error if one occurred
+func (c *Cli) Namespaces(ctx context.Context) ([]string, error) {
+	stdout, _, err := c.Execute(ctx, "get", "namespaces", "--sort-by", "metadata.name", "-o", "jsonpath={.items[*].metadata.name}")
+	if err != nil {
+		return nil, err
+	}
+	return strings.Fields(stdout), nil
+}
+
 // Apply applies the resources defined in the bytes, and returns an error if one occurred
 func (c *Cli) Apply(ctx context.Context, content []byte, extraArgs ...string) error {
 	args := append([]string{"apply", "-f", "-"}, extraArgs...)

--- a/test/gomega/assertions/stats.go
+++ b/test/gomega/assertions/stats.go
@@ -77,7 +77,6 @@ func EventuallyWithOffsetStatisticsMatchAssertions(offset int, statsPortFwd Stat
 		portForwarder.WaitForStop()
 	}()
 
-	By("Ensure port-forward is open before performing assertions")
 	statsRequest, err := http.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:%d/", statsPortFwd.LocalPort), nil)
 	ExpectWithOffset(offset+1, err).NotTo(HaveOccurred())
 	EventuallyWithOffset(offset+1, func(g Gomega) {
@@ -90,7 +89,6 @@ func EventuallyWithOffsetStatisticsMatchAssertions(offset int, statsPortFwd Stat
 		}))
 	}).Should(Succeed())
 
-	By("Perform the assertions while the port forward is open")
 	for _, assertion := range assertions {
 		assertion.WithOffset(offset + 1).ShouldNot(HaveOccurred())
 	}

--- a/test/kube2e/helper/http_echo.go
+++ b/test/kube2e/helper/http_echo.go
@@ -6,6 +6,8 @@ const (
 	HttpEchoPort         = 3000
 )
 
+// Deprecated
+// ported to test/kubernetes/e2e/defaults/testdata/http_echo.yaml
 func NewEchoHttp(namespace string) (TestContainer, error) {
 	return newTestContainer(namespace, defaultHttpEchoImage, HttpEchoName, HttpEchoPort)
 }
@@ -16,6 +18,8 @@ const (
 	TcpEchoPort         = 1025
 )
 
+// Deprecated
+// ported to test/kubernetes/e2e/defaults/testdata/tcp_echo.yaml
 func NewEchoTcp(namespace string) (TestContainer, error) {
 	return newTestContainer(namespace, defaultTcpEchoImage, TcpEchoName, TcpEchoPort)
 }

--- a/test/kube2e/helper/kube.go
+++ b/test/kube2e/helper/kube.go
@@ -51,10 +51,11 @@ func (h *SoloTestHelper) WaitForRollout(ctx context.Context, deploymentName stri
 	}, "30s", "1s").Should(BeTrue())
 }
 
+// Can be replaced entirely with Cli
 func (h *SoloTestHelper) GetContainerLogs(ctx context.Context, namespace string, name string) string {
 	GinkgoHelper()
 
-	out, _, err := h.Cli.Execute(ctx, "-n", namespace, "logs", name)
+	out, err := h.Cli.GetContainerLogs(ctx, namespace, name)
 	Expect(err).ToNot(HaveOccurred())
 	return out
 }

--- a/test/kube2e/helper/testserver.go
+++ b/test/kube2e/helper/testserver.go
@@ -80,6 +80,8 @@ const (
 </html>`
 )
 
+// tests relying on the test server should be ported using the default nginx deployment located at
+// test/kubernetes/e2e/defaults/testdata/nginx_pod.yaml
 func NewTestServer(namespace string) (TestUpstreamServer, error) {
 	testContainer, err := newTestContainer(namespace, defaultTestServerImage, TestServerName, TestServerPort)
 	if err != nil {

--- a/test/kube2e/util.go
+++ b/test/kube2e/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	errors "github.com/rotisserie/eris"
+	"github.com/solo-io/gloo/pkg/utils/fsutils"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/check"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
 	clienthelpers "github.com/solo-io/gloo/projects/gloo/cli/pkg/helpers"
@@ -152,13 +153,10 @@ func UpdateSettingsWithPropagationDelay(updateSettings func(settings *v1.Setting
 }
 
 func ToFile(content string) string {
-	f, err := os.CreateTemp("", "")
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	n, err := f.WriteString(content)
-	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	ExpectWithOffset(1, n).To(Equal(len(content)))
-	_ = f.Close()
-	return f.Name()
+	fname, err := fsutils.ToTempFile(content)
+	Expect(err).ToNot(HaveOccurred())
+
+	return fname
 }
 
 // https://github.com/solo-io/gloo/issues/4043#issuecomment-772706604

--- a/test/kubernetes/e2e/README.md
+++ b/test/kubernetes/e2e/README.md
@@ -18,8 +18,10 @@ We define all tests in the [features](./features) package. This is done for a va
 1. We group the tests by feature, so it's easy to identify which behaviors we assert for a given feature.
 2. We can invoke that same test against different `TestInstallation`s. This means we can test a feature against a variety of installation values, or even against OSS and Enterprise installations.
 
+Many examples of testing features may be found in the [features](./features) package. The general pattern for adding a new feature should be to create a directory for the feature under `features/`, write manifest files for the resources the tests will need into `features/my_feature/testdata/`, define Go objects for them in a file called `features/my_feature/types.go`, and finally define the test suite in `features/my_feature/suite.go`. There are occasions where multiple suites will need to be created under a single feature. See [Suites](#test-suites) for more info on this case. 
+
 ## Test Suites
-A Test Suite is a subset of the Feature concept. A single Feature has at minimum one Test Suite, and can have many. Each Test Suite within the feature must have a function which satisfies the signature `NewSuiteFunc` found in [suite.go](./suite.go).
+A Test Suite is a subset of the Feature concept. A single Feature has at minimum one Test Suite, and can have many. Each Test Suite should have its own appropriately named `.go` file from which is exported an appropriately named function which satisfies the signature `NewSuiteFunc` found in [suite.go](./suite.go).
 
 These test suites are registered by a name and this func in [Tests](#tests) to be run against various `TestInstallation`s.
 

--- a/test/kubernetes/e2e/defaults/defaults.go
+++ b/test/kubernetes/e2e/defaults/defaults.go
@@ -1,10 +1,13 @@
 package defaults
 
 import (
+	"path/filepath"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/solo-io/gloo/pkg/utils/kubeutils/kubectl"
+	"github.com/solo-io/skv2/codegen/util"
 )
 
 var (
@@ -20,4 +23,57 @@ var (
 			Namespace: "curl",
 		},
 	}
+
+	CurlPodManifest = filepath.Join(util.MustGetThisDir(), "testdata", "curl_pod.yaml")
+
+	HttpEchoPod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "http-echo",
+			Namespace: "http-echo",
+		},
+	}
+
+	HttpEchoPodManifest = filepath.Join(util.MustGetThisDir(), "testdata", "http_echo.yaml")
+
+	TcpEchoPod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tcp-echo",
+			Namespace: "tcp-echo",
+		},
+	}
+
+	TcpEchoPodManifest = filepath.Join(util.MustGetThisDir(), "testdata", "tcp_echo.yaml")
+
+	NginxPod = &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nginx",
+			Namespace: "nginx",
+		},
+	}
+
+	NginxPodManifest = filepath.Join(util.MustGetThisDir(), "testdata", "nginx_pod.yaml")
+
+	NginxResponse = `<!DOCTYPE html>
+<html>
+<head>
+<title>Welcome to nginx!</title>
+<style>
+html { color-scheme: light dark; }
+body { width: 35em; margin: 0 auto;
+font-family: Tahoma, Verdana, Arial, sans-serif; }
+</style>
+</head>
+<body>
+<h1>Welcome to nginx!</h1>
+<p>If you see this page, the nginx web server is successfully installed and
+working. Further configuration is required.</p>
+
+<p>For online documentation and support please refer to
+<a href="http://nginx.org/">nginx.org</a>.<br/>
+Commercial support is available at
+<a href="http://nginx.com/">nginx.com</a>.</p>
+
+<p><em>Thank you for using nginx.</em></p>
+</body>
+</html>`
 )

--- a/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
@@ -1,0 +1,36 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: http-echo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: http-echo
+  namespace: http-echo
+spec:
+  selector:
+    app.kubernetes.io/name: http-echo
+  ports:
+    - protocol: TCP
+      port: 3000
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: http-echo
+  namespace: http-echo
+  labels:
+    app.kubernetes.io/name: http-echo
+spec:
+  containers:
+  - name: http-echo
+    image: kennship/http-echo@sha256:144322e8e96be2be6675dcf6e3ee15697c5d052d14d240e8914871a2a83990af
+    ports:
+      - containerPort: 3000
+    resources:
+      requests:
+        cpu: "100m"
+      limits:
+        cpu: "200m"

--- a/test/kubernetes/e2e/defaults/testdata/nginx_pod.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/nginx_pod.yaml
@@ -1,0 +1,138 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx
+spec:
+  selector:
+    app.kubernetes.io/name: nginx
+  ports:
+    - protocol: TCP
+      port: 8080
+      targetPort: http-web-svc
+      name: http
+    - protocol: TCP
+      port: 8443
+      targetPort: https-web-svc
+      name: https
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nginx-conf
+  namespace: nginx
+data:
+  nginx.conf: |
+    user nginx;
+    worker_processes  1;
+    events {
+      worker_connections  10240;
+    }
+    http {
+      server {
+          listen              80;
+          listen              443 ssl;
+          server_name         localhost;
+          ssl_certificate     /etc/nginx/localhost.crt;
+          ssl_certificate_key /etc/nginx/localhost.key;
+
+          location / {
+            root   /usr/share/nginx/html;
+            index  index.html index.htm;
+        }
+      }
+    }
+  # localhost cert and key generated with following command from https://letsencrypt.org/docs/certificates-for-localhost/
+  # openssl req -x509 -out localhost.crt -keyout localhost.key  -newkey rsa:2048 -nodes -sha256 -subj '/CN=localhost' -extensions EXT -config <(printf "[dn]\nCN=localhost\n[req]\ndistinguished_name = dn\n[EXT]\nsubjectAltName=DNS:localhost\nkeyUsage=digitalSignature\nextendedKeyUsage=serverAuth")
+  localhost.crt: |
+    -----BEGIN CERTIFICATE-----
+    MIIDDzCCAfegAwIBAgIUMrxrG4aI7TShlLeuu4tmIsTIO1gwDQYJKoZIhvcNAQEL
+    BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MB4XDTI0MDcwMjIxNDYzNVoXDTI0MDgw
+    MTIxNDYzNVowFDESMBAGA1UEAwwJbG9jYWxob3N0MIIBIjANBgkqhkiG9w0BAQEF
+    AAOCAQ8AMIIBCgKCAQEAw6lxj3IX6kBNKWF0LEQiONJN81vbKNDEVpE+w5zwaA1K
+    zAMSfKxkhdQMPtM+MS64CPkDUZFxdYbUgKygl23uWcuIPWHnD7aqICm+ujMLUMzw
+    RFXablUCZiO9sFfZegkdLwvecmtnvNjVL5s8jk3HjV8Jetu/tE17HMvP4cMdfs/r
+    zdYRxoI2tWyYDWUW1XfD6eTxDykWwfLMdJ6UX0ksZSlQ098OheMMA6E+cxH0JMoe
+    +PLyD4nuAYW8c6tOFTXJjqHUaJzSRlYFg3OG0WRWKcjP9ufeLsPWjWza5M6WSGEj
+    hiPP2bSxMCfkY3DFSO3K71MrYf5xsP4L70YmD2oUowIDAQABo1kwVzAUBgNVHREE
+    DTALgglsb2NhbGhvc3QwCwYDVR0PBAQDAgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMB
+    MB0GA1UdDgQWBBSC36i8yBxdER9rU3KJvR/Dtop9XTANBgkqhkiG9w0BAQsFAAOC
+    AQEAXG1LQfCVJZ3R2rXHZirUHkSgXCPMglUv9dN25XMvGiOwVGX8g9QUv+WuMeoS
+    VK98rLnej7EOLZLb+02lXKqAT8G6eDqXlZONfFCTnS6BWc0+5o2fvnniuJhzxGq0
+    qolf2q4P4JNJk7TRlulaLdIxSOMyJukRne4kRcbkz3SaVE+eGAm6IURSEE1x1AXU
+    BaCZpm5MWgiJtOJulM7/9Nw8SpTir3nKNTcI3Q0M2XGvhWylN9N17AkANrBrNBme
+    LDyhBvUlZrbnOxfblBxzB8jocGxCLDLLtNNlfuEPquy8J263LVIh+Totibxhg4l/
+    MaeHQu7bsnjxU6pWF3x/QsZYzQ==
+    -----END CERTIFICATE-----
+  localhost.key: |
+    -----BEGIN PRIVATE KEY-----
+    MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDqXGPchfqQE0p
+    YXQsRCI40k3zW9so0MRWkT7DnPBoDUrMAxJ8rGSF1Aw+0z4xLrgI+QNRkXF1htSA
+    rKCXbe5Zy4g9YecPtqogKb66MwtQzPBEVdpuVQJmI72wV9l6CR0vC95ya2e82NUv
+    mzyOTceNXwl627+0TXscy8/hwx1+z+vN1hHGgja1bJgNZRbVd8Pp5PEPKRbB8sx0
+    npRfSSxlKVDT3w6F4wwDoT5zEfQkyh748vIPie4Bhbxzq04VNcmOodRonNJGVgWD
+    c4bRZFYpyM/2594uw9aNbNrkzpZIYSOGI8/ZtLEwJ+RjcMVI7crvUyth/nGw/gvv
+    RiYPahSjAgMBAAECggEAPgk8WznWgUwv6t3eQqa7nv52/qDyJMfEaJoWp1jcFHGa
+    dILI2sSh/piT5Vt+zYM9kIK7XaJaseO0/rM9G6YcO1Y/9Q5Uf3PwDtCNi2XhwZWo
+    3FHINtE3OIE+hGnmJz46hY8i0W5ibsrlFPoIQipBCf7G97Ay4Qzr6t5oI/GEKY9e
+    9b3/CJ12cvpjrrEnvvgcQv9XJ83dYVpvBLL8Hm9WjwFsmV1erN3JXB+yHe8b3MHK
+    BGA5rM+bpn+LxV3b7ycnfLXjPVkKY9KXBQCyZDzsGaCfzmQ7dJqIJAdtjR320A3A
+    M3RU/YCfV7lVxuCuPK59N3xhJJFDnfrikkKLWuGYmQKBgQDX2/iMnvPKjgcgYyui
+    Gol7h8VqRpQycXHUS89zCeIhZPr6i5ZjzltblOFhsSE26UP6S9QXG8Hw7v6dEKDx
+    9zVgNK75e1vzr8Gm5Ld+eqo22PQR1RHeQkwJXgXL+3GfHxFes6TG2h9MR3TNBGJU
+    EOayfzeNT6l3JSUV/ae913ognQKBgQDoC/jiytQz8auV4p2c/aiMRziL+xgJkV8f
+    E7q0pw4BZirRf6N6YdNU/mOhgJd1LHkcgYdnPbxHXIhNUUE3uS9Uvc+exujh4R3a
+    FcmUcbEjBG/yRVFDtgmszQtA+U+1upu4JG5MhuzLizGZvYWD0VrpGrKIBOwxlvEW
+    zMFp0JvmPwKBgCBuBdtqjgniaKOvAoEqJ3mNnlUnIWCqtoVElngcBgMqXqKBkiiQ
+    eh06MtoweGL9jJ7wAX8vRmXiIhKKywNPNo+rmpYUuG3V++wM9Jxl5Wi0E4cSUcro
+    fu/xVkGdFybmzf9CUgEmCAm3uo6KmBM1LtOmVTw/uaASzo2NPERDOS/pAoGAWpwq
+    MK0RFcN9xAZ8k0v9n+FDtG11Im9QnHsAwgAlmOhDOhFETcqbUioPz4W+HrQiCr6N
+    mAPkXF1GoCJlfBPk5otD4nU7hNB57qnpT/zhNZJLAGiO5gjUWFSs208/D/BxVANt
+    ypY5KvYMhUMbOrDqdfHF2xVJAcg2FjgYInCiH9MCgYAYGrAdT7gDLjjNtSuoFur7
+    sMtACf59rw24my1UoWCjVOxE1MVWRtCYDV5Qi+7MQ4xNejugKKKNiRwrBa6Z6bCm
+    JnPicvcV8IaWwKQqHBjDQn47DVQ+xXNHara6Alv/kjpyJztXsh12S7Hn2EJY91//
+    hcbfh0ySbbsqheBkTXMrvQ==
+    -----END PRIVATE KEY-----
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx
+  namespace: nginx
+  labels:
+    app.kubernetes.io/name: nginx
+spec:
+  containers:
+  - name: nginx
+    image: nginx:stable
+    ports:
+      - containerPort: 80
+        name: http-web-svc
+      - containerPort: 443
+        name: https-web-svc
+    resources:
+      requests:
+        cpu: "100m"
+      limits:
+        cpu: "200m"
+    volumeMounts:
+    - name: nginx-conf
+      mountPath: /etc/nginx/
+      readOnly: true
+  volumes:
+  - name: nginx-conf
+    configMap:
+      name: nginx-conf
+      items:
+      - key: nginx.conf
+        path: nginx.conf
+      - key: localhost.crt
+        path: localhost.crt
+      - key: localhost.key
+        path: localhost.key

--- a/test/kubernetes/e2e/defaults/testdata/tcp_echo.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/tcp_echo.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tcp-echo
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: tcp-echo
+  namespace: tcp-echo
+spec:
+  selector:
+    app.kubernetes.io/name: tcp-echo
+  ports:
+    - protocol: TCP
+      port: 1025
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: tcp-echo
+  namespace: tcp-echo
+  labels:
+    app.kubernetes.io/name: tcp-echo
+spec:
+  containers:
+  - name: tcp-echo
+    image: soloio/tcp-echo:latest
+    ports:
+      - containerPort: 1025
+    resources:
+      requests:
+        cpu: "100m"
+      limits:
+        cpu: "200m"
+

--- a/test/kubernetes/e2e/example/debug_logging_test.go
+++ b/test/kubernetes/e2e/example/debug_logging_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 
 	"github.com/solo-io/skv2/codegen/util"
 	"github.com/stretchr/testify/suite"
@@ -44,7 +44,7 @@ func TestInstallationWithDebugLogLevel(t *testing.T) {
 	})
 
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	// The name here is important for debuggability

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -2,10 +2,13 @@ package e2e
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/solo-io/gloo/test/kubernetes/testutils/actions"
@@ -185,13 +188,89 @@ func (i *TestInstallation) PreFailHandler(ctx context.Context) {
 	// The idea here is we want to accumulate ALL information about this TestInstallation into a single directory
 	// That way we can upload it in CI, or inspect it locally
 
-	glooLogFilePath := filepath.Join(i.GeneratedFiles.FailureDir, "gloo.log")
-	glooLogFile, err := os.Create(glooLogFilePath)
+	failureDir := i.GeneratedFiles.FailureDir
+	err := os.Mkdir(failureDir, os.ModePerm)
+	// We don't want to fail on the output directory already existing. This could occur
+	// if multiple tests running in the same cluster from the same installation namespace
+	// fail.
+	if err != nil && !errors.Is(err, fs.ErrExist) {
+		i.Assertions.Require.NoError(err)
+	}
+
+	glooLogFilePath := filepath.Join(failureDir, "gloo.log")
+	glooLogFile, err := os.OpenFile(glooLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
 	i.Assertions.Require.NoError(err)
 	defer glooLogFile.Close()
 
-	logsCmd := i.Actions.Kubectl().Command(ctx, "logs", "-n", i.Metadata.InstallNamespace, "deployments/gloo")
-	_ = logsCmd.WithStdout(glooLogFile).WithStderr(glooLogFile).Run()
+	glooLogsCmd := i.Actions.Kubectl().Command(ctx, "logs", "-n", i.Metadata.InstallNamespace, "deployments/gloo")
+	_ = glooLogsCmd.WithStdout(glooLogFile).WithStderr(glooLogFile).Run()
+
+	edgeGatewayLogFilePath := filepath.Join(failureDir, "edge_gateway.log")
+	edgeGatewayLogFile, err := os.OpenFile(edgeGatewayLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	i.Assertions.Require.NoError(err)
+	defer edgeGatewayLogFile.Close()
+
+	kubeGatewayLogFilePath := filepath.Join(failureDir, "kube_gateway.log")
+	kubeGatewayLogFile, err := os.OpenFile(kubeGatewayLogFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	i.Assertions.Require.NoError(err)
+	defer kubeGatewayLogFile.Close()
+
+	namespaces, err := i.Actions.Kubectl().Namespaces(ctx)
+	i.Assertions.Require.NoError(err)
+	for _, n := range namespaces {
+		edgeGatewayLogFile.WriteString(fmt.Sprintf("Logs for edge gateway proxies in namespace %s\n", n))
+		edgeGatewayLogsCmd := i.Actions.Kubectl().Command(ctx, "logs", "--all-containers", "--namespace", n, "--prefix", "-l", "gloo=gateway-proxy")
+		_ = edgeGatewayLogsCmd.WithStdout(edgeGatewayLogFile).WithStderr(edgeGatewayLogFile).Run()
+		edgeGatewayLogFile.WriteString("----------------------------------------------------------------------------------------------------------\n")
+
+		kubeGatewayLogFile.WriteString(fmt.Sprintf("Logs for kube gateway proxies in namespace %s\n", n))
+		kubeGatewayLogsCmd := i.Actions.Kubectl().Command(ctx, "logs", "--all-containers", "--namespace", n, "--prefix", "-l", "gloo=kube-gateway")
+		_ = kubeGatewayLogsCmd.WithStdout(kubeGatewayLogFile).WithStderr(kubeGatewayLogFile).Run()
+		kubeGatewayLogFile.WriteString("----------------------------------------------------------------------------------------------------------\n")
+	}
+
+	clusterStateFilePath := filepath.Join(failureDir, "cluster_state.log")
+	clusterStateFile, err := os.OpenFile(clusterStateFilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, os.ModePerm)
+	i.Assertions.Require.NoError(err)
+	defer clusterStateFile.Close()
+
+	kubectlGetAllCmd := i.Actions.Kubectl().Command(ctx, "get", "all", "-A", "-owide")
+	_ = kubectlGetAllCmd.WithStdout(clusterStateFile).WithStderr(clusterStateFile).Run()
+	clusterStateFile.WriteString("\n")
+
+	resourcesToGet := []string{
+		// Kubernetes resources
+		"secrets",
+		// Kube GW API resources
+		"gateways.gateway.networking.k8s.io",
+		"gatewayclasses.gateway.networking.k8s.io",
+		"httproutes.gateway.networking.k8s.io",
+		"referencegrants.gateway.networking.k8s.io",
+		// GG Kube GW resources
+		"gatewayparameters.gateway.gloo.solo.io",
+		"listeneroptions.gateway.solo.io",     // only implemented for kube gw as of now
+		"httplisteneroptions.gateway.solo.io", // only implemented for kube gw as of now
+		// GG Gloo resources
+		"graphqlapis.graphql.gloo.solo.io",
+		"proxies.gloo.solo.io",
+		"settings.gloo.solo.io",
+		"upstreamgroups.gloo.solo.io",
+		"upstreams.gloo.solo.io",
+		// GG Edge GW resources
+		"gateways.gateway.solo.io",
+		"httpgateways.gateway.solo.io",
+		"tcpgateways.gateway.solo.io",
+		"virtualservices.gateway.solo.io",
+		// Shared GW resources
+		"routeoptions.gateway.solo.io",
+		"virtualhostoptions.gateway.solo.io",
+		// Dataplane extensions resources
+		"authconfigs.enterprise.gloo.solo.io",
+		"ratelimitconfigs.ratelimit.solo.io",
+	}
+	kubectlGetResourcesCmd := i.Actions.Kubectl().Command(ctx, "get", strings.Join(resourcesToGet, ","), "-A", "-owide")
+	_ = kubectlGetResourcesCmd.WithStdout(clusterStateFile).WithStderr(clusterStateFile).Run()
+	clusterStateFile.WriteString("\n")
 }
 
 // GeneratedFiles is a collection of files that are generated during the execution of a set of tests

--- a/test/kubernetes/e2e/tests/automtls_istio_edge_api_test.go
+++ b/test/kubernetes/e2e/tests/automtls_istio_edge_api_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 
 	"github.com/solo-io/skv2/codegen/util"
 
@@ -62,7 +62,7 @@ func TestAutomtlsIstioEdgeApisGateway(t *testing.T) {
 
 	// Install Gloo Gateway with only Gloo Edge Gateway APIs enabled
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	AutomtlsIstioEdgeApiSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/automtls_istio_test.go
+++ b/test/kubernetes/e2e/tests/automtls_istio_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 	"github.com/solo-io/skv2/codegen/util"
 )
 
@@ -64,7 +64,7 @@ func TestK8sGatewayIstioAutoMtls(t *testing.T) {
 	// Install Gloo Gateway
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
 		// istio proxy and sds are added to gateway and take a little longer to start up
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 10*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 10*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	AutomtlsIstioSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/edge_gw_test.go
+++ b/test/kubernetes/e2e/tests/edge_gw_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 	"github.com/solo-io/skv2/codegen/util"
 )
 
@@ -41,7 +41,7 @@ func TestGlooGatewayEdgeGateway(t *testing.T) {
 
 	// Install Gloo Gateway with only Gloo Edge Gateway APIs enabled
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	EdgeGwSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/glooctl_istio_inject_test.go
+++ b/test/kubernetes/e2e/tests/glooctl_istio_inject_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 	"github.com/solo-io/skv2/codegen/util"
 
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
@@ -61,7 +61,7 @@ func TestGlooctlIstioInjectEdgeApiGateway(t *testing.T) {
 
 	// Install Gloo Gateway with only Gloo Edge Gateway APIs enabled
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	GlooctlIstioInjectSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/istio_edge_api_test.go
+++ b/test/kubernetes/e2e/tests/istio_edge_api_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 
 	"github.com/solo-io/skv2/codegen/util"
 )
@@ -66,7 +66,7 @@ func TestIstioEdgeApiGateway(t *testing.T) {
 
 	// Install Gloo Gateway with only Edge APIs enabled
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	IstioEdgeApiSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/istio_regression_test.go
+++ b/test/kubernetes/e2e/tests/istio_regression_test.go
@@ -7,10 +7,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 
 	"github.com/solo-io/skv2/codegen/util"
 )
@@ -66,7 +66,7 @@ func TestIstioRegression(t *testing.T) {
 
 	// Install Gloo Gateway with only Edge APIs enabled
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	IstioRegressionSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/k8s_gw_istio_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_istio_test.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 	"github.com/solo-io/skv2/codegen/util"
 )
 
@@ -60,7 +60,7 @@ func TestK8sGatewayIstio(t *testing.T) {
 	// Install Gloo Gateway
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
 		// istio proxy and sds are added to gateway and take a little longer to start up
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 10*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 10*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	IstioSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/k8s_gw_minimal_default_gatewayparameters_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_minimal_default_gatewayparameters_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/solo-io/gloo/pkg/utils/env"
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 	"github.com/solo-io/gloo/test/testutils"
 	"github.com/solo-io/skv2/codegen/util"
 )
@@ -44,7 +44,7 @@ func TestK8sGatewayMinimalDefaultGatewayParameters(t *testing.T) {
 
 	// Install Gloo Gateway
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	KubeGatewayMinimalDefaultGatewayParametersSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/k8s_gw_no_validation_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_no_validation_test.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/solo-io/skv2/codegen/util"
 
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 )
 
 // TestK8sGatewayNoValidation executes tests against a K8s Gateway gloo install with validation disabled
@@ -42,7 +42,7 @@ func TestK8sGatewayNoValidation(t *testing.T) {
 
 	// Install Gloo Gateway
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	KubeGatewayNoValidationSuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/e2e/tests/k8s_gw_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_test.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/solo-io/gloo/pkg/utils/env"
-	"github.com/solo-io/gloo/test/kube2e/helper"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
 	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
 	"github.com/solo-io/gloo/test/testutils"
 	"github.com/solo-io/skv2/codegen/util"
 )
@@ -43,7 +43,7 @@ func TestK8sGateway(t *testing.T) {
 
 	// Install Gloo Gateway
 	testInstallation.InstallGlooGateway(ctx, func(ctx context.Context) error {
-		return testHelper.InstallGloo(ctx, helper.GATEWAY, 5*time.Minute, helper.ExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
+		return testHelper.InstallGloo(ctx, 5*time.Minute, helper.WithExtraArgs("--values", testInstallation.Metadata.ValuesManifestFile))
 	})
 
 	KubeGatewaySuiteRunner().Run(ctx, t, testInstallation)

--- a/test/kubernetes/testutils/assertions/deployments.go
+++ b/test/kubernetes/testutils/assertions/deployments.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"time"
 
+	"github.com/solo-io/gloo/pkg/utils/kubeutils"
+	"github.com/solo-io/gloo/test/gomega/assertions"
+
+	"github.com/solo-io/go-utils/stats"
+
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	"go.uber.org/zap/zapcore"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/solo-io/gloo/pkg/utils/kubeutils"
 )
 
 func (p *Provider) EventuallyRunningReplicas(ctx context.Context, deploymentMeta metav1.ObjectMeta, replicaMatcher types.GomegaMatcher) {
@@ -24,4 +28,29 @@ func (p *Provider) EventuallyRunningReplicas(ctx context.Context, deploymentMeta
 		WithTimeout(time.Second * 30).
 		WithPolling(time.Millisecond * 200).
 		Should(Succeed())
+}
+
+func (p *Provider) EventuallyGlooReachesConsistentState(installNamespace string) {
+	// We port-forward the Gloo deployment stats port to inspect the metrics and log settings
+	// TODO(jbohanon) clean this up with newer style portforwarder
+	glooStatsForwardConfig := assertions.StatsPortFwd{
+		ResourceName:      "deployment/gloo",
+		ResourceNamespace: installNamespace,
+		LocalPort:         stats.DefaultPort,
+		TargetPort:        stats.DefaultPort,
+	}
+
+	// Gloo components are configured to log to the Info level by default
+	logLevelAssertion := assertions.LogLevelAssertion(zapcore.InfoLevel)
+
+	// The emitter at some point should stabilize and not continue to increase the number of snapshots produced
+	// We choose 4 here as a bit of a magic number, but we feel comfortable that if 4 consecutive polls of the metrics
+	// endpoint returns that same value, then we have stabilized
+	identicalResultInARow := 4
+	emitterMetricAssertion, _ := assertions.IntStatisticReachesConsistentValueAssertion("api_gloosnapshot_gloo_solo_io_emitter_snap_out", identicalResultInARow)
+
+	assertions.EventuallyStatisticsMatchAssertions(glooStatsForwardConfig,
+		logLevelAssertion,
+		emitterMetricAssertion,
+	)
 }

--- a/test/kubernetes/testutils/assertions/glooctl.go
+++ b/test/kubernetes/testutils/assertions/glooctl.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/check"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/options"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/version"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/printers"
 )
 
@@ -39,6 +40,31 @@ func (p *Provider) EventuallyCheckResourcesOk(ctx context.Context) {
 		Should(Succeed())
 }
 
+// EventuallyMatchesVersion asserts that `glooctl version` eventually responds with the expected server version
+func (p *Provider) EventuallyMatchesVersion(ctx context.Context, serverVersion string) {
+	p.expectGlooGatewayContextDefined()
+
+	k := version.NewKube(p.glooGatewayContext.InstallNamespace, p.clusterContext.KubeContext)
+
+	p.Gomega.Eventually(func(innerG Gomega) {
+		contextWithCancel, cancel := context.WithCancel(ctx)
+		defer cancel()
+		csv, err := version.GetClientServerVersions(contextWithCancel, k)
+		innerG.Expect(err).NotTo(HaveOccurred(), "can get client server versions with glooctl")
+		innerG.Expect(csv.GetServer()).To(HaveLen(1), "has detected gloo deployment")
+		kServer := csv.GetServer()[0].GetKubernetes()
+		innerG.Expect(kServer.GetContainers()).ToNot(BeEmpty(), "has containers for gloo deployment")
+		innerG.Expect(kServer.GetContainers()[0].GetTag()).To(Equal(serverVersion), "has expected tag")
+	}).
+		WithContext(ctx).
+		// These are some basic defaults that we expect to work in most cases
+		// We can make these configurable if need be, though most installations
+		// Should be able to become healthy within this window
+		WithTimeout(time.Second * 120).
+		WithPolling(time.Second).
+		Should(Succeed())
+}
+
 func (p *Provider) EventuallyInstallationSucceeded(ctx context.Context) {
 	p.expectGlooGatewayContextDefined()
 
@@ -50,4 +76,13 @@ func (p *Provider) EventuallyUninstallationSucceeded(ctx context.Context) {
 	p.expectGlooGatewayContextDefined()
 
 	p.ExpectNamespaceNotExist(ctx, p.glooGatewayContext.InstallNamespace)
+}
+
+func (p *Provider) EventuallyUpgradeSucceeded(ctx context.Context, version string) {
+	p.expectGlooGatewayContextDefined()
+
+	p.EventuallyMatchesVersion(ctx, version)
+
+	// Check that everything is OK
+	p.EventuallyCheckResourcesOk(ctx)
 }

--- a/test/kubernetes/testutils/helper/docker/Dockerfile
+++ b/test/kubernetes/testutils/helper/docker/Dockerfile
@@ -1,0 +1,10 @@
+# This file is used to build soloio/tcp-echo (https://hub.docker.com/r/soloio/tcp-echo)
+# which has not received updates since 2019
+FROM cjimti/go-echo:latest
+
+RUN apk update
+RUN apk add curl
+
+WORKDIR /
+
+ENTRYPOINT ["/tcp-echo"]

--- a/test/kubernetes/testutils/helper/install.go
+++ b/test/kubernetes/testutils/helper/install.go
@@ -1,0 +1,404 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"helm.sh/helm/v3/pkg/repo"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/afero"
+
+	"github.com/rotisserie/eris"
+	"github.com/solo-io/gloo/pkg/utils/fsutils"
+	"github.com/solo-io/gloo/pkg/utils/kubeutils/kubectl"
+	"github.com/solo-io/go-utils/log"
+	"github.com/solo-io/go-utils/testutils/exec"
+)
+
+// Default test configuration
+var defaults = TestConfig{
+	TestAssetDir:          "_test",
+	BuildAssetDir:         "_output",
+	HelmRepoIndexFileName: "index.yaml",
+}
+
+// supportedArchs is represents the list of architectures we build glooctl for
+var supportedArchs = map[string]struct{}{
+	"arm64": {},
+	"amd64": {},
+}
+
+// returns true if supported, based on `supportedArchs`
+func isSupportedArch() (string, bool) {
+	if goarch, ok := os.LookupEnv("GOARCH"); ok {
+		// if the environment's goarch is supported
+		_, ok := supportedArchs[goarch]
+		return goarch, ok
+	}
+
+	// if the runtime's goarch is supported
+	runtimeArch := runtime.GOARCH
+	_, ok := supportedArchs[runtimeArch]
+	return runtimeArch, ok
+}
+
+// Function to provide/override test configuration. Default values will be passed in.
+type TestConfigFunc func(defaults TestConfig) TestConfig
+
+type TestConfig struct {
+	// All relative paths will assume this as the base directory. This is usually the project base directory.
+	RootDir string
+	// The directory holding the test assets. Must be relative to RootDir.
+	TestAssetDir string
+	// The directory holding the build assets. Must be relative to RootDir.
+	BuildAssetDir string
+	// Helm chart name
+	HelmChartName string
+	// Name of the helm index file name
+	HelmRepoIndexFileName string
+	// The namespace gloo (and the test server) will be installed to. If empty, will use the helm chart version.
+	InstallNamespace string
+	// Name of the glooctl executable
+	GlooctlExecName string
+	// If provided, the licence key to install the enterprise version of Gloo
+	LicenseKey string
+	// Install a released version of gloo. This is the value of the github tag that may have a leading 'v'
+	ReleasedVersion string
+	// If true, glooctl will be run with a -v flag
+	Verbose bool
+
+	// The version of the Helm chart. Calculated from either the chart or the released version. It will not have a leading 'v'
+	version string
+}
+
+type SoloTestHelper struct {
+	*TestConfig
+	// The kubernetes helper
+	*kubectl.Cli
+}
+
+// NewSoloTestHelper is meant to provide a standard way of deploying Gloo/GlooE to a k8s cluster during tests.
+// It assumes that build and test assets are present in the `_output` and `_test` directories (these are configurable).
+// Specifically, it expects the glooctl executable in the BuildAssetDir and a helm chart in TestAssetDir.
+// It also assumes that a kubectl executable is on the PATH.
+func NewSoloTestHelper(configFunc TestConfigFunc) (*SoloTestHelper, error) {
+
+	// Get and validate test config
+	testConfig := defaults
+	if configFunc != nil {
+		testConfig = configFunc(defaults)
+	}
+	// Depending on the testing tool used, GOARCH may always be set if not set already by detecting the local arch
+	// (`go test`), `ginkgo` and other testing tools may not do this requiring keeping the runtime.GOARCH check
+	if testConfig.GlooctlExecName == "" {
+		if arch, ok := isSupportedArch(); ok {
+			testConfig.GlooctlExecName = "glooctl-" + runtime.GOOS + "-" + arch
+		} else {
+			testConfig.GlooctlExecName = "glooctl-" + runtime.GOOS + "-amd64"
+		}
+	}
+
+	// Get chart version
+	if testConfig.ReleasedVersion == "" {
+		if err := validateConfig(testConfig); err != nil {
+			return nil, errors.Wrapf(err, "test config validation failed")
+		}
+		version, err := getChartVersion(testConfig)
+		if err != nil {
+			return nil, errors.Wrapf(err, "getting Helm chart version")
+		}
+		testConfig.version = version
+	} else {
+		// we use the version field as a chart version and tests assume it doesn't have a leading 'v'
+		if testConfig.ReleasedVersion[0] == 'v' {
+			testConfig.version = testConfig.ReleasedVersion[1:]
+		} else {
+			testConfig.version = testConfig.ReleasedVersion
+		}
+	}
+	// Default the install namespace to the chart version.
+	// Currently the test chart version built in CI contains the build id, so the namespace will be unique).
+	if testConfig.InstallNamespace == "" {
+		testConfig.InstallNamespace = testConfig.version
+	}
+
+	testHelper := &SoloTestHelper{
+		TestConfig: &testConfig,
+	}
+
+	return testHelper, nil
+}
+
+func (h *SoloTestHelper) SetKubeCli(cli *kubectl.Cli) {
+	h.Cli = cli
+}
+
+// Return the version of the Helm chart
+func (h *SoloTestHelper) ChartVersion() string {
+	return h.version
+}
+
+// Return the path to the chart used for installation
+func (h *SoloTestHelper) ChartPath() string {
+	return filepath.Join(h.RootDir, h.TestAssetDir, fmt.Sprintf("%s-%s.tgz", h.HelmChartName, h.ChartVersion()))
+}
+
+type OptionsMutator func(opts *Options)
+
+type Options struct {
+	Command []string
+	Verbose bool
+}
+
+func WithExtraArgs(args ...string) OptionsMutator {
+	return func(opts *Options) {
+		opts.Command = append(opts.Command, args...)
+	}
+}
+
+// InstallGloo calls glooctl to install Gloo. This is where image variants are handled as well.
+func (h *SoloTestHelper) InstallGloo(ctx context.Context, timeout time.Duration, options ...OptionsMutator) error {
+	deploymentType := "gateway"
+	log.Printf("installing gloo in [%s] mode to namespace [%s]", deploymentType, h.InstallNamespace)
+	glooctlCommand := []string{
+		filepath.Join(h.BuildAssetDir, h.GlooctlExecName),
+		"install", deploymentType,
+	}
+	if h.LicenseKey != "" {
+		glooctlCommand = append(glooctlCommand, "enterprise", "--license-key", h.LicenseKey)
+	}
+	if h.ReleasedVersion != "" {
+		glooctlCommand = append(glooctlCommand, "-n", h.InstallNamespace, "--version", h.ReleasedVersion)
+	} else {
+		glooctlCommand = append(glooctlCommand,
+			"-n", h.InstallNamespace,
+			"-f", h.ChartPath())
+	}
+	if h.Verbose {
+		glooctlCommand = append(glooctlCommand, "-v")
+	}
+	variant := os.Getenv("IMAGE_VARIANT")
+	if variant != "" {
+		variantValuesFile, err := GenerateVariantValuesFile(variant)
+		if err != nil {
+			return err
+		}
+		options = append(options, WithExtraArgs("--values", variantValuesFile))
+	}
+
+	io := &Options{
+		Command: glooctlCommand,
+		Verbose: true,
+	}
+	for _, opt := range options {
+		opt(io)
+	}
+
+	if err := glooctlInstallWithTimeout(h.RootDir, io, timeout); err != nil {
+		return errors.Wrapf(err, "error running glooctl install command")
+	}
+
+	return nil
+}
+
+func runWithTimeout(rootDir string, opts *Options, timeout time.Duration, operation string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	errChan := make(chan error, 1)
+	go func() {
+		err := exec.RunCommand(rootDir, opts.Verbose, opts.Command...)
+		if err != nil {
+			errChan <- errors.Wrapf(err, "error while executing gloo %s", operation)
+		}
+		errChan <- nil
+	}()
+
+	select {
+	case err := <-errChan:
+		return err // can be nil
+	case <-ctx.Done():
+		return fmt.Errorf("timed out while executing gloo %s", operation)
+	}
+}
+
+// Wait for the glooctl install command to respond, err on timeout.
+// The command returns as soon as certgen completes and all other
+// deployments have been applied, which should only be delayed if
+// there's an issue pulling the certgen docker image.
+// Without this timeout, it would just hang indefinitely.
+func glooctlInstallWithTimeout(rootDir string, opts *Options, timeout time.Duration) error {
+	return runWithTimeout(rootDir, opts, timeout, "install")
+}
+
+// Upgrades Gloo via a helm upgrade. It returns a method that rolls-back helm to the version prior to this upgrade
+func (h *SoloTestHelper) UpgradeGloo(ctx context.Context, timeout time.Duration, options ...OptionsMutator) (revertFunc func() error, err error) {
+	log.Printf("upgrading gloo in namespace [%s]", h.InstallNamespace)
+
+	revision, err := h.CurrentGlooRevision()
+	if err != nil {
+		return nil, err
+	}
+
+	helmCommand := []string{
+		"helm",
+		"upgrade",
+		h.HelmChartName,
+		h.ChartPath(),
+		"-n", h.InstallNamespace,
+	}
+
+	if h.Verbose {
+		helmCommand = append(helmCommand, "-v")
+	}
+
+	opts := &Options{
+		Command: helmCommand,
+		Verbose: true,
+	}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	if err := upgradeGlooWithTimeout(h.RootDir, opts, timeout); err != nil {
+		return nil, errors.Wrapf(err, "error running glooctl install command")
+	}
+
+	return func() error {
+		return h.RevertGlooUpgrade(ctx, timeout, WithExtraArgs([]string{
+			strconv.Itoa(revision),
+		}...))
+	}, nil
+}
+
+func (h *SoloTestHelper) CurrentGlooRevision() (int, error) {
+	command := []string{
+		"bash",
+		"-c",
+		fmt.Sprintf("helm -n %s ls -o json | jq '.[] | select(.name=\"%s\") | .revision' | tr -d '\"'", h.InstallNamespace, h.HelmChartName),
+	}
+	out, err := exec.RunCommandOutput(h.RootDir, false, command...)
+	if err != nil {
+		return 0, errors.Wrapf(err, "error while fetching gloo revision")
+	}
+	return strconv.Atoi(strings.TrimSpace(out))
+}
+
+func upgradeGlooWithTimeout(rootDir string, opts *Options, timeout time.Duration) error {
+	return runWithTimeout(rootDir, opts, timeout, "upgrade")
+}
+
+// Rollback Gloo. The version can be passed via the ExtraArgs option. If not specified it rolls-back to the previous version
+// Eg: RevertGlooUpgrade(ctx, timeout, WithExtraArgs([]string{revision}))
+func (h *SoloTestHelper) RevertGlooUpgrade(ctx context.Context, timeout time.Duration, options ...OptionsMutator) error {
+	log.Printf("reverting gloo upgrade in namespace [%s]", h.InstallNamespace)
+	helmCommand := []string{
+		"helm",
+		"rollback",
+		h.HelmChartName,
+		"-n", h.InstallNamespace,
+	}
+
+	if h.Verbose {
+		helmCommand = append(helmCommand, "-v")
+	}
+
+	opts := &Options{
+		Command: helmCommand,
+		Verbose: true,
+	}
+	for _, opt := range options {
+		opt(opts)
+	}
+
+	if err := upgradeGlooWithTimeout(h.RootDir, opts, timeout); err != nil {
+		return errors.Wrapf(err, "error running glooctl install command")
+	}
+	return nil
+}
+
+// passes the --all flag to glooctl uninstall
+func (h *SoloTestHelper) UninstallGlooAll() error {
+	return h.uninstallGloo(true)
+}
+
+// does not pass the --all flag to glooctl uninstall
+func (h *SoloTestHelper) UninstallGloo() error {
+	return h.uninstallGloo(false)
+}
+
+func (h *SoloTestHelper) uninstallGloo(all bool) error {
+	log.Printf("uninstalling gloo...")
+	cmdArgs := []string{
+		filepath.Join(h.BuildAssetDir, h.GlooctlExecName), "uninstall", "-n", h.InstallNamespace, "--delete-namespace", "--release-name", h.HelmChartName,
+	}
+	if all {
+		cmdArgs = append(cmdArgs, "--all")
+	}
+	return exec.RunCommand(h.RootDir, true, cmdArgs...)
+}
+
+// Parses the Helm index file and returns the version of the chart.
+func getChartVersion(config TestConfig) (string, error) {
+
+	// Find helm index file in test asset directory
+	helmIndexFile := filepath.Join(config.RootDir, config.TestAssetDir, config.HelmRepoIndexFileName)
+	helmIndex, err := repo.LoadIndexFile(helmIndexFile)
+	if err != nil {
+		return "", errors.Wrapf(err, "parsing Helm index file")
+	}
+	log.Printf("found Helm index file at: %s", helmIndexFile)
+
+	// Read and return version from helm index file
+	if chartVersions, ok := helmIndex.Entries[config.HelmChartName]; !ok {
+		return "", eris.Errorf("index file does not contain entry with key: %s", config.HelmChartName)
+	} else if len(chartVersions) == 0 || len(chartVersions) > 1 {
+		return "", eris.Errorf("expected a single entry with name [%s], found: %v", config.HelmChartName, len(chartVersions))
+	} else {
+		version := chartVersions[0].Version
+		log.Printf("version of [%s] Helm chart is: %s", config.HelmChartName, version)
+		return version, nil
+	}
+}
+
+func validateConfig(config TestConfig) error {
+	for _, dirName := range []string{
+		config.RootDir,
+		filepath.Join(config.RootDir, config.BuildAssetDir),
+		filepath.Join(config.RootDir, config.TestAssetDir),
+	} {
+		if !fsutils.IsDirectory(dirName) {
+			return fmt.Errorf("%s does not exist or is not a directory", dirName)
+		}
+	}
+	return nil
+}
+
+func GenerateVariantValuesFile(variant string) (string, error) {
+	content := `global:
+  image:
+    variant: ` + variant
+
+	fs := afero.NewOsFs()
+	dir, err := afero.TempDir(fs, "", "")
+	if err != nil {
+		return "", err
+	}
+
+	tmpFile, err := afero.TempFile(fs, dir, "")
+	if err != nil {
+		return "", err
+	}
+	_, err = tmpFile.WriteString(content)
+	if err != nil {
+		return "", err
+	}
+
+	return tmpFile.Name(), nil
+}

--- a/test/kubernetes/testutils/helper/util.go
+++ b/test/kubernetes/testutils/helper/util.go
@@ -1,0 +1,147 @@
+package helper
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/google/go-github/v32/github"
+	. "github.com/onsi/gomega"
+	errors "github.com/rotisserie/eris"
+	"github.com/solo-io/gloo/test/testutils"
+	"github.com/solo-io/gloo/test/testutils/version"
+	"github.com/solo-io/go-utils/changelogutils"
+	"github.com/solo-io/go-utils/githubutils"
+	"github.com/solo-io/go-utils/versionutils"
+	"github.com/solo-io/skv2/codegen/util"
+)
+
+// Deprecated; if this is needed create a resource yaml for it.
+func GetHttpEchoImage() string {
+	httpEchoImage := "hashicorp/http-echo"
+	if runtime.GOARCH == "arm64" {
+		httpEchoImage = "gcr.io/solo-test-236622/http-echo"
+	}
+	return httpEchoImage
+}
+
+// For nightly runs, we want to install a released version rather than using a locally built chart
+// To do this, set the environment variable RELEASED_VERSION with either a version name or "LATEST" to get the last release
+func GetTestReleasedVersion(ctx context.Context, repoName string) string {
+	releasedVersion := os.Getenv(testutils.ReleasedVersion)
+
+	if releasedVersion == "" {
+		// In the case where the released version is empty, we return an empty string
+		// The function which consumes this value will then use the locally built chart
+		return releasedVersion
+	}
+
+	if releasedVersion == "LATEST" {
+		_, current, err := GetUpgradeVersions(ctx, repoName)
+		Expect(err).NotTo(HaveOccurred())
+		return current.String()
+	}
+
+	// Assume that releasedVersion is a valid version, for a previously released version of Gloo Edge
+	return releasedVersion
+}
+
+func GetTestHelperForRootDir(ctx context.Context, rootDir, namespace string) (*SoloTestHelper, error) {
+	if useVersion := GetTestReleasedVersion(ctx, "gloo"); useVersion != "" {
+		return NewSoloTestHelper(func(defaults TestConfig) TestConfig {
+			defaults.RootDir = rootDir
+			defaults.HelmChartName = "gloo"
+			defaults.InstallNamespace = namespace
+			defaults.ReleasedVersion = useVersion
+			defaults.Verbose = true
+			return defaults
+		})
+	} else {
+		return NewSoloTestHelper(func(defaults TestConfig) TestConfig {
+			defaults.RootDir = rootDir
+			defaults.HelmChartName = "gloo"
+			defaults.InstallNamespace = namespace
+			defaults.Verbose = true
+			return defaults
+		})
+	}
+}
+
+// GetUpgradeVersions returns two semantic versions of a repository:
+//   - prevLtsRelease: the latest patch release of v1.m-1.x
+//   - latestRelease:  the latest patch release of v1.m.x
+//
+// Originally intended for use in upgrade testing, it can return any of:
+//   - (prevLtsRelease, latestRelease, nil): all release versions computable
+//   - (prevLtsRelease, nil, nil):           only prevLtsRelease computable (ie current branch has never been released)
+//   - (nil, nil, err):                      unable to fetch versions for upgrade test
+func GetUpgradeVersions(ctx context.Context, repoName string) (*versionutils.Version, *versionutils.Version, error) {
+	// get the latest and upcoming releases of the current branch
+	files, changelogReadErr := os.ReadDir(filepath.Join(util.GetModuleRoot(), changelogutils.ChangelogDirectory))
+	if changelogReadErr != nil {
+		return nil, nil, changelogutils.ReadChangelogDirError(changelogReadErr)
+	}
+	latestRelease, upcomingRelease, upcomingReleaseErr := version.ChangelogDirForLatestRelease(files...)
+	if upcomingReleaseErr != nil && !errors.Is(upcomingReleaseErr, version.FirstReleaseError) {
+		return nil, nil, upcomingReleaseErr
+	}
+
+	// get latest release of previous LTS branch
+	// TODO(nfuden): Update goutils to not use a struct but rather interface so we can test this more easily.
+	client, githubClientErr := githubutils.GetClient(ctx)
+	if githubClientErr != nil {
+		return nil, nil, errors.Wrapf(githubClientErr, "unable to create github client")
+	}
+	prevLtsRelease, prevLtsReleaseErr := getLatestReleasedPatchVersion(ctx, client, repoName, upcomingRelease.Major, upcomingRelease.Minor-1)
+	if prevLtsReleaseErr != nil {
+		return nil, nil, prevLtsReleaseErr
+	}
+
+	if upcomingReleaseErr != nil {
+		// if we don't yet have a release for the current branch, we can only upgrade from prevLtsRelease
+		return prevLtsRelease, nil, nil
+	} else {
+		// otherwise, we can upgrade from both prevLtsRelease -and- latestRelease
+		return prevLtsRelease, latestRelease, nil
+	}
+}
+
+type latestPatchForMinorPredicate struct {
+	versionPrefix string
+}
+
+func (s *latestPatchForMinorPredicate) Apply(release *github.RepositoryRelease) bool {
+	return strings.HasPrefix(*release.Name, s.versionPrefix) &&
+		!release.GetPrerelease() && // we don't want a prerelease version
+		!strings.Contains(release.GetBody(), "This release build failed") && // we don't want a failed build
+		release.GetPublishedAt().Before(time.Now().In(time.UTC).Add(time.Duration(-60)*time.Minute))
+}
+
+func newLatestPatchForMinorPredicate(versionPrefix string) *latestPatchForMinorPredicate {
+	return &latestPatchForMinorPredicate{
+		versionPrefix: versionPrefix,
+	}
+}
+
+// getLatestReleasedPatchVersion will return the latest released patch version for the given major and minor version
+// NOTE: this attempts to reach out to github to get the latest release
+func getLatestReleasedPatchVersion(ctx context.Context, client *github.Client, repoName string, majorVersion, minorVersion int) (*versionutils.Version, error) {
+
+	versionPrefix := fmt.Sprintf("v%d.%d", majorVersion, minorVersion)
+	releases, err := githubutils.GetRepoReleasesWithPredicateAndMax(ctx, client, "solo-io", repoName, newLatestPatchForMinorPredicate(versionPrefix), 1)
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to get releases")
+	}
+	if len(releases) == 0 {
+		return nil, errors.Errorf("Could not find a recent release with version prefix: %s", versionPrefix)
+	}
+	v, err := versionutils.ParseVersion(*releases[0].Name)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error parsing release name")
+	}
+	return v, nil
+}


### PR DESCRIPTION
Backport of #9720 and #9746

# Description

Migrate the `util.go` and `helper/` from `test/kube2e/` to `kubernetes/testutils/helper/`. 

This is preliminary work to the migration of all tests out of kube2e.

A number of differences exist between the old tool and new tool:
- TestUpstreamServer and the entire testContainer abstraction has been removed.
  - The manifest and go vars for a default nginx server serving http and https has been added, and this should be used as a drop-in replacement for the TestUpstreamServer when migrating
- Numerous assertions were deleted. When a test using this assertion is ported, the developer doing the port should move the required code to `test/kubernetes/testutils/assertions`.
- Some scaffolding for moving to install via helm directly instead of via glooctl has been added.
  - We explicitly want to NOT change the install method until all tests have been ported to reduce the number of things being changed at once and increase our confidence in the port
  - The helm install code is not presently wired all the way through yet.


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works