### PR TITLE
Refactors TCPRoute e2e tests

### DIFF
--- a/changelog/v1.18.0-rc3/issue_10414.yaml
+++ b/changelog/v1.18.0-rc3/issue_10414.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/gloo/issues/10414
+    resolvesIssue: true
+    description: >-
+      Refactors TCPRoute e2e tests to run in parallel, reduce flakes, and
+      parameterize tests for reusability.

--- a/test/kubernetes/e2e/features/services/tcproute/suite.go
+++ b/test/kubernetes/e2e/features/services/tcproute/suite.go
@@ -2,18 +2,24 @@ package tcproute
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	"github.com/stretchr/testify/suite"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/solo-io/gloo/pkg/utils/kubeutils"
+	"github.com/solo-io/gloo/pkg/utils/kubeutils/kubectl"
 	"github.com/solo-io/gloo/pkg/utils/requestutils/curl"
+	"github.com/solo-io/gloo/test/gomega/matchers"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	"github.com/solo-io/gloo/test/kubernetes/e2e/defaults"
 )
 
-// testingSuite is the entire Suite of tests for testing K8s Service-specific features/fixes
+// testingSuite is the entire suite of tests for testing K8s Service-specific features/fixes
 type testingSuite struct {
 	suite.Suite
 
@@ -31,95 +37,190 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	}
 }
 
-func (s *testingSuite) TestConfigureTCPRouteBackingDestinationsWithSingleService() {
-	s.T().Cleanup(func() {
-		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, singleTcpRouteManifest)
-		s.NoError(err, "can delete manifest")
-		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, multiBackendServiceManifest)
-		s.NoError(err, "can delete manifest")
-		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, singleListenerGatewayAndClientManifest)
-		s.NoError(err, "can delete manifest")
-		s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, proxyService, proxyDeployment)
-	})
+func (s *testingSuite) SetupSuite() {
+	var cancel context.CancelFunc
+	s.ctx, cancel = context.WithTimeout(context.Background(), ctxTimeout)
+	s.T().Cleanup(cancel)
 
-	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, singleListenerGatewayAndClientManifest)
-	s.Assert().NoError(err, "can apply gateway and client manifest")
-	s.testInstallation.Assertions.EventuallyGatewayCondition(s.ctx, "tcp-gateway", "default", v1.GatewayConditionAccepted, metav1.ConditionTrue, timeout)
-
-	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, multiBackendServiceManifest)
-	s.Assert().NoError(err, "can apply backend service manifest")
-	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, proxyService, proxyDeployment)
-
-	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, singleTcpRouteManifest)
-	s.Assert().NoError(err, "can apply tcproute manifest")
-	s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, "tcp-app-1", "default", v1.RouteConditionAccepted, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, "tcp-app-1", "default", v1.RouteConditionResolvedRefs, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyGatewayCondition(s.ctx, "tcp-gateway", "default", v1.GatewayConditionProgrammed, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyGatewayListenerAttachedRoutes(s.ctx, "tcp-gateway", "default", v1.SectionName("foo"), int32(1), timeout)
-
-	s.testInstallation.Assertions.AssertEventualCurlResponse(
-		s.ctx,
-		defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
-			curl.WithPort(8088),
-		},
-		expectedTcpFooSvcResp)
-	s.testInstallation.Assertions.AssertEventualCurlResponse(
-		s.ctx,
-		defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
-			curl.WithPort(8088),
-		},
-		expectedTcpBarSvcResp)
+	manifests := []string{
+		singleSvcNsManifest,
+		singleSvcGatewayAndClientManifest,
+		singleSvcBackendManifest,
+		singleSvcTcpRouteManifest,
+		multiSvcNsManifest,
+		multiSvcGatewayAndClientManifest,
+		multiSvcBackendManifest,
+		multiSvcTcpRouteManifest,
+	}
+	for _, file := range manifests {
+		s.Require().NoError(validateManifestFile(file), "Invalid manifest file: %s", file)
+	}
 }
 
