### PR TITLE
tests: Fix wrong path in TestHelmSettings

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -78,7 +78,7 @@ jobs:
         # September 24, 2024: 22 minutes
         - cluster-name: 'cluster-five'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestValidationStrict$$|^TestValidationAlwaysAccept$$|^TestTransformationValidationDisabled$$|^TestGloomtlsGatewayEdgeGateway$$|^TestHelm$$|^TestHelmSettings$$^TestWatchNamespaceSelector$$'
+          go-test-run-regex: '^TestValidationStrict$$|^TestValidationAlwaysAccept$$|^TestTransformationValidationDisabled$$|^TestGloomtlsGatewayEdgeGateway$$|^TestHelm$$|^TestHelmSettings$$|^TestWatchNamespaceSelector$$'
 
         # In our PR tests, we run the suite of tests using the upper ends of versions that we claim to support
         # The versions should mirror: https://docs.solo.io/gloo-edge/latest/reference/support/

--- a/changelog/v1.18.0-beta25/fix-helm-test-path.yaml
+++ b/changelog/v1.18.0-beta25/fix-helm-test-path.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Fix wrong path in TestHelmSettings
+

--- a/test/kubernetes/e2e/features/helm_settings/suite.go
+++ b/test/kubernetes/e2e/features/helm_settings/suite.go
@@ -54,7 +54,7 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 }
 
 func (s *testingSuite) TestApplySettingsManifestsFromUnitTests() {
-	settingsFixturesFolder := filepath.Join(util.GetModuleRoot(), "install", "tests", "fixtures", "settings")
+	settingsFixturesFolder := filepath.Join(util.GetModuleRoot(), "install", "test", "fixtures", "settings")
 
 	err := filepath.Walk(settingsFixturesFolder, func(settingsFixtureFile string, info os.FileInfo, err error) error {
 		if err != nil {


### PR DESCRIPTION
# Description

Fix wrong path in TestHelmSettings

```
--- PASS: TestHelmSettings (101.34s)
    --- PASS: TestHelmSettings/HelmSettings (2.66s)
        --- PASS: TestHelmSettings/HelmSettings/TestApplySettingsManifestsFromUnitTests (2.66s)
PASS

```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
