### PR TITLE
[backport] gateway2/delegation: enable inherited policy overrides (#10470)

### DIFF
--- a/changelog/v1.17.17/fix-sp-7315.yaml
+++ b/changelog/v1.17.17/fix-sp-7315.yaml
@@ -1,0 +1,20 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7315
+    resolvesIssue: false
+    description: |
+      gateway2/delegation: enable inherited policy overrides
+
+      Adds the ability to override inherited policy fields when
+      explicitly permitted by a parent route using the annotation
+      delegation.gateway.solo.io/enable-policy-overrides.
+      It supports a wildcard value "*" or a comma separated list
+      of field names such as "faults,timeouts,retries,headermanipulation".
+
+      Functionally, a child RouteOption may only override the RouteOptions
+      derived from its parent if the above annotation exists on the parent
+      route. This is required to make the override behavior safe to use.
+
+      Testing done:
+      - Translator tests for the new scenarios.
+

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -223,4 +223,7 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("Child route matcher does not match parent", "bug-6621.yaml"),
 	// https://github.com/k8sgateway/k8sgateway/issues/10379
 	Entry("Multi-level multiple parents delegation", "bug-10379.yaml"),
+	Entry("RouteOptions prefer child override when allowed", "route_options_inheritance_child_override_allow.yaml"),
+	Entry("RouteOptions multi level inheritance with child override when allowed", "route_options_multi_level_inheritance_override_allow.yaml"),
+	Entry("RouteOptions multi level inheritance with partial child override", "route_options_multi_level_inheritance_override_partial.yaml"),
 )

--- a/projects/gateway2/translator/routeutils/utils.go
+++ b/projects/gateway2/translator/routeutils/utils.go
@@ -5,16 +5,25 @@ import (
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 )
 
