### PR TITLE
[Documenation] Update istio version support

### DIFF
--- a/changelog/v1.18.0-beta29/istio-version-documentation-update.yaml
+++ b/changelog/v1.18.0-beta29/istio-version-documentation-update.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Clarify that Waypoint support requires Istio version 1.22 or greater

--- a/docs/content/reference/support.md
+++ b/docs/content/reference/support.md
@@ -17,7 +17,10 @@ Gloo Gateway Enterprise offers `n-3` patching support for bug and critical secur
 | 1.15.x | 1.23 - 1.27 | v3 xDS API | >= 3.11 | 1.13 - 1.18 |
 | 1.14.x | 1.23 - 1.25 | v3 xDS API | >= 3.8 | 1.13 - 1.18 |
 
-{{% notice note %}}`†` **Istio versions**: Istio must run on a compatible version of Kubernetes. For example, Istio 1.22 is tested, but not supported, on Kubernetes 1.26. For more information, see the [Istio docs](https://istio.io/latest/docs/releases/supported-releases/). If you want hardened `n-4` versions of Istio for particular requirements such as FIPS, consider using [Gloo Mesh Enterprise](https://www.solo.io/products/gloo-mesh/), which includes ingress gateway and service mesh components.{{% /notice %}}
+{{% notice note %}}`†` **Istio versions**: Istio must run on a compatible version of Kubernetes. For example, Istio 1.22 is tested, but not supported, on Kubernetes 1.26. For more information, see the [Istio docs](https://istio.io/latest/docs/releases/supported-releases/). If you want hardened `n-4` versions of Istio for particular requirements such as FIPS, consider using [Gloo Mesh Enterprise](https://www.solo.io/products/gloo-mesh/), which includes ingress gateway and service mesh components.
+
+Also, note that Waypoint support requires at minimum Istio version 1.22 (though 1.23 or greater is recommended). {{% /notice %}}
+
 
 <!--TO FIND VERSIONS
 For 1.17 and later, go to the version branch, such as v1.17.x. In the .github/workflows.env/nightly-tests directory, open the min_versions.env and max_versions.env files. Example on main: https://github.com/solo-io/gloo/tree/main/.github/workflows/.env/nightly-tests -->


### PR DESCRIPTION
# Description

Update documentation to clarify which version of istio is required for waypoint support.

Context: https://github.com/solo-io/solo-projects/pull/7106


## Docs changes

💯 
