### PR TITLE
docs: mark 1.17 as latest stable

### DIFF
--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -38,7 +38,7 @@ jobs:
           SCAN_DIR: _output/scans
           IMAGE_REGISTRY: quay.io/solo-io
           # ON_LTS_UPDATE - bump version
-          MIN_SCANNED_VERSION: 'v1.13.0' # ⚠️ you should also change docs-gen.yaml ⚠️
+          MIN_SCANNED_VERSION: 'v1.14.0' # ⚠️ you should also change docs-gen.yaml ⚠️
         run: |
           mkdir -p $SCAN_DIR
           make run-security-scan

--- a/.trivyignore
+++ b/.trivyignore
@@ -36,30 +36,3 @@ CVE-2023-2253
 # https://github.com/solo-io/gloo/issues/9187
 # https://github.com/solo-io/gloo/issues/9189
 CVE-2024-26147
-
-
-# ON_LTS_UPDATE - delete below here when MIN_SCANNED_VERSION in Makefile/trivy-analysis-scheduled.yaml is updated past 1.13x - issues identified in https://github.com/solo-io/gloo/issues/9443
-# https://github.com/advisories/GHSA-4374-p667-p6c8
-# This HTTP2 vulnerability is not exploitable in Gloo Edge as the kubectl image is only used for jobs, not serving traffic
-# A fix is not available for the Kubernetes versions supported in 1.13
-# https://github.com/solo-io/gloo/issues/9443
-CVE-2023-39325
-
-# https://github.com/advisories/GHSA-vvjp-q62m-2vph
-# A fix is not available for the Kubernetes versions supported in 1.13 and only affects Windows filepaths
-# https://github.com/solo-io/gloo/issues/9443
-CVE-2023-45283
-
-# https://github.com/advisories/GHSA-4v7x-pqxf-cx7m
-# This vulnerability is resolved on all images except kubectl.
-# This HTTP2 vulnerability is not exploitable in Gloo Edge as the kubectl image is only used for jobs, not serving traffic.
-# A fix is not available for the Kubernetes versions supported in 1.13
-# https://github.com/solo-io/gloo/issues/9443
-CVE-2023-45288
-
-# https://github.com/advisories/GHSA-49gw-vxvf-fc2g
-# This vulnerability is resolved on all images except kubectl.
-# This vulnerability is in the netip package which is not used by kubectl
-# A fix is not available for the Kubernetes versions supported in 1.13
-# https://github.com/solo-io/gloo/issues/9672
-CVE-2024-24790

--- a/Makefile
+++ b/Makefile
@@ -1211,7 +1211,7 @@ SCAN_DIR ?= $(OUTPUT_DIR)/scans
 SCAN_BUCKET ?= solo-gloo-security-scans
 # The minimum version to scan with trivy
 # ON_LTS_UPDATE - bump version
-MIN_SCANNED_VERSION ?= v1.13.0
+MIN_SCANNED_VERSION ?= v1.14.0
 
 .PHONY: run-security-scans
 run-security-scan:

--- a/changelog/v1.18.0-beta8/1-17-ga.yaml
+++ b/changelog/v1.18.0-beta8/1-17-ga.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Promote 1.17.x LTS branch as latest stable branch.

--- a/changelog/v1.18.0-beta8/1-17-ga.yaml
+++ b/changelog/v1.18.0-beta8/1-17-ga.yaml
@@ -2,3 +2,5 @@ changelog:
   - type: NON_USER_FACING
     description: >-
       Promote 1.17.x LTS branch as latest stable branch.
+      
+      skipCI-kube-tests:true

--- a/docs/active_versions.json
+++ b/docs/active_versions.json
@@ -1,12 +1,12 @@
 {
-  "latest": "v1.16.x",
+  "latest": "v1.17.x",
   "versions": [
     "main",
-    "v1.16.x"
+    "v1.17.x"
   ],
   "oldVersions": [
+    "v1.16.x",
     "v1.15.x",
-    "v1.14.x",
-    "v1.13.x"
+    "v1.14.x"
   ]
 }


### PR DESCRIPTION
# Description

Include the 1.17.x branch in the docs and trivy scan versions.


# Context
1.17.0 was released yesterday, and thus the 1.17 branch should follow the pattern of our other LTS branches


## Interesting decisions
 -

## Testing steps
-

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works