### PR TITLE
pkg/syncer: Make servexds not always leak goroutines

### DIFF
--- a/changelog/v1.18.0-beta7/tests-go-leak.yaml
+++ b/changelog/v1.18.0-beta7/tests-go-leak.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Make dev mode routine cancellable.
+      Allows for e2e tests to not leak goroutines.
+      Should not affect real kubernetes environments.
+      
+      skipCI-docs-build:true

--- a/projects/gloo/pkg/syncer/envoy_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/envoy_translator_syncer.go
@@ -201,6 +201,11 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1snap.ApiSnapsh
 // Deprecated: https://github.com/solo-io/gloo/issues/6494
 // Prefer to use the iosnapshot.History
 func (s *translatorSyncer) ServeXdsSnapshots() error {
+	_, err := s.startXdsSnapServer()
+	return err
+}
+
+func (s *translatorSyncer) startXdsSnapServer() (http.Server, error) {
 	r := mux.NewRouter()
 
 	r.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {

--- a/projects/gloo/pkg/syncer/translator_syncer.go
+++ b/projects/gloo/pkg/syncer/translator_syncer.go
@@ -108,7 +108,13 @@ func NewTranslatorSyncer(
 	if devMode {
 		// TODO(ilackarms): move this somewhere else?
 		go func() {
-			_ = s.ServeXdsSnapshots()
+			serve, err := s.startXdsSnapServer()
+			if err != nil {
+				contextutils.LoggerFrom(ctx).Errorw("failed to start xds snapshot server", err)
+			}
+			<-ctx.Done()
+			serve.Close()
+
 		}()
 	}
 	go s.statusSyncer.syncStatusOnEmit(ctx)


### PR DESCRIPTION
# Description

Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
## API changes
- Added x field to y resource
- ...

## Code changes
- Fix error in `Foo()` function
- Add `Bar()` function
- ...

## CI changes
- Adjusted schedule for x job
- ...

## Docs changes
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

I manually verified behavior by ...

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->