### PR TITLE
aws_sts_cluster static cluster config for kubernetes gateway api

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -83,7 +83,7 @@ jobs:
         # October 10, 2024: 12 minutes
         - cluster-name: 'cluster-six'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestDiscoveryWatchlabels$$|^TestK8sGatewayNoValidation$$|^TestHelm$$|^TestHelmSettings$$'
+          go-test-run-regex: '^TestDiscoveryWatchlabels$$|^TestK8sGatewayNoValidation$$|^TestHelm$$|^TestHelmSettings$$|^TestK8sGatewayAws$$'
 
         # In our PR tests, we run the suite of tests using the upper ends of versions that we claim to support
         # The versions should mirror: https://docs.solo.io/gloo-edge/latest/reference/support/

--- a/changelog/v1.18.0-beta31/aws-sts-cluster-config.yaml
+++ b/changelog/v1.18.0-beta31/aws-sts-cluster-config.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/6847
+    resolvesIssue: false
+    description: >-
+      The existing Helm values `settings.aws.enableServiceAccountCredentials` and `settings.aws.stsCredentialsRegion` are now respected when using Kubernetes Gateway API,
+      as part of supporting [AWS Lambda with EKS ServiceAccounts](https://docs.solo.io/gloo-edge/latest/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/).
+      When `settings.aws.enableServiceAccountCredentials` is true, a `aws_sts_cluster` cluster, configured with the STS endpoint specified by `settings.aws.stsCredentialsRegion`,
+      will automatically be added to dynamically provisioned proxies, so that Envoy can reach AWS to assume the role needed to access Lambdas.

--- a/install/test/k8sgateway_test.go
+++ b/install/test/k8sgateway_test.go
@@ -1,7 +1,6 @@
 package test
 
 import (
-	"encoding/json"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -66,14 +65,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 				testManifest.Expect("ClusterRoleBinding", "", deployerRbacName+"-binding").NotTo(BeNil())
 			})
 			It("renders default GatewayParameters", func() {
-				gwpUnstructured := testManifest.ExpectCustomResource("GatewayParameters", namespace, wellknown.DefaultGatewayParametersName)
-				Expect(gwpUnstructured).NotTo(BeNil())
-
-				var gwp v1alpha1.GatewayParameters
-				b, err := gwpUnstructured.MarshalJSON()
-				Expect(err).ToNot(HaveOccurred())
-				err = json.Unmarshal(b, &gwp)
-				Expect(err).ToNot(HaveOccurred())
+				gwp := getDefaultGatewayParameters(testManifest)
 
 				gwpKube := gwp.Spec.Kube
 				Expect(gwpKube).ToNot(BeNil())
@@ -194,14 +186,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 					valuesArgs = append(valuesArgs, extraValuesArgs...)
 				})
 				It("passes overrides to default GatewayParameters with Istio container", func() {
-					gwpUnstructured := testManifest.ExpectCustomResource("GatewayParameters", namespace, wellknown.DefaultGatewayParametersName)
-					Expect(gwpUnstructured).NotTo(BeNil())
-
-					var gwp v1alpha1.GatewayParameters
-					b, err := gwpUnstructured.MarshalJSON()
-					Expect(err).ToNot(HaveOccurred())
-					err = json.Unmarshal(b, &gwp)
-					Expect(err).ToNot(HaveOccurred())
+					gwp := getDefaultGatewayParameters(testManifest)
 
 					gwpKube := gwp.Spec.Kube
 					Expect(gwpKube).ToNot(BeNil())
@@ -309,14 +294,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 					valuesArgs = append(valuesArgs, extraValuesArgs...)
 				})
 				It("passes overrides to default GatewayParameters with custom sidecar", func() {
-					gwpUnstructured := testManifest.ExpectCustomResource("GatewayParameters", namespace, wellknown.DefaultGatewayParametersName)
-					Expect(gwpUnstructured).NotTo(BeNil())
-
-					var gwp v1alpha1.GatewayParameters
-					b, err := gwpUnstructured.MarshalJSON()
-					Expect(err).ToNot(HaveOccurred())
-					err = json.Unmarshal(b, &gwp)
-					Expect(err).ToNot(HaveOccurred())
+					gwp := getDefaultGatewayParameters(testManifest)
 
 					gwpKube := gwp.Spec.Kube
 					Expect(gwpKube).ToNot(BeNil())
@@ -351,12 +329,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 					// Updated values so need to re-render
 					prepareHelmManifest(namespace, glootestutils.HelmValues{ValuesArgs: valuesArgs})
 
-					gwpUnstructured := testManifest.ExpectCustomResource("GatewayParameters", namespace, wellknown.DefaultGatewayParametersName)
-					obj, err := kuberesource.ConvertUnstructured(gwpUnstructured)
-					Expect(err).NotTo(HaveOccurred())
-
-					gwp, ok := obj.(*v1alpha1.GatewayParameters)
-					Expect(ok).To(BeTrue())
+					gwp := getDefaultGatewayParameters(testManifest)
 
 					gwpKube := gwp.Spec.Kube
 					Expect(gwpKube).ToNot(BeNil())
@@ -404,3 +377,13 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 	}
 	runTests(allTests)
 })
