### PR TITLE
[1.18] tests: Fix failing K8sGateway/Metrics test in enterprise

### DIFF
--- a/changelog/v1.18.1/fix-metrics-suite.yaml
+++ b/changelog/v1.18.1/fix-metrics-suite.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/7405
+  description: Fixes the failing K8sGateway/Metrics in enterprise caused by using the wrong BaseTestingSuite constructor.
+

--- a/test/kubernetes/e2e/features/helm/suite.go
+++ b/test/kubernetes/e2e/features/helm/suite.go
@@ -31,7 +31,7 @@ type testingSuite struct {
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		base.NewBaseTestingSuite(ctx, testInst, e2e.MustTestHelper(ctx, testInst), base.SimpleTestCase{}, helmTestCases),
+		base.NewBaseTestingSuiteWithUpgrades(ctx, testInst, e2e.MustTestHelper(ctx, testInst), base.SimpleTestCase{}, helmTestCases),
 	}
 }
 

--- a/test/kubernetes/e2e/features/metrics/suite.go
+++ b/test/kubernetes/e2e/features/metrics/suite.go
@@ -30,7 +30,7 @@ type testingSuite struct {
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		base.NewBaseTestingSuite(ctx, testInst, e2e.MustTestHelper(ctx, testInst), base.SimpleTestCase{}, testCases),
+		base.NewBaseTestingSuite(ctx, testInst, base.SimpleTestCase{}, testCases),
 	}
 }
 

--- a/test/kubernetes/e2e/features/upgrade/suite.go
+++ b/test/kubernetes/e2e/features/upgrade/suite.go
@@ -29,7 +29,7 @@ func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.
 	testInst.Metadata.ReleasedVersion = releaseVersion
 
 	return &testingSuite{
-		base.NewBaseTestingSuite(ctx, testInst, testHelper, base.SimpleTestCase{}, nil),
+		base.NewBaseTestingSuiteWithUpgrades(ctx, testInst, testHelper, base.SimpleTestCase{}, nil),
 	}
 }
 

--- a/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
+++ b/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
@@ -19,7 +19,7 @@ type testingSuite struct {
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		base.NewBaseTestingSuiteWithoutUpgrades(ctx, testInst, setupSuite, testCases),
+		base.NewBaseTestingSuite(ctx, testInst, setupSuite, testCases),
 	}
 }
 

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
@@ -22,7 +22,7 @@ type testingSuite struct {
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		base.NewBaseTestingSuite(ctx, testInst, base.SimpleTestCase{}, zeroDowntimeTestCases),
+		base.NewBaseTestingSuiteWithUpgrades(ctx, testInst, e2e.MustTestHelper(ctx, testInst), base.SimpleTestCase{}, zeroDowntimeTestCases),
 	}
 }
 

--- a/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
+++ b/test/kubernetes/e2e/features/zero_downtime_rollout/suite.go
@@ -22,7 +22,7 @@ type testingSuite struct {
 
 func NewTestingSuite(ctx context.Context, testInst *e2e.TestInstallation) suite.TestingSuite {
 	return &testingSuite{
-		base.NewBaseTestingSuite(ctx, testInst, e2e.MustTestHelper(ctx, testInst), base.SimpleTestCase{}, zeroDowntimeTestCases),
+		base.NewBaseTestingSuite(ctx, testInst, base.SimpleTestCase{}, zeroDowntimeTestCases),
 	}
 }
 

--- a/test/kubernetes/e2e/tests/base/base_suite.go
+++ b/test/kubernetes/e2e/tests/base/base_suite.go
@@ -50,12 +50,12 @@ type BaseTestingSuite struct {
 	Setup            SimpleTestCase
 }
 
-// NewBaseTestingSuite returns a BaseTestingSuite that performs all the pre-requisites of upgrading helm installations,
+// NewBaseTestingSuiteWithUpgrades returns a BaseTestingSuite that performs all the pre-requisites of upgrading helm installations,
 // applying manifests and verifying resources exist before a suite and tests and the corresponding post-run cleanup.
 // The pre-requisites for the suite are defined in the setup parameter and for each test in the individual testCase.
-// Currently, tests that require upgrades (eg: to change settings) can not be run in Enterprise. To do so,
-// the test must be written without upgrades and call the `NewBaseTestingSuiteWithoutUpgrades` constructor.
-func NewBaseTestingSuite(ctx context.Context, testInst *e2e.TestInstallation, testHelper *helper.SoloTestHelper, setup SimpleTestCase, testCase map[string]*TestCase) *BaseTestingSuite {
+// WARNING: Testing suites that call this method can not run in enterprise as they require upgrades (eg: to change settings).
+// To use the BaseTestingSuite, the test must be written without upgrades and call the `NewBaseTestingSuite` constructor.
+func NewBaseTestingSuiteWithUpgrades(ctx context.Context, testInst *e2e.TestInstallation, testHelper *helper.SoloTestHelper, setup SimpleTestCase, testCase map[string]*TestCase) *BaseTestingSuite {
 	namespace = testInst.Metadata.InstallNamespace
 	return &BaseTestingSuite{
 		Ctx:              ctx,
@@ -66,9 +66,10 @@ func NewBaseTestingSuite(ctx context.Context, testInst *e2e.TestInstallation, te
 	}
 }
 
-// NewBaseTestingSuiteWithoutUpgrades returns a BaseTestingSuite without allowing upgrades and reverts before the suite and tests.
-// This is useful when creating tests that need to run in Enterprise since the helm values change between OSS and Enterprise installations.
-func NewBaseTestingSuiteWithoutUpgrades(ctx context.Context, testInst *e2e.TestInstallation, setup SimpleTestCase, testCase map[string]*TestCase) *BaseTestingSuite {
+// NewBaseTestingSuite returns a BaseTestingSuite without allowing upgrades and reverts before the suite and tests.
+// Testing suites that call this method can safely run in Enterprise since the helm values change between OSS and Enterprise installations.
+// If tests require upgrades, call the `NewBaseTestingSuiteWithUpgrades` constructor, however those tests can not run in Enterprise.
+func NewBaseTestingSuite(ctx context.Context, testInst *e2e.TestInstallation, setup SimpleTestCase, testCase map[string]*TestCase) *BaseTestingSuite {
 	namespace = testInst.Metadata.InstallNamespace
 	return &BaseTestingSuite{
 		Ctx:              ctx,


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/10477

Fixes the failing K8sGateway/Metrics in enterprise caused by using the wrong BaseTestingSuite constructor

# Context

The NewBaseTestingSuite requires a TestHelper in its constructor, however calling `e2e.MustTestHelper` in OSS causes issues in enterprise since it makes assumptions about the repo that require significant changes to fix. Hence, I opted to rename the constructors to make things clear

## Testing steps

Tests are passing in enterprise
```
--- PASS: TestOssFeatures (189.26s)
    --- PASS: TestOssFeatures/OssK8sGateway (189.26s)
        --- PASS: TestOssFeatures/OssK8sGateway/Metrics (122.34s)
            --- PASS: TestOssFeatures/OssK8sGateway/Metrics/TestKubeServiceSuccessStats (61.53s)
            --- PASS: TestOssFeatures/OssK8sGateway/Metrics/TestKubeUpstreamSuccessStats (60.81s)
```

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/7405