### PR TITLE
Make k8s gateway Service labels/annotations configurable via helm

### DIFF
--- a/changelog/v1.18.0-beta31/k8s-gw-svc-extra-anno.yaml
+++ b/changelog/v1.18.0-beta31/k8s-gw-svc-extra-anno.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/solo-projects/issues/7090
+    resolvesIssue: false
+    description: >-
+      Expose new Helm values `kubeGateway.gatewayParameters.glooGateway.service.extraLabels` and
+      `kubeGateway.gatewayParameters.glooGateway.service.extraAnnotations` to set extra labels and
+      extra annotations on the default GatewayParameters.

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -40,6 +40,8 @@
 |kubeGateway.gatewayParameters.glooGateway.envoyContainer.resources.requests.cpu|string||amount of CPUs|
 |kubeGateway.gatewayParameters.glooGateway.proxyDeployment.replicas|int32|1|number of instances to deploy. If set to null, a default of 1 will be imposed.|
 |kubeGateway.gatewayParameters.glooGateway.service.type|string|LoadBalancer|K8s service type. If set to null, a default of LoadBalancer will be imposed.|
+|kubeGateway.gatewayParameters.glooGateway.service.extraLabels.NAME|string||Extra labels to add to the service.|
+|kubeGateway.gatewayParameters.glooGateway.service.extraAnnotations.NAME|string||Extra annotations to add to the service.|
 |kubeGateway.gatewayParameters.glooGateway.serviceAccount.extraLabels.NAME|string||Extra labels to add to the service account.|
 |kubeGateway.gatewayParameters.glooGateway.serviceAccount.extraAnnotations.NAME|string||Extra annotations to add to the service account.|
 |kubeGateway.gatewayParameters.glooGateway.sdsContainer.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -354,7 +354,9 @@ type ProvisionedDeployment struct {
 }
 
 type ProvisionedService struct {
-	Type *string `json:"type,omitempty" desc:"K8s service type. If set to null, a default of LoadBalancer will be imposed."`
+	Type             *string           `json:"type,omitempty" desc:"K8s service type. If set to null, a default of LoadBalancer will be imposed."`
+	ExtraLabels      map[string]string `json:"extraLabels,omitempty" desc:"Extra labels to add to the service."`
+	ExtraAnnotations map[string]string `json:"extraAnnotations,omitempty" desc:"Extra annotations to add to the service."`
 }
 
 type ProvisionedServiceAccount struct {

--- a/install/helm/gloo/templates/43-gatewayparameters.yaml
+++ b/install/helm/gloo/templates/43-gatewayparameters.yaml
@@ -31,6 +31,14 @@ spec:
 {{- end }}{{/* if $gg.service */}}
     service:
       type: {{ $serviceType }}
+      {{- with ($gg.service).extraLabels }}
+      extraLabels:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with ($gg.service).extraAnnotations }}
+      extraAnnotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- if $gg.serviceAccount }}
     serviceAccount:
       {{- with $gg.serviceAccount.extraLabels }}

--- a/install/test/k8sgateway_test.go
+++ b/install/test/k8sgateway_test.go
@@ -151,6 +151,8 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 						fmt.Sprintf("kubeGateway.gatewayParameters.glooGateway.envoyContainer.resources.limits.cpu=%s", envoyLimits["cpu"].ToUnstructured()),
 						"kubeGateway.gatewayParameters.glooGateway.proxyDeployment.replicas=5",
 						"kubeGateway.gatewayParameters.glooGateway.service.type=ClusterIP",
+						"kubeGateway.gatewayParameters.glooGateway.service.extraLabels.svclabel1=x",
+						"kubeGateway.gatewayParameters.glooGateway.service.extraAnnotations.svcanno1=y",
 						"kubeGateway.gatewayParameters.glooGateway.serviceAccount.extraLabels.label1=a",
 						"kubeGateway.gatewayParameters.glooGateway.serviceAccount.extraAnnotations.anno1=b",
 						"kubeGateway.gatewayParameters.glooGateway.sdsContainer.image.tag=sds-override-tag",
@@ -242,6 +244,8 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 					Expect(gwpKube.GetSdsContainer().GetResources().Limits).To(matchers.ContainMapElements(sdsLimits))
 
 					Expect(*gwpKube.GetService().GetType()).To(Equal(corev1.ServiceTypeClusterIP))
