### PR TITLE
 Update actions/cache to use v4/node20

### DIFF
--- a/.github/workflows/composite-actions/prep-go-runner/action.yaml
+++ b/.github/workflows/composite-actions/prep-go-runner/action.yaml
@@ -49,7 +49,7 @@ runs:
       run: |
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache
       with:
         # https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/changelog/v1.18.0-beta17/update-actions-cache-to-v4.yaml
+++ b/changelog/v1.18.0-beta17/update-actions-cache-to-v4.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update actions/cache to use v4/node20


### PR DESCRIPTION
# Description

Update `actions/cache` to v4 to use node 20.

Successful run:
https://github.com/solo-io/gloo/actions/runs/10562875616

Run from main with warnings:
https://github.com/solo-io/gloo/actions/runs/10555969742