### PR TITLE
fix: Handle errors in ggv2 plugins when resource is not in a watched …

### DIFF
--- a/changelog/v1.18.0-beta29/fix-unwatched-resource-npe.yaml
+++ b/changelog/v1.18.0-beta29/fix-unwatched-resource-npe.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/7082
+  resolvesIssue: false
+  description: Fixes a bug where gloo segfaults if resources are applied to a unwatched namespace.
+

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
+	"github.com/rotisserie/eris"
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 	"github.com/solo-io/go-utils/contextutils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
@@ -133,9 +135,14 @@ func (p *plugin) ApplyStatusPlugin(ctx context.Context, statusCtx *plugins.Statu
 		}
 	}
 	routeOptionReport := make(reporter.ResourceReports)
+	var multierr *multierror.Error
 	for roKey, status := range p.legacyStatusCache {
 		// get the obj by namespacedName
-		roObj, _ := p.routeOptionClient.Read(roKey.Namespace, roKey.Name, clients.ReadOpts{Ctx: ctx})
+		roObj, err := p.routeOptionClient.Read(roKey.Namespace, roKey.Name, clients.ReadOpts{Ctx: ctx})
+		if err != nil {
+			multierr = multierror.Append(multierr, eris.Wrapf(err, "error reading RouteOption %s in namespace %s", roKey.Name, roKey.Namespace))
+			continue
+		}
 
 		// mark this object to be processed
 		routeOptionReport.Accept(roObj)
@@ -146,12 +153,13 @@ func (p *plugin) ApplyStatusPlugin(ctx context.Context, statusCtx *plugins.Statu
 		}
 
 		// actually write out the reports!
-		err := p.statusReporter.WriteReports(ctx, routeOptionReport, status.subresourceStatus)
+		err = p.statusReporter.WriteReports(ctx, routeOptionReport, status.subresourceStatus)
 		if err != nil {
-			return fmt.Errorf("error writing status report from RouteOptionPlugin: %w", err)
+			multierr = multierror.Append(multierr, fmt.Errorf("error writing status report from RouteOptionPlugin: %w", err))
+			continue
 		}
 	}
-	return nil
+	return multierr.ErrorOrNil()
 }
 
 // tracks the attachment of a RouteOption so we know which RouteOptions to report status for


### PR DESCRIPTION
…namespace

# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