+					Expect(gwpKube.GetService().GetExtraLabels()).To(matchers.ContainMapElements(map[string]string{"svclabel1": "x"}))
+					Expect(gwpKube.GetService().GetExtraAnnotations()).To(matchers.ContainMapElements(map[string]string{"svcanno1": "y"}))
 
 					Expect(gwpKube.GetServiceAccount().GetExtraLabels()).To(matchers.ContainMapElements(map[string]string{"label1": "a"}))
 					Expect(gwpKube.GetServiceAccount().GetExtraAnnotations()).To(matchers.ContainMapElements(map[string]string{"anno1": "b"}))
@@ -276,6 +280,8 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 						"kubeGateway.gatewayParameters.glooGateway.envoyContainer.image.pullPolicy=Always",
 						"kubeGateway.gatewayParameters.glooGateway.proxyDeployment.replicas=5",
 						"kubeGateway.gatewayParameters.glooGateway.service.type=ClusterIP",
+						"kubeGateway.gatewayParameters.glooGateway.service.extraLabels.svclabel1=a",
+						"kubeGateway.gatewayParameters.glooGateway.service.extraAnnotations.svcanno1=b",
 						"kubeGateway.gatewayParameters.glooGateway.serviceAccount.extraLabels.label1=a",
 						"kubeGateway.gatewayParameters.glooGateway.serviceAccount.extraAnnotations.anno1=b",
 						"kubeGateway.gatewayParameters.glooGateway.sdsContainer.image.tag=sds-override-tag",
@@ -316,6 +322,8 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 					Expect(*gwpKube.GetSdsContainer().GetBootstrap().GetLogLevel()).To(Equal("debug"))
 
 					Expect(*gwpKube.GetService().GetType()).To(Equal(corev1.ServiceTypeClusterIP))
+					Expect(gwpKube.GetService().GetExtraLabels()).To(matchers.ContainMapElements(map[string]string{"svclabel1": "a"}))
+					Expect(gwpKube.GetService().GetExtraAnnotations()).To(matchers.ContainMapElements(map[string]string{"svcanno1": "b"}))
 
 					Expect(gwpKube.GetServiceAccount().GetExtraLabels()).To(matchers.ContainMapElements(map[string]string{"label1": "a"}))
 					Expect(gwpKube.GetServiceAccount().GetExtraAnnotations()).To(matchers.ContainMapElements(map[string]string{"anno1": "b"}))

