### PR TITLE
Bump Go version to 1.23.3

### DIFF
--- a/changelog/v1.18.0-beta34/bump-go-1-23-3.yaml
+++ b/changelog/v1.18.0-beta34/bump-go-1-23-3.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  description: Bumped the go version to 1.23.3
+  dependencyOwner: golang
+  dependencyRepo: go
+  dependencyTag: v1.23.3

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.10.2'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -44,7 +44,7 @@ steps:
   - 'us-central1-a'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.2'
   id: 'publish-docker'
   args:
   - 'publish-docker'
@@ -65,7 +65,7 @@ steps:
   waitFor:
   - 'publish-docker'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.2'
   id: 'release-chart'
   dir: *dir
   args:
@@ -80,7 +80,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.2'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.10.2'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -23,7 +23,7 @@ steps:
     cd /go/pkg
     gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.2'
   id: 'prepare-envoy'
   dir: *dir
   entrypoint: 'bash'
@@ -77,7 +77,7 @@ steps:
   waitFor:
   - 'prepare-gcr-zone'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.2'
   id: 'prepare-test-tools'
   dir: *dir
   args:
@@ -88,7 +88,7 @@ steps:
   - 'prepare-gcr-zone'
   - 'prepare-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.10.2'
   id: 'run-tests'
   dir: *dir
   entrypoint: 'make'
@@ -99,7 +99,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.10.2'
   id: 'run-e2e-tests'
   dir: *dir
   entrypoint: 'make'
@@ -110,7 +110,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.10.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.10.2'
   id: 'run-hashicorp-e2e-tests'
   dir: *dir
   entrypoint: 'make'

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -1,6 +1,6 @@
 options:
   env:
-    - "_GO_VERSION=1.23.1"
+    - "_GO_VERSION=1.23.3"
 
 steps:
 - name: gcr.io/cloud-builders/gsutil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo
 
-go 1.23.1
+go 1.23.3
 
 // Note for developers: upgrading go will also require upgrading go in the following files:
 // ./cloudbuild-cache.yaml,


### PR DESCRIPTION
# Description

Bump Go version to 1.23.3

# Context

The Go version in solo-projects is being bumped in https://github.com/solo-io/solo-projects/pull/7152 due to the same bump in ext-auth-service, and we'd like to keep solo-projects and gloo Go versions in sync.

## CI changes

Bump in cloudbuild as well

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
-->
