### PR TITLE
[DRAFT] Investigating and resolving flaky test TestMultipleVirtualHostOptionsManualSetup

### DIFF
--- a/projects/gateway2/translator/plugins/virtualhostoptions/virtualhost_options_plugin.go
+++ b/projects/gateway2/translator/plugins/virtualhostoptions/virtualhost_options_plugin.go
@@ -114,6 +114,13 @@ func (p *plugin) ApplyListenerPlugin(
 		return nil
 	}
 
+	logger := contextutils.LoggerFrom(ctx)
+	for _, opt := range attachedOptions {
+		logger.Infof("VirtualHostOption %s attached to listener %s on Gateway %s/%s: %v",
+			client.ObjectKeyFromObject(opt), listenerCtx.GwListener.Name, listenerCtx.Gateway.Namespace,
+			listenerCtx.Gateway.Name, &opt)
+	}
+
 	// the first option is highest priority, so we will merge all options into this one,
 	// see for more context: https://github.com/solo-io/solo-projects/issues/6313
 	merged := attachedOptions[0]

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -69,6 +69,7 @@ func (p *Provider) EventuallyResourceStatusMatchesState(
 		status, err := getResourceNamespacedStatus(getter)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
 		g.Expect(status).ToNot(gomega.BeNil())
+		fmt.Printf("status: %v\n", status)
 		g.Expect(status).To(gomega.HaveValue(statusStateMatcher))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
 }

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -2,6 +2,7 @@ package assertions
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/onsi/ginkgo/v2"
@@ -31,6 +32,7 @@ func (p *Provider) EventuallyResourceStatusMatchesWarningReasons(getter helpers.
 		status, err := getResourceNamespacedStatus(getter)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
 		g.Expect(status).ToNot(gomega.BeNil())
+		fmt.Printf("status: %v\n", status)
 		g.Expect(status).To(gomega.HaveValue(statusWarningsMatcher))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
 }


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
