### PR TITLE
helm: support PriorityClassName on gateway-proxy

### DIFF
--- a/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
+++ b/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/gloo/issues/8677
+    resolvesIssue: false
+    description: >-
+      Introduce `gatewayProxy.NAME.podTemplate.priorityClassName` which allows you to set the PriorityClassName
+      for gateway-proxy Pods. This is already supported on all other Gloo deployments.
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/9010
+    resolvesIssue: false
+    description: >-
+      Support defining the PriorityClassName on a GatewayProxy deployment. This allows users to
+      attach pods to PriorityClasses (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)

--- a/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
+++ b/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
@@ -3,8 +3,9 @@ changelog:
     issueLink: https://github.com/solo-io/gloo/issues/8677
     resolvesIssue: false
     description: >-
-      Introduce `gatewayProxy.NAME.podTemplate.priorityClassName` which allows you to set the PriorityClassName
-      for gateway-proxy Pods. This is already supported on all other Gloo deployments.
+      Ensure that gateway-proxy deployments respect the  `gatewayProxy.NAME.kind.deployment.priorityClassName` field.
+      This API allows you to set the PriorityClassName for gateway-proxy Pods.
+      This is already supported on all other Gloo deployments.
   - type: FIX
     issueLink: https://github.com/solo-io/gloo/issues/9010
     resolvesIssue: false

--- a/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
+++ b/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
@@ -11,3 +11,8 @@ changelog:
     description: >-
       Support defining the PriorityClassName on a GatewayProxy deployment. This allows users to
       attach pods to PriorityClasses (https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/)
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/9823
+    resolvesIssue: false
+    description: >-
+      This is a duplicate issue that tracks the single enhancement that we are adding here.

--- a/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
+++ b/changelog/v1.18.0-beta16/helm-priority-class-name.yaml
@@ -16,3 +16,13 @@ changelog:
     resolvesIssue: false
     description: >-
       This is a duplicate issue that tracks the single enhancement that we are adding here.
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/9731
+    resolvesIssue: false
+    description: >-
+      This is a duplicate issue that tracks the single enhancement that we are adding here.
+      
+      
+      
+      
+      

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -797,6 +797,7 @@
 |gatewayProxies.NAME.podTemplate.tolerations[].value|string|||
 |gatewayProxies.NAME.podTemplate.tolerations[].effect|string|||
 |gatewayProxies.NAME.podTemplate.tolerations[].tolerationSeconds|int64|||
+|gatewayProxies.NAME.podTemplate.priorityClassName|string||name of a defined priority class|
 |gatewayProxies.NAME.podTemplate.probes|bool||Set to true to enable a readiness probe (default is false). Then, you can also enable a liveness probe.|
 |gatewayProxies.NAME.podTemplate.livenessProbeEnabled|bool||Set to true to enable a liveness probe (default is false).|
 |gatewayProxies.NAME.podTemplate.resources.limits.memory|string||amount of memory|
@@ -1045,6 +1046,7 @@
 |gatewayProxies.gatewayProxy.podTemplate.tolerations[].value|string|||
 |gatewayProxies.gatewayProxy.podTemplate.tolerations[].effect|string|||
 |gatewayProxies.gatewayProxy.podTemplate.tolerations[].tolerationSeconds|int64|||
+|gatewayProxies.gatewayProxy.podTemplate.priorityClassName|string||name of a defined priority class|
 |gatewayProxies.gatewayProxy.podTemplate.probes|bool|false|Set to true to enable a readiness probe (default is false). Then, you can also enable a liveness probe.|
 |gatewayProxies.gatewayProxy.podTemplate.livenessProbeEnabled|bool||Set to true to enable a liveness probe (default is false).|
 |gatewayProxies.gatewayProxy.podTemplate.resources.limits.memory|string||amount of memory|

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -797,7 +797,6 @@
 |gatewayProxies.NAME.podTemplate.tolerations[].value|string|||
 |gatewayProxies.NAME.podTemplate.tolerations[].effect|string|||
 |gatewayProxies.NAME.podTemplate.tolerations[].tolerationSeconds|int64|||
-|gatewayProxies.NAME.podTemplate.priorityClassName|string||name of a defined priority class|
 |gatewayProxies.NAME.podTemplate.probes|bool||Set to true to enable a readiness probe (default is false). Then, you can also enable a liveness probe.|
 |gatewayProxies.NAME.podTemplate.livenessProbeEnabled|bool||Set to true to enable a liveness probe (default is false).|
 |gatewayProxies.NAME.podTemplate.resources.limits.memory|string||amount of memory|
