### PR TITLE
tests: Wait for pods and jobs to complete on upgrades

### DIFF
--- a/changelog/v1.18.0-beta26/tests-wait-on-upgrades.yaml
+++ b/changelog/v1.18.0-beta26/tests-wait-on-upgrades.yaml
@@ -1,4 +1,4 @@
 changelog:
 - type: NON_USER_FACING
-  description: Update tests so all pods are in the Running state and for jobs to complete after an upgrade.
+  description: Update tests to wait until all pods are in the Running state after an upgrade.
 

--- a/changelog/v1.18.0-beta26/tests-wait-on-upgrades.yaml
+++ b/changelog/v1.18.0-beta26/tests-wait-on-upgrades.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Update tests so all pods are in the Running state and for jobs to complete after an upgrade.
+

--- a/test/kubernetes/testutils/helper/install.go
+++ b/test/kubernetes/testutils/helper/install.go
@@ -363,7 +363,6 @@ func (h *SoloTestHelper) UpgradeGloo(ctx context.Context, timeout time.Duration,
 		chartPath,
 		"-n", h.InstallNamespace,
 		"--wait",
-		"--wait-for-jobs",
 		"--history-max",
 		"0",
 	}

--- a/test/kubernetes/testutils/helper/install.go
+++ b/test/kubernetes/testutils/helper/install.go
@@ -362,6 +362,8 @@ func (h *SoloTestHelper) UpgradeGloo(ctx context.Context, timeout time.Duration,
 		h.HelmChartName,
 		chartPath,
 		"-n", h.InstallNamespace,
+		"--wait",
+		"--wait-for-jobs",
 		"--history-max",
 		"0",
 	}


### PR DESCRIPTION
# Description

Modify the testutils so all upgrades wait until all pods are Running after an upgrade before a test can begin.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