-func (s *testingSuite) TestConfigureTCPRouteBackingDestinationsWithMultiServices() {
-	s.T().Skip("skipping test until we resolve the reason it is flaky")
+type tcpRouteTestCase struct {
+	name                string
+	nsManifest          string
+	gtwName             string
+	gtwNs               string
+	gtwManifest         string
+	svcManifest         string
+	tcpRouteManifest    string
+	proxyService        *corev1.Service
+	proxyDeployment     *appsv1.Deployment
+	expectedResponses   []*matchers.HttpResponse
+	ports               []int
+	listenerNames       []v1.SectionName
+	expectedRouteCounts []int32
+	tcpRouteNames       []string
+}
 
-	s.T().Cleanup(func() {
-		err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, multiTcpRouteManifest)
-		s.NoError(err, "can delete manifest")
-		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, multiBackendServiceManifest)
-		s.NoError(err, "can delete manifest")
-		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, multiListenerGatewayAndClientManifest)
-		s.NoError(err, "can delete manifest")
-		s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, proxyService, proxyDeployment)
-	})
-
-	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, multiListenerGatewayAndClientManifest)
-	s.Assert().NoError(err, "can apply gateway and client manifest")
-	s.testInstallation.Assertions.EventuallyGatewayCondition(s.ctx, "tcp-gateway", "default", v1.GatewayConditionAccepted, metav1.ConditionTrue, timeout)
-
-	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, multiBackendServiceManifest)
-	s.Assert().NoError(err, "can apply backend service manifest")
-	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, proxyService, proxyDeployment)
-
-	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, multiTcpRouteManifest)
-	s.Assert().NoError(err, "can apply tcproute manifest")
-	s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, "tcp-app-1", "default", v1.RouteConditionAccepted, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, "tcp-app-1", "default", v1.RouteConditionResolvedRefs, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, "tcp-app-2", "default", v1.RouteConditionAccepted, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, "tcp-app-2", "default", v1.RouteConditionResolvedRefs, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyGatewayCondition(s.ctx, "tcp-gateway", "default", v1.GatewayConditionProgrammed, metav1.ConditionTrue, timeout)
-	s.testInstallation.Assertions.EventuallyGatewayListenerAttachedRoutes(s.ctx, "tcp-gateway", "default", v1.SectionName("foo"), int32(1), timeout)
-	s.testInstallation.Assertions.EventuallyGatewayListenerAttachedRoutes(s.ctx, "tcp-gateway", "default", v1.SectionName("bar"), int32(1), timeout)
-
-	s.testInstallation.Assertions.AssertEventualCurlResponse(
-		s.ctx,
-		defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
-			curl.WithPort(8088),
+func (s *testingSuite) TestConfigureTCPRouteBackingDestinations() {
+	testCases := []tcpRouteTestCase{
+		{
+			name:             "SingleServiceTCPRoute",
+			nsManifest:       singleSvcNsManifest,
+			gtwName:          singleSvcGatewayName,
+			gtwNs:            singleSvcNsName,
+			gtwManifest:      singleSvcGatewayAndClientManifest,
+			svcManifest:      singleSvcBackendManifest,
+			tcpRouteManifest: singleSvcTcpRouteManifest,
+			proxyService:     singleSvcProxyService,
+			proxyDeployment:  singleSvcProxyDeployment,
+			expectedResponses: []*matchers.HttpResponse{
+				expectedSingleSvcResp,
+			},
+			ports: []int{8087},
+			listenerNames: []v1.SectionName{
+				v1.SectionName(singleSvcListenerName8087),
+			},
+			expectedRouteCounts: []int32{1},
+			tcpRouteNames:       []string{singleSvcTCPRouteName},
 		},
-		expectedTcpFooSvcResp)
-	s.testInstallation.Assertions.AssertEventualCurlResponse(
-		s.ctx,
-		defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
-			curl.WithPort(8089),
+		{
+			name:             "MultiServicesTCPRoute",
+			nsManifest:       multiSvcNsManifest,
+			gtwName:          multiSvcGatewayName,
+			gtwNs:            multiSvcNsName,
+			gtwManifest:      multiSvcGatewayAndClientManifest,
+			svcManifest:      multiSvcBackendManifest,
+			tcpRouteManifest: multiSvcTcpRouteManifest,
+			proxyService:     multiProxyService,
+			proxyDeployment:  multiProxyDeployment,
+			expectedResponses: []*matchers.HttpResponse{
+				expectedMultiSvc1Resp,
+				expectedMultiSvc2Resp,
+			},
+			ports: []int{8088, 8089},
+			listenerNames: []v1.SectionName{
+				v1.SectionName(multiSvcListenerName8088),
+				v1.SectionName(multiSvcListenerName8089),
+			},
+			expectedRouteCounts: []int32{1, 1},
+			tcpRouteNames:       []string{multiSvcTCPRouteName1, multiSvcTCPRouteName2},
 		},
-		expectedTcpBarSvcResp)
+	}
+
+	for _, tc := range testCases {
+		tc := tc // capture range variable
+		s.Run(tc.name, func() {
+			// Cleanup function
+			s.T().Cleanup(func() {
+				err := s.deleteManifests(tc.nsManifest)
+				s.Require().NoError(err, fmt.Sprintf("Failed to delete manifest %s", tc.nsManifest))
+
+				s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: tc.gtwNs}})
+			})
+
+			// Setup environment
+			s.setupTestEnvironment(
+				tc.nsManifest,
+				tc.gtwName,
+				tc.gtwNs,
+				tc.gtwManifest,
+				tc.svcManifest,
+				tc.proxyService,
+				tc.proxyDeployment,
+			)
+
+			// Apply TCPRoute manifest
+			err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, tc.tcpRouteManifest)
+			s.Require().NoError(err, fmt.Sprintf("Failed to apply manifest %s", tc.tcpRouteManifest))
+
+			// Assert gateway conditions
+			s.testInstallation.Assertions.EventuallyGatewayCondition(s.ctx, tc.gtwName, tc.gtwNs, v1.GatewayConditionAccepted, metav1.ConditionTrue, timeout)
+
+			// Assert TCPRoute conditions
+			for _, tcpRouteName := range tc.tcpRouteNames {
+				s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, tcpRouteName, tc.gtwNs, v1.RouteConditionAccepted, metav1.ConditionTrue, timeout)
+				s.testInstallation.Assertions.EventuallyTCPRouteCondition(s.ctx, tcpRouteName, tc.gtwNs, v1.RouteConditionResolvedRefs, metav1.ConditionTrue, timeout)
+			}
+
+			// Assert gateway programmed condition
+			s.testInstallation.Assertions.EventuallyGatewayCondition(s.ctx, tc.gtwName, tc.gtwNs, v1.GatewayConditionProgrammed, metav1.ConditionTrue, timeout)
+
+			// Assert listener attached routes
+			for i, listenerName := range tc.listenerNames {
+				expectedRouteCount := tc.expectedRouteCounts[i]
+				s.testInstallation.Assertions.EventuallyGatewayListenerAttachedRoutes(s.ctx, tc.gtwName, tc.gtwNs, listenerName, expectedRouteCount, timeout)
+			}
+
+			// Assert expected responses
+			for i, port := range tc.ports {
+				expectedResponse := tc.expectedResponses[i]
+				s.testInstallation.Assertions.AssertEventualCurlResponse(
+					s.ctx,
+					s.execOpts(tc.gtwNs),
+					[]curl.Option{
+						curl.WithHost(kubeutils.ServiceFQDN(tc.proxyService.ObjectMeta)),
+						curl.WithPort(port),
+					},
+					expectedResponse)
+			}
+		})
+	}
+}
+
+func validateManifestFile(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return fmt.Errorf("Manifest file not found: %s", path)
+	}
+	return nil
+}
+
+func (s *testingSuite) setupTestEnvironment(nsManifest, gtwName, gtwNs, gtwManifest, svcManifest string, proxySvc *corev1.Service, proxyDeploy *appsv1.Deployment) {
+	s.applyManifests(nsManifest)
+
+	s.applyManifests(gtwManifest)
+	s.testInstallation.Assertions.EventuallyGatewayCondition(s.ctx, gtwName, gtwNs, v1.GatewayConditionAccepted, metav1.ConditionTrue, timeout)
+
+	s.applyManifests(svcManifest)
+	s.testInstallation.Assertions.EventuallyObjectsExist(s.ctx, proxySvc, proxyDeploy)
+}
+
+func (s *testingSuite) applyManifests(manifests ...string) {
+	for _, manifest := range manifests {
+		s.Eventually(func() bool {
+			err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, manifest)
+			if err != nil {
+				s.T().Logf("Retrying apply manifest: %s, error: %v", manifest, err)
+				return false
+			}
+			return true
+		}, waitTime, tickTime, fmt.Sprintf("Can apply manifest %s", manifest))
+	}
+}
+
+func (s *testingSuite) deleteManifests(manifests ...string) error {
+	for _, manifest := range manifests {
+		if err := s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, manifest); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *testingSuite) execOpts(ns string) kubectl.PodExecOptions {
+	opts := defaults.CurlPodExecOpt
+	opts.Namespace = ns
+	return opts
 }

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/multi-backend-service.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/multi-backend-service.yaml
@@ -1,9 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: foo
+  name: multi-svc-1
+  namespace: multi-tcp-route
   labels:
