### PR TITLE
[backport] gateway2/route-options: merge extensionRef based attachments (#9834)

### DIFF
--- a/changelog/v1.17.4/extref-merge.yaml
+++ b/changelog/v1.17.4/extref-merge.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6675
+    resolvesIssue: false
+    description: |
+      gateway2/route-options: merge extensionRef based attachments
+
+      Enables merging of multiple ExtensionRef based RouteOption
+      attachments for a rule within an HTTPRoute.

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -49,7 +49,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",
-			}}),
+			},
+		}),
 	Entry(
 		"https gateway with basic routing",
 		translatorTestCase{
@@ -58,7 +59,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with multiple listeners on the same port",
 		translatorTestCase{
@@ -67,7 +69,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "http",
-			}}),
+			},
+		}),
 	Entry(
 		"https gateway with multiple listeners on the same port",
 		translatorTestCase{
@@ -76,7 +79,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "http",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with multiple routing rules and HeaderModifier filter",
 		translatorTestCase{
@@ -85,7 +89,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "gw",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with lambda destination",
 		translatorTestCase{
@@ -94,7 +99,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "gw",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with azure destination",
 		translatorTestCase{
@@ -103,7 +109,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "gw",
-			}}),
+			},
+		}),
 	Entry(
 		"gateway with correctly sorted routes",
 		translatorTestCase{
@@ -112,7 +119,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
 				Name:      "example-gateway",
-			}}),
+			},
+		}),
 	Entry(
 		"route with missing backend reports correctly",
 		translatorTestCase{
@@ -159,6 +167,16 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 				resolvedRefs := meta.FindStatusCondition(routeStatus.Parents[0].Conditions, string(gwv1.RouteConditionResolvedRefs))
 				Expect(resolvedRefs).NotTo(BeNil())
 				Expect(resolvedRefs.Message).To(Equal("unknown backend kind"))
+			},
+		}),
+	Entry(
+		"RouteOptions merging",
+		translatorTestCase{
+			inputFile:  "route_options/merge.yaml",
+			outputFile: "route_options/merge.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "gw",
 			},
 		}),
 )

--- a/projects/gateway2/translator/plugins/routeoptions/query/query_test.go
+++ b/projects/gateway2/translator/plugins/routeoptions/query/query_test.go
@@ -2,9 +2,11 @@ package query_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
@@ -129,6 +131,43 @@ var _ = Describe("Query", func() {
 			Expect(rtOpt).To(BeNil())
 			Expect(sources).To(BeEmpty())
 		})
+
+		It("should merge extensionRef and targetRef RouteOptions", func() {
+			ctx := context.Background()
+
+			opt1 := attachedRouteOption1()
+			opt2 := attachedRouteOption2()
+			opt3 := attachedRouteOption3()
+
+			hr := httpRouteWithFilters()
+			hrNsName := types.NamespacedName{Namespace: hr.GetNamespace(), Name: hr.GetName()}
+			deps := []client.Object{
+				hr,
+				opt1,
+				opt2,
+				opt3,
+			}
+			fakeClient := builder.WithObjects(deps...).Build()
+
+			query := query.NewQuery(fakeClient)
+			gwQuery := testutils.BuildGatewayQueriesWithClient(fakeClient)
+
+			rtOpt, sources, err := query.GetRouteOptionForRouteRule(ctx, hrNsName, &hr.Spec.Rules[0], gwQuery)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rtOpt).ToNot(BeNil())
+			Expect(sources).To(HaveLen(3))
+
+			// First ExtensionRef gets first priority
+			Expect(rtOpt.Spec.GetOptions().GetFaults().GetAbort().GetPercentage()).To(Equal(opt1.Spec.GetOptions().GetFaults().GetAbort().GetPercentage()))
+			Expect(rtOpt.Spec.GetOptions().GetFaults().GetAbort().GetHttpStatus()).To(Equal(opt1.Spec.GetOptions().GetFaults().GetAbort().GetHttpStatus()))
+
+			// Second ExtensionRef gets second priority
+			Expect(rtOpt.Spec.GetOptions().GetPrefixRewrite().GetValue()).To(Equal(opt2.Spec.GetOptions().GetPrefixRewrite().GetValue()))
+
+			// TargetRef gets last priority
+			Expect(rtOpt.Spec.GetOptions().GetTimeout().GetNanos()).To(Equal(opt3.Spec.GetOptions().GetTimeout().GetNanos()))
+		})
 	})
 })
 
