### PR TITLE
1.15 - Discovery resource version err (#10118)

### DIFF
--- a/changelog/v1.15.32/discovery-watchlabels-bugfix.yaml
+++ b/changelog/v1.15.32/discovery-watchlabels-bugfix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/8635
+    description: >
+      Fix a bug that caused discovered Upstreams to not reflect the updated state of parent Services discovered using
+      watchLabels
+    resolvesIssue: false

--- a/projects/gloo/pkg/discovery/discovery.go
+++ b/projects/gloo/pkg/discovery/discovery.go
@@ -44,7 +44,6 @@ type UpstreamDiscovery struct {
 	discoveryPlugins       []DiscoveryPlugin
 	lock                   sync.Mutex
 	latestDesiredUpstreams map[DiscoveryPlugin]v1.UpstreamList
-	extraSelectorLabels    map[string]string
 }
 
 type EndpointDiscovery struct {
@@ -95,7 +94,7 @@ func NewUpstreamDiscovery(
 // launch a goroutine for all the UDS plugins
 func (d *UpstreamDiscovery) StartUds(opts clients.WatchOpts, discOpts Opts) (chan error, error) {
 	aggregatedErrs := make(chan error)
-	d.extraSelectorLabels = opts.Selector
+
 	for _, uds := range d.discoveryPlugins {
 		upstreams, errs, err := uds.DiscoverUpstreams(d.watchNamespaces, d.writeNamespace, opts, discOpts)
 		if err != nil {
@@ -136,12 +135,14 @@ func (d *UpstreamDiscovery) Resync(ctx context.Context) error {
 	for uds, desiredUpstreams := range d.latestDesiredUpstreams {
 		udsName := strings.Replace(reflect.TypeOf(uds).String(), "*", "", -1)
 		udsName = strings.Replace(udsName, ".", "", -1)
+
+		// selecting on the discovery plugin label will get all Upstreams created by Discovery
+		// there is no need to select on watchLabels as these are not present on Upstream metadata, nor are they
+		// necessary to identify Upstreams that may need to be resynced
 		selector := map[string]string{
 			"discovered_by": udsName,
 		}
-		for k, v := range d.extraSelectorLabels {
-			selector[k] = v
-		}
+
 		logger.Debugw("reconciling upstream details", zap.Any("upstreams", desiredUpstreams))
 		if err := d.upstreamReconciler.Reconcile(d.writeNamespace, desiredUpstreams, uds.UpdateUpstream, clients.ListOpts{
 			Ctx:      ctx,

--- a/test/kube2e/gateway/gateway_test.go
+++ b/test/kube2e/gateway/gateway_test.go
@@ -1079,6 +1079,7 @@ var _ = Describe("Kube2e: gateway", func() {
 		})
 	})
 
+	// as of v1.17 these tests are replaced by the discovery watchlabels suite in the new kubernetes e2e tests
 	Context("upstream discovery", func() {
 		var createdServices []string
 
@@ -1211,6 +1212,64 @@ var _ = Describe("Kube2e: gateway", func() {
 			Eventually(func() (*gloov1.Upstream, error) {
 				return getUpstream(svcName)
 			}, "15s", "0.5s").ShouldNot(BeNil())
+		})
+
+		It("Modifies discovered Upstream when Service is modified", func() {
+			// This tests the fix for a bug whereby Discovery would fail to update discovered Upstreams on Service
+			// updates when watchLabels were enabled
+
+			watchedKey, watchedValue := "watchKey", "watchValue"
+			bonusKey, bonusValue, modifiedBonusValue := "foo", "bar", "modified-bar"
+
+			// set watchLabels for Discovery to select on
+			labels := map[string]string{
+				watchedKey: watchedValue,
+			}
+			setWatchLabels(labels)
+
+			// add an additional label which we'll modify later
+			labels[bonusKey] = bonusValue
+
+			svcName := "uds-test-service"
+			createServiceWithWatchedLabels(svcName, labels)
+
+			// confirm the Upstream has the Service's labels in its DiscoveryMetadata
+			Eventually(func() (map[string]string, error) {
+				us, err := getUpstream(svcName)
+				if err != nil {
+					return nil, err
+				}
+				return us.DiscoveryMetadata.GetLabels(), nil
+			}, "15s", "0.5s").Should(BeEquivalentTo(
+				map[string]string{
+					"gloo":     svcName,
+					watchedKey: watchedValue,
+					bonusKey:   bonusValue,
+				},
+			))
+
+			// get the service, modify its bonus label, and update it
+			svc, err := resourceClientset.KubeClients().CoreV1().Services(namespace).Get(ctx, svcName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			svc.Labels[bonusKey] = modifiedBonusValue
+
+			_, err = resourceClientset.KubeClients().CoreV1().Services(namespace).Update(ctx, svc, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			// expect the discovered Upstream's DiscoveryMetadata to eventually reflect the updated label
+			Eventually(func() (map[string]string, error) {
+				us, err := getUpstream(svcName)
+				if err != nil {
+					return nil, err
+				}
+				return us.DiscoveryMetadata.GetLabels(), nil
+			}, "15s", "0.5s").Should(BeEquivalentTo(
+				map[string]string{
+					"gloo":     svcName,
+					watchedKey: watchedValue,
+					bonusKey:   modifiedBonusValue,
+				},
+			))
 		})
 
 		It("Does not discover upstream with no label when watched labels are set", func() {


### PR DESCRIPTION
# Description

Backport #10118 

# Context

This cherry-pick omits tests added in the kubernetes/e2e as that directory/framework is not present in 1.16

## Testing steps

Manual testing has not been done for 1.16, however the kube2e test running in CI should be sufficient to prove the bug has been fixed

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
