### PR TITLE
Improve sync status time

### DIFF
--- a/changelog/v1.17.2/fix-only-update-status-on-change.yaml
+++ b/changelog/v1.17.2/fix-only-update-status-on-change.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6638
+    resolvesIssue: true
+    description: |
+      Only update the K8s Gateway resource statuses on change to improve HTTPRoute translation time.

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -176,6 +176,9 @@ func (s *ProxySyncer) Start(ctx context.Context) error {
 func (s *ProxySyncer) syncRouteStatus(ctx context.Context, rm reports.ReportMap) {
 	ctx = contextutils.WithLogger(ctx, "routeStatusSyncer")
 	logger := contextutils.LoggerFrom(ctx)
+	logger.Debugf("syncing k8s gateway route status")
+	startTime := time.Now()
+
 	rl := apiv1.HTTPRouteList{}
 	err := s.mgr.GetClient().List(ctx, &rl)
 	if err != nil {
@@ -192,12 +195,16 @@ func (s *ProxySyncer) syncRouteStatus(ctx context.Context, rm reports.ReportMap)
 			}
 		}
 	}
+	contextutils.LoggerFrom(ctx).Debugf("synced route statuses in %v", time.Since(startTime))
 }
 
 // syncStatus updates the status of the Gateway CRs
 func (s *ProxySyncer) syncStatus(ctx context.Context, rm reports.ReportMap, gwl apiv1.GatewayList) {
 	ctx = contextutils.WithLogger(ctx, "statusSyncer")
 	logger := contextutils.LoggerFrom(ctx)
+	logger.Debugf("syncing k8s gateway proxy status")
+	startTime := time.Now()
+
 	for _, gw := range gwl.Items {
 		gw := gw // pike
 		if status := rm.BuildGWStatus(ctx, gw); status != nil {
@@ -207,6 +214,7 @@ func (s *ProxySyncer) syncStatus(ctx context.Context, rm reports.ReportMap, gwl 
 			}
 		}
 	}
+	contextutils.LoggerFrom(ctx).Debugf("synced statuses in %v", time.Since(startTime))
 }
 
 // reconcileProxies persists the proxies that were generated during translations and stores them in an in-memory cache


### PR DESCRIPTION
# Description

This fixes one of the issues from https://github.com/solo-io/solo-projects/issues/6638 so that there are no extraneous status updates. 

This also adds some debug logs to show reconcile time for the proxy syncer. 

Before:
```

{"level":"debug","ts":"2024-08-01T16:45:37.113Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:99","msg":"starting syncer for k8s gateway proxies"}
{"level":"debug","ts":"2024-08-01T16:45:37.220Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:111","msg":"resyncing k8s gateway proxies [1]"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:207","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:221","msg":"synced statuses in 83ns"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:179","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:200","msg":"synced route statuses in 6.125µs"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:159","msg":"translated and wrote 0 proxies in 113.667µs"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:111","msg":"resyncing k8s gateway proxies [2]"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:207","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:221","msg":"synced statuses in 83ns"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:179","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:200","msg":"synced route statuses in 2µs"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:159","msg":"translated and wrote 0 proxies in 46.625µs"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:111","msg":"resyncing k8s gateway proxies [3]"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:207","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:221","msg":"synced statuses in 167ns"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:179","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:45:37.221Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:200","msg":"synced route statuses in 4.667µs"}
{"level":"debug","ts":"2024-08-01T16:45:37.222Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:159","msg":"translated and wrote 0 proxies in 75.292µs"}
{"level":"debug","ts":"2024-08-01T16:45:51.626Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:111","msg":"resyncing k8s gateway proxies [4]"}
{"level":"debug","ts":"2024-08-01T16:45:51.626Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:207","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:45:51.626Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:221","msg":"synced statuses in 458ns"}
{"level":"debug","ts":"2024-08-01T16:45:51.626Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:179","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:45:51.626Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:200","msg":"synced route statuses in 7.041µs"}
{"level":"debug","ts":"2024-08-01T16:45:51.626Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:159","msg":"translated and wrote 0 proxies in 117.916µs"}
```

After change:
```
Fix:

{"level":"debug","ts":"2024-08-01T16:34:47.158Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:100","msg":"starting syncer for k8s gateway proxies"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:112","msg":"resyncing k8s gateway proxies [1]"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:208","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:222","msg":"synced statuses in 125ns"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:180","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:201","msg":"synced route statuses in 5.125µs"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:160","msg":"translated and wrote 0 proxies in 88.708µs"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:112","msg":"resyncing k8s gateway proxies [2]"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:208","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:222","msg":"synced statuses in 84ns"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:180","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:201","msg":"synced route statuses in 1.625µs"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:160","msg":"translated and wrote 0 proxies in 37.959µs"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:112","msg":"resyncing k8s gateway proxies [3]"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:208","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:222","msg":"synced statuses in 125ns"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:180","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:201","msg":"synced route statuses in 2.5µs"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:160","msg":"translated and wrote 0 proxies in 31.417µs"}
{"level":"debug","ts":"2024-08-01T16:34:47.262Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:112","msg":"resyncing k8s gateway proxies [4]"}
{"level":"debug","ts":"2024-08-01T16:34:47.263Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:208","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:34:47.263Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:222","msg":"synced statuses in 83ns"}
{"level":"debug","ts":"2024-08-01T16:34:47.263Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:180","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:34:47.263Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:201","msg":"synced route statuses in 1.459µs"}
{"level":"debug","ts":"2024-08-01T16:34:47.263Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:160","msg":"translated and wrote 0 proxies in 35.25µs"}
{"level":"debug","ts":"2024-08-01T16:35:01.695Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:112","msg":"resyncing k8s gateway proxies [5]"}
{"level":"debug","ts":"2024-08-01T16:35:01.695Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:208","msg":"syncing k8s gateway proxy status"}
{"level":"debug","ts":"2024-08-01T16:35:01.695Z","logger":"k8s-gw-syncer.statusSyncer","caller":"proxy_syncer/proxy_syncer.go:222","msg":"synced statuses in 125ns"}
{"level":"debug","ts":"2024-08-01T16:35:01.695Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:180","msg":"syncing k8s gateway route status"}
{"level":"debug","ts":"2024-08-01T16:35:01.695Z","logger":"k8s-gw-syncer.routeStatusSyncer","caller":"proxy_syncer/proxy_syncer.go:201","msg":"synced route statuses in 3.625µs"}
{"level":"debug","ts":"2024-08-01T16:35:01.695Z","logger":"k8s-gw-syncer","caller":"proxy_syncer/proxy_syncer.go:160","msg":"translated and wrote 0 proxies in 48.958µs"}
```

## API changes
None

## Code changes
- Fix error in `Foo()` function
- Add `Bar()` function
- ...

## CI changes
- Adjusted schedule for x job
- ...

## Docs changes
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...

# Context

Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)

## Interesting decisions
 
We chose to do things this way because ...

## Testing steps

I manually verified behavior by ...

## Notes for reviewers

Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release 
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->