### PR TITLE
v1.15.x - Fix "should return latest patch" test

### DIFF
--- a/changelog/v1.15.35/fix-latest-patch-test.yaml
+++ b/changelog/v1.15.35/fix-latest-patch-test.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/10369
+    resolvesIssue: false
+    description: >-
+      Updating versions used in upgrade patch tests

--- a/test/kube2e/upgrade/upgrade_utils_test.go
+++ b/test/kube2e/upgrade/upgrade_utils_test.go
@@ -26,9 +26,9 @@ var _ = Describe("upgrade utils unit tests", func() {
 		It("should return latest patch", func() {
 			ctx := context.Background()
 			client, _ := githubutils.GetClient(ctx)
-			minor, err := getLatestReleasedPatchVersion(ctx, client, "gloo", 1, 8)
+			minor, err := getLatestReleasedPatchVersion(ctx, client, "gloo", 1, 9)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(minor.String()).To(Equal("v1.8.37"))
+			Expect(minor.String()).To(Equal("v1.9.30"))
 		})
 	})
 


### PR DESCRIPTION
# Description
Update test to use version that has been synced to the gloo repo. Partial backport of changes introduced in https://github.com/solo-io/gloo/pull/10359

context: https://solo-io-corp.slack.com/archives/C07077NS0NP/p1731702298691159