-    app: backend-1
+    app: multi-svc
 spec:
   ports:
     - name: http
@@ -15,9 +16,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: bar
+  name: multi-svc-2
+  namespace: multi-tcp-route
   labels:
-    app: backend-2
+    app: multi-svc
 spec:
   ports:
     - name: http
@@ -30,6 +32,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backend-1
+  namespace: multi-tcp-route
 spec:
   replicas: 1
   selector:
@@ -58,12 +61,13 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: SERVICE_NAME
-              value: foo
+              value: multi-svc-1
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: backend-2
+  namespace: multi-tcp-route
 spec:
   replicas: 1
   selector:
@@ -92,4 +96,4 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: SERVICE_NAME
-              value: bar
+              value: multi-svc-2

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/multi-listener-gateway-and-client.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/multi-listener-gateway-and-client.yaml
@@ -1,17 +1,18 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: tcp-gateway
+  name: multi-tcp-gateway
+  namespace: multi-tcp-route
 spec:
   gatewayClassName: gloo-gateway
   listeners:
-  - name: foo
+  - name: listener-8088
     protocol: TCP
     port: 8088
     allowedRoutes:
       kinds:
       - kind: TCPRoute
-  - name: bar
+  - name: listener-8089
     protocol: TCP
     port: 8089
     allowedRoutes:
