### PR TITLE
test/kubernetes/e2e: relax validation constraints for gloogateway.context

### DIFF
--- a/changelog/v1.18.0-beta24/production-helm-profiles-in-tests-part2.yaml
+++ b/changelog/v1.18.0-beta24/production-helm-profiles-in-tests-part2.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/docs/issues/489
+    resolvesIssue: false
+    description: >-
+      Validate the gloogateway.Context object in a way that it can be invoked by an Enterprise installation

--- a/pkg/utils/helmutils/unmarshal.go
+++ b/pkg/utils/helmutils/unmarshal.go
@@ -1,0 +1,46 @@
+package helmutils
+
+import (
+	"os"
+
+	k8syamlutil "sigs.k8s.io/yaml"
+)
+
+// UnmarshalValuesFile reads a file and returns a map containing the unmarshalled values
+func UnmarshalValuesFile(filePath string) (map[string]interface{}, error) {
+	mapFromFile := map[string]interface{}{}
+
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE: This is not the default golang yaml.Unmarshal, because that implementation
+	// does not unmarshal into a map[string]interface{}; it unmarshals the file into a map[interface{}]interface{}
+	// https://github.com/go-yaml/yaml/issues/139
+	if err := k8syamlutil.Unmarshal(bytes, &mapFromFile); err != nil {
+		return nil, err
+	}
+
+	return mapFromFile, nil
+}
+
+// MergeMaps comes from Helm internals: https://github.com/helm/helm/blob/release-3.0/pkg/cli/values/options.go#L88
+func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(a))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		if v, ok := v.(map[string]interface{}); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					out[k] = MergeMaps(bv, v)
+					continue
+				}
+			}
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -53,6 +53,11 @@ func CreateTestInstallation(
 	runtimeContext := testruntime.NewContext()
 	clusterContext := cluster.MustKindContext(runtimeContext.ClusterName)
 
+	if err := gloogateway.ValidateGlooGatewayContext(glooGatewayContext); err != nil {
+		// We error loudly if the context is misconfigured
+		panic(err)
+	}
+
 	return CreateTestInstallationForCluster(t, runtimeContext, clusterContext, glooGatewayContext)
 }
 
