### PR TITLE
trivy ignore pgx cve

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -54,10 +54,11 @@ CVE-2024-34156
 # or later
 CVE-2024-45258
 
-# This CVE affects the packc/pgx dependency which is used in ext-auth-service
+# These CVEs affect the packc/pgx dependency which is used in ext-auth-service
 # The dependency is exclusively used in the monetization feature which we don't believe any customer uses and which is
 # set to be deprecated
-# Nevertheless the CVE has been addressed in the v1.15 LTS branch and later, however it is impractical to resolve in 1.14
+# Nevertheless the CVEs have been addressed in the v1.15 LTS branch and later, however it is impractical to resolve in 1.14
 # due to a number of other requisite dependency bumps
 # Therefore we include this entry for now and should remove it once 1.14 is no longer an LTS branch
 CVE-2024-27289
+CVE-2024-27304

--- a/changelog/v1.18.0-beta25/trivy-ignore-pgx.yaml
+++ b/changelog/v1.18.0-beta25/trivy-ignore-pgx.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Add CVE-2024-27304 to trivyignore as we are not planning on fixing in 1.14 and it does not impact Gateway 
+      functionality.
+      
+      skipCI-kube-tests:true
+      skipCI-storybook-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

Follow-up to https://github.com/solo-io/gloo/pull/10087, there was another pgx CVE that falls into the same category and we will ignore it in 1.14 (fixed in 1.15+)



# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

