### PR TITLE
.github/workflows: do not add work in progress label by default

### DIFF
--- a/.github/workflows/add-pr-label.yaml
+++ b/.github/workflows/add-pr-label.yaml
@@ -23,6 +23,5 @@ jobs:
         with:
           labels: |
             keep pr updated
-            work in progress
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog/v1.18.0-rc3/work-in-progress-default-false.yaml
+++ b/changelog/v1.18.0-rc3/work-in-progress-default-false.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Do not add the `work in progress` label to PRs by default. This label prevents code from merging into the
+      target branch, and was intended to help prevent merges before they were intended to happen.
+      Instead however, it has caused engineering toil as removing the label is not intuitive for many developers.
+      
+      skipCI-docs-build:true
+      skipCI-kube-tests:true


### PR DESCRIPTION
# Description

Reverts the work in https://github.com/k8sgateway/k8sgateway/pull/9849

# Context
A number of slack threads opened by engineers about how this is confusing and leads to toil.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
