### PR TITLE
tests: Add missing Kubernetes tests to PR runs

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -60,10 +60,10 @@ jobs:
           go-test-args: '-v -timeout=25m'
           go-test-run-regex: '^TestK8sGateway$$/^RouteDelegation$$|^TestK8sGateway$$/^Services$$|^TestGlooctlGlooGatewayEdgeGateway$$|^TestGlooctlK8sGateway$$'
 
-        # Oct 3, 2024: 20 minutes
+        # Oct 3, 2024: 25 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$'
+          go-test-run-regex: '^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$|^TestK8sGateway/HttpListenerOptions$$|^TestK8sGateway/ListenerOptions$$|^TestDiscoveryWatchlabels$$'
 
         # Oct 3, 2024: 25 minutes
         - cluster-name: 'cluster-three'

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -63,7 +63,7 @@ jobs:
         # Oct 3, 2024: 25 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$|^TestK8sGateway$$/^HttpListenerOptions$$|^TestK8sGateway$$/^ListenerOptions$$|^TestDiscoveryWatchlabels$$'
+          go-test-run-regex: '^TestDiscoveryWatchlabels$$|^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$|^TestK8sGateway$$/^HttpListenerOptions$$|^TestK8sGateway$$/^ListenerOptions$$|^TestK8sGateway$$/^GlooAdminServer$$'
 
         # Oct 3, 2024: 25 minutes
         - cluster-name: 'cluster-three'

--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -63,7 +63,7 @@ jobs:
         # Oct 3, 2024: 25 minutes
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$|^TestK8sGateway/HttpListenerOptions$$|^TestK8sGateway/ListenerOptions$$|^TestDiscoveryWatchlabels$$'
+          go-test-run-regex: '^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$|^TestK8sGateway$$/^HttpListenerOptions$$|^TestK8sGateway$$/^ListenerOptions$$|^TestDiscoveryWatchlabels$$'
 
         # Oct 3, 2024: 25 minutes
         - cluster-name: 'cluster-three'

--- a/changelog/v1.18.0-beta26/run-missing-tests.yaml
+++ b/changelog/v1.18.0-beta26/run-missing-tests.yaml
@@ -1,3 +1,5 @@
 changelog:
 - type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/issues/10103
+  resolvesIssue: false
   description: Add missing Kubernetes tests to PR runs.

--- a/changelog/v1.18.0-beta26/run-missing-tests.yaml
+++ b/changelog/v1.18.0-beta26/run-missing-tests.yaml
@@ -1,0 +1,3 @@
+changelog:
+- type: NON_USER_FACING
+  description: Add missing Kubernetes tests to PR runs.

--- a/test/kubernetes/e2e/README.md
+++ b/test/kubernetes/e2e/README.md
@@ -43,7 +43,7 @@ e.g. In order to add a feature suite to be run with the test installation define
 
 ## Adding Tests to CI
 
-When writing new tests, they should be added to the the [`Kubernetes Tests` that run on PRs](https://github.com/solo-io/gloo/blob/47de5cd472a743eebc9355613f5299b3617cd07a/.github/workflows/pr-kubernetes-tests.yaml#L57-L81).
+When writing new tests, they should be added to the the [`Kubernetes Tests` that run on all PRs](https://github.com/solo-io/gloo/blob/47de5cd472a743eebc9355613f5299b3617cd07a/.github/workflows/pr-kubernetes-tests.yaml#L57-L81) if they are not already covered by an existing regex. This way we ensure parity between PR runs and nightlies. Additionally they should be added to the [OSS Tests](https://github.com/solo-io/solo-projects/blob/38bc0ac4b01ff12abaa1ab37aa8d64b6548227e5/test/kubernetes/e2e/tests/oss_test.go#L44-L135) which run in Enterprise that verify that the feature works in Enterprise as well.
 When adding it to the list, ensure that the tests are load balanced to allow quick iteration on PRs and update the date and the duration of corresponding test.
 The only exception to this is the Upgrade tests that are not run on the main branch but all LTS branches.
 

--- a/test/kubernetes/e2e/README.md
+++ b/test/kubernetes/e2e/README.md
@@ -41,6 +41,12 @@ Each `*_test.go` file contains a specific test installation and exists within th
 In order to add a feature suite to be run in a given test installation, it must be added to the exported function in the corresponding `*_tests.go` file.
 e.g. In order to add a feature suite to be run with the test installation defined in `istio_test.go`, we have to register it by adding it to `IstioTests()` in `istio_tests.go` following the existing paradigm.
 
+## Adding Tests to CI
+
+When writing new tests, they should be added to the the [`Kubernetes Tests` that run on PRs](https://github.com/solo-io/gloo/blob/47de5cd472a743eebc9355613f5299b3617cd07a/.github/workflows/pr-kubernetes-tests.yaml#L57-L81).
+When adding it to the list, ensure that the tests are load balanced to allow quick iteration on PRs and update the date and the duration of corresponding test.
+The only exception to this is the Upgrade tests that are not run on the main branch but all LTS branches.
+
 ## Environment Variables
 
 Some tests may require environment variables to be set. Some required env vars are:


### PR DESCRIPTION
# Description

Add missing Kubernetes tests to PR runs. This brings parity between the PR runs and nightly runs except for upgrade tests since main is not an LTS branch

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
