### PR TITLE
Bump timeout on e2e tests

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -174,6 +174,7 @@ jobs:
           istio-version: ${{ steps.dotenv.outputs.istio_version }}
           matrix-label: ${{ matrix.version-files.label }}
 
+  # Reminder: when setting up the job next release branch, copy from "end_to_end_tests_main" not the previous release job as configuration may have changed
   end_to_end_tests_17:
     name: End-to-End (branch=v1.17.x, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'v1.17.x') || github.event.schedule == '0 6 * * 1' }}

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -56,7 +56,7 @@ jobs:
     name: End-to-End (branch=${{ github.ref_name }}, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'workflow_initiating_branch' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 150
+    timeout-minutes: 180
     strategy:
       # Since we are running these on a schedule, there is no value in failing fast
       # In fact, we want to ensure that all tests run, so that we have a clearer picture of which tests are prone to flaking
@@ -66,7 +66,7 @@ jobs:
           # When running the tests at night, there is no value in splitting the tests across multiple clusters and running them in parallel.
           # As a result, we increase the threshold for the tests, since they all run serially on a single cluster
           - cluster-name: 'cluster-one'
-            go-test-args: '-v -timeout=120m'
+            go-test-args: '-v -timeout=150m'
             go-test-run-regex: ${{ inputs.kubernetes-end-to-end-run-regex }}
         # In our nightly tests, we run the suite of tests using the lower and upper ends of versions that we claim to support
         # The versions should mirror: https://docs.solo.io/gloo-edge/latest/reference/support/
@@ -117,7 +117,7 @@ jobs:
     name: End-to-End (branch=main, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'main') || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-22.04
-    timeout-minutes: 150
+    timeout-minutes: 180
     strategy:
       # Since we are running these on a schedule, there is no value in failing fast
       # In fact, we want to ensure that all tests run, so that we have a clearer picture of which tests are prone to flaking
@@ -127,7 +127,7 @@ jobs:
           # When running the tests at night, there is no value in splitting the tests across multiple clusters and running them in parallel.
           # As a result, we increase the threshold for the tests, since they all run serially on a single cluster
           - cluster-name: 'cluster-one'
-            go-test-args: '-v -timeout=120m'
+            go-test-args: '-v -timeout=150m'
             # Specifying an empty regex means all tests will be run.
             go-test-run-regex: ""
         # In our nightly tests, we run the suite of tests using the lower and upper ends of versions that we claim to support

--- a/changelog/v1.18.0-rc2/e2e-timeout-bump.yaml
+++ b/changelog/v1.18.0-rc2/e2e-timeout-bump.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/10380
+    resolvesIssue: true
+    description: >-
+      Bump the timeout for the nightly e2e tests


### PR DESCRIPTION
# Description
As we add more tests, they take longer to run and have started to timeout on the nightly runs.

Bump the timeout to allow them to finish.

Run without timeouts:
* passed: https://github.com/solo-io/gloo/actions/runs/11916032859/job/33207732984
* failed but didn't timeout: https://github.com/solo-io/gloo/actions/runs/11916032859/job/33207731345
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/10380