### PR TITLE
helm/gloo: introduce component label for grouping resources

### DIFF
--- a/changelog/v1.18.0-beta18/group-certgen-helm.yaml
+++ b/changelog/v1.18.0-beta18/group-certgen-helm.yaml
@@ -1,0 +1,14 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/solo-projects/issues/6824
+    resolvesIssue: false
+    description: |
+      helm/gloo: introduce component label for grouping resources
+
+      Introduces a `gloo.solo.io/component` label to group Helm resources
+      that are associated with a given component. This is required by
+      downstream projects that use Helm as a templating engine to be able
+      to group resources associated with a component and customize their
+      behavior. This change groups resources related required by the
+      certgen component using the new label.
+

--- a/install/helm/gloo/templates/6.5-gateway-certgen-cronjob.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-cronjob.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
 {{ include "gloo.labels" . | indent 4}}
     gloo: gateway-certgen-cronjob
+    gloo.solo.io/component: certgen
   name: gateway-certgen-cronjob
   namespace: {{ .Release.Namespace }}
 spec:

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job-secret-create-role.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job-secret-create-role.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
 {{ include "gloo.labels" . | indent 4}}
     gloo: rbac
+    gloo.solo.io/component: certgen
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job-secret-create-rolebinding.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job-secret-create-rolebinding.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
 {{ include "gloo.labels" . | indent 4}}
     gloo: rbac
+    gloo.solo.io/component: certgen
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job-service-account.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job-service-account.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
 {{ include "gloo.labels" . | indent 4}}
     gloo: rbac
+    gloo.solo.io/component: certgen
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job-vwc-update-clusterrole.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job-vwc-update-clusterrole.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
 {{ include "gloo.labels" . | indent 4}}
     gloo: rbac
+    gloo.solo.io/component: certgen
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job-vwc-update-clusterrolebinding.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job-vwc-update-clusterrolebinding.yaml
@@ -8,6 +8,7 @@ metadata:
   labels:
 {{ include "gloo.labels" . | indent 4}}
     gloo: rbac
+    gloo.solo.io/component: certgen
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "5" # must be executed before cert-gen job

--- a/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
+++ b/install/helm/gloo/templates/6.5-gateway-certgen-job.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
 {{ include "gloo.labels" . | indent 4}}
     gloo: gateway-certgen
+    gloo.solo.io/component: certgen
   name: gateway-certgen
   namespace: {{ .Release.Namespace }}
   annotations:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4697,6 +4697,7 @@ metadata:
   labels:
     app: gloo
     gloo: gateway-certgen
+    gloo.solo.io/component: certgen
   name: gateway-certgen
   namespace: ` + namespace + `
   annotations:
@@ -4800,6 +4801,7 @@ metadata:
     labels:
         app: gloo
         gloo: rbac
+        gloo.solo.io/component: certgen
     annotations:
       "helm.sh/hook": "pre-install,pre-upgrade"
       "helm.sh/hook-weight": "5"
@@ -4820,6 +4822,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
+    gloo.solo.io/component: certgen
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "5"
@@ -4843,6 +4846,7 @@ metadata:
   labels:
     app: gloo
     gloo: rbac
+    gloo.solo.io/component: certgen
   annotations:
     "helm.sh/hook": "pre-install,pre-upgrade"
     "helm.sh/hook-weight": "5"
@@ -6579,7 +6583,6 @@ metadata:
 						},
 						Equal(securitycontext.ExpectedContainers),
 					)
-
 				})
 
 				It("global security setings override container-specific values", func() {
@@ -6626,7 +6629,6 @@ metadata:
 					if container.SecurityContext != nil {
 						Expect(container.SecurityContext.RunAsUser).To(BeNil(), "resource: %s, container: %s", resourceName, container.Name)
 					}
-
 				},
 					Entry("14-clusteringress-proxy-deployment.yaml", "clusteringress-proxy", "clusteringress-proxy", "Deployment", securitycontext.ApplyClusterIngressSecurityDefaults, "settings.integrations.knative.version=0.1.0", "settings.integrations.knative.enabled=true"),
 				)