+
+func getDefaultGatewayParameters(t TestManifest) *v1alpha1.GatewayParameters {
+	gwpUnstructured := t.ExpectCustomResource("GatewayParameters", namespace, wellknown.DefaultGatewayParametersName)
+	obj, err := kuberesource.ConvertUnstructured(gwpUnstructured)
+	Expect(err).NotTo(HaveOccurred())
+
+	gwp, ok := obj.(*v1alpha1.GatewayParameters)
+	Expect(ok).To(BeTrue())
+	return gwp
+}

--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -50,6 +50,7 @@ type GatewayConfig struct {
 
 	ControlPlane            deployer.ControlPlaneInfo
 	IstioIntegrationEnabled bool
+	Aws                     *deployer.AwsInfo
 
 	Extensions extensions.K8sGatewayExtensions
 }
@@ -168,6 +169,7 @@ func (c *controllerBuilder) watchGw(ctx context.Context) error {
 		Dev:                     c.cfg.Dev,
 		IstioIntegrationEnabled: c.cfg.IstioIntegrationEnabled,
 		ControlPlane:            c.cfg.ControlPlane,
+		Aws:                     c.cfg.Aws,
 	})
 	if err != nil {
 		return err

--- a/projects/gateway2/deployer/deployer.go
+++ b/projects/gateway2/deployer/deployer.go
@@ -55,12 +55,19 @@ type ControlPlaneInfo struct {
 	XdsPort int32
 }
 
+type AwsInfo struct {
+	EnableServiceAccountCredentials bool
+	StsClusterName                  string
+	StsUri                          string
+}
+
 // Inputs is the set of options used to configure the gateway deployer deployment
 type Inputs struct {
 	ControllerName          string
 	Dev                     bool
 	IstioIntegrationEnabled bool
 	ControlPlane            ControlPlaneInfo
+	Aws                     *AwsInfo
 }
 
 // NewDeployer creates a new gateway deployer
@@ -338,6 +345,11 @@ func (d *Deployer) getValues(gw *api.Gateway, gwParam *v1alpha1.GatewayParameter
 	gateway.Istio = getIstioValues(d.inputs.IstioIntegrationEnabled, istioConfig)
 	gateway.SdsContainer = getSdsContainerValues(sdsContainerConfig)
 	gateway.IstioContainer = getIstioContainerValues(istioContainerConfig)
+
+	// aws values
+	gateway.Aws = getAwsValues(d.inputs.Aws)
+
+	// ai values
 	gateway.AIExtension, err = getAIExtensionValues(aiExtensionConfig)
 	if err != nil {
 		return nil, err

--- a/projects/gateway2/deployer/values.go
+++ b/projects/gateway2/deployer/values.go
@@ -58,6 +58,9 @@ type helmGateway struct {
 
 	// AI extension values
 	AIExtension *helmAIExtension `json:"aiExtension,omitempty"`
+
+	// AWS values
+	Aws *helmAws `json:"aws,omitempty"`
 }
 
 // helmPort represents a Gateway Listener port
@@ -145,4 +148,10 @@ type helmAIExtension struct {
 	Env             []*corev1.EnvVar             `json:"env,omitempty"`
 	Ports           []*corev1.ContainerPort      `json:"ports,omitempty"`
 	Stats           []byte                       `json:"stats,omitempty"`
+}
+
+type helmAws struct {
+	EnableServiceAccountCredentials *bool   `json:"enableServiceAccountCredentials,omitempty"`
+	StsClusterName                  *string `json:"stsClusterName,omitempty"`
+	StsUri                          *string `json:"stsUri,omitempty"`
 }

--- a/projects/gateway2/deployer/values_helpers.go
+++ b/projects/gateway2/deployer/values_helpers.go
@@ -145,6 +145,18 @@ func getIstioValues(istioIntegrationEnabled bool, istioConfig *v1alpha1.IstioInt
 	}
 }
 
+// Converts AwsInfo (which come from Settings values) into aws helm values
+func getAwsValues(awsInfo *AwsInfo) *helmAws {
+	if awsInfo != nil {
+		return &helmAws{
+			EnableServiceAccountCredentials: &awsInfo.EnableServiceAccountCredentials,
+			StsClusterName:                  &awsInfo.StsClusterName,
+			StsUri:                          &awsInfo.StsUri,
+		}
+	}
+	return nil
+}
+
 // Get the image values for the envoy container in the proxy deployment.
 func getImageValues(image *v1alpha1.Image) *helmImage {
 	if image == nil {

--- a/projects/gateway2/helm/gloo-gateway/templates/gateway/proxy-deployment.yaml
+++ b/projects/gateway2/helm/gloo-gateway/templates/gateway/proxy-deployment.yaml
@@ -542,6 +542,26 @@ data:
                         address: 127.0.0.1
                         port_value: 8234
         {{- end }} {{/* if $gateway.istio.enabled */}}
+        {{- if ($gateway.aws).enableServiceAccountCredentials }}
+        - name: {{ $gateway.aws.stsClusterName }}
+          connect_timeout: 5.000s
+          type: LOGICAL_DNS
+          lb_policy: ROUND_ROBIN
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+              sni: {{ $gateway.aws.stsUri }}
+          load_assignment:
+            cluster_name: {{ $gateway.aws.stsClusterName }}
+            endpoints:
+            - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      port_value: 443
+                      address: {{ $gateway.aws.stsUri }}
+        {{- end}} {{- /* if ($gateway.aws).enableServiceAccountCredentials */}}
     dynamic_resources:
       ads_config:
         transport_api_version: V3

--- a/test/kubernetes/e2e/tests/k8s_gw_aws_test.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_aws_test.go
@@ -1,0 +1,60 @@
+package tests_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/solo-io/gloo/pkg/utils/envutils"
+	"github.com/solo-io/gloo/test/kubernetes/e2e"
+	. "github.com/solo-io/gloo/test/kubernetes/e2e/tests"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/gloogateway"
+	"github.com/solo-io/gloo/test/testutils"
+)
+
+// TestK8sGatewayAws is the function which executes a series of tests against a given installation
+// with Kubernetes Gateway integration enabled and AWS lambda options configured
+func TestK8sGatewayAws(t *testing.T) {
+	ctx := context.Background()
+	installNs, nsEnvPredefined := envutils.LookupOrDefault(testutils.InstallNamespace, "k8s-gw-aws-test")
+	testInstallation := e2e.CreateTestInstallation(
+		t,
+		&gloogateway.Context{
+			InstallNamespace:          installNs,
+			ProfileValuesManifestFile: e2e.KubernetesGatewayProfilePath,
+			ValuesManifestFile:        e2e.ManifestPath("aws-lambda-helm.yaml"),
+			K8sGatewayEnabled:         true,
+			// these should correspond to the `settings.aws.*` values in the aws-lambda-helm.yaml manifest
+			AwsOptions: &gloogateway.AwsOptions{
+				EnableServiceAccountCredentials: true,
+				StsCredentialsRegion:            "us-west-2",
+			},
+		},
+	)
+
+	testHelper := e2e.MustTestHelper(ctx, testInstallation)
+
+	// Set the env to the install namespace if it is not already set
+	if !nsEnvPredefined {
+		os.Setenv(testutils.InstallNamespace, installNs)
+	}
+
+	// We register the cleanup function _before_ we actually perform the installation.
+	// This allows us to uninstall Gloo Gateway, in case the original installation only completed partially
+	t.Cleanup(func() {
+		if !nsEnvPredefined {
+			os.Unsetenv(testutils.InstallNamespace)
+		}
+		if t.Failed() {
+			testInstallation.PreFailHandler(ctx)
+		}
+
+		testInstallation.UninstallGlooGatewayWithTestHelper(ctx, testHelper)
+	})
+
+	// Install Gloo Gateway
+	testInstallation.InstallGlooGatewayWithTestHelper(ctx, testHelper, 5*time.Minute)
+
+	KubeGatewayAwsSuiteRunner().Run(ctx, t, testInstallation)
+}

--- a/test/kubernetes/e2e/tests/k8s_gw_aws_tests.go
+++ b/test/kubernetes/e2e/tests/k8s_gw_aws_tests.go
@@ -1,0 +1,14 @@
+package tests
+
+import (
+	"github.com/solo-io/gloo/test/kubernetes/e2e"
+	"github.com/solo-io/gloo/test/kubernetes/e2e/features/deployer"
+)
+
+func KubeGatewayAwsSuiteRunner() e2e.SuiteRunner {
+	runner := e2e.NewSuiteRunner(false)
+
+	runner.Register("Deployer", deployer.NewTestingSuite)
+
+	return runner
+}

--- a/test/kubernetes/e2e/tests/manifests/aws-lambda-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/aws-lambda-helm.yaml
@@ -1,0 +1,4 @@
+settings:
+  aws:
+    enableServiceAccountCredentials: true
+    stsCredentialsRegion: us-west-2

--- a/test/kubernetes/testutils/gloogateway/context.go
+++ b/test/kubernetes/testutils/gloogateway/context.go
@@ -28,6 +28,9 @@ type Context struct {
 	// i.e. if this is set to true, the webhook will accept regardless of errors found during validation
 	ValidationAlwaysAccept bool
 
+	// is populated if the installation has any AWS options configured (via `settings.aws.*` Helm values)
+	AwsOptions *AwsOptions
+
 	// TestAssetDir is the directory holding the test assets. Must be relative to RootDir.
 	TestAssetDir string
 
@@ -45,6 +48,15 @@ type Context struct {
 
 	// The path to the local helm chart used for testing. Based on the TestAssertDir and relative to RootDir.
 	ChartUri string
+}
+
+// AWS options that the installation was configured with
+type AwsOptions struct {
+	// corresponds to the `settings.aws.enableServiceAccountCredentials` helm value
+	EnableServiceAccountCredentials bool
+
+	// corresponds to the `settings.aws.stsCredentialsRegion` helm value
+	StsCredentialsRegion string
 }
 
 // ValidateGlooGatewayContext returns an error if the provided Context is invalid


### PR DESCRIPTION
# Description

As part of supporting [AWS Lambda with EKS ServiceAccounts](https://docs.solo.io/gloo-edge/latest/guides/traffic_management/destination_types/aws_lambda/eks-service-accounts/) with the Kubernetes Gateway API, the existing Helm values `settings.aws.enableServiceAccountCredentials` and `settings.aws.stsCredentialsRegion` are now respected when using Kubernetes Gateway API. 

The AWS options from Settings CR (which are configured at install time) are passed through to the kubernetes gateway controller. When `enableServiceAccountCredentials` is true, a `aws_sts_cluster` cluster, configured with the STS endpoint specified by `stsCredentialsRegion`, will automatically be added to dynamically provisioned proxies, so that Envoy can reach AWS to assume the role needed to access Lambdas.

## Testing

The following tests were added:
- Deployer unit tests showing that passing aws options to the deployer results in the expected envoy cluster config
- Added new TestK8sGatewayAws kubernetes e2e test suite which installs GG with aws options configured. For now it only runs the Deployer tests, to make sure that the aws options are correctly passed through to the configured proxies.
- For a complete e2e test using aws/lambda, we plan to run our k8s gateway lambda workshop using a dev build with these changes and verify all steps in the workshop succeed

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works