@@ -141,13 +180,54 @@ func httpRoute() *gwv1.HTTPRoute {
 	}
 }
 
+func httpRouteWithFilters() *gwv1.HTTPRoute {
+	return &gwv1.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test",
+		},
+		Spec: gwv1.HTTPRouteSpec{
+			Rules: []gwv1.HTTPRouteRule{
+				{
+					Filters: []gwv1.HTTPRouteFilter{
+						{
+							Type: gwv1.HTTPRouteFilterExtensionRef,
+							ExtensionRef: &gwv1.LocalObjectReference{
+								Group: gwv1.Group(sologatewayv1.RouteOptionGVK.Group),
+								Kind:  gwv1.Kind(sologatewayv1.RouteOptionGVK.Kind),
+								Name:  gwv1.ObjectName(attachedRouteOption1().GetName()),
+							},
+						},
+						{
+							Type: gwv1.HTTPRouteFilterExtensionRef,
+							ExtensionRef: &gwv1.LocalObjectReference{
+								Group: gwv1.Group(sologatewayv1.RouteOptionGVK.Group),
+								Kind:  gwv1.Kind(sologatewayv1.RouteOptionGVK.Kind),
+								Name:  gwv1.ObjectName(attachedRouteOption2().GetName()),
+							},
+						},
+					},
+					BackendRefs: []gwv1.HTTPBackendRef{
+						{
+							BackendRef: gwv1.BackendRef{
+								BackendObjectReference: gwv1.BackendObjectReference{
+									Name: "foo",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
 func attachedRouteOption() *solokubev1.RouteOption {
-	now := metav1.Now()
 	return &solokubev1.RouteOption{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:              "good-policy",
 			Namespace:         "default",
-			CreationTimestamp: now,
+			CreationTimestamp: metav1.Now(),
 		},
 		Spec: sologatewayv1.RouteOption{
 			TargetRefs: []*corev1.PolicyTargetReference{
@@ -165,6 +245,77 @@ func attachedRouteOption() *solokubev1.RouteOption {
 						HttpStatus: 500,
 					},
 				},
+			},
+		},
+	}
+}
+
+func attachedRouteOption1() *solokubev1.RouteOption {
+	return &solokubev1.RouteOption{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "good-policy",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: sologatewayv1.RouteOption{
+			Options: &v1.RouteOptions{
+				Faults: &faultinjection.RouteFaults{
+					Abort: &faultinjection.RouteAbort{
+						Percentage: 1.00,
+						HttpStatus: 500,
+					},
+				},
+			},
+		},
+	}
+}
+
+func attachedRouteOption2() *solokubev1.RouteOption {
+	return &solokubev1.RouteOption{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "good-policy2",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: sologatewayv1.RouteOption{
+			Options: &v1.RouteOptions{
+				Faults: &faultinjection.RouteFaults{
+					Abort: &faultinjection.RouteAbort{
+						Percentage: 2.00,
+						HttpStatus: 400,
+					},
+				},
+				PrefixRewrite: wrapperspb.String("/foo"),
+			},
+		},
+	}
+}
+
+func attachedRouteOption3() *solokubev1.RouteOption {
+	return &solokubev1.RouteOption{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "good-policy3",
+			Namespace:         "default",
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: sologatewayv1.RouteOption{
+			TargetRefs: []*corev1.PolicyTargetReference{
+				{
+					Group:     gwv1.GroupVersion.Group,
+					Kind:      wellknown.HTTPRouteKind,
+					Name:      "test",
+					Namespace: wrapperspb.String("default"),
+				},
+			},
+			Options: &v1.RouteOptions{
+				Faults: &faultinjection.RouteFaults{
+					Abort: &faultinjection.RouteAbort{
+						Percentage: 3.00,
+						HttpStatus: 404,
+					},
+				},
+				PrefixRewrite: wrapperspb.String("/baz"),
+				Timeout:       durationpb.New(5 * time.Second),
 			},
 		},
 	}

--- a/projects/gateway2/translator/plugins/utils/plugin_utils.go
+++ b/projects/gateway2/translator/plugins/utils/plugin_utils.go
@@ -52,30 +52,30 @@ func FindAppliedRouteFilter(
 	return nil
 }
 
-// FindExtensionRefFilter finds the first instance of an ExtensionRef filter that
+// FindExtensionRefFilters returns a list ExtensionRef filters that
 // references the supplied GroupKind in the Rule being processed.
 // Returns nil if the Rule doesn't contain a matching ExtensionRef filter
-func FindExtensionRefFilter(
+func FindExtensionRefFilters(
 	rule *gwv1.HTTPRouteRule,
 	gk schema.GroupKind,
-) *gwv1.HTTPRouteFilter {
+) []gwv1.HTTPRouteFilter {
 	if rule == nil {
 		return nil
 	}
+
+	var filters []gwv1.HTTPRouteFilter
 	// TODO: check full Filter list for duplicates and error?
 	for _, filter := range rule.Filters {
 		if filter.Type == gwv1.HTTPRouteFilterExtensionRef {
 			if filter.ExtensionRef.Group == gwv1.Group(gk.Group) && filter.ExtensionRef.Kind == gwv1.Kind(gk.Kind) {
-				return &filter
+				filters = append(filters, filter)
 			}
 		}
 	}
-	return nil
+	return filters
 }
 
-var (
-	ErrTypesNotEqual = fmt.Errorf("types not equal")
-)
+var ErrTypesNotEqual = fmt.Errorf("types not equal")
 
 // GetExtensionRefObj uses the provided query engine to retrieve an ExtensionRef object
 // and return the object of the same type as the type parameter.

--- a/projects/gateway2/translator/plugins/utils/plugin_utils_test.go
+++ b/projects/gateway2/translator/plugins/utils/plugin_utils_test.go
@@ -31,12 +31,34 @@ func TestExtensionRef(t *testing.T) {
 		Group: sologatewayv1.RouteOptionGVK.Group,
 		Kind:  sologatewayv1.RouteOptionGVK.Kind,
 	}
-	filter := utils.FindExtensionRefFilter(rtCtx.Rule, gk)
-	g.Expect(filter).ToNot(BeNil())
+	filters := utils.FindExtensionRefFilters(rtCtx.Rule, gk)
+	g.Expect(filters).ToNot(BeEmpty())
 
-	routeOption, err := utils.GetExtensionRefObj[*solokubev1.RouteOption](context.Background(), rtCtx.Route, queries, filter.ExtensionRef)
+	routeOption, err := utils.GetExtensionRefObj[*solokubev1.RouteOption](context.Background(), rtCtx.Route, queries, filters[0].ExtensionRef)
 	g.Expect(err).NotTo(HaveOccurred())
 	g.Expect(routeOption.Spec.GetOptions().GetFaults().GetAbort().GetPercentage()).To(BeEquivalentTo(1))
+}
+
+func TestMultipleExtensionRef(t *testing.T) {
+	g := NewWithT(t)
+	deps := []client.Object{routeOption(), routeOption2()}
+	queries := testutils.BuildGatewayQueries(deps)
+
+	rtCtx := routeContextMultipleFilters()
+	gk := schema.GroupKind{
+		Group: sologatewayv1.RouteOptionGVK.Group,
+		Kind:  sologatewayv1.RouteOptionGVK.Kind,
+	}
+	filters := utils.FindExtensionRefFilters(rtCtx.Rule, gk)
+	g.Expect(filters).ToNot(BeEmpty())
+
+	routeOption1, err := utils.GetExtensionRefObj[*solokubev1.RouteOption](context.Background(), rtCtx.Route, queries, filters[0].ExtensionRef)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(routeOption1.Spec.GetOptions().GetFaults().GetAbort().GetPercentage()).To(BeEquivalentTo(1))
+
+	routeOption2, err := utils.GetExtensionRefObj[*solokubev1.RouteOption](context.Background(), rtCtx.Route, queries, filters[1].ExtensionRef)
+	g.Expect(err).NotTo(HaveOccurred())
+	g.Expect(routeOption2.Spec.GetOptions().GetFaults().GetAbort().GetPercentage()).To(BeEquivalentTo(2))
 }
 
 func TestExtensionRefWrongObject(t *testing.T) {
@@ -49,10 +71,10 @@ func TestExtensionRefWrongObject(t *testing.T) {
 		Group: sologatewayv1.RouteOptionGVK.Group,
 		Kind:  sologatewayv1.RouteOptionGVK.Kind,
 	}
-	filter := utils.FindExtensionRefFilter(rtCtx.Rule, gk)
-	g.Expect(filter).ToNot(BeNil())
+	filters := utils.FindExtensionRefFilters(rtCtx.Rule, gk)
+	g.Expect(filters).ToNot(BeEmpty())
 
-	_, err := utils.GetExtensionRefObj[*solokubev1.VirtualHostOption](context.Background(), rtCtx.Route, queries, filter.ExtensionRef)
+	_, err := utils.GetExtensionRefObj[*solokubev1.VirtualHostOption](context.Background(), rtCtx.Route, queries, filters[0].ExtensionRef)
 	g.Expect(err).To(HaveOccurred())
 	g.Expect(errors.Is(err, utils.ErrTypesNotEqual)).To(BeTrue())
 }
@@ -75,6 +97,24 @@ func routeOption() *solokubev1.RouteOption {
 	}
 }
 
+func routeOption2() *solokubev1.RouteOption {
+	return &solokubev1.RouteOption{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "policy2",
+			Namespace: "default",
+		},
+		Spec: sologatewayv1.RouteOption{
+			Options: &v1.RouteOptions{
+				Faults: &faultinjection.RouteFaults{
+					Abort: &faultinjection.RouteAbort{
+						Percentage: 2.00,
+					},
+				},
+			},
+		},
+	}
+}
+
 func routeContext() plugins.RouteContext {
 	return plugins.RouteContext{
 		Route: &gwv1.HTTPRoute{},
@@ -86,6 +126,32 @@ func routeContext() plugins.RouteContext {
 						Group: gwv1.Group(sologatewayv1.RouteOptionGVK.Group),
 						Kind:  gwv1.Kind(sologatewayv1.RouteOptionGVK.Kind),
 						Name:  "policy",
+					},
+				},
+			},
+		},
+	}
+}
+
+func routeContextMultipleFilters() plugins.RouteContext {
+	return plugins.RouteContext{
+		Route: &gwv1.HTTPRoute{},
+		Rule: &gwv1.HTTPRouteRule{
+			Filters: []gwv1.HTTPRouteFilter{
+				{
+					Type: gwv1.HTTPRouteFilterExtensionRef,
+					ExtensionRef: &gwv1.LocalObjectReference{
+						Group: gwv1.Group(sologatewayv1.RouteOptionGVK.Group),
+						Kind:  gwv1.Kind(sologatewayv1.RouteOptionGVK.Kind),
+						Name:  "policy",
+					},
+				},
+				{
+					Type: gwv1.HTTPRouteFilterExtensionRef,
+					ExtensionRef: &gwv1.LocalObjectReference{
+						Group: gwv1.Group(sologatewayv1.RouteOptionGVK.Group),
+						Kind:  gwv1.Kind(sologatewayv1.RouteOptionGVK.Kind),
+						Name:  "policy2",
 					},
 				},
 			},

--- a/projects/gateway2/translator/testutils/inputs/route_options/merge.yaml
+++ b/projects/gateway2/translator/testutils/inputs/route_options/merge.yaml
@@ -1,50 +1,16 @@
-apiVersion: v1
-kind: Service
+kind: Gateway
+apiVersion: gateway.networking.k8s.io/v1
 metadata:
-  name: httpbin
-  labels:
-    app: httpbin
+  name: gw
 spec:
-  ports:
-  - name: http
-    port: 8000
-    targetPort: 8080
-  selector:
-    app: httpbin
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: httpbin
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: httpbin
-      version: v1
-  template:
-    metadata:
-      labels:
-        app: httpbin
-        version: v1
-    spec:
-      containers:
-      - image: docker.io/kennethreitz/httpbin
-        imagePullPolicy: IfNotPresent
-        name: httpbin
-        command:
-        - gunicorn
-        - -b
-        - 0.0.0.0:8080
-        - httpbin:app
-        - -k
-        - gevent
-        env:
-        # Tells pipenv to use a writable directory instead of $HOME
-        - name: WORKON_HOME
-          value: /tmp
-        ports:
-        - containerPort: 8080
+  gatewayClassName: gloo-gateway
+  listeners:
+    - protocol: HTTP
+      port: 8080
+      name: http
+      allowedRoutes:
+        namespaces:
+          from: Same
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
@@ -127,3 +93,17 @@ spec:
           key: x-foo
           value: target-2
     hostRewrite: foo.com
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  labels:
+    app: httpbin
+spec:
+  ports:
+  - name: http
+    port: 8000
+    targetPort: 8080
+  selector:
+    app: httpbin

--- a/projects/gateway2/translator/testutils/outputs/route_options/merge.yaml
+++ b/projects/gateway2/translator/testutils/outputs/route_options/merge.yaml
@@ -1,0 +1,59 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - prefix: /
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: extref1
+                  namespace: default
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: extref2
+                  namespace: default
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: target-1
+                  namespace: default
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: target-2
+                  namespace: default
+            options:
+              appendXForwardedHost: true
+              headerManipulation:
+                responseHeadersToAdd:
+                - header:
+                    key: x-foo
+                    value: extref
+              hostRewrite: foo.com
+              prefixRewrite: /anything/rewrite
+            routeAction:
+              single:
+                kube:
+                  port: 8000
+                  ref:
+                    name: httpbin
+                    namespace: default
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: default
+  name: default-gw
+  namespace: gloo-system

--- a/test/kubernetes/e2e/features/route_options/types.go
+++ b/test/kubernetes/e2e/features/route_options/types.go
@@ -49,7 +49,8 @@ var (
 	extraRtoTargetRefMeta = objectMetaInDefault("extra-rto-targetref")
 	badRtoMeta            = objectMetaInDefault("bad-rto")
 	badRtoTargetRefMeta   = objectMetaInDefault("bad-rto-targetref")
-	extrefRtoMeta         = objectMetaInDefault("extref")
+	extref1RtoMeta        = objectMetaInDefault("extref1")
+	extref2RtoMeta        = objectMetaInDefault("extref2")
 	target1RtoMeta        = objectMetaInDefault("target-1")
 	target2RtoMeta        = objectMetaInDefault("target-2")
 


### PR DESCRIPTION
# Backports 383a6e264 (https://github.com/solo-io/gloo/pull/9834) from main
Enables merging of multiple ExtensionRef based RouteOption attachments for a rule within an HTTPRoute.