### PR TITLE
gateway2/delegation: fix extraneous route arising from invalid child rule

### DIFF
--- a/changelog/v1.18.0-beta11/deleg-fix-6621.yaml
+++ b/changelog/v1.18.0-beta11/deleg-fix-6621.yaml
@@ -1,0 +1,26 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6621
+    resolvesIssue: false
+    description: |
+      gateway2/delegation: fix extraneous route arising from invalid child rule
+
+      There's a bug where if a child route contains an invalid rule (rule
+      not matching the parent matcher), then even though the matcher is
+      discarded, the rule with an empty matcher but valid backendRef
+      is returned by GetDelegatedRoutes(). The result is that a `/`
+      route is programmed for such an invalid route rule. A more
+      precise fix is to also prune the rules that do not have a valid
+      matcher so that we do not rely on the translator to interpret
+      a route without a valid matcher as '/', which could be an alternative
+      fix though fragile.
+
+      The essence of this fix is to prune both the `rules` and `matches`
+      field on the child route when we process it in the context of the
+      parent matcher, so that:
+      1. invalid matchers on the child route are discarded
+      2. invalid rules (no valid child matchers) are also discarded
+
+      Previously, 2. was missing so a child route with a rule without
+      a matcher was configured, which results in a `/` route being exposed
+      for the corresponding backendRef.

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -249,4 +249,5 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("RouteOptions merge child override on no conflict", "route_options_inheritance_child_override_ok.yaml"),
 	Entry("RouteOptions multi level inheritance with child override", "route_options_multi_level_inheritance_override_ok.yaml"),
 	Entry("RouteOptions filter override merge", "route_options_filter_override_merge.yaml"),
+	Entry("https://github.com/solo-io/solo-projects/issues/6621", "bug-6621.yaml"),
 )

--- a/projects/gateway2/translator/testutils/inputs/delegation/bug-6621.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/bug-6621.yaml
@@ -1,0 +1,64 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /random
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/outputs/delegation/bug-6621.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/bug-6621.yaml
@@ -1,0 +1,33 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - prefix: /a/1
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system


### PR DESCRIPTION
# Description

There's a bug where if a child route contains an invalid rule (rule not matching the parent matcher), then even though the matcher is discarded, the rule with an empty matcher but valid backendRef is returned by GetDelegatedRoutes(). The result is that a `/` route is programmed for such an invalid route rule. A more precise fix is to also prune the rules that do not have a valid matcher so that we do not rely on the translator to interpret a route without a valid matcher as '/', which could be an alternative fix though fragile.

The essence of this fix is to prune both the `rules` and `matches` field on the child route when we process it in the context of the parent matcher, so that:
1. invalid matchers on the child route are discarded
2. invalid rules (no valid child matchers) are also discarded

Previously, 2. was missing so a child route with a rule without a matcher was configured, which results in a `/` route being exposed for the corresponding backendRef.

## Testing steps

Run the same translator test without the fix and verify that a route `/` gets programmed for the backendRef on the route.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
