### PR TITLE
feat: allow disabling pod locality in xDS

### DIFF
--- a/changelog/v1.18.0-rc3/pod-xds-disable.yaml
+++ b/changelog/v1.18.0-rc3/pod-xds-disable.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/7302
+    description: >-
+      Allow disabling pod locality considerations in xDS using undocumented env-var `DISABLE_POD_LOCALITY_XDS`.

--- a/projects/gateway2/krtcollections/uniqueclients_test.go
+++ b/projects/gateway2/krtcollections/uniqueclients_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/krt/krttest"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,15 +66,35 @@ func TestUniqueClients(t *testing.T) {
 			},
 			result: sets.New(fmt.Sprintf("gloo-kube-gateway-api~best-proxy-role~%d~ns", utils.HashLabels(map[string]string{corev1.LabelTopologyRegion: "region", corev1.LabelTopologyZone: "zone", "a": "b"}))),
 		},
+		{
+			name:   "no-pods",
+			inputs: nil,
+			requests: []*envoy_service_discovery_v3.DiscoveryRequest{
+				{
+					Node: &corev3.Node{
+						Id: "podname.ns",
+						Metadata: &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								xds.RoleKey: structpb.NewStringValue(glooutils.GatewayApiProxyValue + "~best-proxy-role"),
+							},
+						},
+					},
+				},
+			},
+			result: sets.New(fmt.Sprintf(glooutils.GatewayApiProxyValue + "~best-proxy-role")),
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			g := NewWithT(t)
-			mock := krttest.NewMock(t, tc.inputs)
-			nodes := NewNodeMetadataCollection(krttest.GetMockCollection[*corev1.Node](mock))
-			pods := NewLocalityPodsCollection(nodes, krttest.GetMockCollection[*corev1.Pod](mock), nil)
-			pods.Synced().WaitUntilSynced(context.Background().Done())
+			var pods krt.Collection[LocalityPod]
+			if tc.inputs != nil {
+				mock := krttest.NewMock(t, tc.inputs)
+				nodes := NewNodeMetadataCollection(krttest.GetMockCollection[*corev1.Node](mock))
+				pods = NewLocalityPodsCollection(nodes, krttest.GetMockCollection[*corev1.Pod](mock), nil)
+				pods.Synced().WaitUntilSynced(context.Background().Done())
+			}
 
 			cb, uccBuilder := NewUniquelyConnectedClients()
 			ucc := uccBuilder(context.Background(), nil, pods)

--- a/projects/gateway2/setup/ggv2setup.go
+++ b/projects/gateway2/setup/ggv2setup.go
@@ -118,7 +118,12 @@ func StartGGv2WithConfig(ctx context.Context,
 		settingsGVR,
 		krt.WithName("GlooSettings"))
 
-	ucc := uccBuilder(ctx, setupOpts.KrtDebugger, augmentedPods)
+	augmentedPodsForUcc := augmentedPods
+	if envutils.IsEnvTruthy("DISABLE_POD_LOCALITY_XDS") {
+		augmentedPodsForUcc = nil
+	}
+
+	ucc := uccBuilder(ctx, setupOpts.KrtDebugger, augmentedPodsForUcc)
 
 	settingsSingle := krt.NewSingleton(func(ctx krt.HandlerContext) *glookubev1.Settings {
 		s := krt.FetchOne(ctx, setting,


### PR DESCRIPTION
When this is enabled - it means destination rules won't work correctly; but things like VMs and other WorkloadEntries based workloads will. This is not documented as it is meant as a temporary hotfix, with a durable fix for supporting WorkloadEntries coming later.

to enable, set DISABLE_POD_LOCALITY_XDS to true in the gloo deployment.
BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/7302