@@ -19,15 +20,10 @@ spec:
       - kind: TCPRoute
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: curl
----
-apiVersion: v1
 kind: Pod
 metadata:
   name: curl
-  namespace: curl
+  namespace:  multi-tcp-route
   labels:
     app: curl
     version: v1

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/multi-ns.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/multi-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: multi-tcp-route

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/multi-tcproute.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/multi-tcproute.yaml
@@ -1,27 +1,29 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: tcp-app-1
+  name: tcp-route-1
+  namespace: multi-tcp-route
 spec:
   parentRefs:
-  - name: tcp-gateway
-    sectionName: foo
+  - name: multi-tcp-gateway
+    sectionName: listener-8088
   rules:
   - backendRefs:
-    - name: foo
+    - name: multi-svc-1
       port: 3001
       weight: 60
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: tcp-app-2
+  name: tcp-route-2
+  namespace: multi-tcp-route
 spec:
   parentRefs:
-  - name: tcp-gateway
-    sectionName: bar
+  - name: multi-tcp-gateway
+    sectionName: listener-8089
   rules:
   - backendRefs:
-    - name: bar
+    - name: multi-svc-2
       port: 3002
       weight: 40

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/single-backend-service.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/single-backend-service.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: single-svc
+  namespace: single-tcp-route
+  labels:
+    app: single-svc
+spec:
+  ports:
+    - name: http
+      port: 3001
+      targetPort: 3000
+  selector:
+    app: backend-0
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: backend-0
+  namespace: single-tcp-route
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: backend-0
+      version: v1
+  template:
+    metadata:
+      labels:
+        app: backend-0
+        version: v1
+    spec:
+      containers:
+        - image: gcr.io/k8s-staging-gateway-api/echo-basic:v20231214-v1.0.0-140-gf544a46e
+          imagePullPolicy: IfNotPresent
+          name: backend-0
+          ports:
+            - containerPort: 3000
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: SERVICE_NAME
+              value: single-svc

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/single-listener-gateway-and-client.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/single-listener-gateway-and-client.yaml
@@ -1,27 +1,23 @@
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
-  name: tcp-gateway
+  name: single-tcp-gateway
+  namespace: single-tcp-route
 spec:
   gatewayClassName: gloo-gateway
   listeners:
-  - name: foo
+  - name: listener-8087
     protocol: TCP
-    port: 8088
+    port: 8087
     allowedRoutes:
       kinds:
       - kind: TCPRoute
 ---
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: curl
----
-apiVersion: v1
 kind: Pod
 metadata:
   name: curl
-  namespace: curl
+  namespace: single-tcp-route
   labels:
     app: curl
     version: v1

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/single-ns.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/single-ns.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: single-tcp-route

--- a/test/kubernetes/e2e/features/services/tcproute/testdata/single-tcproute.yaml
+++ b/test/kubernetes/e2e/features/services/tcproute/testdata/single-tcproute.yaml
@@ -1,14 +1,13 @@
 apiVersion: gateway.networking.k8s.io/v1alpha2
 kind: TCPRoute
 metadata:
