### PR TITLE
Deallocate TLS slots on worker threads - v1.16.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:8c6db7bd035e6c0bcd295b327b68add6b406ceac
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.27.7-patch2
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ VERSION ?= 1.0.1-dev
 
 SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.27.6-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:8c6db7bd035e6c0bcd295b327b68add6b406ceac
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS := all="-N -l"
 

--- a/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
+++ b/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
@@ -1,8 +1,5 @@
 changelog:
   - type: FIX
-    dependencyOwner: solo-io
-    dependencyRepo: envoy-gloo
-    dependencyTag: v1.27.7-patch2
     issueLink: https://github.com/solo-io/solo-projects/issues/6713
     resolvesIssue: false
     description: >

--- a/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
+++ b/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
@@ -2,7 +2,7 @@ changelog:
   - type: DEPENDENCY_BUMP
     dependencyOwner: solo-io
     dependencyRepo: envoy-gloo
-    dependencyTag: v1.27.7-patch3
+    dependencyTag: v1.27.7-patch2
     issueLink: https://github.com/solo-io/solo-projects/issues/6713
     resolvesIssue: false
     description: >

--- a/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
+++ b/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6713
+    resolvesIssue: false
+    description: >
+      Enable thread-local slots to be deallocated on worker threads. This
+      provides greater stability in Envoy when the main thread is under heavy
+      load.

--- a/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
+++ b/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
@@ -1,8 +1,12 @@
 changelog:
-  - type: FIX
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: v1.27.7-patch3
     issueLink: https://github.com/solo-io/solo-projects/issues/6713
     resolvesIssue: false
     description: >
-      Enable thread-local slots to be deallocated on worker threads. This
-      provides greater stability in Envoy when the main thread is under heavy
-      load.
+      Update Envoy to enable thread-local slots to be deallocated on worker
+      threads. This provides greater stability in Envoy when the main thread is
+      under heavy load. This behaviour can be disabled by toggling the runtime
+      flag envoy_restart_features_allow_slot_destroy_on_worker_threads.

--- a/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
+++ b/changelog/v1.16.19/deallocate-tls-on-worker-thread.yaml
@@ -1,5 +1,5 @@
 changelog:
-  - type: DEPENDENCY_BUMP
+  - type: FIX
     dependencyOwner: solo-io
     dependencyRepo: envoy-gloo
     dependencyTag: v1.27.7-patch2
@@ -10,3 +10,7 @@ changelog:
       threads. This provides greater stability in Envoy when the main thread is
       under heavy load. This behaviour can be disabled by toggling the runtime
       flag envoy_restart_features_allow_slot_destroy_on_worker_threads.
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: v1.27.7-patch2


### PR DESCRIPTION
# Description

Bump Envoy to incorporate fix that allows thread-local slots to be deallocated on worker threads.

# Context

See slack conversation [here](https://solo-io-corp.slack.com/archives/C011H3TU17T/p1722369125146919)

## Testing steps

The fix in our Envoy repositories includes the tests added by upstream which pass successfully

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works