### PR TITLE
Makes MustKindContextWithScheme() Private

### DIFF
--- a/test/kubernetes/testutils/cluster/kind.go
+++ b/test/kubernetes/testutils/cluster/kind.go
@@ -18,11 +18,11 @@ import (
 
 // MustKindContext returns the Context for a KinD cluster with the given name
 func MustKindContext(clusterName string) *Context {
-	return MustKindContextWithScheme(clusterName, kubetestclients.MustClientScheme())
+	return mustKindContextWithScheme(clusterName, kubetestclients.MustClientScheme())
 }
 
-// MustKindContextWithScheme returns the Context for a KinD cluster with the given name and scheme
-func MustKindContextWithScheme(clusterName string, scheme *runtime.Scheme) *Context {
+// mustKindContextWithScheme returns the Context for a KinD cluster with the given name and scheme
+func mustKindContextWithScheme(clusterName string, scheme *runtime.Scheme) *Context {
 	if len(clusterName) == 0 {
 		// We fall back to the cluster named `kind` if no cluster name was provided
 		clusterName = "kind"


### PR DESCRIPTION
# Description

MustKindContextWithScheme() was only being called from the cluster pkg so the function has been updated to be private.

## Testing steps

I successfully ran `go test -v -timeout 600s ./test/kubernetes/e2e/tests -run ^TestK8sGateway$/^Deployer$` which calls this function through `CreateTestInstallation()`.

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
