### PR TITLE
1.17 - Relax gloogateway.Context validation 

### DIFF
--- a/changelog/v1.17.12/production-helm-profiles-in-tests-part2.yaml
+++ b/changelog/v1.17.12/production-helm-profiles-in-tests-part2.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/docs/issues/489
+    resolvesIssue: false
+    description: >-
+      Validate the gloogateway.Context object in a way that it can be invoked by an Enterprise installation

--- a/changelog/v1.17.12/production-helm-profiles-in-tests-part2.yaml
+++ b/changelog/v1.17.12/production-helm-profiles-in-tests-part2.yaml
@@ -1,6 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    issueLink: https://github.com/solo-io/docs/issues/489
-    resolvesIssue: false
-    description: >-
-      Validate the gloogateway.Context object in a way that it can be invoked by an Enterprise installation

--- a/changelog/v1.17.13/production-helm-profiles-in-tests-part2.yaml
+++ b/changelog/v1.17.13/production-helm-profiles-in-tests-part2.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/docs/issues/489
+    resolvesIssue: false
+    description: >-
+      Validate the gloogateway.Context object in a way that it can be invoked by an Enterprise installation

--- a/pkg/utils/helmutils/unmarshal.go
+++ b/pkg/utils/helmutils/unmarshal.go
@@ -1,0 +1,46 @@
+package helmutils
+
+import (
+	"os"
+
+	k8syamlutil "sigs.k8s.io/yaml"
+)
+
+// UnmarshalValuesFile reads a file and returns a map containing the unmarshalled values
+func UnmarshalValuesFile(filePath string) (map[string]interface{}, error) {
+	mapFromFile := map[string]interface{}{}
+
+	bytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+
+	// NOTE: This is not the default golang yaml.Unmarshal, because that implementation
+	// does not unmarshal into a map[string]interface{}; it unmarshals the file into a map[interface{}]interface{}
+	// https://github.com/go-yaml/yaml/issues/139
+	if err := k8syamlutil.Unmarshal(bytes, &mapFromFile); err != nil {
+		return nil, err
+	}
+
+	return mapFromFile, nil
+}
+
+// MergeMaps comes from Helm internals: https://github.com/helm/helm/blob/release-3.0/pkg/cli/values/options.go#L88
+func MergeMaps(a, b map[string]interface{}) map[string]interface{} {
+	out := make(map[string]interface{}, len(a))
+	for k, v := range a {
+		out[k] = v
+	}
+	for k, v := range b {
+		if v, ok := v.(map[string]interface{}); ok {
+			if bv, ok := out[k]; ok {
+				if bv, ok := bv.(map[string]interface{}); ok {
+					out[k] = MergeMaps(bv, v)
+					continue
+				}
+			}
+		}
+		out[k] = v
+	}
+	return out
+}

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -53,6 +53,11 @@ func CreateTestInstallation(
 	runtimeContext := testruntime.NewContext()
 	clusterContext := cluster.MustKindContext(runtimeContext.ClusterName)
 
+	if err := gloogateway.ValidateGlooGatewayContext(glooGatewayContext); err != nil {
+		// We error loudly if the context is misconfigured
+		panic(err)
+	}
+
 	return CreateTestInstallationForCluster(t, runtimeContext, clusterContext, glooGatewayContext)
 }
 
@@ -68,11 +73,6 @@ func CreateTestInstallationForCluster(
 	clusterContext *cluster.Context,
 	glooGatewayContext *gloogateway.Context,
 ) *TestInstallation {
-	if err := glooGatewayContext.Validate(); err != nil {
-		// We error loudly if the context is misconfigured
-		panic(err)
-	}
-
 	installation := &TestInstallation{
 		// RuntimeContext contains the set of properties that are defined at runtime by whoever is invoking tests
 		RuntimeContext: runtimeContext,


### PR DESCRIPTION
Backport #10132

# Context

It is not possible to use OSS validation code from EE, and therefore we are backporting the PR that removed the validation requirement in main

See #10132 for additional context

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
