### PR TITLE
Install script - don't pull amd64 bin on arm64

### DIFF
--- a/changelog/v1.18.0-beta29/install-script-arm64.yaml
+++ b/changelog/v1.18.0-beta29/install-script-arm64.yaml
@@ -1,0 +1,3 @@
+changelog:
+  - type: NON_USER_FACING
+    description: Fix install script to pull correct `glooctl` binaries by arch

--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -39,8 +39,12 @@ else
   OS=linux
 fi
 
-# TODO (celsosantos): Add ARM64 binaries support
-GOARCH=amd64
+arch=$(uname -m)
+if [ "$arch" = "aarch64" ] || [ "$arch" = "arm64" ]; then
+  GOARCH=arm64
+else
+  GOARCH=amd64
+fi
 
 for gloo_version in $GLOO_VERSIONS; do
 


### PR DESCRIPTION
# Description

On linux-aarch64 (or darwin), pull the correct published binary instead of the hardcoded one in the install script.

