### PR TITLE
fix broken GA CI build

### DIFF
--- a/changelog/v1.19.0-beta1/ci-multiarch-fixes.yaml
+++ b/changelog/v1.19.0-beta1/ci-multiarch-fixes.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Build & push multiarch images tocGCS besides quay instead of retagging them in CI build.
+      Also enabled publishing images to GCR for dev build so we can catch errors before running GA build.
+
+      skipCI-docs-build:true

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -100,14 +100,15 @@ steps:
   waitFor:
   - 'gcr-auth'
 
-# Run make targets to retag and push docker images to GCR
+# Run make targets to build and push docker images to GCR
 - name: 'gcr.io/$PROJECT_ID/go-mod-make:0.10.2'
-  id: 'docker-push-extended-gcr'
+  id: 'publish-docker-extended-gcr'
   dir: *dir
   args:
-  - 'publish-docker-retag'
+  - publish-docker
   env:
-  - 'ORIGINAL_IMAGE_REGISTRY=quay.io/solo-io'
+  - 'MULTIARCH=true'
+  - 'MULTIARCH_PUSH=true'
   - 'IMAGE_REGISTRY=gcr.io/gloo-edge'
   secretEnv:
   - 'GITHUB_TOKEN'


### PR DESCRIPTION
Follow-up for PR : https://github.com/solo-io/gloo/pull/10421
issue: above PR broke GA CI build for re-tagging and pushing images to GCR.

Fix:
- building & pushing images to GCR instead of retagging them.