-  name: tcp-app-1
+  name: single-tcp-route
+  namespace: single-tcp-route
 spec:
   parentRefs:
-  - name: tcp-gateway
-    sectionName: foo
+  - name: single-tcp-gateway
+    sectionName: listener-8087
   rules:
   - backendRefs:
-    - name: foo
+    - name: single-svc
       port: 3001
-    - name: bar
-      port: 3002

--- a/test/kubernetes/e2e/features/services/tcproute/types.go
+++ b/test/kubernetes/e2e/features/services/tcproute/types.go
@@ -1,6 +1,7 @@
 package tcproute
 
 import (
+	"fmt"
 	"net/http"
 	"path/filepath"
 	"time"
@@ -15,36 +16,93 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// Constants used by TestConfigureTCPRouteBackingDestinationsWithSingleService
+	singleSvcNsName           = "single-tcp-route"
+	singleSvcGatewayName      = "single-tcp-gateway"
+	singleSvcListenerName8087 = "listener-8087"
+	singleSvcName             = "single-svc"
+	singleSvcTCPRouteName     = "single-tcp-route"
+
+	// Constants used by TestConfigureTCPRouteBackingDestinationsWithMultiServices
+	multiSvcNsName           = "multi-tcp-route"
+	multiSvcGatewayName      = "multi-tcp-gateway"
+	multiSvcListenerName8089 = "listener-8089"
+	multiSvcListenerName8088 = "listener-8088"
+	multiSvc1Name            = "multi-svc-1"
+	multiSvc2Name            = "multi-svc-2"
+	multiSvcTCPRouteName1    = "tcp-route-1"
+	multiSvcTCPRouteName2    = "tcp-route-2"
+)
+
 var (
-	multiListenerGatewayAndClientManifest  = filepath.Join(util.MustGetThisDir(), "testdata", "multi-listener-gateway-and-client.yaml")
-	multiBackendServiceManifest            = filepath.Join(util.MustGetThisDir(), "testdata", "multi-backend-service.yaml")
-	multiTcpRouteManifest                  = filepath.Join(util.MustGetThisDir(), "testdata", "multi-tcproute.yaml")
-	singleListenerGatewayAndClientManifest = filepath.Join(util.MustGetThisDir(), "testdata", "single-listener-gateway-and-client.yaml")
-	singleTcpRouteManifest                 = filepath.Join(util.MustGetThisDir(), "testdata", "single-tcproute.yaml")
-	// Test assertion timeout
-	timeout = 30 * time.Second
+	// Variables used by TestConfigureTCPRouteBackingDestinationsWithSingleService
+	multiSvcNsManifest               = filepath.Join(util.MustGetThisDir(), "testdata", "multi-ns.yaml")
+	multiSvcGatewayAndClientManifest = filepath.Join(util.MustGetThisDir(), "testdata", "multi-listener-gateway-and-client.yaml")
+	multiSvcBackendManifest          = filepath.Join(util.MustGetThisDir(), "testdata", "multi-backend-service.yaml")
+	multiSvcTcpRouteManifest         = filepath.Join(util.MustGetThisDir(), "testdata", "multi-tcproute.yaml")
 
-	// Proxy resource to be translated
-	glooProxyObjectMeta = metav1.ObjectMeta{
-		Name:      "gloo-proxy-tcp-gateway",
-		Namespace: "default",
+	// Variables used by TestConfigureTCPRouteBackingDestinationsWithMultiServices
+	singleSvcNsManifest               = filepath.Join(util.MustGetThisDir(), "testdata", "single-ns.yaml")
+	singleSvcGatewayAndClientManifest = filepath.Join(util.MustGetThisDir(), "testdata", "single-listener-gateway-and-client.yaml")
+	singleSvcBackendManifest          = filepath.Join(util.MustGetThisDir(), "testdata", "single-backend-service.yaml")
+	singleSvcTcpRouteManifest         = filepath.Join(util.MustGetThisDir(), "testdata", "single-tcproute.yaml")
+
+	// Assertion test timers
+	ctxTimeout = 5 * time.Minute
+	timeout    = 30 * time.Second
+	waitTime   = 5 * time.Second
+	tickTime   = 1 * time.Second
+
+	// Proxy resources to be translated
+	singleSvcNS = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: singleSvcNsName,
+		},
 	}