@@ -1046,7 +1045,6 @@
 |gatewayProxies.gatewayProxy.podTemplate.tolerations[].value|string|||
 |gatewayProxies.gatewayProxy.podTemplate.tolerations[].effect|string|||
 |gatewayProxies.gatewayProxy.podTemplate.tolerations[].tolerationSeconds|int64|||
-|gatewayProxies.gatewayProxy.podTemplate.priorityClassName|string||name of a defined priority class|
 |gatewayProxies.gatewayProxy.podTemplate.probes|bool|false|Set to true to enable a readiness probe (default is false). Then, you can also enable a liveness probe.|
 |gatewayProxies.gatewayProxy.podTemplate.livenessProbeEnabled|bool||Set to true to enable a liveness probe (default is false).|
 |gatewayProxies.gatewayProxy.podTemplate.resources.limits.memory|string||amount of memory|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -643,6 +643,13 @@ type DaemonSetSpec struct {
 	HostNetwork *bool `json:"hostNetwork,omitempty"`
 }
 
+// GatewayProxyPodTemplate contains the Helm API available to configure the PodTemplate on the gateway-proxy Deployment
+//
+//	Note to Developers:
+//	The PodSpec defined below is our standard way of exposing these APIs consistently. This PodTemplate pre-dated that struct, so
+//	we didn't rely on it, and instead have to manage each of the fields individually.
+//	Since some of the fields available on the PodSpec aren't all exposed in this PodTemplate, and instead are availabe up a level on the API,
+//	there isn't ean easy way to rely on that PodSpec definition. One solution would be to deprecate the old fields, and migrate them all to this API
 type GatewayProxyPodTemplate struct {
 	HttpPort                      *int                  `json:"httpPort,omitempty" desc:"HTTP port for the gateway service target port."`
 	HttpsPort                     *int                  `json:"httpsPort,omitempty" desc:"HTTPS port for the gateway service target port."`
@@ -651,6 +658,7 @@ type GatewayProxyPodTemplate struct {
 	NodeName                      *string               `json:"nodeName,omitempty" desc:"name of node to run on."`
 	NodeSelector                  map[string]string     `json:"nodeSelector,omitempty" desc:"label selector for nodes."`
 	Tolerations                   []*corev1.Toleration  `json:"tolerations,omitempty"`
+	PriorityClassName             *string               `json:"priorityClassName,omitempty" desc:"name of a defined priority class"`
 	Probes                        *bool                 `json:"probes,omitempty" desc:"Set to true to enable a readiness probe (default is false). Then, you can also enable a liveness probe."`
 	LivenessProbeEnabled          *bool                 `json:"livenessProbeEnabled,omitempty" desc:"Set to true to enable a liveness probe (default is false)."`
 	Resources                     *ResourceRequirements `json:"resources,omitempty"`

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -645,11 +645,10 @@ type DaemonSetSpec struct {
 
 // GatewayProxyPodTemplate contains the Helm API available to configure the PodTemplate on the gateway-proxy Deployment
 //
-//	Note to Developers:
-//	The PodSpec defined below is our standard way of exposing these APIs consistently. This PodTemplate pre-dated that struct, so
-//	we didn't rely on it, and instead have to manage each of the fields individually.
-//	Since some of the fields available on the PodSpec aren't all exposed in this PodTemplate, and instead are availabe up a level on the API,
-//	there isn't ean easy way to rely on that PodSpec definition. One solution would be to deprecate the old fields, and migrate them all to this API
+//	Note to Developers: The Helm API for the PodTemplate is split between the values defined in this struct, and the values
+//		in the PodSpec, which is available for a GatewayProxy under `gatewayProxy.kind.Deployment`.
+//		The side effect of this, is that there may be Helm values which may live on both structs, but only one is used by our templates.
+//		Always refer back to the Helm templates to see which is used.
 type GatewayProxyPodTemplate struct {
 	HttpPort                      *int                  `json:"httpPort,omitempty" desc:"HTTP port for the gateway service target port."`
 	HttpsPort                     *int                  `json:"httpsPort,omitempty" desc:"HTTPS port for the gateway service target port."`
@@ -658,7 +657,6 @@ type GatewayProxyPodTemplate struct {
 	NodeName                      *string               `json:"nodeName,omitempty" desc:"name of node to run on."`
 	NodeSelector                  map[string]string     `json:"nodeSelector,omitempty" desc:"label selector for nodes."`
 	Tolerations                   []*corev1.Toleration  `json:"tolerations,omitempty"`
-	PriorityClassName             *string               `json:"priorityClassName,omitempty" desc:"name of a defined priority class"`
 	Probes                        *bool                 `json:"probes,omitempty" desc:"Set to true to enable a readiness probe (default is false). Then, you can also enable a liveness probe."`
 	LivenessProbeEnabled          *bool                 `json:"livenessProbeEnabled,omitempty" desc:"Set to true to enable a liveness probe (default is false)."`
 	Resources                     *ResourceRequirements `json:"resources,omitempty"`

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -142,6 +142,9 @@ spec:
       {{- if $spec.podTemplate.nodeName }}
       nodeName: {{$spec.podTemplate.nodeName}}
       {{- end }}
+      {{- if $spec.podTemplate.priorityClassName }}
+      priorityClassName: {{$spec.podTemplate.priorityClassName}}
+      {{- end }}
       {{- if $spec.podTemplate.nodeSelector }}
       nodeSelector:
       {{- range $key, $value := $spec.podTemplate.nodeSelector }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -142,8 +142,10 @@ spec:
       {{- if $spec.podTemplate.nodeName }}
       nodeName: {{$spec.podTemplate.nodeName}}
       {{- end }}
+      {{- if $spec.kind.deployment}}
       {{- if $spec.kind.deployment.priorityClassName }}
       priorityClassName: {{ $spec.kind.deployment.priorityClassName }}
+      {{- end }}
       {{- end }}
       {{- if $spec.podTemplate.nodeSelector }}
       nodeSelector:

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -142,8 +142,8 @@ spec:
       {{- if $spec.podTemplate.nodeName }}
       nodeName: {{$spec.podTemplate.nodeName}}
       {{- end }}
-      {{- if $spec.podTemplate.priorityClassName }}
-      priorityClassName: {{$spec.podTemplate.priorityClassName}}
+      {{- if $spec.kind.deployment.priorityClassName }}
+      priorityClassName: {{ $spec.kind.deployment.priorityClassName }}
       {{- end }}
       {{- if $spec.podTemplate.nodeSelector }}
       nodeSelector:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3297,6 +3297,17 @@ spec:
 						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
 					})
 
+					It("enables priorityClassName", func() {
+						prepareMakefile(namespace, glootestutils.HelmValues{
+							ValuesArgs: []string{
+								"gatewayProxies.gatewayProxy.podTemplate.priorityClassName=example-priority",
+							},
+						})
+
+						gatewayProxyDeployment.Spec.Template.Spec.PriorityClassName = "example-priority"
+						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
+					})
+
 					It("supports custom readiness and liveness probe", func() {
 						prepareMakefile(namespace, glootestutils.HelmValues{
 							ValuesArgs: []string{

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3300,7 +3300,7 @@ spec:
 					It("enables priorityClassName", func() {
 						prepareMakefile(namespace, glootestutils.HelmValues{
 							ValuesArgs: []string{
-								"gatewayProxies.gatewayProxy.podTemplate.priorityClassName=example-priority",
+								"gatewayProxies.gatewayProxy.kind.deployment.priorityClassName=example-priority",
 							},
 						})
 


### PR DESCRIPTION
# Description
Ensure that gateway-proxy deployments respect the  `gatewayProxy.NAME.kind.deployment.priorityClassName` field. This API allows you to set the PriorityClassName for gateway-proxy Pods. This is already supported on all other Gloo deployments.

# Context
## Priority and Preemption
https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/

This is an important Kubernetes feature, that is especially relevant for Pods (like the data plane) that customers want to assign high priorities to.

## Helm API
We have a `PodSpec` API, which was available under `kind.deployment`, but was not being used. I added a comment to clarify how this is confusing to developers.

## Solution
I re-used an existing Helm field in our `PodSpec`. 

This allows us to expose the relevant APIs that caused users to rely on the `kubeResourceOverride`. When using that override, users hit https://github.com/solo-io/gloo/issues/8025.

## Interesting decisions
-

## Testing steps
- [x] I added a unit test to verify that this configures the field, as expected
- [x] All Helm unit tests pass locally:
```
TEST_PKG=install/test/... make test
```
- [ ] I opened an EE PR to share a dev build with @AlfredoFausto 

## Notes for reviewers
-

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works