### PR TITLE
gateway2/delegation: fix cycle detection

### DIFF
--- a/changelog/v1.18.0-rc3/fix-10379.yaml
+++ b/changelog/v1.18.0-rc3/fix-10379.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/k8sgateway/k8sgateway/issues/10379
+    resolvesIssue: false
+    description: |
+      There's a bug in how cycles are detected when evaluating a
+      delegation chain, because of which a multi-level delegation
+      tree with the same child route being referenced by multiple
+      parent HTTP routes is broken. This change fixes the detection
+      of cycles during the evaluation of the delegation chain.
+

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -51,7 +51,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",
-			}}),
+			},
+		}),
 	Entry(
 		"https gateway with basic routing",
 		translatorTestCase{
@@ -60,7 +61,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with multiple listeners on the same port",
 		translatorTestCase{
@@ -69,7 +71,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "http",
-			}}),
+			},
+		}),
 	Entry(
 		"https gateway with multiple listeners on the same port",
 		translatorTestCase{
@@ -78,7 +81,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "http",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with multiple routing rules and HeaderModifier filter",
 		translatorTestCase{
@@ -87,7 +91,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "gw",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with lambda destination",
 		translatorTestCase{
@@ -96,7 +101,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "gw",
-			}}),
+			},
+		}),
 	Entry(
 		"http gateway with azure destination",
 		translatorTestCase{
@@ -105,7 +111,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "gw",
-			}}),
+			},
+		}),
 	Entry(
 		"gateway with correctly sorted routes",
 		translatorTestCase{
@@ -114,7 +121,8 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "infra",
 				Name:      "example-gateway",
-			}}),
+			},
+		}),
 	Entry(
 		"httproute with missing backend reports correctly",
 		translatorTestCase{
@@ -300,4 +308,6 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("RouteOptions multi level inheritance with child override", "route_options_multi_level_inheritance_override_ok.yaml"),
 	Entry("RouteOptions filter override merge", "route_options_filter_override_merge.yaml"),
 	Entry("Child route matcher does not match parent", "bug-6621.yaml"),
+	// https://github.com/k8sgateway/k8sgateway/issues/10379
+	Entry("Multi-level multiple parents delegation", "bug-10379.yaml"),
 )

--- a/projects/gateway2/translator/testutils/inputs/delegation/bug-10379.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/bug-10379.yaml
@@ -1,0 +1,127 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-example-com
+  namespace: infra
+  labels:
+    app: apis
+spec:
+  parentRefs:
+    - name: example-gateway
+  hostnames:
+    - "api.example.com"
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /api1
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: apiproduct-1
+        namespace: default
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /api2
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: apiproduct-2
+        namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: apiproduct-1
+  namespace: default
+  labels:
+    app: apis
+  annotations:
+    delegation.gateway.solo.io/inherit-parent-matcher: "true"
+spec:
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: httpbin
+        namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: apiproduct-2
+  namespace: default
+  labels:
+    app: apis
+  annotations:
+    delegation.gateway.solo.io/inherit-parent-matcher: "true"
+spec:
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: httpbin
+        namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: default
+  labels:
+    app: apis
+  annotations:
+    delegation.gateway.solo.io/inherit-parent-matcher: "true"
+spec:
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+      - name: httpbin
+        namespace: default
+        port: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 8000

--- a/projects/gateway2/translator/testutils/outputs/delegation/bug-10379.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/bug-10379.yaml
@@ -1,0 +1,53 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~api_example_com
+    httpResources:
+      virtualHosts:
+        http~api_example_com:
+          domains:
+          - api.example.com
+          name: http~api_example_com
+          routes:
+          - matchers:
+            - prefix: /api1
+            name: httproute-httpbin-default-0-0
+            options:
+              regexRewrite:
+                pattern:
+                  regex: ^/api1\/*
+                substitution: /
+            routeAction:
+              single:
+                kube:
+                  port: 8000
+                  ref:
+                    name: httpbin
+                    namespace: default
+          - matchers:
+            - prefix: /api2
+            name: httproute-httpbin-default-0-0
+            options:
+              regexRewrite:
+                pattern:
+                  regex: ^/api2\/*
+                substitution: /
+            routeAction:
+              single:
+                kube:
+                  port: 8000
+                  ref:
+                    name: httpbin
+                    namespace: default
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system


### PR DESCRIPTION
There's a bug in how cycles are detected when evaluating a delegation chain, because of which a multi-level delegation tree with the same child route being referenced by multiple parent HTTP routes is broken. This change fixes the detection of cycles during the evaluation of the delegation chain.

---
Testing done:

Added a new translator unit test which fails without the fix.