### PR TITLE
Add ginkgo to make install-go-tools command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ install-go-tools: mod-download ## Download and install Go dependencies
 	go install github.com/cratonica/2goarray
 	go install github.com/golang/mock/mockgen
 	go install github.com/saiskee/gettercheck
-	go install github.com/onsi/ginkgo/v2/ginkgo@v2.17.0
+	go install github.com/onsi/ginkgo/v2/ginkgo@$(GINKGO_VERSION)
 	# This version must stay in sync with the version used in CI: .github/workflows/static-analysis.yaml
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINTER_VERSION)
 	go install github.com/quasilyte/go-ruleguard/cmd/ruleguard@v0.3.16

--- a/Makefile
+++ b/Makefile
@@ -167,6 +167,7 @@ install-go-tools: mod-download ## Download and install Go dependencies
 	go install github.com/cratonica/2goarray
 	go install github.com/golang/mock/mockgen
 	go install github.com/saiskee/gettercheck
+	go install github.com/onsi/ginkgo/v2/ginkgo@v2.17.0
 	# This version must stay in sync with the version used in CI: .github/workflows/static-analysis.yaml
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(LINTER_VERSION)
 	go install github.com/quasilyte/go-ruleguard/cmd/ruleguard@v0.3.16

--- a/changelog/v1.18.0-beta16/install-ginkgo-make-install-go-tools.yaml
+++ b/changelog/v1.18.0-beta16/install-ginkgo-make-install-go-tools.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Install ginkgo in the make install-go-tools target.


### PR DESCRIPTION
# Description

This PR adds `ginkgo` as a installation requirement in the `_output/bin` directory when running `make install-go-tools`. `ginkgo` is a requirement of the test harness, and should be installed similar to other go tools.