### PR TITLE
Fix published Helm docs from main branch

### DIFF
--- a/changelog/v1.18.0-beta35/helm-doc-gen.yaml
+++ b/changelog/v1.18.0-beta35/helm-doc-gen.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/6888
+    resolvesIssue: false
+    description: >-
+      Update helm public docs generation to work from main branch and only pull in released changes

--- a/docs/cmd/generate_docs.go
+++ b/docs/cmd/generate_docs.go
@@ -454,11 +454,9 @@ func fetchEnterpriseHelmValues(_ []string) error {
 	if err != nil {
 		return err
 	}
-	version, err := semver.NewVersion(string(semverReleaseTag))
-	if err != nil {
-		return err
-	}
-	minorReleaseTag := fmt.Sprintf("v%d.%d.x", version.Major(), version.Minor())
+
+	minorReleaseTag := "v" + string(semverReleaseTag)
+
 	files, err := githubutils.GetFilesFromGit(ctx, client, repoOwner, glooEnterpriseRepo, minorReleaseTag, path)
 	if err != nil {
 		return err

--- a/pkg/github-action-utils/version.go
+++ b/pkg/github-action-utils/version.go
@@ -35,7 +35,9 @@ func GetLatestEnterpriseVersion(repoRootPath string, repo string, owner string) 
 		return err
 	}
 	defer f.Close()
-	enterpriseVersion, err := version.GetLatestHelmChartVersionWithMaxVersion(version.EnterpriseHelmRepoIndex, version.GlooEE, true, maxGlooEVersion)
+	// get the latest version from the helm repo, include unstable versions so it works from the main branches
+	// for LTS branches, unstable versions will be filtered out by the version constraints
+	enterpriseVersion, err := version.GetLatestHelmChartVersionWithMaxVersion(version.EnterpriseHelmRepoIndex, version.GlooEE, false, maxGlooEVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
# Description
When pulling in EE Helm docs, there are 2 steps:
1) Find the appropriate EE version
2) Use that version to pull in the Helm docs

Currently the first step is only looking at stable versions 


Update how docs generation pulls in Helm values from solo-projects:
* When pulling the latest Helm chart version, allow non-stable releases to be pulled
  * In main branch, this allows the beta/rc versions to be used
  * In LTS branches, the version constrains will prevent the main/unstable releases from being used
* When generating the docs
  * Update from using the LTS branch itself to the latest tag identified when the version is pulled
  * This will change how LTS docs are generated
    * We are currently pulling ref for the LTS branch itself, which results in committed but unreleased changes being included
    * After updating to pulling by the release tag, docs will only be published for released changes
  * For the main branch, the latest released version will be used
    * It is currently using the latest stable version for main, which leads to it being a version behind


## Docs changes
Updated docs generation scripts

## Interesting decisions
Confirmed with docs we should generate from the latest appropriate EE release and not the tip of the EE branch: https://solo-io-corp.slack.com/archives/CHJV572TG/p1731523839498749

## Testing steps
To generate docs:
```
cd docs
make site-common
```

To check output:
```
grep ambient content/static/content/glooe-values.docgen
```

You should see the missing field identified in the issue:

```
|ambient.waypoint.enabled|bool|false||
```

The files are copied in CI [here](https://github.com/solo-io/gloo/blob/sheidkamp/helm-doc-gen/.github/workflows/push-docs.yaml#L136) - by the [push-docs action](https://github.com/solo-io/gloo/actions/workflows/push-docs.yaml) and would like to validate e2e before merging

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
