### PR TITLE
Attempt to change http-echo image

### DIFF
--- a/changelog/v1.17.15/change-echo-server-image.yaml
+++ b/changelog/v1.17.15/change-echo-server-image.yaml
@@ -1,0 +1,7 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Change the image used in our kubernetes/e2e tests from kennship/http-echo
+    to jmalloc/echo-server. This image supports http/2. It is also smaller and
+    faster, which may speed up our e2e tests and reduce CI costs.
+

--- a/changelog/v1.17.15/change-echo-server-image.yaml
+++ b/changelog/v1.17.15/change-echo-server-image.yaml
@@ -4,4 +4,6 @@ changelog:
     Change the image used in our kubernetes/e2e tests from kennship/http-echo
     to jmalloc/echo-server. This image supports http/2. It is also smaller and
     faster, which may speed up our e2e tests and reduce CI costs.
+    kennship/http-echo is also an archived project that appears to not have
+    been updated in 6 years.
 

--- a/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
@@ -14,6 +14,7 @@ spec:
     app.kubernetes.io/name: http-echo
   ports:
     - protocol: TCP
+      targetPort: 8080
       port: 3000
 ---
 apiVersion: v1
@@ -26,9 +27,9 @@ metadata:
 spec:
   containers:
   - name: http-echo
-    image: kennship/http-echo@sha256:144322e8e96be2be6675dcf6e3ee15697c5d052d14d240e8914871a2a83990af
+    image: jmalloc/echo-server
     ports:
-      - containerPort: 3000
+      - containerPort: 8080
     resources:
       requests:
         cpu: "100m"

--- a/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
@@ -27,7 +27,8 @@ metadata:
 spec:
   containers:
   - name: http-echo
-    image: jmalloc/echo-server@sha256:c87f80de8dbb976a59b228fc9ecf257e0574c6f760c2f1c5f05f64c7ac7fbc1e
+    # we avoid using checksums so that we automatically select amd64 or arm64
+    image: jmalloc/echo-server@v0.3.7
     ports:
       - containerPort: 8080
     resources:

--- a/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
+++ b/test/kubernetes/e2e/defaults/testdata/http_echo.yaml
@@ -27,7 +27,7 @@ metadata:
 spec:
   containers:
   - name: http-echo
-    image: jmalloc/echo-server
+    image: jmalloc/echo-server@sha256:c87f80de8dbb976a59b228fc9ecf257e0574c6f760c2f1c5f05f64c7ac7fbc1e
     ports:
       - containerPort: 8080
     resources:


### PR DESCRIPTION
# Description

This is just a test to see if we can change the image used for our tests from kennship/http-echo to jmalloc/echo-server. See changelog for details.

CI passes successfully, so it doesn't seem like this change causes any harm. I was hoping that CI runs would be faster since this image is smaller than the previous one, but it does not appear to make any difference - compare to the times for CI to run on [this pull request](https://github.com/solo-io/gloo/actions/runs/11165938304/job/31041201811) as an example and you can see that the times to run do not change much at all.

However, this change does still provide an improvement in that the new image supports HTTP/2 while the other previous image does not:

```
ashish@laptop5 ~/go/src/github.com/solo-io/gloo/test/kubernetes/e2e/features/tracing/testdata $ kubectl -n curl exec -it curl -- curl --http2 http-echo.http-echo.svc.cluster.local:3000
curl: (52) Empty reply from server
command terminated with exit code 52

ashish@laptop5 ~/go/src/github.com/solo-io/gloo/test/kubernetes/e2e/features/tracing/testdata $ kubectl -n curl exec -it curl -- curl http-echo.http-echo.svc.cluster.local:3000
{"path":"/","headers":{"host":"http-echo.http-echo.svc.cluster.local:3000","user-agent":"curl/7.83.1-DEV","accept":"*/*"},"method":"GET","body":{},"fresh":false,"hostname":"http-echo.http-echo.svc.cluster.local","ip":"::ffff:10.244.0.230","ips":[],"protocol":"http","query":{},"subdomains":["svc","http-echo","http-echo"],"xhr":false}
```

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

Change http-echo image to use jmalloc/echo-server instead

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
