### PR TITLE
Ignore false positive istio cves

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -36,3 +36,9 @@ CVE-2023-2253
 # https://github.com/solo-io/gloo/issues/9187
 # https://github.com/solo-io/gloo/issues/9189
 CVE-2024-26147
+
+# Ignore a few istio.io/istio vulnerabilities. These CVEs are from very old versions of istio for which patches have already been merged - these come up as false positives from trivy because we pin the dependencies and trivy is unable to determine that the pinned versions already have the fix. This is due to istio's tags not following go's strict semver and therefore falling back to a go pseudo version.
+CVE-2019-14993
+CVE-2021-39155
+CVE-2021-39156
+CVE-2022-23635

--- a/changelog/v1.18.0-beta11/ignore-false-positive-istio-cve.yaml
+++ b/changelog/v1.18.0-beta11/ignore-false-positive-istio-cve.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    issueLink: https://github.com/solo-io/solo-projects/issues/6624
+    description: >-
+      Add istio.io/istio false positives CVEs to `.trivyignore`. These CVEs are
+      from very old versions of istio for which patches have already been
+      merged - these come up as false positives from trivy because we pin the
+      dependencies and trivy is unable to determine that the pinned versions
+      already have the fix. This is due to istio's tags not following go's
+      strict semver and therefore falling back to a go pseudo version.


### PR DESCRIPTION
# Description

This is a cherry-pick (of sorts) of the fix for some false positive CVE reports on solo-projects. While this repository is not affected by the CVE (because it does not actually contain this dependency), it serves as a point of documentation as to why trivy may falsely report this repository as having this CVE reported.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->