### PR TITLE
tests: Remove helm from nightly suite

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -243,7 +243,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        kube-e2e-test-type: ['gateway', 'gloo', 'helm', 'upgrade']
+        kube-e2e-test-type: ['gateway', 'gloo', 'upgrade']
         kube-version: [ { node: 'v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b', kubectl: 'v1.25.16', kind: 'v0.20.0', helm: 'v3.13.2' },
                         { node: 'v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865', kubectl: 'v1.31.0', kind: 'v0.24.0', helm: 'v3.14.4' }]
         image-variant:
@@ -272,7 +272,7 @@ jobs:
         #   We should extend the support/usage of those .env files to these other jobs.
         #   The tests are currently in flux, and some of these regression tests are being migrated, so we decided
         #   to limit the scope (and potentially unnecessary work) for now
-        kube-e2e-test-type: ['gateway', 'gloo', 'helm', 'upgrade']
+        kube-e2e-test-type: ['gateway', 'gloo', 'upgrade']
         kube-version: [ { node: 'v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72', kubectl: 'v1.27.3', kind: 'v0.20.0', helm: 'v3.13.2' },
                         { node: 'v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865', kubectl: 'v1.31.0', kind: 'v0.24.0', helm: 'v3.14.4' }]
         image-variant:

--- a/changelog/v1.18.0-beta25/remove-helm-nightly.yaml
+++ b/changelog/v1.18.0-beta25/remove-helm-nightly.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Remove helm tests from nightly suite.
+
+    skipCI-kube-tests:true
+    skipCI-docs-build:true


### PR DESCRIPTION
# Description

Followup to https://github.com/solo-io/gloo/pull/10165

Removes the helm tests from the nightly run

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
