### PR TITLE
Update test HttpRequestBuilder DefaultHost from test.com to jsonplaceholder.typicode.com/

### DIFF
--- a/changelog/v1.18.0-beta34/oss-test.com-flake-fix.yaml
+++ b/changelog/v1.18.0-beta34/oss-test.com-flake-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/5812
+    resolvesIssue: false
+    description: >-
+      Update the DefaultHost for the e2e testcontext to use `jsonplaceholder.typicode.com/` with the HttpRequestBuilder instead of 
+      the inconsistent/not meant for testing `test.com`

--- a/test/e2e/buffer_test.go
+++ b/test/e2e/buffer_test.go
@@ -119,7 +119,7 @@ var _ = Describe("buffer", func() {
 				vsToTestUpstream := helpers.NewVirtualServiceBuilder().
 					WithName("vs-test").
 					WithNamespace(writeNamespace).
-					WithDomain("test.com").
+					WithDomain(e2e.DefaultHost).
 					WithVirtualHostOptions(&gloov1.VirtualHostOptions{
 						BufferPerRoute: &buffer.BufferPerRoute{
 							Override: &buffer.BufferPerRoute_Buffer{
@@ -168,7 +168,7 @@ var _ = Describe("buffer", func() {
 				vsToTestUpstream := helpers.NewVirtualServiceBuilder().
 					WithName("vs-test").
 					WithNamespace(writeNamespace).
-					WithDomain("test.com").
+					WithDomain(e2e.DefaultHost).
 					WithVirtualHostOptions(&gloov1.VirtualHostOptions{
 						BufferPerRoute: &buffer.BufferPerRoute{
 							Override: &buffer.BufferPerRoute_Buffer{
@@ -222,7 +222,7 @@ var _ = Describe("buffer", func() {
 				vsToTestUpstream := helpers.NewVirtualServiceBuilder().
 					WithName("vs-test").
 					WithNamespace(writeNamespace).
-					WithDomain("test.com").
+					WithDomain(e2e.DefaultHost).
 					WithRoutePrefixMatcher("test", "/").
 					WithRouteActionToUpstream("test", testContext.TestUpstream().Upstream).
 					WithRouteOptions("test", &gloov1.RouteOptions{
@@ -271,7 +271,7 @@ var _ = Describe("buffer", func() {
 				vsToTestUpstream := helpers.NewVirtualServiceBuilder().
 					WithName("vs-test").
 					WithNamespace(writeNamespace).
-					WithDomain("test.com").
+					WithDomain(e2e.DefaultHost).
 					WithRoutePrefixMatcher("test", "/").
 					WithRouteActionToUpstream("test", testContext.TestUpstream().Upstream).
 					WithRouteOptions("test", &gloov1.RouteOptions{

--- a/test/e2e/csrf_test.go
+++ b/test/e2e/csrf_test.go
@@ -144,7 +144,7 @@ var _ = Describe("CSRF", func() {
 			vs := helpers.NewVirtualServiceBuilder().
 				WithName("vs-test").
 				WithNamespace(writeNamespace).
-				WithDomain("test.com").
+				WithDomain(e2e.DefaultHost).
 				WithRoutePrefixMatcher("test", "/").
 				WithRouteActionToUpstream("test", testContext.TestUpstream().Upstream).
 				WithRouteOptions("test", &gloov1.RouteOptions{
@@ -173,7 +173,7 @@ var _ = Describe("CSRF", func() {
 			vs := helpers.NewVirtualServiceBuilder().
 				WithName("vs-test").
 				WithNamespace(writeNamespace).
-				WithDomain("test.com").
+				WithDomain(e2e.DefaultHost).
 				WithVirtualHostOptions(&gloov1.VirtualHostOptions{
 					Csrf: getCsrfPolicyWithFilterEnabled(allowedOrigin),
 				}).
@@ -202,7 +202,7 @@ var _ = Describe("CSRF", func() {
 			vs := helpers.NewVirtualServiceBuilder().
 				WithName("vs-test").
 				WithNamespace(writeNamespace).
-				WithDomain("test.com").
+				WithDomain(e2e.DefaultHost).
 				WithRoutePrefixMatcher("test", "/").
 				WithRouteActionToMultiDestination("test", &gloov1.MultiDestination{
 					Destinations: []*gloov1.WeightedDestination{{
@@ -245,7 +245,7 @@ var _ = Describe("CSRF", func() {
 			vs := helpers.NewVirtualServiceBuilder().
 				WithName("vs-test").
 				WithNamespace(writeNamespace).
-				WithDomain("test.com").
+				WithDomain(e2e.DefaultHost).
 				WithVirtualHostOptions(&gloov1.VirtualHostOptions{
 					Csrf: getCsrfPolicyWithFilterEnabled(allowedOrigin),
 				}).

--- a/test/e2e/test_context.go
+++ b/test/e2e/test_context.go
@@ -36,7 +36,7 @@ const (
 	// To make our tests more explicit we define VirtualServices with an explicit set
 	// of domains (which match the `Host` header of a request), and DefaultHost
 	// is the domain we use by default
-	DefaultHost = "test.com"
+	DefaultHost = "jsonplaceholder.typicode.com"
 )
 
 var (

--- a/test/e2e/zipkin_test.go
+++ b/test/e2e/zipkin_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/solo-io/gloo/test/e2e"
 	"github.com/solo-io/gloo/test/services/envoy"
 
 	"github.com/solo-io/gloo/test/testutils"
@@ -129,7 +130,7 @@ var _ = Describe("Tracing config loading", Serial, func() {
 			vsToTestUpstream := gloohelpers.NewVirtualServiceBuilder().
 				WithName("vs-test").
 				WithNamespace(writeNamespace).
-				WithDomain("test.com").
+				WithDomain(e2e.DefaultHost).
 				WithRoutePrefixMatcher("test", "/").
 				WithRouteActionToUpstream("test", testUpstream.Upstream).
 				Build()
@@ -197,7 +198,7 @@ var _ = Describe("Tracing config loading", Serial, func() {
 				v1helpers.CurlRequest{
 					RootCA: nil,
 					Port:   envoyInstance.HttpPort,
-					Host:   "test.com", // to match the vs-test
+					Host:   e2e.DefaultHost, // to match the vs-test
 					Path:   "/",
 					Body:   []byte("solo.io test"),
 				},


### PR DESCRIPTION
# Description
"side port" of https://github.com/solo-io/solo-projects/pull/7163

Update the DefaultHost for the e2e testcontext to use jsonplaceholder.typicode.com with the HttpRequestBuilder instead of the inconsistent/not meant for testing test.com

A few tests required updating hardcoded references to "test.com"