### PR TITLE
gateway2/delegation: add unit test for multi-level multi-parent config

### DIFF
--- a/changelog/v1.17.17/1.17-deleg.yaml
+++ b/changelog/v1.17.17/1.17-deleg.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/k8sgateway/k8sgateway/issues/10379
+    resolvesIssue: false
+    description: |
+      Gateway: add unit test for multi-level and multi-parent delegation.
+

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -221,4 +221,6 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("RouteOptions multi level inheritance with child override", "route_options_multi_level_inheritance_override_ok.yaml"),
 	Entry("RouteOptions filter override merge", "route_options_filter_override_merge.yaml"),
 	Entry("Child route matcher does not match parent", "bug-6621.yaml"),
+	// https://github.com/k8sgateway/k8sgateway/issues/10379
+	Entry("Multi-level multiple parents delegation", "bug-10379.yaml"),
 )

--- a/projects/gateway2/translator/testutils/inputs/delegation/bug-10379.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/bug-10379.yaml
@@ -1,0 +1,127 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: api-example-com
+  namespace: infra
+  labels:
+    app: apis
+spec:
+  parentRefs:
+    - name: example-gateway
+  hostnames:
+    - "api.example.com"
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /api1
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: apiproduct-1
+        namespace: default
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /api2
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: apiproduct-2
+        namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: apiproduct-1
+  namespace: default
+  labels:
+    app: apis
+  annotations:
+    delegation.gateway.solo.io/inherit-parent-matcher: "true"
+spec:
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: httpbin
+        namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: apiproduct-2
+  namespace: default
+  labels:
+    app: apis
+  annotations:
+    delegation.gateway.solo.io/inherit-parent-matcher: "true"
+spec:
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /
+      backendRefs:
+      - group: gateway.networking.k8s.io
+        kind: HTTPRoute
+        name: httpbin
+        namespace: default
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: httpbin
+  namespace: default
+  labels:
+    app: apis
+  annotations:
+    delegation.gateway.solo.io/inherit-parent-matcher: "true"
+spec:
+  rules:
+    - matches:
+      - path:
+          type: PathPrefix
+          value: /
+      backendRefs:
+      - name: httpbin
+        namespace: default
+        port: 8000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: default
+spec:
+  ports:
+    - protocol: TCP
+      port: 8000

--- a/projects/gateway2/translator/testutils/outputs/delegation/bug-10379.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/bug-10379.yaml
@@ -1,0 +1,51 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~api_example_com
+    httpResources:
+      virtualHosts:
+        http~api_example_com:
+          domains:
+          - api.example.com
+          name: http~api_example_com
+          routes:
+          - matchers:
+            - prefix: /api1
+            options:
+              regexRewrite:
+                pattern:
+                  regex: ^/api1\/*
+                substitution: /
+            routeAction:
+              single:
+                kube:
+                  port: 8000
+                  ref:
+                    name: httpbin
+                    namespace: default
+          - matchers:
+            - prefix: /api2
+            options:
+              regexRewrite:
+                pattern:
+                  regex: ^/api2\/*
+                substitution: /
+            routeAction:
+              single:
+                kube:
+                  port: 8000
+                  ref:
+                    name: httpbin
+                    namespace: default
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system


### PR DESCRIPTION
# Description

Adds a unit test to validate the behavior of multi-level delegation involving multiple parents. This test is required to prevent regressions.

Backports the test added in https://github.com/solo-io/gloo/pull/10405