-	proxyDeployment = &appsv1.Deployment{ObjectMeta: glooProxyObjectMeta}
-	proxyService    = &corev1.Service{ObjectMeta: glooProxyObjectMeta}
 
-	expectedTcpFooSvcResp = &testmatchers.HttpResponse{
+	singleGlooProxy = metav1.ObjectMeta{
+		Name:      "gloo-proxy-single-tcp-gateway",
+		Namespace: singleSvcNsName,
+	}
+	singleSvcProxyDeployment = &appsv1.Deployment{ObjectMeta: singleGlooProxy}
+	singleSvcProxyService    = &corev1.Service{ObjectMeta: singleGlooProxy}
+
+	multieSvcNS = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: multiSvcNsName,
+		},
+	}
+
+	multiGlooProxy = metav1.ObjectMeta{
+		Name:      "gloo-proxy-multi-tcp-gateway",
+		Namespace: multiSvcNsName,
+	}
+	multiProxyDeployment = &appsv1.Deployment{ObjectMeta: multiGlooProxy}
+	multiProxyService    = &corev1.Service{ObjectMeta: multiGlooProxy}
+
+	// Expected curl responses from tests
+	expectedSingleSvcResp = &testmatchers.HttpResponse{
 		StatusCode: http.StatusOK,
 		Body: gomega.SatisfyAll(
-			gomega.MatchRegexp(`"namespace"\s*:\s*"default"`),
-			gomega.MatchRegexp(`"service"\s*:\s*"foo"`),
+			gomega.MatchRegexp(fmt.Sprintf(`"namespace"\s*:\s*"%s"`, singleSvcNsName)),
+			gomega.MatchRegexp(`"service"\s*:\s*"single-svc"`),
 		),
 	}
 
-	expectedTcpBarSvcResp = &testmatchers.HttpResponse{
+	expectedMultiSvc1Resp = &testmatchers.HttpResponse{
 		StatusCode: http.StatusOK,
 		Body: gomega.SatisfyAll(
-			gomega.MatchRegexp(`"namespace"\s*:\s*"default"`),
-			gomega.MatchRegexp(`"service"\s*:\s*"bar"`),
+			gomega.MatchRegexp(fmt.Sprintf(`"namespace"\s*:\s*"%s"`, multiSvcNsName)),
+			gomega.MatchRegexp(fmt.Sprintf(`"service"\s*:\s*"%s"`, multiSvc1Name)),
+		),
+	}
+
+	expectedMultiSvc2Resp = &testmatchers.HttpResponse{
+		StatusCode: http.StatusOK,
+		Body: gomega.SatisfyAll(
+			gomega.MatchRegexp(fmt.Sprintf(`"namespace"\s*:\s*"%s"`, multiSvcNsName)),
+			gomega.MatchRegexp(fmt.Sprintf(`"service"\s*:\s*"%s"`, multiSvc2Name)),
 		),
 	}
 )

--- a/test/kubernetes/testutils/assertions/objects.go
+++ b/test/kubernetes/testutils/assertions/objects.go
@@ -35,7 +35,7 @@ func (p *Provider) EventuallyObjectsNotExist(ctx context.Context, objects ...cli
 			innerG.Expect(apierrors.IsNotFound(err)).To(BeTrue(), "object %s %s should not be found in cluster", o.GetObjectKind().GroupVersionKind().String(), client.ObjectKeyFromObject(o).String())
 		}).
 			WithContext(ctx).
-			WithTimeout(time.Second*20).
+			WithTimeout(time.Second*60).
 			WithPolling(time.Millisecond*200).
 			Should(Succeed(), fmt.Sprintf("object %s %s should not be found in cluster", o.GetObjectKind().GroupVersionKind().String(), client.ObjectKeyFromObject(o).String()))
 	}


### PR DESCRIPTION
Refactors TCPRoute e2e tests to run in parallel, reduce flakes, and parameterize tests for reusability.

- Separates manifests/resources on a per-test basis.
- Uses namespaces for test isolation and to support parallelizing test runs.
- Bumps the timeout for `EventuallyObjectsNotExist` to 60 seconds since deleting a namespace can take longer than then previous time (20 seconds).
- Uses `Eventually` assertions to reduce flakes due to eventual consistency.
- Combines test methods into a single parameterized test method.
- Implements helper functions to reduce code repeatition.

Fixes #10414
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/10414