### PR TITLE
1.17: envoy: bump to 1.30.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 # for more information, see https://github.com/solo-io/gloo/pull/9633
 # and
 # https://soloio.slab.com/posts/extended-http-methods-design-doc-40j7pjeu
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.30.4-patch4
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.30.6-patch2
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS ?=
 

--- a/changelog/v1.17.11/bump-envoy.yaml
+++ b/changelog/v1.17.11/bump-envoy.yaml
@@ -1,0 +1,12 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo-ee
+    dependencyTag: v1.30.6-patch2
+    description: >
+      Upgrade envoy-gloo to pull in OTel backport for descriptors.
+      Also tackles 
+      CVE-2024-45808: Malicious log injection via access logs
+      CVE-2024-45806: Potential manipulate x-envoy headers from external sources
+      CVE-2024-45809: Jwt filter crash in the clear route cache with remote JWKs
+      CVE-2024-45810: Envoy crashes for LocalReply in http async client


### PR DESCRIPTION
Bump envoy to 1.30.6, this is handled in ee pr already