### PR TITLE
Zero downtime upgrade test

### DIFF
--- a/changelog/v1.19.0-beta1/zd-upgrade-test.yaml
+++ b/changelog/v1.19.0-beta1/zd-upgrade-test.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Add a kube gateway zero-downtime upgrade test.
+      
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/common.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/common.go
@@ -1,0 +1,116 @@
+package zero_downtime_rollout
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	. "github.com/onsi/gomega"
+	"github.com/solo-io/gloo/pkg/utils/kubeutils"
+	"github.com/solo-io/gloo/pkg/utils/requestutils/curl"
+	testmatchers "github.com/solo-io/gloo/test/gomega/matchers"
+	"github.com/solo-io/gloo/test/kubernetes/e2e/defaults"
+	"github.com/solo-io/gloo/test/kubernetes/e2e/tests/base"
+)
+
+type commonTestingSuite struct {
+	*base.BaseTestingSuite
+}
+
+func (s *commonTestingSuite) waitProxyRunning() {
+	// Ensure the gloo gateway pod is up and running
+	s.TestInstallation.Assertions.EventuallyRunningReplicas(s.Ctx, glooProxyObjectMeta, Equal(1))
+	s.TestInstallation.Assertions.AssertEventualCurlResponse(
+		s.Ctx,
+		defaults.CurlPodExecOpt,
+		[]curl.Option{
+			curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
+			curl.WithHostHeader("example.com"),
+		},
+		&testmatchers.HttpResponse{
+			StatusCode: http.StatusOK,
+		})
+}
+
+// ensureZeroDowntimeDuringAction continuously sends traffic to the proxy while performing an action specified by
+// `actionFunc`, and ensures there is no downtime.
+// `numRequests` specifies the total number of requests to send
+func (s *commonTestingSuite) ensureZeroDowntimeDuringAction(actionFunc func(), numRequests int) {
+	// Send traffic to the gloo gateway pod while performing the specified action.
+	// Run this for long enough to perform the action since there's no easy way
+	// to stop this command once the test is over
+	// e.g. for numRequests=800, this executes 800 req @ 4 req/sec = 20s (3 * terminationGracePeriodSeconds (5) + buffer)
+	// kubectl exec -n hey hey -- hey -disable-keepalive -c 4 -q 10 --cpus 1 -n 1200 -m GET -t 1 -host example.com http://gloo-proxy-gw.default.svc.cluster.local:8080
+	args := []string{"exec", "-n", "hey", "hey", "--", "hey", "-disable-keepalive", "-c", "4", "-q", "10", "--cpus", "1", "-n", strconv.Itoa(numRequests), "-m", "GET", "-t", "1", "-host", "example.com", "http://gloo-proxy-gw.default.svc.cluster.local:8080"}
+
+	var err error
+	cmd := s.TestHelper.Cli.Command(s.Ctx, args...)
+	err = cmd.Start()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Perform the specified action. There should be no downtime since the gloo gateway pod should have the readiness probes configured
+	actionFunc()
+
+	now := time.Now()
+	err = cmd.Wait()
+	Expect(err).ToNot(HaveOccurred())
+
+	// Since there's no easy way to stop the command after we've performed the action,
+	// we ensure that at least 1 second has passed since we began sending traffic to the gloo gateway pod
+	after := int(time.Now().Sub(now).Abs().Seconds())
+	s.GreaterOrEqual(after, 1)
+
+	// 	Summary:
+	// 		Total:	30.0113 secs
+	// 		Slowest:	0.0985 secs
+	// 		Fastest:	0.0025 secs
+	// 		Average:	0.0069 secs
+	// 		Requests/sec:	39.9849
+	//
+	// 	Total data:	738000 bytes
+	// 		Size/request:	615 bytes
+	//
+	//   Response time histogram:
+	// 		0.003 [1]		|
+	// 		0.012 [1165]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
+	// 		0.022 [24]		|■
+	// 		0.031 [4]		|
+	// 		0.041 [0]		|
+	// 		0.050 [0]		|
+	// 		0.060 [0]		|
+	// 		0.070 [0]		|
+	// 		0.079 [0]		|
+	// 		0.089 [1]		|
+	// 		0.098 [5]		|
+	//
+	//   Latency distribution:
+	// 		10% in 0.0036 secs
+	// 		25% in 0.0044 secs
+	// 		50% in 0.0060 secs
+	// 		75% in 0.0082 secs
+	// 		90% in 0.0099 secs
+	// 		95% in 0.0109 secs
+	// 		99% in 0.0187 secs
+	//
+	//   Details (average, fastest, slowest):
+	// 		DNS+dialup:	0.0028 secs, 0.0025 secs, 0.0985 secs
+	// 		DNS-lookup:	0.0016 secs, 0.0001 secs, 0.0116 secs
+	// 		req write:	0.0003 secs, 0.0001 secs, 0.0041 secs
+	// 		resp wait:	0.0034 secs, 0.0012 secs, 0.0782 secs
+	// 		resp read:	0.0003 secs, 0.0001 secs, 0.0039 secs
+	//
+	//   Status code distribution:
+	// 		[200]	800 responses
+	//
+	// ***** Should not contain something like this *****
+	//   Status code distribution:
+	// 		[200]	779 responses
+	// 	Error distribution:
+	//   	[17]	Get http://gloo-proxy-gw.default.svc.cluster.local:8080: dial tcp 10.96.177.91:8080: connection refused
+	//   	[4]	Get http://gloo-proxy-gw.default.svc.cluster.local:8080: net/http: request canceled while waiting for connection
+
+	// Verify that there were no errors
+	Expect(cmd.Output()).To(ContainSubstring(fmt.Sprintf("[200]	%d responses", numRequests)))
+	Expect(cmd.Output()).ToNot(ContainSubstring("Error distribution"))
+}

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
@@ -2,125 +2,52 @@ package zero_downtime_rollout
 
 import (
 	"context"
-	"net/http"
 	"time"
 
 	. "github.com/onsi/gomega"
-	"github.com/stretchr/testify/suite"
-
-	"github.com/solo-io/gloo/pkg/utils/kubeutils"
-	"github.com/solo-io/gloo/pkg/utils/requestutils/curl"
-	testmatchers "github.com/solo-io/gloo/test/gomega/matchers"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	"github.com/solo-io/gloo/test/kubernetes/e2e/defaults"
 	"github.com/solo-io/gloo/test/kubernetes/e2e/tests/base"
+	"github.com/stretchr/testify/suite"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type testingSuite struct {
-	*base.BaseTestingSuite
+var _ e2e.NewSuiteFunc = NewNonUpgradeSuite
+
+var (
+	nonUpgradeTestCases = map[string]*base.TestCase{
+		"TestRestartProxyDeployment": {
+			SimpleTestCase: base.SimpleTestCase{
+				Manifests: []string{defaults.CurlPodManifest, serviceManifest, routeWithServiceManifest},
+				Resources: []client.Object{proxyDeployment, proxyService, defaults.CurlPod, heyPod},
+			},
+		},
+	}
+)
+
+type nonUpgradeTestingSuite struct {
+	*commonTestingSuite
 }
 
-func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
-	return &testingSuite{
-		base.NewBaseTestingSuite(ctx, testInst, e2e.MustTestHelper(ctx, testInst), base.SimpleTestCase{}, zeroDowntimeTestCases),
+func NewNonUpgradeSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	return &nonUpgradeTestingSuite{
+		&commonTestingSuite{
+			base.NewBaseTestingSuite(ctx, testInst, e2e.MustTestHelper(ctx, testInst), base.SimpleTestCase{}, nonUpgradeTestCases),
+		},
 	}
 }
 
-func (s *testingSuite) TestZeroDowntimeRollout() {
-	// Ensure the gloo gateway pod is up and running
-	s.TestInstallation.Assertions.EventuallyRunningReplicas(s.Ctx, glooProxyObjectMeta, Equal(1))
-	s.TestInstallation.Assertions.AssertEventualCurlResponse(
-		s.Ctx,
-		defaults.CurlPodExecOpt,
-		[]curl.Option{
-			curl.WithHost(kubeutils.ServiceFQDN(proxyService.ObjectMeta)),
-			curl.WithHostHeader("example.com"),
-		},
-		&testmatchers.HttpResponse{
-			StatusCode: http.StatusOK,
-		})
+func (s *nonUpgradeTestingSuite) TestRestartProxyDeployment() {
+	s.waitProxyRunning()
 
-	// Send traffic to the gloo gateway pod while we restart the deployment
-	// Run this for 30s which is long enough to restart the deployment since there's no easy way
-	// to stop this command once the test is over
-	// This executes 800 req @ 4 req/sec = 20s (3 * terminationGracePeriodSeconds (5) + buffer)
-	// kubectl exec -n hey hey -- hey -disable-keepalive -c 4 -q 10 --cpus 1 -n 1200 -m GET -t 1 -host example.com http://gloo-proxy-gw.default.svc.cluster.local:8080
-	args := []string{"exec", "-n", "hey", "hey", "--", "hey", "-disable-keepalive", "-c", "4", "-q", "10", "--cpus", "1", "-n", "800", "-m", "GET", "-t", "1", "-host", "example.com", "http://gloo-proxy-gw.default.svc.cluster.local:8080"}
+	s.ensureZeroDowntimeDuringAction(func() {
+		err := s.TestHelper.RestartDeploymentAndWait(s.Ctx, "gloo-proxy-gw")
+		Expect(err).ToNot(HaveOccurred())
 
-	var err error
-	cmd := s.TestHelper.Cli.Command(s.Ctx, args...)
-	err = cmd.Start()
-	Expect(err).ToNot(HaveOccurred())
+		time.Sleep(1 * time.Second)
 
-	// Restart the deployment. There should be no downtime since the gloo gateway pod should have the readiness probes configured
-	err = s.TestHelper.RestartDeploymentAndWait(s.Ctx, "gloo-proxy-gw")
-	Expect(err).ToNot(HaveOccurred())
-
-	time.Sleep(1 * time.Second)
-
-	// We're just flexing at this point
-	err = s.TestHelper.RestartDeploymentAndWait(s.Ctx, "gloo-proxy-gw")
-	Expect(err).ToNot(HaveOccurred())
-
-	now := time.Now()
-	err = cmd.Wait()
-	Expect(err).ToNot(HaveOccurred())
-
-	// Since there's no easy way to stop the command after we've restarted the deployment,
-	// we ensure that at least 1 second has passed since we began sending traffic to the gloo gateway pod
-	after := int(time.Now().Sub(now).Abs().Seconds())
-	s.GreaterOrEqual(after, 1)
-
-	// 	Summary:
-	// 		Total:	30.0113 secs
-	// 		Slowest:	0.0985 secs
-	// 		Fastest:	0.0025 secs
-	// 		Average:	0.0069 secs
-	// 		Requests/sec:	39.9849
-	//
-	// 	Total data:	738000 bytes
-	// 		Size/request:	615 bytes
-	//
-	//   Response time histogram:
-	// 		0.003 [1]		|
-	// 		0.012 [1165]	|■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■■
-	// 		0.022 [24]		|■
-	// 		0.031 [4]		|
-	// 		0.041 [0]		|
-	// 		0.050 [0]		|
-	// 		0.060 [0]		|
-	// 		0.070 [0]		|
-	// 		0.079 [0]		|
-	// 		0.089 [1]		|
-	// 		0.098 [5]		|
-	//
-	//   Latency distribution:
-	// 		10% in 0.0036 secs
-	// 		25% in 0.0044 secs
-	// 		50% in 0.0060 secs
-	// 		75% in 0.0082 secs
-	// 		90% in 0.0099 secs
-	// 		95% in 0.0109 secs
-	// 		99% in 0.0187 secs
-	//
-	//   Details (average, fastest, slowest):
-	// 		DNS+dialup:	0.0028 secs, 0.0025 secs, 0.0985 secs
-	// 		DNS-lookup:	0.0016 secs, 0.0001 secs, 0.0116 secs
-	// 		req write:	0.0003 secs, 0.0001 secs, 0.0041 secs
-	// 		resp wait:	0.0034 secs, 0.0012 secs, 0.0782 secs
-	// 		resp read:	0.0003 secs, 0.0001 secs, 0.0039 secs
-	//
-	//   Status code distribution:
-	// 		[200]	800 responses
-	//
-	// ***** Should not contain something like this *****
-	//   Status code distribution:
-	// 		[200]	779 responses
-	// 	Error distribution:
-	//   	[17]	Get http://gloo-proxy-gw.default.svc.cluster.local:8080: dial tcp 10.96.177.91:8080: connection refused
-	//   	[4]	Get http://gloo-proxy-gw.default.svc.cluster.local:8080: net/http: request canceled while waiting for connection
-
-	// Verify that there were no errors
-	Expect(cmd.Output()).To(ContainSubstring("[200]	800 responses"))
-	Expect(cmd.Output()).ToNot(ContainSubstring("Error distribution"))
+		// We're just flexing at this point
+		err = s.TestHelper.RestartDeploymentAndWait(s.Ctx, "gloo-proxy-gw")
+		Expect(err).ToNot(HaveOccurred())
+	}, 800)
 }

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/testdata/manifests/zero-downtime-upgrade.yaml
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/testdata/manifests/zero-downtime-upgrade.yaml
@@ -1,0 +1,24 @@
+kubeGateway:
+  enabled: true
+  # Enable the probes to ensure zero downtime
+  gatewayParameters:
+    glooGateway:
+      service:
+        extraLabels:
+          new-service-label-key: new-service-label-val
+      podTemplate:
+        terminationGracePeriodSeconds: 5
+        gracefulShutdown:
+          enabled: true
+          sleepTimeSeconds: 2
+        probes: true
+        customLivenessProbe:
+          exec:
+            command:
+            - wget
+            - -O
+            - /dev/null
+            - 127.0.0.1:19000/server_info
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          failureThreshold: 3

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/types.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/types.go
@@ -3,10 +3,6 @@ package zero_downtime_rollout
 import (
 	"path/filepath"
 
-	"github.com/solo-io/gloo/test/kubernetes/e2e/defaults"
-	"github.com/solo-io/gloo/test/kubernetes/e2e/tests/base"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/solo-io/skv2/codegen/util"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -29,15 +25,6 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "hey",
 			Namespace: "hey",
-		},
-	}
-
-	zeroDowntimeTestCases = map[string]*base.TestCase{
-		"TestZeroDowntimeRollout": {
-			SimpleTestCase: base.SimpleTestCase{
-				Manifests: []string{defaults.CurlPodManifest, serviceManifest, routeWithServiceManifest},
-				Resources: []client.Object{proxyDeployment, proxyService, defaults.CurlPod, heyPod},
-			},
 		},
 	}
 )

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/upgrade_suite.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/upgrade_suite.go
@@ -1,0 +1,94 @@
+package zero_downtime_rollout
+
+import (
+	"context"
+	"path/filepath"
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/solo-io/gloo/test/kubernetes/e2e"
+	"github.com/solo-io/gloo/test/kubernetes/e2e/defaults"
+	"github.com/solo-io/gloo/test/kubernetes/e2e/tests/base"
+	"github.com/solo-io/gloo/test/kubernetes/testutils/helper"
+	"github.com/solo-io/skv2/codegen/util"
+	"github.com/stretchr/testify/suite"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ e2e.NewSuiteFunc = NewUpgradeSuite
+
+var (
+	upgradeTestCases = map[string]*base.TestCase{
+		"TestUpgradeToCurrentVersion": {
+			SimpleTestCase: base.SimpleTestCase{
+				Manifests: []string{defaults.CurlPodManifest, serviceManifest, routeWithServiceManifest},
+				Resources: []client.Object{proxyDeployment, proxyService, defaults.CurlPod, heyPod},
+			},
+		},
+	}
+)
+
+type upgradeTestingSuite struct {
+	*commonTestingSuite
+}
+
+func NewUpgradeSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
+	// Note: some of this file is copied from features/upgrade/suite.go, however this test suite is
+	// located within the zero downtime feature suite so we can share some util code with it.
+	// We might want to eventually combine the zero-downtime suite with the upgrade suite
+	// (if it makes sense to).
+
+	// The release version in the test installation gets overwritten by the test helper
+	// So we keep it safe and update it
+	releaseVersion := testInst.Metadata.ReleasedVersion
+	testHelper := e2e.MustTestHelper(ctx, testInst)
+	testHelper.ReleasedVersion = releaseVersion
+	testInst.Metadata.ReleasedVersion = releaseVersion
+
+	return &upgradeTestingSuite{
+		&commonTestingSuite{
+			base.NewBaseTestingSuite(ctx, testInst, testHelper, base.SimpleTestCase{}, upgradeTestCases),
+		},
+	}
+}
+
+func (s *upgradeTestingSuite) BeforeTest(suiteName, testName string) {
+	// the old release is installed before the test
+	err := s.TestHelper.InstallGloo(s.Ctx, 600*time.Second, helper.WithExtraArgs([]string{
+		"--values", s.TestInstallation.Metadata.ProfileValuesManifestFile,
+		"--values", s.TestInstallation.Metadata.ValuesManifestFile,
+	}...),
+		helper.WithCRDs(filepath.Join(s.TestHelper.RootDir, "install", "helm", "gloo", "crds")))
+	s.TestInstallation.Assertions.Require.NoError(err)
+
+	// apply manifests
+	s.BaseTestingSuite.BeforeTest(suiteName, testName)
+}
+
+func (s *upgradeTestingSuite) AfterTest(suiteName, testName string) {
+	// delete manifests
+	s.BaseTestingSuite.AfterTest(suiteName, testName)
+
+	s.TestInstallation.UninstallGlooGateway(s.Ctx, func(ctx context.Context) error {
+		return s.TestHelper.UninstallGlooAll()
+	})
+}
+
+func (s *upgradeTestingSuite) TestUpgradeToCurrentVersion() {
+	s.waitProxyRunning()
+
+	s.ensureZeroDowntimeDuringAction(func() {
+		s.UpgradeWithCustomValuesFile(filepath.Join(util.MustGetThisDir(), "testdata/manifests", "zero-downtime-upgrade.yaml"))
+	}, 2000)
+
+	// as a sanity check make sure the deployer re-deployed resources with the new values
+	svc := &corev1.Service{}
+	err := s.TestInstallation.ClusterContext.Client.Get(s.Ctx,
+		types.NamespacedName{Name: glooProxyObjectMeta.Name, Namespace: glooProxyObjectMeta.Namespace},
+		svc)
+	s.Require().NoError(err)
+	s.TestInstallation.Assertions.Gomega.Expect(svc.GetLabels()).To(
+		gomega.HaveKeyWithValue("new-service-label-key", "new-service-label-val"))
+}

--- a/test/kubernetes/e2e/tests/base/base_suite.go
+++ b/test/kubernetes/e2e/tests/base/base_suite.go
@@ -152,7 +152,7 @@ func (s *BaseTestingSuite) BeforeTest(suiteName, testName string) {
 
 	testCase, ok := s.TestCase[testName]
 	if !ok {
-		return
+		s.FailNow("no manifests found for " + testName)
 	}
 
 	if testCase.UpgradeValues != "" {
@@ -196,7 +196,7 @@ func (s *BaseTestingSuite) AfterTest(suiteName, testName string) {
 	// Delete test-specific manifests
 	testCase, ok := s.TestCase[testName]
 	if !ok {
-		return
+		s.FailNow("no manifests found for " + testName)
 	}
 
 	if testCase.UpgradeValues != "" {

--- a/test/kubernetes/e2e/tests/upgrade_tests.go
+++ b/test/kubernetes/e2e/tests/upgrade_tests.go
@@ -3,10 +3,12 @@ package tests
 import (
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
 	"github.com/solo-io/gloo/test/kubernetes/e2e/features/upgrade"
+	"github.com/solo-io/gloo/test/kubernetes/e2e/features/zero_downtime_rollout"
 )
 
 func UpgradeSuiteRunner() e2e.SuiteRunner {
 	upgradeSuiteRunner := e2e.NewSuiteRunner(false)
 	upgradeSuiteRunner.Register("Upgrade", upgrade.NewTestingSuite)
+	upgradeSuiteRunner.Register("ZeroDowntimeUpgrade", zero_downtime_rollout.NewUpgradeSuite)
 	return upgradeSuiteRunner
 }

--- a/test/kubernetes/e2e/tests/zero_downtime_tests.go
+++ b/test/kubernetes/e2e/tests/zero_downtime_tests.go
@@ -7,6 +7,6 @@ import (
 
 func ZeroDowntimeRolloutSuiteRunner() e2e.SuiteRunner {
 	zeroDowntimeSuiteRunner := e2e.NewSuiteRunner(false)
-	zeroDowntimeSuiteRunner.Register("ZeroDowntimeRollout", zero_downtime_rollout.NewTestingSuite)
+	zeroDowntimeSuiteRunner.Register("ZeroDowntimeRollout", zero_downtime_rollout.NewNonUpgradeSuite)
 	return zeroDowntimeSuiteRunner
 }


### PR DESCRIPTION
# Description

Add a zero-downtime upgrade test for k8s gateway api.

## Context

Was originally [requested](https://github.com/solo-io/gloo/pull/10403#pullrequestreview-2473073112) in a separate PR. The test failed on that branch (as expected), but I think the test is useful enough to split out into its own PR independently of the other PR (which will be rewritten)

## Testing steps

Like other upgrade tests, this test only runs on nightlies and not on PRs.

The upgrade tests can be run locally with following steps:
```
kind delete cluster --name kind
rm -rf _test _output
ci/kind/setup-kind.sh
make install-test-tools -B

go test -v -timeout 600s ./test/kubernetes/e2e/tests -run ^TestUpgradeFromLastPatchPreviousMinor$
```

Output:
```
--- PASS: TestUpgradeFromLastPatchPreviousMinor (433.79s)
    --- PASS: TestUpgradeFromLastPatchPreviousMinor/Upgrade (244.76s)
        --- PASS: TestUpgradeFromLastPatchPreviousMinor/Upgrade/TestAddSecondGatewayProxySeparateNamespace (94.10s)
        --- PASS: TestUpgradeFromLastPatchPreviousMinor/Upgrade/TestUpdateValidationServerGrpcMaxSizeBytes (75.18s)
        --- PASS: TestUpgradeFromLastPatchPreviousMinor/Upgrade/TestValidationWebhookCABundle (75.47s)
    --- PASS: TestUpgradeFromLastPatchPreviousMinor/ZeroDowntimeUpgrade (188.04s)
        --- PASS: TestUpgradeFromLastPatchPreviousMinor/ZeroDowntimeUpgrade/TestUpgradeToCurrentVersion (188.02s)
PASS
ok  	github.com/solo-io/gloo/test/kubernetes/e2e/tests	435.057s
```


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

