### PR TITLE
Removes endpoints from the 44-rbac.yaml Helm template

### DIFF
--- a/changelog/v1.18.0-beta34/issue_10323.yaml
+++ b/changelog/v1.18.0-beta34/issue_10323.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/10323
+    resolvesIssue: true
+    description: >-
+      Removes the endpoints resource from Helm RBAC manifest when kubeGateway is enabled.

--- a/install/helm/gloo/templates/44-rbac.yaml
+++ b/install/helm/gloo/templates/44-rbac.yaml
@@ -22,7 +22,6 @@ rules:
   - services
   - pods
   - nodes
-  - endpoints
   - secrets
   - namespaces
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
Removes endpoints from the `44-rbac.yaml` Helm template since the gw API controller uses EndpointSlices instead of Endpoints due to https://github.com/solo-io/gloo/pull/10265.

BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/10323