### PR TITLE
tests: Fix flaky TestWatchNamespaceSelector

### DIFF
--- a/changelog/v1.18.0-beta25/fix-watch-ns.yaml
+++ b/changelog/v1.18.0-beta25/fix-watch-ns.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Fixes the flaky TestMatchLabels that could be caused by not removing the label on a namespace after the test.
+

--- a/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
+++ b/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
@@ -59,6 +59,11 @@ func (s *testingSuite) testWatchNamespaceSelector(key, value string) {
 
 	// The VS defined in the random namespace should be translated
 	s.TestInstallation.Assertions.CurlEventuallyRespondsWithStatus(s.Ctx, "random/", http.StatusOK)
+
+	s.unwatchNamespace(key)
+
+	// Ensure CRs defined in non watched-namespaces are not translated
+	s.TestInstallation.Assertions.CurlConsistentlyRespondsWithStatus(s.Ctx, "random/", http.StatusNotFound)
 }
 
 func (s *testingSuite) TestUnwatchedNamespaceValidation() {

--- a/test/kubernetes/e2e/features/watch_namespace_selector/types.go
+++ b/test/kubernetes/e2e/features/watch_namespace_selector/types.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/solo-io/gloo/test/kubernetes/e2e/tests/base"
 	"github.com/solo-io/skv2/codegen/util"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
@@ -16,7 +17,13 @@ var (
 	installNamespaceVSManifest = filepath.Join(util.MustGetThisDir(), "testdata", "vs-install-ns.yaml")
 
 	unlabeledRandomNamespaceManifest = filepath.Join(util.MustGetThisDir(), "testdata", "random-ns-unlabeled.yaml")
-	randomVSManifest                 = filepath.Join(util.MustGetThisDir(), "testdata", "vs-random.yaml")
+	randomNamespace                  = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "random",
+		},
+	}
+
+	randomVSManifest = filepath.Join(util.MustGetThisDir(), "testdata", "vs-random.yaml")
 
 	randomUpstreamManifest                       = filepath.Join(util.MustGetThisDir(), "testdata", "upstream-random.yaml")
 	installNamespaceWithRandomUpstreamVSManifest = filepath.Join(util.MustGetThisDir(), "testdata", "vs-upstream.yaml")
@@ -36,13 +43,13 @@ var (
 		"TestMatchLabels": {
 			SimpleTestCase: base.SimpleTestCase{
 				Manifests: []string{unlabeledRandomNamespaceManifest, randomVSManifest},
-				Resources: []client.Object{randomNamespaceVS},
+				Resources: []client.Object{randomNamespace, randomNamespaceVS},
 			},
 		},
 		"TestMatchExpressions": {
 			SimpleTestCase: base.SimpleTestCase{
 				Manifests: []string{unlabeledRandomNamespaceManifest, randomVSManifest},
-				Resources: []client.Object{randomNamespaceVS},
+				Resources: []client.Object{randomNamespace, randomNamespaceVS},
 			},
 		},
 		"TestUnwatchedNamespaceValidation": {


### PR DESCRIPTION
# Description

Fixes the flaky TestMatchLabels that could be caused by not removing the label on a namespace after the test.
The presence of the label on the namespace (from the prior test even though the namespace was deleted???) could be present which causes the test to flake.
I've run this test ~20 times without flakes so it appears to be stable now

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
