### PR TITLE
1.17: projects/utils/ssl: Add a check for ssl secrets that will be rejected by envoy but not go

### DIFF
--- a/changelog/v1.17.8/strict-tls-validation.yaml
+++ b/changelog/v1.17.8/strict-tls-validation.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/6772
+    resolvesIssue: false
+    description: >-
+      Plugs a gap where go would check a secret for validity per spec but envoy is more aggressive.
+      For example a tls secret with a certchain that contains an invalid pem block will be rejected by envoy but not go.
+      Prior to this pr these types of secrets would be accepted by gloo and nacked by envoy.
+  

--- a/projects/gateway2/translator/sslutils/ssl_utils.go
+++ b/projects/gateway2/translator/sslutils/ssl_utils.go
@@ -57,6 +57,9 @@ func isValidSslKeyPair(certChain, privateKey, rootCa []byte) error {
 		return err
 	}
 	reencoded, err := cert.EncodeCertificates(candidateCert...)
+	if err != nil {
+		return err
+	}
 	trimmedEncoded := strings.TrimSpace(string(reencoded))
 	if trimmedEncoded != strings.TrimSpace(string(certChain)) {
 		return fmt.Errorf("certificate chain does not match parsed certificate")

--- a/projects/gateway2/translator/sslutils/ssl_utils.go
+++ b/projects/gateway2/translator/sslutils/ssl_utils.go
@@ -52,7 +52,8 @@ func isValidSslKeyPair(certChain, privateKey, rootCa []byte) error {
 	}
 	candidateCert, err := cert.ParseCertsPEM([]byte(certChain))
 	if err != nil {
-		// return err rather than overriding certchain to maintain ux with kubernetes gateway
+		// return err rather than sanitize. This is to maintain UX with older versions and to prevent a large refactor
+		// for gatewayv2 secret validation code.
 		return err
 	}
 	reencoded, err := cert.EncodeCertificates(candidateCert...)

--- a/projects/gateway2/translator/sslutils/ssl_utils.go
+++ b/projects/gateway2/translator/sslutils/ssl_utils.go
@@ -50,7 +50,11 @@ func isValidSslKeyPair(certChain, privateKey, rootCa []byte) error {
 	if err != nil {
 		return err
 	}
-	candidateCert, err := cert.ParseCertsPEM([]byte(certChain))
+	// validate that the parsed piece is valid
+	// this is still faster than a call out to openssl despite this second parsing pass of the cert
+	// pem parsing in go is permissive while envoy is not
+	// this might not be needed once we have larger envoy validation
+	candidateCert, err := cert.ParseCertsPEM(certChain)
 	if err != nil {
 		// return err rather than sanitize. This is to maintain UX with older versions and to prevent a large refactor
 		// for gatewayv2 secret validation code.

--- a/projects/gloo/pkg/utils/ssl.go
+++ b/projects/gloo/pkg/utils/ssl.go
@@ -452,6 +452,9 @@ func isValidSslKeyPair(certChain, privateKey, rootCa string) error {
 		return err
 	}
 	reencoded, err := cert.EncodeCertificates(candidateCert...)
+	if err != nil {
+		return err
+	}
 	trimmedEncoded := strings.TrimSpace(string(reencoded))
 	if trimmedEncoded != strings.TrimSpace(certChain) {
 		return fmt.Errorf("certificate chain does not match parsed certificate")

--- a/projects/gloo/pkg/utils/ssl.go
+++ b/projects/gloo/pkg/utils/ssl.go
@@ -448,7 +448,7 @@ func isValidSslKeyPair(certChain, privateKey, rootCa string) error {
 	// this might not be needed once we have larger envoy validation
 	candidateCert, err := cert.ParseCertsPEM([]byte(certChain))
 	if err != nil {
-		// return err rather than overriding certchain to maintain ux with kubernetes gateway
+		// return err rather than sanitize. This is to maintain UX with older versions and to keep in line with gateway2 pkg.
 		return err
 	}
 	reencoded, err := cert.EncodeCertificates(candidateCert...)

--- a/projects/gloo/pkg/utils/ssl.go
+++ b/projects/gloo/pkg/utils/ssl.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/tls"
 	"fmt"
+	"strings"
 
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoygrpccredential "github.com/envoyproxy/go-control-plane/envoy/config/grpc_credential/v3"
@@ -14,6 +15,7 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"k8s.io/client-go/util/cert"
 )
 
 //go:generate mockgen -destination mocks/mock_ssl.go github.com/solo-io/gloo/projects/gloo/pkg/utils SslConfigTranslator
@@ -433,7 +435,28 @@ func isValidSslKeyPair(certChain, privateKey, rootCa string) error {
 		return nil
 	}
 
+	// validate that the cert and key are a valid pair
 	_, err := tls.X509KeyPair([]byte(certChain), []byte(privateKey))
+	if err != nil {
+
+		return err
+	}
+
+	// validate that the parsed piece is valid
+	// this is still faster than a call out to openssl despite this second parsing pass of the cert
+	// pem parsing in go is permissive while envoy is not
+	// this might not be needed once we have larger envoy validation
+	candidateCert, err := cert.ParseCertsPEM([]byte(certChain))
+	if err != nil {
+		// return err rather than overriding certchain to maintain ux with kubernetes gateway
+		return err
+	}
+	reencoded, err := cert.EncodeCertificates(candidateCert...)
+	trimmedEncoded := strings.TrimSpace(string(reencoded))
+	if trimmedEncoded != strings.TrimSpace(certChain) {
+		return fmt.Errorf("certificate chain does not match parsed certificate")
+	}
+
 	return err
 }
 

--- a/projects/gloo/pkg/utils/ssl_test.go
+++ b/projects/gloo/pkg/utils/ssl_test.go
@@ -177,6 +177,18 @@ var _ = Describe("Ssl", func() {
 			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
 			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
 		)
+		DescribeTable("should fail if invalid for envoy cert is provided",
+			func(c func() utils.CertSource) {
+				// unterminated cert in chain is valid for go b ut not envoy
+				tlsSecret.CertChain += `-----BEGIN CERTIFICATE-----
+MIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD`
+				_, err := resolveCommonSslConfig(c(), secrets)
+				Expect(err).To(HaveOccurred())
+
+			},
+			Entry("upstreamCfg", func() utils.CertSource { return upstreamCfg }),
+			Entry("downstreamCfg", func() utils.CertSource { return downstreamCfg }),
+		)
 		DescribeTable("should not have validation context if no rootca",
 			func(c func() utils.CertSource) {
 				tlsSecret.RootCa = ""


### PR DESCRIPTION
# Description

In go pem decoding is intentionally spec compliant. This means that it is very permissive with its decoding and will skip un-parsable, possibly usable or just commented data.

This means that when we consume crt data we may pass along info that is rejected by envoy which can stall configuration and is generally something we try to avoid.

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

Rely on kubernetes cert encoding to check to see if anything was dropped in decoding from pem and then emit an error if anything was dropped.

## Interesting decisions

Originally we attempted to go the route as seen in https://gist.github.com/anitgandhi/58b0618512fdb3caa89e86c8a6a536ab  from https://github.com/golang/go/issues/34069 
While this mostly worked and caught several issues we continued to find more edge cases such as with headers. Given this we decided to lean heavily on kubernetes setup to make sure that we are most compliant with what another big project does.

For example the gist catches the unterminated cert block but did not catch invalid headers being provided for example 
`-----BEGIN HEADERS-----
Header: 1
-----END HEADERS-----` 
is invalid as it does not have a newline like
`-----BEGIN HEADERS-----
Header: 1

-----END HEADERS-----`


## Testing steps

Reproduction:
Follow https://docs.solo.io/gloo-edge/latest/guides/security/tls/server_tls/
Now update the crt by adding 
`-----BEGIN CERTIFICATE-----
MIID6TCCA1ICAQEwDQYJKoZIhvcNAQEFBQAwgYsxCzAJBgNVBAYTAlVTMRMwEQYD`
Then update your secret

` kubectl create secret tls animal-certs  --key tls.key \
    --cert tls.crt --namespace gloo-system \
--save-config \
--dry-run=client \
-o yaml | \
kubectl apply -f -`

Next update something to kick translation ideally a route on the accepted vs.

See that envoy nacks the request.

Remove the secret reference. 
Upgrade to this pr's image
Readd the reference and see validation block the update.




# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
