### PR TITLE
ggv2: make cluster names parseable

### DIFF
--- a/projects/gateway2/proxy_syncer/endpoints.go
+++ b/projects/gateway2/proxy_syncer/endpoints.go
@@ -11,14 +11,12 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
-	"github.com/solo-io/gloo/pkg/utils/envutils"
 	"github.com/solo-io/gloo/projects/gateway2/krtcollections"
 	ggv2utils "github.com/solo-io/gloo/projects/gateway2/utils"
 	"github.com/solo-io/gloo/projects/gloo/constants"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	glookubev1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
 	kubeplugin "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/kubernetes"
-	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/translator"
 	"github.com/solo-io/go-utils/contextutils"
 	"istio.io/istio/pkg/kube"
@@ -323,13 +321,7 @@ func findFirstPortInEndpointSubsets(subset corev1.EndpointSubset, singlePortServ
 }
 
 func getEndpointClusterName(upstream *v1.Upstream) string {
-	// TODO it would be nice to avoid duplicating the env logic
-	legacyClusterNames := envutils.IsEnvTruthy(constants.GlooGatewayKubeStyleClusterNames)
-	clusterName, ok := kubernetes.ClusterNameForKube(upstream)
-	if !ok || legacyClusterNames {
-		clusterName = translator.UpstreamToClusterName(upstream.GetMetadata().Ref())
-	}
-
+	clusterName := translator.KubeGatewayUpstreamToClusterName(upstream)
 	endpointClusterName, err := translator.GetEndpointClusterName(clusterName, upstream)
 	if err != nil {
 		panic(err)

--- a/projects/gateway2/proxy_syncer/kube_gw_translator_syncer.go
+++ b/projects/gateway2/proxy_syncer/kube_gw_translator_syncer.go
@@ -8,10 +8,8 @@ import (
 	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
 	"istio.io/istio/pkg/kube/krt"
 
-	"github.com/solo-io/gloo/pkg/utils/envutils"
 	"github.com/solo-io/gloo/pkg/utils/settingsutil"
 	"github.com/solo-io/gloo/pkg/utils/statsutils"
-	"github.com/solo-io/gloo/projects/gloo/constants"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	v1snap "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/gloosnapshot"
@@ -66,12 +64,10 @@ func (s *ProxyTranslator) buildXdsSnapshot(
 		Messages: map[*core.ResourceRef][]string{},
 	}
 
-	legacyClusterNames := envutils.IsEnvTruthy(constants.GlooGatewayKubeStyleClusterNames)
 	tx := s.translator.NewTranslator(
 		ctx,
 		settings,
-		translator.ForGatewayV2(),
-		translator.WithParseableClusterNames(!legacyClusterNames),
+		translator.ForKubeGatewayAPI(),
 	)
 	xdsSnapshot, reports, proxyReport := tx.Translate(params, proxy)
 

--- a/projects/gateway2/validation/validator_test.go
+++ b/projects/gateway2/validation/validator_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Kube Gateway API Policy Validation Helper", func() {
 			settings,
 			pluginRegistry,
 			translator.EnvoyCacheResourcesListToFnvHash,
+			translator.ForGatewayV2(),
 		)
 		vc = gloovalidation.ValidatorConfig{
 			Ctx: context.Background(),

--- a/projects/gateway2/validation/validator_test.go
+++ b/projects/gateway2/validation/validator_test.go
@@ -81,7 +81,7 @@ var _ = Describe("Kube Gateway API Policy Validation Helper", func() {
 			settings,
 			pluginRegistry,
 			translator.EnvoyCacheResourcesListToFnvHash,
-			translator.ForGatewayV2(),
+			translator.ForKubeGatewayAPI(),
 		)
 		vc = gloovalidation.ValidatorConfig{
 			Ctx: context.Background(),

--- a/projects/gloo/constants/gloo_gateway.go
+++ b/projects/gloo/constants/gloo_gateway.go
@@ -2,4 +2,5 @@ package constants
 
 const (
 	GlooGatewayEnableK8sGwControllerEnv = "GG_K8S_GW_CONTROLLER"
+	GlooGatewayKubeStyleClusterNames    = "GG_K8S_GW_LEGACY_CLUSTER_NAMES"
 )

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
@@ -24,6 +24,8 @@ import (
 // these labels are used to propagate internal data
 // on synthetic Gloo resources generated from other Kubernetes
 // resources (generally Service).
+// The `~` is an invalid character that prevents these labels from ending up
+// on actual Kubernetes resources.
 const (
 	// KubeSourceResourceLabel indicates the kind of resource that the synthetic
 	// resource is based on.
@@ -84,9 +86,10 @@ func (uc *KubeUpstreamConverter) CreateUpstream(ctx context.Context, svc *corev1
 		// preserve parts of the source service in a structured way
 		// so we don't rely on string parsing to recover these
 		// this is more extensible than relying on casting Spec to Upstream_Kube
-		KubeNameLabel:        meta.Name,
-		KubeNamespaceLabel:   meta.Namespace,
-		KubeServicePortLabel: strconv.Itoa(int(port.Port)),
+		KubeSourceResourceLabel: "kube-svc",
+		KubeNameLabel:           meta.Name,
+		KubeNamespaceLabel:      meta.Namespace,
+		KubeServicePortLabel:    strconv.Itoa(int(port.Port)),
 	}
 
 	us := &v1.Upstream{

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes/serviceconverter"
 	"github.com/solo-io/go-utils/contextutils"
@@ -19,6 +20,37 @@ import (
 	"github.com/solo-io/solo-kit/pkg/utils/kubeutils"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// these labels are used to propagate internal data
+// on synthetic Gloo resources generated from other Kubernetes
+// resources (generally Service).
+const (
+	// KubeSourceResourceLabel indicates the kind of resource that the synthetic
+	// resource is based on.
+	KubeSourceResourceLabel = "~internal.solo.io/kubernetes-source-resource"
+	// KubeSourceResourceLabel indicates the original name of the resource that
+	// the synthetic resource is based on.
+	KubeNameLabel = "~internal.solo.io/kubernetes-name"
+	// KubeSourceResourceLabel indicates the original namespace of the resource
+	// that the synthetic resource is based on.
+	KubeNamespaceLabel = "~internal.solo.io/kubernetes-namespace"
+	// KubeSourceResourceLabel indicates the service port when applicable.
+	KubeServicePortLabel = "~internal.solo.io/kubernetes-service-port"
+)
+
+// ClusterNameForKube builds the cluster name based on _internal_ labels.
+// All of the kind, name, namespace and port must be provided.
+func ClusterNameForKube(us *v1.Upstream) (string, bool) {
+	labels := us.Metadata.GetLabels()
+	kind, kok := labels[KubeSourceResourceLabel]
+	name, nok := labels[KubeNameLabel]
+	ns, nsok := labels[KubeNamespaceLabel]
+	port, pok := labels[KubeServicePortLabel]
+	if !(kok && nok && nsok && pok) {
+		return "", false
+	}
+	return fmt.Sprintf("%s_%s_%s_%s", kind, name, ns, port), true
+}
 
 type UpstreamConverter interface {
 	UpstreamsForService(ctx context.Context, svc *corev1.Service) v1.UpstreamList
@@ -48,7 +80,14 @@ func (uc *KubeUpstreamConverter) CreateUpstream(ctx context.Context, svc *corev1
 	coremeta.ResourceVersion = ""
 	coremeta.Name = UpstreamName(meta.Namespace, meta.Name, port.Port)
 	labels := coremeta.GetLabels()
-	coremeta.Labels = make(map[string]string)
+	coremeta.Labels = map[string]string{
+		// preserve parts of the source service in a structured way
+		// so we don't rely on string parsing to recover these
+		// this is more extensible than relying on casting Spec to Upstream_Kube
+		KubeNameLabel:        meta.Name,
+		KubeNamespaceLabel:   meta.Namespace,
+		KubeServicePortLabel: strconv.Itoa(int(port.Port)),
+	}
 
 	us := &v1.Upstream{
 		Metadata: coremeta,

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
@@ -41,7 +41,7 @@ const (
 // ClusterNameForKube builds the cluster name based on _internal_ labels.
 // All of the kind, name, namespace and port must be provided.
 func ClusterNameForKube(us *v1.Upstream) (string, bool) {
-	labels := us.Metadata.GetLabels()
+	labels := us.GetMetadata().GetLabels()
 	kind, kok := labels[KubeSourceResourceLabel]
 	name, nok := labels[KubeNameLabel]
 	ns, nsok := labels[KubeNamespaceLabel]

--- a/projects/gloo/pkg/syncer/setup/translator.go
+++ b/projects/gloo/pkg/syncer/setup/translator.go
@@ -13,12 +13,13 @@ type TranslatorFactory struct {
 	PluginRegistry plugins.PluginRegistryFactory
 }
 
-func (tf TranslatorFactory) NewTranslator(ctx context.Context, settings *v1.Settings) translator.Translator {
+func (tf TranslatorFactory) NewTranslator(ctx context.Context, settings *v1.Settings, opts ...translator.Option) translator.Translator {
 	return translator.NewTranslatorWithHasher(
 		sslutils.NewSslConfigTranslator(),
 		settings,
 		tf.PluginRegistry(ctx),
 		translator.EnvoyCacheResourcesListToFnvHash,
+		opts...,
 	)
 }
 

--- a/projects/gloo/pkg/translator/clusters.go
+++ b/projects/gloo/pkg/translator/clusters.go
@@ -1,11 +1,10 @@
 package translator
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 	"time"
-
-	"errors"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -20,7 +19,6 @@ import (
 	v1_options "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
-	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
 	upstream_proxy_protocol "github.com/solo-io/gloo/projects/gloo/pkg/plugins/utils/upstreamproxyprotocol"
 	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
@@ -141,11 +139,8 @@ func (t *translatorInstance) initializeCluster(
 	}
 
 	clusterName := UpstreamToClusterName(upstream.GetMetadata().Ref())
-	// TODO maybe drop the ggv2 flag is redundant
-	if t.opts.ggv2 && t.opts.parseableClusterNames {
-		if k8sStyle, ok := kubernetes.ClusterNameForKube(upstream); ok {
-			clusterName = k8sStyle
-		}
+	if t.opts.kubeGatewayAPI {
+		clusterName = KubeGatewayUpstreamToClusterName(upstream)
 	}
 
 	circuitBreakers := t.settings.GetGloo().GetCircuitBreakers()

--- a/projects/gloo/pkg/translator/translator.go
+++ b/projects/gloo/pkg/translator/translator.go
@@ -69,26 +69,15 @@ type translatorInstance struct {
 
 type Option func(o *translatorOpts)
 
-// Maybe just have a separate New to make this harder to miss...
-func ForGatewayV2() Option {
+func ForKubeGatewayAPI() Option {
 	return func(o *translatorOpts) {
-		o.ggv2 = true
-	}
-}
-
-func WithParseableClusterNames(enabled bool) Option {
-	return func(o *translatorOpts) {
-		o.parseableClusterNames = enabled
+		o.kubeGatewayAPI = true
 	}
 }
 
 type translatorOpts struct {
-	// ggv2 should only be set for translating ggv2 proxies.
-	ggv2 bool
-	// parseableClusterNames only applies when GGv2 is also true.
-	// When set, we will format cluster names for Kubernetes resources
-	// in a way that is pareseable for telemetry.
-	parseableClusterNames bool
+	// kubeGatewayAPI should only be set for translating kubeGatewayAPI proxies.
+	kubeGatewayAPI bool
 }
 
 func NewTranslatorWithHasher(

--- a/projects/gloo/pkg/translator/utils.go
+++ b/projects/gloo/pkg/translator/utils.go
@@ -12,13 +12,27 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
+	"github.com/solo-io/gloo/pkg/utils/envutils"
+	"github.com/solo-io/gloo/projects/gloo/constants"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 )
 
 // returns the name of the cluster created for a given upstream
-func UpstreamToClusterName(upstream *core.ResourceRef) string {
+// used only for kube gateway api (aka ggv2) proxies.
+func KubeGatewayUpstreamToClusterName(upstream *v1.Upstream) string {
+	legacyClusterNames := envutils.IsEnvTruthy(constants.GlooGatewayKubeStyleClusterNames)
+	clusterName, ok := kubernetes.ClusterNameForKube(upstream)
+	if !ok || legacyClusterNames {
+		return UpstreamToClusterName(upstream.GetMetadata().Ref())
+	}
+	return clusterName
+}
 
+// returns the name of the cluster created for a given upstream
+func UpstreamToClusterName(upstream *core.ResourceRef) string {
 	// For non-namespaced resources, return only name
 	if upstream.GetNamespace() == "" {
 		return upstream.GetName()
@@ -30,7 +44,6 @@ func UpstreamToClusterName(upstream *core.ResourceRef) string {
 
 // returns the ref of the upstream for a given cluster
 func ClusterToUpstreamRef(cluster string) (*core.ResourceRef, error) {
-
 	split := strings.Split(cluster, "_")
 	if len(split) > 2 || len(split) < 1 {
 		return nil, errors.Errorf("unable to convert cluster %s back to upstream ref", cluster)
@@ -47,7 +60,6 @@ func ClusterToUpstreamRef(cluster string) (*core.ResourceRef, error) {
 }
 
 func NewFilterWithTypedConfig(name string, config proto.Message) (*envoy_config_listener_v3.Filter, error) {
-
 	s := &envoy_config_listener_v3.Filter{
 		Name: name,
 	}
@@ -107,14 +119,12 @@ func IsIpv4Address(bindAddress string) (validIpv4, strictIPv4 bool, err error) {
 	if bindIP == nil {
 		// If bindAddress is not a valid textual representation of an IP address
 		return false, false, errors.Errorf("bindAddress %s is not a valid IP address", bindAddress)
-
 	} else if bindIP.To4() == nil {
 		// If bindIP is not an IPv4 address, To4 returns nil.
 		// so this is not an acceptable ipv4
 		return false, false, nil
 	}
 	return true, isPureIPv4Address(bindAddress), nil
-
 }
 
 // isPureIPv4Address checks the string to see if it is


### PR DESCRIPTION
# Description

https://github.com/solo-io/solo-projects/issues/7105

This will make cluster names for kube services look like `kube-svc_name_namespace_port` or `kube-svc_reviews_bookinfo_8080`. If we add other resources besides a kube service, this also lets us get things like `istio-se_helloworld_backend-ns_5000`. 

This will only happen for Gateway v2 translation. We can disable it using the env var `GG_K8S_GW_LEGACY_CLUSTER_NAMES`.

## API changes

We can disable it using the env var `GG_K8S_GW_LEGACY_CLUSTER_NAMES`.

## Code changes

* XDS translator now takes options that can customize this new behavior. We instantiate translator separately for v2, so that is the only path to enable it. 
* Added another function to customize the generated name rather than modifying the existing cluster name function (it has over 100 usages! mostly in unit tests)
* Use internal labels to propagate the info in a structured way. 



## Docs changes

We should document this as a breaking change; users who rely on the old format should use the env var or update their EnvoyFilters or whatever config relies on XDS names... 

# Context

https://github.com/solo-io/solo-projects/issues/7105

## Interesting decisions

* Use internal labels to propagate the info in a structured way. This was done so we can support more than just Upstream_Kube upstreams. 
* Functional options for translator constructor. I didn't feel like updating the many references to this constructor, so varargs help. In hindsight, a second constructor could have also solved this. 

## Testing steps

TODO!
