### PR TITLE
Update `docs-gen.yaml` to scan from 1.14+

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -7,10 +7,10 @@ on:
   push:
     branches:
     - 'main'
+    - 'v1.17.x'
     - 'v1.16.x'
     - 'v1.15.x'
     - 'v1.14.x'
-    - 'v1.13.x'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -2,7 +2,7 @@ name: Docs
 
 env:
     SLACK_DEBUG_TESTING: false      # when set to "true", send notifications to #slack-integration-testing.  Otherwise, post to #edge-team-bots
-    MIN_SCANNED_VERSION: 'v1.13.0'  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
+    MIN_SCANNED_VERSION: 'v1.14.0'  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
 on:
   push:
     branches:

--- a/changelog/v1.18.0-beta8/update-docs-gen-scanner-min-version-1.14.yaml
+++ b/changelog/v1.18.0-beta8/update-docs-gen-scanner-min-version-1.14.yaml
@@ -1,6 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: >-
-      Update the MIN_SCANNED_VERSION to v1.14 in docs-gen.yaml so v1.13 does not get scanned for vulnerabilities.
-      skipCI-kube-tests:true
-      skipCI-docs-build:true

--- a/changelog/v1.18.0-beta8/update-docs-gen-scanner-min-version-1.14.yaml
+++ b/changelog/v1.18.0-beta8/update-docs-gen-scanner-min-version-1.14.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update the MIN_SCANNED_VERSION to v1.14 in docs-gen.yaml so v1.13 does not get scanned for vulnerabilities.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/changelog/v1.18.0-beta9/update-docs-gen-scanner-min-version-1.14.yaml
+++ b/changelog/v1.18.0-beta9/update-docs-gen-scanner-min-version-1.14.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update the MIN_SCANNED_VERSION to v1.14 in docs-gen.yaml so v1.13 does not get scanned for vulnerabilities.
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

With the GA release of 1.17, our minimum supported version moved from 1.13 to 1.14.

_Fill out any of the following sections that are relevant and remove the others_

## CI changes
- Updated `docs-gen.yaml` to scan from 1.14+.

## Docs changes
- Scanning/publishing scans for 1.14+.

# Context

We did updates update the minimum version [here](https://github.com/solo-io/gloo/pull/9769), but missed this file.

## Testing steps

I manually verified behavior by ...

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works