### PR TITLE
[v1.17.x] reorg and rename various components to be more readable

### DIFF
--- a/changelog/v1.17.5/minor-reorg-and-rename.yaml
+++ b/changelog/v1.17.5/minor-reorg-and-rename.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Reogrganizes and renames various components to be more correct and readable

--- a/devel/contributing/conventions.md
+++ b/devel/contributing/conventions.md
@@ -21,3 +21,12 @@ See [writing tests](/devel/testing/writing-tests.md) for more details about writ
 - Go source files and directories use underscores, not dashes.
     - Package directories should generally avoid using separators as much as possible. When package names are multiple words, they usually should be in nested subdirectories.
 - Document directories and filenames should use dashes rather than underscores.
+
+### VSCode-specific conventions
+VSCode supports section marking by adding comments prefixed with `MARK:`.
+
+These marks will also show up on the [VSCode minimap](https://code.visualstudio.com/docs/getstarted/userinterface#_minimap).
+
+Ideally files, methods, and functions are factored to be concise and easily parseable by reading.
+However, in circumstances that require long files etc., `MARK:` comments are a good way of providing helpful
+high-level indicators of where you are while navigating a file. Be sure to not abuse them!

--- a/projects/gateway/pkg/syncer/translator_syncer.go
+++ b/projects/gateway/pkg/syncer/translator_syncer.go
@@ -106,8 +106,10 @@ func (s *TranslatorSyncer) Sync(ctx context.Context, snap *gloov1snap.ApiSnapsho
 
 // This replaced a watch on the proxy CR from when the gloo and gateway pods were separate
 // Now it is called at the end of the gloo translation loop after statuses have been set for proxies
-// This is where we update statuses on gateway types based on the proxy statuses
-func (s *TranslatorSyncer) UpdateProxies(ctx context.Context) {
+// This is where we update statuses on gateway types based on the proxy statuses.
+// After this method runs, all Proxies (those retrieved from the proxy client) will have their status
+// written, along with the translation reports that correspond to the Gateway resources.
+func (s *TranslatorSyncer) UpdateStatusForAllProxies(ctx context.Context) {
 	s.statusSyncer.handleUpdatedProxies(ctx)
 }
 func (s *TranslatorSyncer) GeneratedDesiredProxies(ctx context.Context, snap *gloov1snap.ApiSnapshot) (reconciler.GeneratedProxies, reconciler.InvalidProxies) {

--- a/projects/gateway/pkg/syncer/translator_syncer_integration_test.go
+++ b/projects/gateway/pkg/syncer/translator_syncer_integration_test.go
@@ -195,7 +195,7 @@ var _ = Describe("TranslatorSyncer integration test", func() {
 		// write the proxy status.
 		AcceptProxy()
 		ts, _ := ts.(*TranslatorSyncer)
-		ts.UpdateProxies(ctx)
+		ts.UpdateStatusForAllProxies(ctx)
 		// wait for the proxy status to be written in the VS
 		EventuallyProxyStatusInVs().Should(Equal(core.Status_Accepted))
 
@@ -212,7 +212,7 @@ var _ = Describe("TranslatorSyncer integration test", func() {
 
 		// re-sync to process the new VS
 		ts.Sync(ctx, snapshot())
-		ts.UpdateProxies(ctx)
+		ts.UpdateStatusForAllProxies(ctx)
 		// wait for proxy status to become pending
 		EventuallyProxyStatus().Should(Equal(core.Status_Pending))
 
@@ -222,7 +222,7 @@ var _ = Describe("TranslatorSyncer integration test", func() {
 		// write the proxy status again to the same status as the one currently in the snapshot
 		AcceptProxy()
 
-		ts.UpdateProxies(ctx)
+		ts.UpdateStatusForAllProxies(ctx)
 		// status should be accepted.
 		// this tests the bug that we saw where the status stayed pending.
 		// the vs sub resource status did not update,

--- a/projects/gateway2/install.sh
+++ b/projects/gateway2/install.sh
@@ -6,6 +6,4 @@ set -eux
 helm upgrade --install --create-namespace \
   --namespace gloo-system gloo \
   ./_test/gloo-1.0.0-ci1.tgz \
-  --set kubeGateway.enabled=true \
-  --set discovery.enabled=false \
-  --set gateway.validation.alwaysAcceptResources=false
+  -f ./test/kubernetes/e2e/tests/manifests/k8s-gateway-test-helm.yaml

--- a/projects/gloo/pkg/discovery/discovery.go
+++ b/projects/gloo/pkg/discovery/discovery.go
@@ -169,7 +169,7 @@ func setLabels(udsName string, upstreamList v1.UpstreamList) v1.UpstreamList {
 	return clone
 }
 
-// launch a goroutine for all the UDS plugins with a single cancel to close them all
+// launch a goroutine for all the EDS plugins with a single cancel to close them all
 func (d *EndpointDiscovery) StartEds(upstreamsToTrack v1.UpstreamList, opts clients.WatchOpts) (chan error, error) {
 	aggregatedErrs := make(chan error)
 	logger := contextutils.LoggerFrom(opts.Ctx)
@@ -233,9 +233,9 @@ func (d *EndpointDiscovery) Ready() <-chan struct{} {
 	return d.ready
 }
 
-func aggregateEndpoints(endpointsByUds map[DiscoveryPlugin]v1.EndpointList) v1.EndpointList {
+func aggregateEndpoints(endpointsByEds map[DiscoveryPlugin]v1.EndpointList) v1.EndpointList {
 	var endpoints v1.EndpointList
-	for _, endpointList := range endpointsByUds {
+	for _, endpointList := range endpointsByEds {
 		endpoints = append(endpoints, endpointList...)
 	}
 	sort.SliceStable(endpoints, func(i, j int) bool {

--- a/projects/gloo/pkg/discovery/run.go
+++ b/projects/gloo/pkg/discovery/run.go
@@ -14,16 +14,16 @@ import (
 )
 
 type syncer struct {
-	eds         *EndpointDiscovery
-	refreshRate time.Duration
-	discOpts    Opts
+	edsDiscovery *EndpointDiscovery
+	refreshRate  time.Duration
+	discOpts     Opts
 }
 
 func NewEdsSyncer(disc *EndpointDiscovery, discOpts Opts, refreshRate time.Duration) v1.EdsSyncer {
 	s := &syncer{
-		eds:         disc,
-		refreshRate: refreshRate,
-		discOpts:    discOpts,
+		edsDiscovery: disc,
+		refreshRate:  refreshRate,
+		discOpts:     discOpts,
 	}
 	return s
 }
@@ -46,7 +46,7 @@ func (s *syncer) Sync(ctx context.Context, snap *v1.EdsSnapshot) error {
 		RefreshRate: s.refreshRate,
 	}
 
-	udsErrs, err := s.eds.StartEds(snap.Upstreams, opts)
+	edsErrs, err := s.edsDiscovery.StartEds(snap.Upstreams, opts)
 	if err != nil {
 		return err
 	}
@@ -54,7 +54,7 @@ func (s *syncer) Sync(ctx context.Context, snap *v1.EdsSnapshot) error {
 	go func() {
 		for {
 			select {
-			case err := <-udsErrs:
+			case err := <-edsErrs:
 				contextutils.LoggerFrom(ctx).Errorf("error in EDS: %v", err)
 			case <-ctx.Done():
 				return

--- a/projects/gloo/pkg/syncer/translator_syncer.go
+++ b/projects/gloo/pkg/syncer/translator_syncer.go
@@ -146,7 +146,7 @@ func (s *translatorSyncer) Sync(ctx context.Context, snap *v1snap.ApiSnapshot) e
 
 	// After reports are written for proxies, save in gateway syncer (previously gw watched for status changes to proxies)
 	if s.gatewaySyncer != nil {
-		s.gatewaySyncer.UpdateProxies(ctx)
+		s.gatewaySyncer.UpdateStatusForAllProxies(ctx)
 	}
 
 	s.statusSyncer.reportsLock.Lock()


### PR DESCRIPTION
reorg and rename various components to be more readable

this commit contains no functional changes

note: backport of (#9883)

# Description

Reorg setup_syncer and rename various variables related to the core translator/syncer logic to be more 'correct' and readable.

These were all found while digging into syncers and translators and impeded my ability to read and grok the flow of data and control.

No functional changes

Introduces `MARK:` comments for help navigating via [VSCode minimap](https://code.visualstudio.com/docs/getstarted/userinterface#_minimap)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works