### PR TITLE
1.17 - Discovery resource version err (#10118)

### DIFF
--- a/changelog/v1.17.11/discovery-watchlabels-bugfix.yaml
+++ b/changelog/v1.17.11/discovery-watchlabels-bugfix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8635
+    description: >
+      Fix a bug that caused discovered Upstreams to not reflect the updated state of parent Services discovered using
+      watchLabels
+    resolvesIssue: false

--- a/projects/gloo/pkg/discovery/discovery.go
+++ b/projects/gloo/pkg/discovery/discovery.go
@@ -44,7 +44,6 @@ type UpstreamDiscovery struct {
 	discoveryPlugins       []DiscoveryPlugin
 	lock                   sync.Mutex
 	latestDesiredUpstreams map[DiscoveryPlugin]v1.UpstreamList
-	extraSelectorLabels    map[string]string
 }
 
 type EndpointDiscovery struct {
@@ -95,7 +94,7 @@ func NewUpstreamDiscovery(
 // launch a goroutine for all the UDS plugins
 func (d *UpstreamDiscovery) StartUds(opts clients.WatchOpts, discOpts Opts) (chan error, error) {
 	aggregatedErrs := make(chan error)
-	d.extraSelectorLabels = opts.Selector
+
 	for _, uds := range d.discoveryPlugins {
 		upstreams, errs, err := uds.DiscoverUpstreams(d.watchNamespaces, d.writeNamespace, opts, discOpts)
 		if err != nil {
@@ -136,12 +135,14 @@ func (d *UpstreamDiscovery) Resync(ctx context.Context) error {
 	for uds, desiredUpstreams := range d.latestDesiredUpstreams {
 		udsName := strings.Replace(reflect.TypeOf(uds).String(), "*", "", -1)
 		udsName = strings.Replace(udsName, ".", "", -1)
+
+		// selecting on the discovery plugin label will get all Upstreams created by Discovery
+		// there is no need to select on watchLabels as these are not present on Upstream metadata, nor are they
+		// necessary to identify Upstreams that may need to be resynced
 		selector := map[string]string{
 			"discovered_by": udsName,
 		}
-		for k, v := range d.extraSelectorLabels {
-			selector[k] = v
-		}
+
 		logger.Debugw("reconciling upstream details", zap.Any("upstreams", desiredUpstreams))
 		if err := d.upstreamReconciler.Reconcile(d.writeNamespace, desiredUpstreams, uds.UpdateUpstream, clients.ListOpts{
 			Ctx:      ctx,

--- a/test/kubernetes/e2e/debugging.md
+++ b/test/kubernetes/e2e/debugging.md
@@ -6,7 +6,7 @@ This document describes workflows that may be useful when debugging e2e tests wi
 
 The entry point for an e2e test is a Go test function of the form `func TestXyz(t *testing.T)` which represents a top level suite against an installation mode of Gloo. For example, the `TestK8sGateway` function in [k8s_gw_test.go](/test/kubernetes/e2e/tests/k8s_gw_test.go) is a top-level suite comprising multiple feature specific suites that are invoked as subtests.
 
-Each feature suite is invoked as a subtest of the top level suite. The subtests use [testify](https://github.com/stretchr/testify) to structure the tests in the feature's test suite and make use of the libarary's assertions.
+Each feature suite is invoked as a subtest of the top level suite. The subtests use [testify](https://github.com/stretchr/testify) to structure the tests in the feature's test suite and make use of the library's assertions.
 
 ## Workflows
 

--- a/test/kubernetes/e2e/features/discovery_watchlabels/discovery_watchlabels_suite.go
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/discovery_watchlabels_suite.go
@@ -1,0 +1,161 @@
+package discovery_watchlabels
+
+import (
+	"context"
+
+	"github.com/onsi/gomega"
+
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/solo-io/gloo/projects/gloo/pkg/defaults"
+	"github.com/solo-io/gloo/test/kubernetes/e2e"
+	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+	"github.com/stretchr/testify/suite"
+)
+
+var _ e2e.NewSuiteFunc = NewDiscoveryWatchlabelsSuite
+
+// discoveryWatchlabelsSuite is the Suite of tests for validating Upstream discovery behavior when watchLabels are enabled
+// This suite replaces the "upstream discovery" Context block from kube2e gateway tests
+type discoveryWatchlabelsSuite struct {
+	suite.Suite
+
+	ctx context.Context
+
+	// testInstallation contains all the metadata/utilities necessary to execute a series of tests
+	// against an installation of Gloo Gateway
+	testInstallation *e2e.TestInstallation
+}
+
+func NewDiscoveryWatchlabelsSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &discoveryWatchlabelsSuite{
+		ctx:              ctx,
+		testInstallation: testInst,
+	}
+}
+
+func (s *discoveryWatchlabelsSuite) TestDiscoverUpstreamMatchingWatchLabels() {
+	s.T().Cleanup(func() {
+		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, serviceWithLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+		s.Assertions.NoError(err, "can delete service")
+
+		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, serviceWithoutLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+		s.Assertions.NoError(err, "can delete service")
+
+		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, serviceWithNoMatchingLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+		s.Assertions.NoError(err, "can delete service")
+	})
+
+	// add one service with labels matching our watchLabels
+	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, serviceWithLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+	s.Assert().NoError(err, "can apply service")
+
+	// add one service without labels matching our watchLabels
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, serviceWithoutLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+	s.Assert().NoError(err, "can apply service")
+
+	// add one service with a label matching our watchLabels but with an unwatched value
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, serviceWithNoMatchingLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+	s.Assert().NoError(err, "can apply service")
+
+	// eventually an Upstream should be created for the Service with matching labels
+	labeledUsName := kubernetes.UpstreamName(s.testInstallation.Metadata.InstallNamespace, "example-svc", 8000)
+	s.testInstallation.Assertions.EventuallyResourceStatusMatchesState(
+		func() (resources.InputResource, error) {
+			return s.testInstallation.ResourceClients.UpstreamClient().Read(s.testInstallation.Metadata.InstallNamespace, labeledUsName, clients.ReadOpts{Ctx: s.ctx})
+		},
+		core.Status_Accepted,
+		defaults.GlooReporter,
+	)
+
+	// the Upstream should have DiscoveryMetadata labels matching the parent Service
+	us, err := s.testInstallation.ResourceClients.UpstreamClient().Read(s.testInstallation.Metadata.InstallNamespace, labeledUsName, clients.ReadOpts{Ctx: s.ctx})
+	s.Assert().NoError(err, "can read upstream")
+
+	s.Assert().Equal(map[string]string{
+		"watchedKey": "watchedValue",
+		"bonusKey":   "bonusValue",
+	}, us.GetDiscoveryMetadata().GetLabels())
+
+	// no Upstream should be created for the Service that does not have the watchLabels
+	noLabelsUsName := kubernetes.UpstreamName(s.testInstallation.Metadata.InstallNamespace, "example-svc-no-labels", 8000)
+	s.testInstallation.Assertions.ConsistentlyObjectsNotExist(
+		s.ctx, &v1.Upstream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      noLabelsUsName,
+				Namespace: s.testInstallation.Metadata.InstallNamespace,
+			},
+		},
+	)
+
+	// no Upstream should be created for the Service that has a watched label without a watched value
+	noMatchingLabelsUsName := kubernetes.UpstreamName(s.testInstallation.Metadata.InstallNamespace, "example-svc-no-matching-labels", 8000)
+	s.testInstallation.Assertions.ConsistentlyObjectsNotExist(
+		s.ctx, &v1.Upstream{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      noMatchingLabelsUsName,
+				Namespace: s.testInstallation.Metadata.InstallNamespace,
+			},
+		},
+	)
+
+	// modify the non-watched label on the labeled service
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, serviceWithModifiedLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+	s.Assert().NoError(err, "can re-apply service")
+
+	// expect the Upstream's DiscoveryMeta to eventually match the modified labels from the parent Service
+	s.testInstallation.Assertions.Gomega.Eventually(func() (map[string]string, error) {
+		us, err = s.testInstallation.ResourceClients.UpstreamClient().Read(s.testInstallation.Metadata.InstallNamespace, labeledUsName, clients.ReadOpts{Ctx: s.ctx})
+		return us.GetDiscoveryMetadata().GetLabels(), err
+	}).Should(gomega.Equal(map[string]string{
+		"watchedKey": "watchedValue",
+		"bonusKey":   "bonusValue-modified",
+	}))
+}
+
+func (s *discoveryWatchlabelsSuite) TestDiscoverySpecPreserved() {
+	s.T().Cleanup(func() {
+		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, serviceWithLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+		s.Assertions.NoError(err, "can delete service")
+	})
+
+	// add one service with labels matching our watchLabels
+	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, serviceWithLabelsManifest, "-n", s.testInstallation.Metadata.InstallNamespace)
+	s.Assert().NoError(err, "can apply service")
+
+	// eventually an Upstream should be created for the Service with matching labels
+	labeledUsName := kubernetes.UpstreamName(s.testInstallation.Metadata.InstallNamespace, "example-svc", 8000)
+	s.testInstallation.Assertions.EventuallyResourceStatusMatchesState(
+		func() (resources.InputResource, error) {
+			return s.testInstallation.ResourceClients.UpstreamClient().Read(s.testInstallation.Metadata.InstallNamespace, labeledUsName, clients.ReadOpts{Ctx: s.ctx})
+		},
+		core.Status_Accepted,
+		defaults.GlooReporter,
+	)
+
+	// the Upstream should have DiscoveryMetadata labels matching the parent Service
+	us, err := s.testInstallation.ResourceClients.UpstreamClient().Read(s.testInstallation.Metadata.InstallNamespace, labeledUsName, clients.ReadOpts{Ctx: s.ctx})
+	s.Assert().NoError(err, "can read upstream")
+
+	s.Assert().NotNil(us.GetKube())
+	s.Assert().Nil(us.GetKube().GetServiceSpec())
+
+	// modify the Upstream to have a ServiceSpec
+	us.GetKube().ServiceSpec = &options.ServiceSpec{
+		PluginType: &options.ServiceSpec_GrpcJsonTranscoder{},
+	}
+	updatedUs, err := s.testInstallation.ResourceClients.UpstreamClient().Write(us, clients.WriteOpts{Ctx: s.ctx, OverwriteExisting: true})
+	s.Assert().NoError(err, "can update upstream")
+	s.Assert().NotNil(updatedUs.GetKube().GetServiceSpec())
+
+	// expect the Upstream to consistently have the modified Spec
+	s.testInstallation.Assertions.Gomega.Consistently(func() (*options.ServiceSpec, error) {
+		us, err := s.testInstallation.ResourceClients.UpstreamClient().Read(us.GetMetadata().GetNamespace(), us.GetMetadata().GetName(), clients.ReadOpts{Ctx: s.ctx})
+		return us.GetKube().GetServiceSpec(), err
+	}).Should(gomega.Not(gomega.BeNil()))
+}

--- a/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-with-labels.yaml
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-with-labels.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    watchedKey: watchedValue
+    bonusKey: bonusValue
+  name: example-svc
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080
+  selector:
+    selectorKey: selectorValue

--- a/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-with-modified-labels.yaml
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-with-modified-labels.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    watchedKey: watchedValue
+    bonusKey: bonusValue-modified
+  name: example-svc
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080
+  selector:
+    selectorKey: selectorValue

--- a/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-with-no-matching-labels.yaml
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-with-no-matching-labels.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    watchedKey: unwatchedValue
+  name: example-svc-no-matching-labels
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080
+  selector:
+    selectorKey: selectorValue

--- a/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-without-labels.yaml
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-without-labels.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc-no-labels
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 8080
+  selector:
+    selectorKey: selectorValue

--- a/test/kubernetes/e2e/features/discovery_watchlabels/types.go
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/types.go
@@ -1,0 +1,14 @@
+package discovery_watchlabels
+
+import (
+	"path/filepath"
+
+	"github.com/solo-io/skv2/codegen/util"
+)
+
+var (
+	serviceWithLabelsManifest           = filepath.Join(util.MustGetThisDir(), "testdata/service-with-labels.yaml")
+	serviceWithModifiedLabelsManifest   = filepath.Join(util.MustGetThisDir(), "testdata/service-with-modified-labels.yaml")
+	serviceWithoutLabelsManifest        = filepath.Join(util.MustGetThisDir(), "testdata/service-without-labels.yaml")
+	serviceWithNoMatchingLabelsManifest = filepath.Join(util.MustGetThisDir(), "testdata/service-with-no-matching-labels.yaml")
+)

--- a/test/kubernetes/e2e/tests/discovery_watchlabels_test.go
+++ b/test/kubernetes/e2e/tests/discovery_watchlabels_test.go
@@ -1,0 +1,57 @@
+package tests_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/solo-io/gloo/pkg/utils/envutils"
+	"github.com/solo-io/gloo/test/kubernetes/e2e"
+	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/testutils"
+	"github.com/solo-io/skv2/codegen/util"
+)
+
+// TestDiscoveryWatchlabels is the function which executes a series of tests against a given installation where
+// Discovery is enabled with watchLabels
+func TestDiscoveryWatchlabels(t *testing.T) {
+	ctx := context.Background()
+	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "discovery-watchlabels-test")
+	testInstallation := e2e.CreateTestInstallation(
+		t,
+		&gloogateway.Context{
+			InstallNamespace:          installNs,
+			ProfileValuesManifestFile: e2e.KubernetesGatewayProfilePath,
+			ValuesManifestFile:        filepath.Join(util.MustGetThisDir(), "manifests", "discovery-watchlabels-test-helm.yaml"),
+		},
+	)
+
+	testHelper := e2e.MustTestHelper(ctx, testInstallation)
+	// Set the env to the install namespace if it is not already set
+	if !nsEnvPredefined {
+		os.Setenv(testutils.InstallNamespace, installNs)
+	}
+
+	// We register the cleanup function _before_ we actually perform the installation.
+	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
+	t.Cleanup(func() {
+		if !nsEnvPredefined {
+			os.Unsetenv(testutils.InstallNamespace)
+		}
+		if t.Failed() {
+			testInstallation.PreFailHandler(ctx)
+		}
+
+		testInstallation.UninstallGlooGateway(ctx, func(ctx context.Context) error {
+			return testHelper.UninstallGlooAll()
+		})
+	})
+
+	// Install Gloo Gateway with only Gloo Edge Gateway APIs enabled
+	testInstallation.InstallGlooGatewayWithTestHelper(ctx, testHelper, 5*time.Minute)
+
+	DiscoveryWatchlabelsSuiteRunner().Run(ctx, t, testInstallation)
+}

--- a/test/kubernetes/e2e/tests/discovery_watchlabels_tests.go
+++ b/test/kubernetes/e2e/tests/discovery_watchlabels_tests.go
@@ -1,0 +1,14 @@
+package tests
+
+import (
+	"github.com/solo-io/gloo/test/kubernetes/e2e"
+	"github.com/solo-io/gloo/test/kubernetes/e2e/features/discovery_watchlabels"
+)
+
+func DiscoveryWatchlabelsSuiteRunner() e2e.SuiteRunner {
+	discoveryWatchlabelsSuiteRunner := e2e.NewSuiteRunner(false)
+
+	discoveryWatchlabelsSuiteRunner.Register("Discovery", discovery_watchlabels.NewDiscoveryWatchlabelsSuite)
+
+	return discoveryWatchlabelsSuiteRunner
+}

--- a/test/kubernetes/e2e/tests/manifests/discovery-watchlabels-test-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/discovery-watchlabels-test-helm.yaml
@@ -1,0 +1,5 @@
+discovery:
+  enabled: true
+  udsOptions:
+    watchLabels:
+      watchedKey: watchedValue


### PR DESCRIPTION
# Description

Backport #10118

# Context

This is a clean cherry-pick with no modifications

## Interesting decisions

This branch will contain redundant Discovery tests, with functionality tested in both kube2e and kubernetes/e2e 
Earlier versions will only have kube2e while later versions will only have kubernetes/e2e

## Testing steps

Manual testings has not been done for 1.17, however the kube2e and kubernetes/e2e tests running in CI should be sufficient to prove the bug has been fixed

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