@@ -6661,7 +6663,6 @@ metadata:
 				)
 
 				DescribeTable("applies default restricted container security contexts", func(seccompType string) {
-
 					helmArgs := append(
 						helmRenderEverythingValues(),
 						"global.podSecurityStandards.container.enableRestrictedContainerDefaults=true",
@@ -6697,7 +6698,6 @@ metadata:
 						},
 						Equal(securitycontext.ExpectedContainers),
 					)
-
 				},
 					Entry("null/default", ""),
 					Entry("RuntimeDefault", "RuntimeDefault"),

--- a/install/test/rbac_test.go
+++ b/install/test/rbac_test.go
@@ -16,7 +16,7 @@ import (
 
 var _ = Describe("RBAC Test", func() {
 	format.MaxLength = 10000000
-	var allTests = func(testCase renderTestCase) {
+	allTests := func(testCase renderTestCase) {
 		Describe(testCase.rendererName, func() {
 			var (
 				testManifest    TestManifest
@@ -573,8 +573,9 @@ var _ = Describe("RBAC Test", func() {
 								Name:      "gloo-gateway-secret-create-gloo-system",
 								Namespace: "gloo-system",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -588,7 +589,8 @@ var _ = Describe("RBAC Test", func() {
 									Resources:       []string{"secrets"},
 									ResourceNames:   nil,
 									NonResourceURLs: nil,
-								}},
+								},
+							},
 						})
 						testManifest.ExpectClusterRole(&rbacv1.ClusterRole{
 							TypeMeta: metav1.TypeMeta{
@@ -598,8 +600,9 @@ var _ = Describe("RBAC Test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "gloo-gateway-vwc-update-gloo-system",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -613,7 +616,8 @@ var _ = Describe("RBAC Test", func() {
 									Resources:       []string{"validatingwebhookconfigurations"},
 									ResourceNames:   nil,
 									NonResourceURLs: nil,
-								}},
+								},
+							},
 							AggregationRule: nil,
 						})
 					})
@@ -627,8 +631,9 @@ var _ = Describe("RBAC Test", func() {
 								Name:      "gloo-gateway-secret-create-gloo-system",
 								Namespace: "gloo-system",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -655,8 +660,9 @@ var _ = Describe("RBAC Test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "gloo-gateway-vwc-update-gloo-system",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -689,8 +695,9 @@ var _ = Describe("RBAC Test", func() {
 								Name:      "gloo-gateway-secret-create",
 								Namespace: "gloo-system",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -713,8 +720,9 @@ var _ = Describe("RBAC Test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "gloo-gateway-vwc-update",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -728,7 +736,8 @@ var _ = Describe("RBAC Test", func() {
 									Resources:       []string{"validatingwebhookconfigurations"},
 									ResourceNames:   nil,
 									NonResourceURLs: nil,
-								}},
+								},
+							},
 							AggregationRule: nil,
 						})
 					})
@@ -742,8 +751,9 @@ var _ = Describe("RBAC Test", func() {
 								Name:      "gloo-gateway-secret-create",
 								Namespace: "gloo-system",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -770,8 +780,9 @@ var _ = Describe("RBAC Test", func() {
 							ObjectMeta: metav1.ObjectMeta{
 								Name: "gloo-gateway-vwc-update",
 								Labels: map[string]string{
-									"app":  "gloo",
-									"gloo": "rbac",
+									"app":                    "gloo",
+									"gloo":                   "rbac",
+									"gloo.solo.io/component": "certgen",
 								},
 								Annotations: map[string]string{
 									"helm.sh/hook-weight": "5",
@@ -814,11 +825,12 @@ var _ = Describe("RBAC Test", func() {
 							Kind:     "ClusterRole",
 							Name:     "gloo-resource-mutator",
 						},
-						Subjects: []rbacv1.Subject{{
-							Kind:      "ServiceAccount",
-							Name:      "gateway",
-							Namespace: namespace,
-						},
+						Subjects: []rbacv1.Subject{
+							{
+								Kind:      "ServiceAccount",
+								Name:      "gateway",
+								Namespace: namespace,
+							},
 							{
 								Kind:      "ServiceAccount",
 								Name:      "gloo",


### PR DESCRIPTION
# Description
Introduces a `gloo.solo.io/component` label to group Helm resources that are associated with a given component. This is required by downstream projects that use Helm as a templating engine to be able to group resources associated with a component and customize their behavior. This change groups resources required by the certgen component using the new label.

# Context

Refer to https://github.com/solo-io/solo-projects/issues/6824

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation n/a
- [X] I have added tests that prove my fix is effective or that my feature works
