### PR TITLE
Trivyignore updates

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -50,4 +50,8 @@ CVE-2024-34156
 # This CVE affects the imroc/req dependency which is used in go-utils
 # go-utils exclusively uses this package to upload security scans to Github and as such the vulnerability does not
 # impact Gateway functionality
+# This dependency is removed in go-utils v0.27.0, so this entry can be removed once all LTS branches are on that version
+# or later
 CVE-2024-45258
+
+CVE

--- a/.trivyignore
+++ b/.trivyignore
@@ -54,4 +54,10 @@ CVE-2024-34156
 # or later
 CVE-2024-45258
 
-CVE
+# This CVE affects the packc/pgx dependency which is used in ext-auth-service
+# The dependency is exclusively used in the monetization feature which we don't believe any customer uses and which is
+# set to be deprecated
+# Nevertheless the CVE has been addressed in the v1.15 LTS branch and later, however it is impractical to resolve in 1.14
+# due to a number of other requisite dependency bumps
+# Therefore we include this entry for now and should remove it once 1.14 is no longer an LTS branch
+CVE-2024-27289

--- a/changelog/v1.18.0-beta23/update-trivy0ignore-cve-2024-27289.yaml
+++ b/changelog/v1.18.0-beta23/update-trivy0ignore-cve-2024-27289.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Add CVE-2024-27289 to trivyignore as we are not planning on fixing in 1.14 and it does not impact Gateway 
+      functionality. Also update description of previous entry.
+      
+      skipCI-kube-tests:true
+      skipCI-storybook-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

Update trivignore to clarify when one entry can be removed and to add another entry

# Context

solo-io/go-utils#533 resolves CVE-2024-45258
That CVE does not impact Gateway, so there's no point expending the effort to backport it and bring it into LTS branches, however once all LTS branches have caught up with that PR, which is expected to be included in v0.27.0, the trivyignore entry for that CVE can be removed

More detail on why we're not resolving CVE-2024-27289 for 1.14 [here](https://github.com/solo-io/solo-projects/issues/6869#issuecomment-2362025363)

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
