### PR TITLE
Fix 1.16.x ingress test

### DIFF
--- a/changelog/v1.16.20/fix-status-syncer-test.yaml
+++ b/changelog/v1.16.20/fix-status-syncer-test.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/9916
+    description: >-
+      Fix status syncer ingress test. 

--- a/test/kube2e/ingress/status_syncer_test.go
+++ b/test/kube2e/ingress/status_syncer_test.go
@@ -480,10 +480,12 @@ var _ = Describe("StatusSyncer", func() {
 				return err
 			}, time.Second*10).ShouldNot(HaveOccurred())
 
-			if len(kubeSvc.Status.LoadBalancer.Ingress) == 0 {
-				// kubernetes does set ingress lb, set service status explicitly instead
-				kubeSvc, err = kubeSvcClient.UpdateStatus(ctx, &kubeSvcDefinition, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
+			if kubeSvc.Spec.Type == kubev1.ServiceTypeLoadBalancer {
+				if len(kubeSvc.Status.LoadBalancer.Ingress) == 0 {
+					// kubernetes does set ingress lb, set service status explicitly instead
+					kubeSvc, err = kubeSvcClient.UpdateStatus(ctx, &kubeSvcDefinition, metav1.UpdateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+				}
 			}
 
 			// The only service that we have configured should be rejected


### PR DESCRIPTION
Nightly tests were failing on [status_syncer_test.go:486](https://github.com/solo-io/gloo/blob/v1.16.x/test/kube2e/ingress/status_syncer_test.go#L486) on 1.16.x: 
```
      Service "dusty" is invalid: status.loadBalancer.ingress: Forbidden: may only be used when `spec.type` is 'LoadBalancer'
      {
          ErrStatus: {
              TypeMeta: {Kind: "", APIVersion: ""},
              ListMeta: {
                  SelfLink: "",
                  ResourceVersion: "",
                  Continue: "",
                  RemainingItemCount: nil,
              },
              Status: "Failure",
              Message: "Service \"dusty\" is invalid: status.loadBalancer.ingress: Forbidden: may only be used when `spec.type` is 'LoadBalancer'",
              Reason: "Invalid",
              Details: {
                  Name: "dusty",
                  Group: "",
                  Kind: "Service",
                  UID: "",
                  Causes: [
                      {
                          Type: "FieldValueForbidden",
                          Message: "Forbidden: may only be used when `spec.type` is 'LoadBalancer'",
                          Field: "status.loadBalancer.ingress",
                      },
                  ],
                  RetryAfterSeconds: 0,
              },
              Code: 422,
          },
      }
  occurred
```

These tests are disabled in 1.17.x and main. 
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/9916