### PR TITLE
Doc fixes 1.17

### DIFF
--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -159,3 +159,36 @@ jobs:
           --head ${{ steps.create-branch.outputs.branch }} \
           --reviewer solo-io/solo-docs
         popd || exit 1
+
+  slack-notification:
+    runs-on: ubuntu-latest
+    needs:
+      - copy-docs
+    steps:
+    - name: Notify on workflow success
+      if: |
+        needs.copy-docs.result == 'success'
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      run: |
+        MESSAGE="✅ *Success:* Automated copy of reference docs for ${{ steps.version-variables.outputs.minor }} was successful. <https://github.com/solo-io/docs/pulls|Review the PR>"
+
+        curl \
+          -d "text=$MESSAGE" \
+          -d "channel=doctopus-tests" \
+          -d "token=${SLACK_BOT_TOKEN}" \
+          -X POST https://slack.com/api/chat.postMessage
+    - name: Notify on workflow failure
+      if: |
+        needs.copy-docs.result == 'failure'
+      env:
+        SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      run: |
+        JOB_URL=https://github.com/solo-io/gloo/actions/runs/${GITHUB_RUN_ID}
+        MESSAGE="❌ *Failure:* Automated copy of reference docs for ${{ steps.version-variables.outputs.minor }} failed. <${JOB_URL}|Review the workflow failure>"
+
+        curl \
+          -d "text=$MESSAGE" \
+          -d "channel=doctopus-tests" \
+          -d "token=${SLACK_BOT_TOKEN}" \
+          -X POST https://slack.com/api/chat.postMessage

--- a/docs/content/reference/cheatsheets/timeouts/_index.md
+++ b/docs/content/reference/cheatsheets/timeouts/_index.md
@@ -81,7 +81,7 @@ Review this page for a list of commonly used timeout settings in Gloo Gateway, o
   - `sslConfig`
     - `transportSocketConnectTimeout` disabled by default, **unlimited** (or limited by connection/idle timeout). Suggested is 10 seconds.
   - `virtualHost`
-    - `options` (see also {{< protobuf name="gloo.solo.io.VirtualHostOptions" display="VirtualHostOptions" >}} )
+    - `options` (see also {{< protobuf name="gloo.solo.io.Options" display="Options" >}} )
       - `retries`
         - `perTryTimeout` defaults to **15 seconds** (Route timeout)
       - `jwtStaged`
@@ -91,7 +91,7 @@ Review this page for a list of commonly used timeout settings in Gloo Gateway, o
               - `remote`
                 - `cacheDuration` defaults to **5 minutes**
     - `routes`
-      - `options` (see also {{< protobuf name="gloo.solo.io.RouteOptions" display="RouteOptions" >}})
+      - `options` (see also {{< protobuf name="gloo.solo.io.Options" display="Options" >}})
         - `timeout` defaults to **15 seconds**
         - `retries`
           - `perTryTimeout` defaults to **15 seconds** (Route timeout)


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