@@ -68,11 +73,6 @@ func CreateTestInstallationForCluster(
 	clusterContext *cluster.Context,
 	glooGatewayContext *gloogateway.Context,
 ) *TestInstallation {
-	if err := glooGatewayContext.Validate(); err != nil {
-		// We error loudly if the context is misconfigured
-		panic(err)
-	}
-
 	installation := &TestInstallation{
 		// RuntimeContext contains the set of properties that are defined at runtime by whoever is invoking tests
 		RuntimeContext: runtimeContext,

--- a/test/testutils/helm_values.go
+++ b/test/testutils/helm_values.go
@@ -2,11 +2,12 @@ package testutils
 
 import (
 	"encoding/json"
+	"path"
+
 	"github.com/solo-io/gloo/install/helm/gloo/generate"
 	"github.com/solo-io/gloo/pkg/utils/helmutils"
 	"helm.sh/helm/v3/pkg/strvals"
 	"knative.dev/pkg/test/helpers"
-	"path"
 	k8syamlutil "sigs.k8s.io/yaml"
 )
 

--- a/test/testutils/helm_values.go
+++ b/test/testutils/helm_values.go
@@ -2,12 +2,11 @@ package testutils
 
 import (
 	"encoding/json"
-	"os"
-	"path"
-
 	"github.com/solo-io/gloo/install/helm/gloo/generate"
+	"github.com/solo-io/gloo/pkg/utils/helmutils"
 	"helm.sh/helm/v3/pkg/strvals"
 	"knative.dev/pkg/test/helpers"
+	"path"
 	k8syamlutil "sigs.k8s.io/yaml"
 )
 
@@ -54,8 +53,21 @@ func ValidateHelmValues(unstructuredHelmValues map[string]interface{}) error {
 // BuildHelmValues reads the base values.yaml file from a Helm chart and merges it with the provided values
 // each entry in valuesArgs should look like `path.to.helm.field=value`
 func BuildHelmValues(values HelmValues) (map[string]interface{}, error) {
+	// read the chart's base values file first
+	rootDir, err := helpers.GetRootDir()
+	if err != nil {
+		return nil, err
+	}
+	chartPath := path.Join(rootDir, "install", "helm", "gloo")
 
-	finalValues, err := readFinalValues()
+	return BuildHelmValuesForChart(chartPath, values)
+}
+
+// BuildHelmValuesForChart reads the base values.yaml file from a Helm chart and merges it with the provided values
+// each entry in valuesArgs should look like `path.to.helm.field=value`
+func BuildHelmValuesForChart(chartPath string, values HelmValues) (map[string]interface{}, error) {
+	// read the chart's base values file first
+	finalValues, err := helmutils.UnmarshalValuesFile(path.Join(chartPath, "values.yaml"))
 	if err != nil {
 		return nil, err
 	}
@@ -70,62 +82,14 @@ func BuildHelmValues(values HelmValues) (map[string]interface{}, error) {
 	if values.ValuesFile != "" {
 		// these lines ripped out of Helm internals
 		// https://github.com/helm/helm/blob/release-3.0/pkg/cli/values/options.go
-		mapFromFile, err := readValuesFile(values.ValuesFile)
+		mapFromFile, err := helmutils.UnmarshalValuesFile(values.ValuesFile)
 		if err != nil {
 			return nil, err
 		}
 
 		// Merge with the previous map
-		finalValues = mergeMaps(finalValues, mapFromFile)
+		finalValues = helmutils.MergeMaps(finalValues, mapFromFile)
 	}
 
 	return finalValues, nil
-}
-
-func readFinalValues() (map[string]interface{}, error) {
-	// read the chart's base values file first
-	rootDir, err := helpers.GetRootDir()
-	if err != nil {
-		return nil, err
-	}
-	filePath := path.Join(rootDir, "install", "helm", "gloo", "values.yaml")
-	return readValuesFile(filePath)
-}
-
-func readValuesFile(filePath string) (map[string]interface{}, error) {
-	mapFromFile := map[string]interface{}{}
-
-	bytes, err := os.ReadFile(filePath)
-	if err != nil {
-		return nil, err
-	}
-
-	// NOTE: This is not the default golang yaml.Unmarshal, because that implementation
-	// does not unmarshal into a map[string]interface{}; it unmarshals the file into a map[interface{}]interface{}
-	// https://github.com/go-yaml/yaml/issues/139
-	if err := k8syamlutil.Unmarshal(bytes, &mapFromFile); err != nil {
-		return nil, err
-	}
-
-	return mapFromFile, nil
-}
-
-// mergeMaps comes from Helm internals: https://github.com/helm/helm/blob/release-3.0/pkg/cli/values/options.go#L88
-func mergeMaps(a, b map[string]interface{}) map[string]interface{} {
-	out := make(map[string]interface{}, len(a))
-	for k, v := range a {
-		out[k] = v
-	}
-	for k, v := range b {
-		if v, ok := v.(map[string]interface{}); ok {
-			if bv, ok := out[k]; ok {
-				if bv, ok := bv.(map[string]interface{}); ok {
-					out[k] = mergeMaps(bv, v)
-					continue
-				}
-			}
-		}
-		out[k] = v
-	}
-	return out
 }


### PR DESCRIPTION
# Description
Adjust the way that the gloogateway.Context is validated for a given TestInstallation

# Context
## E2E Test Fast-Follow
Fast follow to https://github.com/solo-io/gloo/pull/10106

In the previous PR, we introduced a way to validate a file that contained Helm values for a given installation. Baked into that validation is an assumption that the file contains values for an open source installation of Gloo Gateway.

However, we want to make it so that the same functionality can be invoked for an Enterprise installation.

The proposed solution is two-fold:
- Adjust the constructor to not perform validation, and follow the "new is glue" motto
- Adjust the validation function to accept a validator, and inject an oss implementation for the oss tests

## Helm Test De-Duplication
While I was working on an EE PR, I found some code that was duplicated and could just be defined in OSS and invoked from EE. I added those changes to this PR as well.

## Interesting decisions
-

## Testing steps
- CI passes
- [ ] EE PR can be run successfully

## Notes for reviewers
-

# Checklist:
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works