### PR TITLE
fix upstream status flicker

### DIFF
--- a/projects/gloo/pkg/syncer/envoy_translator_syncer.go
+++ b/projects/gloo/pkg/syncer/envoy_translator_syncer.go
@@ -142,11 +142,16 @@ func (s *translatorSyncer) syncEnvoy(ctx context.Context, snap *v1snap.ApiSnapsh
 		}
 	}
 
-	allReports.Accept(snap.Upstreams.AsInputResources()...)
-	allReports.Accept(snap.UpstreamGroups.AsInputResources()...)
 	// Only mark non-kube gateways as accepted
 	// Regardless, kube gw proxies are filtered out of these reports before reporting in translator_syncer.go
 	allReports.Accept(nonKubeProxies.AsInputResources()...)
+
+	// report Upstream[Group]s as Accepted initially but only if we at least 1 edge proxy
+	// otherwise, we won't actually translate them, and so if there is an error, we will incorrectly report Accepted
+	if len(nonKubeProxies) > 0 {
+		allReports.Accept(snap.Upstreams.AsInputResources()...)
+		allReports.Accept(snap.UpstreamGroups.AsInputResources()...)
+	}
 
 	// sync non-kube gw proxies
 	for _, proxy := range nonKubeProxies {


### PR DESCRIPTION
# Description

When only Kube GW proxies are present, we still rely on the edge translator_syncer for extension syncing. The edge translator will mark `Upstreams` & `UpstreamGroups` as `Accepted` then perform xds translation where status may be changed to e.g. `Rejected` if there is an error. 

However, in the case where there are no edge proxies, translation doesn't actually occur, so any actual errors on the `Upstream` are never encountered, thus the status is never set to `Rejected`. We end up in a scenario where the Kube GW syncer (correctly) reports Rejected status while the Edge syncer reports Accepted and they will fight each other indefinitely.

## Code changes

This changes the edge translator_syncer to no longer mark `Upstream[Group]s` as `Accepted` unless it will also perform translation.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works