-func AppendSourceToRoute(route *v1.Route, newSources []*gloov1.SourceMetadata_SourceRef, preserveExisting bool) {
+func AppendRouteSources(route *v1.Route, newSources []*gloov1.SourceMetadata_SourceRef) {
 	meta := route.GetMetadataStatic()
 	if meta == nil {
 		meta = &gloov1.SourceMetadata{}
 	}
 	sources := meta.GetSources()
-	if !preserveExisting {
-		sources = nil
-	}
 	sources = append(sources, newSources...)
+	route.OpaqueMetadata = &gloov1.Route_MetadataStatic{
+		MetadataStatic: &gloov1.SourceMetadata{
+			Sources: sources,
+		},
+	}
+}
+
+func SetRouteSources(route *v1.Route, sources []*gloov1.SourceMetadata_SourceRef) {
+	meta := route.GetMetadataStatic()
+	if meta == nil {
+		meta = &gloov1.SourceMetadata{}
+	}
 	route.OpaqueMetadata = &gloov1.Route_MetadataStatic{
 		MetadataStatic: &gloov1.SourceMetadata{
 			Sources: sources,

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_child_override_allow.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_inheritance_child_override_allow.yaml
@@ -1,0 +1,106 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+  annotations:
+    delegation.gateway.solo.io/enable-policy-overrides: "*"
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: example-opt
+  namespace: infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route
+  options:
+    faults:
+      abort:
+        percentage: 100
+        httpStatus: 418
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: route-a-opt
+  namespace: a
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-a
+  options:
+    faults:
+      abort:
+        percentage: 80
+        httpStatus: 404
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_multi_level_inheritance_override_allow.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_multi_level_inheritance_override_allow.yaml
@@ -1,0 +1,147 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+  annotations:
+    delegation.gateway.solo.io/enable-policy-overrides: "*"
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a-root
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: example-opt
+  namespace: infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route
+  options:
+    faults:
+      abort:
+        percentage: 100
+        httpStatus: 418
+    cors:
+      exposeHeaders:
+        - example
+      allowOrigin:
+        - example
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a-root
+  namespace: a-root
+  annotations:
+    delegation.gateway.solo.io/enable-policy-overrides: "*"
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: route-a-root-opt
+  namespace: a-root
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-a-root
+  options:
+    headerManipulation:
+      requestHeadersToRemove: ["foo"]
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: route-a-opt
+  namespace: a
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-a
+  options:
+    headerManipulation:
+      requestHeadersToRemove: ["override"]
+    cors:
+      exposeHeaders:
+        - foo
+      allowOrigin:
+        - baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/inputs/delegation/route_options_multi_level_inheritance_override_partial.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/route_options_multi_level_inheritance_override_partial.yaml
@@ -1,0 +1,146 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+  # Policy override annotation is missing
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a-root
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: example-opt
+  namespace: infra
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: example-route
+  options:
+    faults:
+      abort:
+        percentage: 100
+        httpStatus: 418
+    cors:
+      exposeHeaders:
+        - example
+      allowOrigin:
+        - example
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a-root
+  namespace: a-root
+  annotations:
+    delegation.gateway.solo.io/enable-policy-overrides: "headerManipulation,faults"
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: a
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: route-a-root-opt
+  namespace: a-root
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-a-root
+  options:
+    headerManipulation:
+      requestHeadersToRemove: ["foo"]
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a
+  namespace: a
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: gateway.solo.io/v1
+kind: RouteOption
+metadata:
+  name: route-a-opt
+  namespace: a
+spec:
+  targetRefs:
+  - group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: route-a
+  options:
+    headerManipulation:
+      requestHeadersToRemove: ["override"]
+    cors:
+      exposeHeaders:
+        - foo
+      allowOrigin:
+        - baz
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/outputs/delegation/route_options_inheritance_child_override_allow.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/route_options_inheritance_child_override_allow.yaml
@@ -1,0 +1,63 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - prefix: /a/1
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: route-a-opt
+                  namespace: a
+            options:
+              faults:
+                abort:
+                  httpStatus: 404
+                  percentage: 80
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - prefix: /
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: example-opt
+                  namespace: infra
+            options:
+              faults:
+                abort:
+                  httpStatus: 418
+                  percentage: 100
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: example-svc
+                    namespace: infra
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system

--- a/projects/gateway2/translator/testutils/outputs/delegation/route_options_multi_level_inheritance_override_allow.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/route_options_multi_level_inheritance_override_allow.yaml
@@ -1,0 +1,80 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - prefix: /a/1
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: route-a-opt
+                  namespace: a
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: example-opt
+                  namespace: infra
+            options:
+              cors:
+                allowOrigin:
+                - baz
+                exposeHeaders:
+                - foo
+              faults:
+                abort:
+                  httpStatus: 418
+                  percentage: 100
+              headerManipulation:
+                requestHeadersToRemove:
+                - override
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - prefix: /
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: example-opt
+                  namespace: infra
+            options:
+              cors:
+                allowOrigin:
+                - example
+                exposeHeaders:
+                - example
+              faults:
+                abort:
+                  httpStatus: 418
+                  percentage: 100
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: example-svc
+                    namespace: infra
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system

--- a/projects/gateway2/translator/testutils/outputs/delegation/route_options_multi_level_inheritance_override_partial.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/route_options_multi_level_inheritance_override_partial.yaml
@@ -1,0 +1,80 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - prefix: /a/1
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: route-a-opt
+                  namespace: a
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: example-opt
+                  namespace: infra
+            options:
+              cors:
+                allowOrigin:
+                - example
+                exposeHeaders:
+                - example
+              faults:
+                abort:
+                  httpStatus: 418
+                  percentage: 100
+              headerManipulation:
+                requestHeadersToRemove:
+                - override
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - prefix: /
+            metadataStatic:
+              sources:
+              - resourceKind: RouteOption
+                resourceRef:
+                  name: example-opt
+                  namespace: infra
+            options:
+              cors:
+                allowOrigin:
+                - example
+                exposeHeaders:
+                - example
+              faults:
+                abort:
+                  httpStatus: 418
+                  percentage: 100
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: example-svc
+                    namespace: infra
+  bindAddress: '::'
+  bindPort: 8080
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system

--- a/projects/gloo/pkg/utils/merge.go
+++ b/projects/gloo/pkg/utils/merge.go
@@ -2,8 +2,27 @@ package utils
 
 import (
 	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/util/sets"
 
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+)
+
+const wildcardField = "*"
+
+// OptionsMergeResult is an enum indicating the result of the merge of options from src to dst.
+type OptionsMergeResult int
+
+const (
+	// OptionsMergedNone indicates that no fields were merged from src to dst.
+	OptionsMergedNone OptionsMergeResult = iota
+
+	// OptionsMergedPartial indicates that some but not all fields were merged from src to dst.
+	OptionsMergedPartial
+
+	// OptionsMergedFull indicates that all fields set in dst were overwritten by src.
+	OptionsMergedFull
 )
 
 // ShallowMerge sets dst to the value of src, if src is non-zero and dst is zero-valued or overwrite=true.
@@ -97,4 +116,64 @@ func ShallowMergeVirtualHostOptions(dst, src *v1.VirtualHostOptions) (*v1.Virtua
 	}
 
 	return dst, overwrote
+}
+
+// MergeRouteOptionsWithOverrides merges the top-level fields of src that are allowed to be merged into dst.
+// allowedOverrides is a set of field names in lowercase that are allowed to be merged, and may contain a wildcard field "*"
+// to allow all fields to be merged.
+// When allowedOverrides is empty, only fields unset in dst and set in src will be merged into dst.
+//
+// It returns an Enum indicating the result of the merge.
+func MergeRouteOptionsWithOverrides(dst, src *v1.RouteOptions, allowedOverrides sets.Set[string]) (*v1.RouteOptions, OptionsMergeResult) {
+	if src == nil {
+		return dst, OptionsMergedNone
+	}
+
+	if dst == nil {
+		return src.Clone().(*v1.RouteOptions), OptionsMergedFull
+	}
+
+	dstValue, srcValue := reflect.ValueOf(dst).Elem(), reflect.ValueOf(src).Elem()
+
+	// By default, do not allow fields in src to overwrite fields in dst.
+	// If allowedOverrides is non-empty, enable overwrites for the allowed fields.
+	overwriteByDefault := false
+	if allowedOverrides.Len() > 0 {
+		overwriteByDefault = true
+	}
+
+	var srcFieldsUsed int
+	var dstFieldsSet int
+	var dstFieldsOverwritten int
+	for i := range dstValue.NumField() {
+		dstField, srcField := dstValue.Field(i), srcValue.Field(i)
+		if overwriteByDefault && !(allowedOverrides.Has(wildcardField) ||
+			allowedOverrides.Has(strings.ToLower(dstValue.Type().Field(i).Name))) {
+			continue
+		}
+		// NOTE: important to pre-compute this for use in the conditional below
+		// because dstFieldsOverwritten needs to be incremented based on the original value of dstField
+		// and not the state of the field after the merge
+		dstOverridable := dstField.CanSet() && !isEmptyValue(dstField)
+		if dstOverridable {
+			dstFieldsSet++
+		}
+		if srcOverride := ShallowMerge(dstField, srcField, overwriteByDefault); srcOverride {
+			srcFieldsUsed++
+			if dstOverridable {
+				dstFieldsOverwritten++
+			}
+		}
+	}
+
+	var overrideState OptionsMergeResult
+	if srcFieldsUsed == 0 {
+		overrideState = OptionsMergedNone
+	} else if dstFieldsSet == dstFieldsOverwritten {
+		overrideState = OptionsMergedFull
+	} else {
+		overrideState = OptionsMergedPartial
+	}
+
+	return dst, overrideState
 }


### PR DESCRIPTION
# Description
Backports 1bed38058 from main
---
Adds the ability to override inherited policy fields when explicitly permitted by a parent route using the annotation delegation.gateway.solo.io/enable-policy-overrides. It supports a wildcard value "*" or a comma separated list of field names such as "faults,timeouts,retries,headermanipulation".

Functionally, a child RouteOption may only override the RouteOptions derived from its parent if the above annotation exists on the parent route. This is required to make the override behavior safe to use.

---

Testing done:
- Translator tests for the new scenarios.
- Repro script provided by Arka

## Testing steps

Use the examples added in the translator tests to verify the override behavior of inherited policies with delegation.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation `TODO`
- [X] I have added tests that prove my fix is effective or that my feature works
