### PR TITLE
[1.17] Fix HTTPS listener aggregation with kube gateway

### DIFF
--- a/changelog/v1.17.0-rc12/listeners-reuse-ports.yaml
+++ b/changelog/v1.17.0-rc12/listeners-reuse-ports.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6559
+    resolvesIssue: false
+    description: >-
+      Resolves issue of HTTPS listeners not aggregating appropriately when defined using the
+      same port on a kube gateway.

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -68,6 +68,60 @@ var _ = Describe("GatewayTranslator", func() {
 		}]).To(BeTrue())
 	})
 
+	It("should translate a gateway with http routing with multiple listeners on the same port", func() {
+		results, err := TestCase{
+			Name:       "multiple-listeners-http-routing",
+			InputFiles: []string{dir + "/testutils/inputs/multiple-listeners-http-routing"},
+			ResultsByGateway: map[types.NamespacedName]ExpectedTestResult{
+				{
+					Namespace: "default",
+					Name:      "http",
+				}: {
+					Proxy: dir + "/testutils/outputs/multiple-listeners-http-routing-proxy.yaml",
+					// Reports:     nil,
+				},
+			},
+		}.Run(ctx)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results).To(HaveKey(types.NamespacedName{
+			Namespace: "default",
+			Name:      "http",
+		}))
+		Expect(results[types.NamespacedName{
+			Namespace: "default",
+			Name:      "http",
+		}]).To(BeTrue())
+	})
+
+	It("should translate a gateway with https routing with multiple listeners on the same port", func() {
+		results, err := TestCase{
+			Name:       "multiple-listeners-https-routing",
+			InputFiles: []string{dir + "/testutils/inputs/multiple-listeners-https-routing"},
+			ResultsByGateway: map[types.NamespacedName]ExpectedTestResult{
+				{
+					Namespace: "default",
+					Name:      "http",
+				}: {
+					Proxy: dir + "/testutils/outputs/multiple-listeners-https-routing-proxy.yaml",
+					// Reports:     nil,
+				},
+			},
+		}.Run(ctx)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results).To(HaveKey(types.NamespacedName{
+			Namespace: "default",
+			Name:      "http",
+		}))
+		Expect(results[types.NamespacedName{
+			Namespace: "default",
+			Name:      "http",
+		}]).To(BeTrue())
+	})
+
 	It("should translate an http gateway with multiple routing rules and use the HeaderModifier filter", func() {
 		results, err := TestCase{
 			Name:       "http-routing-with-header-modifier-filter",

--- a/projects/gateway2/translator/testutils/inputs/multiple-listeners-http-routing/gateway.yaml
+++ b/projects/gateway2/translator/testutils/inputs/multiple-listeners-http-routing/gateway.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: http
+spec:
+  gatewayClassName: gloo-gateway
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: httpbin.example.com
+    name: http-httpbin
+    port: 80
+    protocol: HTTP
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: bookinfo.example.com
+    name: http-bookinfo
+    port: 80
+    protocol: HTTP

--- a/projects/gateway2/translator/testutils/inputs/multiple-listeners-https-routing/gateway.yaml
+++ b/projects/gateway2/translator/testutils/inputs/multiple-listeners-https-routing/gateway.yaml
@@ -1,0 +1,33 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: http
+spec:
+  gatewayClassName: gloo-gateway
+  listeners:
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: httpbin.example.com
+    name: https-httpbin
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: httpbin-tls-secret
+      mode: Terminate
+  - allowedRoutes:
+      namespaces:
+        from: All
+    hostname: bookinfo.example.com
+    name: https-bookinfo
+    port: 443
+    protocol: HTTPS
+    tls:
+      certificateRefs:
+      - group: ""
+        kind: Secret
+        name: bookinfo-tls-secret
+      mode: Terminate

--- a/projects/gateway2/translator/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
+++ b/projects/gateway2/translator/testutils/outputs/multiple-listeners-http-routing-proxy.yaml
@@ -1,0 +1,15 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains: 
+    - matcher: {}
+    httpResources: {}
+  bindAddress: '::'
+  bindPort: 8080
+  name: http-httpbin~http-bookinfo
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: default
+  name: default-http
+  namespace: gloo-system

--- a/projects/gateway2/translator/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
+++ b/projects/gateway2/translator/testutils/outputs/multiple-listeners-https-routing-proxy.yaml
@@ -1,0 +1,13 @@
+---
+listeners:
+- aggregateListener:
+    httpResources: {}
+  bindAddress: '::'
+  bindPort: 8443
+  name: https-httpbin~https-bookinfo
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: default
+  name: default-http
+  namespace: gloo-system


### PR DESCRIPTION
Backport of #9750 

# Description

HTTPS listeners on kube gateways were not aggregating properly due to translating away from privileged ports.

## Code changes
- Translate port before looking up if we already have listener

# Context

Users ran into this bug when applying a Gateway with multiple HTTPS listeners using the same port

See slack conversation [here](https://solo-io-corp.slack.com/archives/C07077NS0NP/p1720729966605369)

## Testing steps

Translation unit tests added. Can be manually verified using the resource specified in the issue.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works