### PR TITLE
[gateway2] Updates Gateway Controller Watch Predicate

### DIFF
--- a/changelog/v1.18.0-beta26/issue_10099.yaml
+++ b/changelog/v1.18.0-beta26/issue_10099.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/10099
+    resolvesIssue: true
+    description: >-
+      Previously, the controller would only watch Gateway objects for generation field
+      changes which is not updated when annotations change. Since Gateway reconciliation
+      should be triggered when the gateway.gloo.solo.io/gateway-parameters-name annotation
+      is added, removed, or modified, the predicate was updated to check for changes in
+      either the generation field or the annotations.

--- a/test/kubernetes/e2e/features/deployer/istio_integration_suite.go
+++ b/test/kubernetes/e2e/features/deployer/istio_integration_suite.go
@@ -45,11 +45,11 @@ func NewIstioIntegrationTestingSuite(ctx context.Context, testInst *e2e.TestInst
 
 func (s *istioIntegrationDeployerSuite) SetupSuite() {
 	s.manifests = map[string][]string{
-		"TestConfigureIstioIntegrationFromGatewayParameters": {testdefaults.NginxPodManifest, istioGatewayParametersManifestFile},
+		"TestConfigureIstioIntegrationFromGatewayParameters": {testdefaults.NginxPodManifest, istioGatewayParameters},
 	}
 	s.manifestObjects = map[string][]client.Object{
-		testdefaults.NginxPodManifest:      {testdefaults.NginxPod, testdefaults.NginxSvc},
-		istioGatewayParametersManifestFile: {proxyService, proxyServiceAccount, proxyDeployment, gwParams},
+		testdefaults.NginxPodManifest: {testdefaults.NginxPod, testdefaults.NginxSvc},
+		istioGatewayParameters:        {proxyService, proxyServiceAccount, proxyDeployment, gwParamsDefault},
 	}
 }
 

--- a/test/kubernetes/e2e/features/deployer/minimal_default_gatewayparameters_suite.go
+++ b/test/kubernetes/e2e/features/deployer/minimal_default_gatewayparameters_suite.go
@@ -46,7 +46,7 @@ func (s *minimalDefaultGatewayParametersDeployerSuite) SetupSuite() {
 	}
 	s.manifestObjects = map[string][]client.Object{
 		testdefaults.NginxPodManifest: {testdefaults.NginxPod, testdefaults.NginxSvc},
-		gatewayWithParameters:         {proxyService, proxyServiceAccount, proxyDeployment, gwParams},
+		gatewayWithParameters:         {proxyService, proxyServiceAccount, proxyDeployment, gwParamsDefault},
 	}
 }
 

--- a/test/kubernetes/e2e/features/deployer/testdata/gateway-with-parameters.yaml
+++ b/test/kubernetes/e2e/features/deployer/testdata/gateway-with-parameters.yaml
@@ -56,4 +56,3 @@ spec:
         runAsUser: null
         runAsNonRoot: false
         allowPrivilegeEscalation: true
-

--- a/test/kubernetes/e2e/features/deployer/testdata/gatewayparameters-custom.yaml
+++ b/test/kubernetes/e2e/features/deployer/testdata/gatewayparameters-custom.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.gloo.solo.io/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: gw-params-custom
+spec:
+  kube:
+    deployment:
+      replicas: 2
+    podTemplate:
+      extraLabels:
+        pod-label-key: pod-label-val
+      extraAnnotations:
+        pod-anno-key: pod-anno-val
+    envoyContainer:
+      bootstrap:
+        logLevel: debug
+        componentLogLevels:
+          upstream: debug
+          connection: trace
+      securityContext:
+        runAsUser: null
+        runAsNonRoot: false
+        allowPrivilegeEscalation: true

--- a/test/kubernetes/e2e/features/deployer/types.go
+++ b/test/kubernetes/e2e/features/deployer/types.go
@@ -7,15 +7,17 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwapiv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/solo-io/gloo/projects/gateway2/api/v1alpha1"
 )
 
 var (
-	gatewayWithoutParameters           = filepath.Join(util.MustGetThisDir(), "testdata", "gateway-without-parameters.yaml")
-	gatewayWithParameters              = filepath.Join(util.MustGetThisDir(), "testdata", "gateway-with-parameters.yaml")
-	istioGatewayParametersManifestFile = filepath.Join(util.MustGetThisDir(), "testdata", "istio-gateway-parameters.yaml")
-	selfManagedGatewayManifestFile     = filepath.Join(util.MustGetThisDir(), "testdata", "self-managed-gateway.yaml")
+	gatewayWithoutParameters = filepath.Join(util.MustGetThisDir(), "testdata", "gateway-without-parameters.yaml")
+	gatewayWithParameters    = filepath.Join(util.MustGetThisDir(), "testdata", "gateway-with-parameters.yaml")
+	gatewayParametersCustom  = filepath.Join(util.MustGetThisDir(), "testdata", "gatewayparameters-custom.yaml")
+	istioGatewayParameters   = filepath.Join(util.MustGetThisDir(), "testdata", "istio-gateway-parameters.yaml")
+	selfManagedGateway       = filepath.Join(util.MustGetThisDir(), "testdata", "self-managed-gateway.yaml")
 
 	// When we apply the deployer-provision.yaml file, we expect resources to be created with this metadata
 	glooProxyObjectMeta = metav1.ObjectMeta{
@@ -26,9 +28,23 @@ var (
 	proxyService        = &corev1.Service{ObjectMeta: glooProxyObjectMeta}
 	proxyServiceAccount = &corev1.ServiceAccount{ObjectMeta: glooProxyObjectMeta}
 
-	gwParams = &v1alpha1.GatewayParameters{
+	gwParamsDefault = &v1alpha1.GatewayParameters{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "gw-params",
+			Namespace: "default",
+		},
+	}
+
+	gwParamsCustom = &v1alpha1.GatewayParameters{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw-params-custom",
+			Namespace: "default",
+		},
+	}
+
+	gw = &gwapiv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gw",
 			Namespace: "default",
 		},
 	}


### PR DESCRIPTION
Previously, the controller would only watch Gateway objects for `generation` field changes which is not updated when annotations change. Since Gateway reconciliation should be triggered when the `gateway.gloo.solo.io/gateway-parameters-name` annotation is added, removed, or modified, the predicate was updated to check for changes in either the generation field or the annotations.

Fixes #10099


BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/10099