### PR TITLE
Deallocate TLS slots on worker threads - v1.17.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 # for more information, see https://github.com/solo-io/gloo/pull/9633
 # and
 # https://soloio.slab.com/posts/extended-http-methods-design-doc-40j7pjeu
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.30.4-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.30.4-patch4
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS ?=
 

--- a/changelog/v1.17.4/update-envoy-gloo.yaml
+++ b/changelog/v1.17.4/update-envoy-gloo.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6713
+    resolvesIssue: false
+    description: >
+      Update Envoy to enable thread-local slots to be deallocated on worker
+      threads. This provides greater stability in Envoy when the main thread is
+      under heavy load. This behaviour can be disabled by toggling the runtime
+      flag envoy_restart_features_allow_slot_destroy_on_worker_threads.
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: 1.30.4-patch4


### PR DESCRIPTION
# Description

Bump Envoy to incorporate fix that allows thread-local slots to be deallocated on worker threads.

# Context

See slack conversation [here](https://solo-io-corp.slack.com/archives/C011H3TU17T/p1722369125146919)

## Testing steps

The fix in our Envoy repositories includes the tests added by upstream which pass successfully

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works