--- a/projects/gateway2/deployer/deployer_test.go
+++ b/projects/gateway2/deployer/deployer_test.go
@@ -199,6 +199,9 @@ var _ = Describe("Deployer", func() {
 						Service: &gw2_v1alpha1.Service{
 							Type:      ptr.To(corev1.ServiceTypeClusterIP),
 							ClusterIP: ptr.To("99.99.99.99"),
+							ExtraLabels: map[string]string{
+								"foo-label": "bar-label",
+							},
 							ExtraAnnotations: map[string]string{
 								"foo": "bar",
 							},
@@ -578,6 +581,9 @@ var _ = Describe("Deployer", func() {
 							Service: &gw2_v1alpha1.Service{
 								Type:      ptr.To(corev1.ServiceTypeClusterIP),
 								ClusterIP: ptr.To("99.99.99.99"),
+								ExtraLabels: map[string]string{
+									"override-foo-label": "override-bar-label",
+								},
 								ExtraAnnotations: map[string]string{
 									"override-foo": "override-bar",
 								},
@@ -640,6 +646,10 @@ var _ = Describe("Deployer", func() {
 							Service: &gw2_v1alpha1.Service{
 								Type:      ptr.To(corev1.ServiceTypeClusterIP),
 								ClusterIP: ptr.To("99.99.99.99"),
+								ExtraLabels: map[string]string{
+									"foo-label":          "bar-label",
+									"override-foo-label": "override-bar-label",
+								},
 								ExtraAnnotations: map[string]string{
 									"foo":          "bar",
 									"override-foo": "override-bar",
@@ -793,7 +803,9 @@ var _ = Describe("Deployer", func() {
 				svc := objs.findService(defaultNamespace, defaultServiceName)
 				Expect(svc).ToNot(BeNil())
 				Expect(svc.GetAnnotations()).ToNot(BeNil())
-				Expect(svc.Annotations).To(matchers.ContainMapElements(expectedGwp.Service.ExtraAnnotations))
+				Expect(svc.GetAnnotations()).To(matchers.ContainMapElements(expectedGwp.Service.ExtraAnnotations))
+				Expect(svc.GetLabels()).ToNot(BeNil())
+				Expect(svc.GetLabels()).To(matchers.ContainMapElements(expectedGwp.Service.ExtraLabels))
 				Expect(svc.Spec.Type).To(Equal(*expectedGwp.Service.Type))
 				Expect(svc.Spec.ClusterIP).To(Equal(*expectedGwp.Service.ClusterIP))
 
@@ -907,7 +919,9 @@ var _ = Describe("Deployer", func() {
 			svc := objs.findService(defaultNamespace, defaultServiceName)
 			Expect(svc).ToNot(BeNil())
 			Expect(svc.GetAnnotations()).ToNot(BeNil())
-			Expect(svc.Annotations).To(matchers.ContainMapElements(expectedGwp.Service.ExtraAnnotations))
+			Expect(svc.GetAnnotations()).To(matchers.ContainMapElements(expectedGwp.Service.ExtraAnnotations))
+			Expect(svc.GetLabels()).ToNot(BeNil())
+			Expect(svc.GetLabels()).To(matchers.ContainMapElements(expectedGwp.Service.ExtraLabels))
 			Expect(svc.Spec.Type).To(Equal(*expectedGwp.Service.Type))
 			Expect(svc.Spec.ClusterIP).To(Equal(*expectedGwp.Service.ClusterIP))
 

--- a/test/kubernetes/e2e/features/deployer/suite.go
+++ b/test/kubernetes/e2e/features/deployer/suite.go
@@ -130,6 +130,17 @@ func (s *testingSuite) TestConfigureProxiesFromGatewayParameters() {
 	s.testInstallation.Assertions.Gomega.Expect(sa.GetAnnotations()).To(
 		gomega.HaveKeyWithValue("sa-anno-key", "sa-anno-val"))
 
+	// check that the labels and annotations got passed through from GatewayParameters to the Service
+	svc := &corev1.Service{}
+	err = s.testInstallation.ClusterContext.Client.Get(s.ctx,
+		types.NamespacedName{Name: glooProxyObjectMeta.Name, Namespace: glooProxyObjectMeta.Namespace},
+		svc)
+	s.Require().NoError(err)
+	s.testInstallation.Assertions.Gomega.Expect(svc.GetLabels()).To(
+		gomega.HaveKeyWithValue("svc-label-key", "svc-label-val"))
+	s.testInstallation.Assertions.Gomega.Expect(svc.GetAnnotations()).To(
+		gomega.HaveKeyWithValue("svc-anno-key", "svc-anno-val"))
+
 	// Update the Gateway to use the custom GatewayParameters
 	gwName := types.NamespacedName{Name: gw.Name, Namespace: gw.Namespace}
 	err = s.testInstallation.ClusterContext.Client.Get(s.ctx, gwName, gw)

--- a/test/kubernetes/e2e/features/deployer/testdata/gateway-with-parameters.yaml
+++ b/test/kubernetes/e2e/features/deployer/testdata/gateway-with-parameters.yaml
@@ -41,6 +41,11 @@ spec:
         pod-label-key: pod-label-val
       extraAnnotations:
         pod-anno-key: pod-anno-val
+    service:
+      extraLabels:
+        svc-label-key: svc-label-val
+      extraAnnotations:
+        svc-anno-key: svc-anno-val
     serviceAccount:
       extraLabels:
         sa-label-key: sa-label-val


### PR DESCRIPTION
# Description

For kubernetes gateway api: Add new helm values `kubeGateway.gatewayParameters.glooGateway.service.extraLabels` and `kubeGateway.gatewayParameters.glooGateway.service.extraAnnotations` to configure the proxy service's default labels/annotations. (Note that these values already existed on GatewayParameters via `spec.kube.service.extraLabels` and `spec.kube.service.extraAnnotations`; this PR just allows them to be set via helm values at install time)



# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

