### PR TITLE
[1.18] tests: Fix flakey TestConfigureNotAttachedHttpListenerOptions

### DIFF
--- a/changelog/v1.18.1/fix-flakey-TestConfigureNotAttachedHttpListenerOptions.yaml
+++ b/changelog/v1.18.1/fix-flakey-TestConfigureNotAttachedHttpListenerOptions.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/6617
+  description: Fix flakey TestConfigureNotAttachedHttpListenerOptions caused by the gateway-proxy pod being deployed after the test begins leading to a timeout.

--- a/test/gomega/matchers/pod.go
+++ b/test/gomega/matchers/pod.go
@@ -16,6 +16,9 @@ type ExpectedPod struct {
 	// Status is the pod phase status (e.g. Running, Pending, Succeeded, Failed). Optional.
 	Status corev1.PodPhase
 
+	// Ready indicates that the Pod is able to serve requests. Optional.
+	Ready bool
+
 	// TODO(npolshak): Add more fields to match on as needed
 }
 
@@ -41,16 +44,30 @@ func (pm *podMatcher) Match(actual interface{}) (bool, error) {
 			}
 		}
 		if !foundContainer {
-			log.Printf("expected pod to have container '%s', but it was not found", pm.expectedPod.ContainerName)
+			log.Printf("expected pod %s to have container '%s', but it was not found", pod.Name, pm.expectedPod.ContainerName)
 			return false, nil
 		}
 	}
 
 	if pm.expectedPod.Status != "" {
 		if pod.Status.Phase != pm.expectedPod.Status {
-			log.Printf("expected pod to have status %s, but it was %s", pm.expectedPod.Status, pod.Status.Phase)
+			log.Printf("expected pod %s to have status %s, but it was %s", pod.Name, pm.expectedPod.Status, pod.Status.Phase)
 			return false, nil
 		}
+	}
+
+	if pm.expectedPod.Ready {
+		for _, condition := range pod.Status.Conditions {
+			if condition.Type == corev1.PodReady {
+				ready := condition.Status == corev1.ConditionTrue
+				if !ready {
+					log.Printf("expected pod %s to have condition ready, but it was not ready", pod.Name)
+				}
+				return ready, nil
+			}
+		}
+		log.Printf("expected pod %s to have condition ready, but it was not found", pod.Name)
+		return false, nil
 	}
 
 	return true, nil
@@ -58,11 +75,16 @@ func (pm *podMatcher) Match(actual interface{}) (bool, error) {
 
 func (pm *podMatcher) FailureMessage(actual interface{}) string {
 	var errorMsg string
+	pod, ok := actual.(corev1.Pod)
+	if !ok {
+		return fmt.Sprintf("expected a pod, got %T", actual)
+	}
+
 	if pm.expectedPod.ContainerName != "" {
-		errorMsg += fmt.Sprintf("Expected pod to have container '%s', but it was not found", pm.expectedPod.ContainerName)
+		errorMsg += fmt.Sprintf("Expected pod %s to have container '%s', but it was not found", pod.Name, pm.expectedPod.ContainerName)
 	}
 	if pm.expectedPod.Status != "" {
-		errorMsg += fmt.Sprintf("Expected pod to have status '%s', but it was not found", pm.expectedPod.Status)
+		errorMsg += fmt.Sprintf("Expected pod %s to have status '%s', but it was not found", pod.Name, pm.expectedPod.Status)
 	}
 	return errorMsg
 }
@@ -76,10 +98,10 @@ func (pm *podMatcher) NegatedFailureMessage(actual interface{}) string {
 		for _, container := range pod.Spec.Containers {
 			containers += container.Name + ", "
 		}
-		errorMsg += fmt.Sprintf("Expected pod to have container '%s', but it found %s", pm.expectedPod.ContainerName, containers)
+		errorMsg += fmt.Sprintf("Expected pod %s to have container '%s', but it found %s", pod.Name, pm.expectedPod.ContainerName, containers)
 	}
 	if pm.expectedPod.Status != "" {
-		errorMsg += fmt.Sprintf("Expected pod to have status '%s', but it found %s", pm.expectedPod.Status, pod.Status.Phase)
+		errorMsg += fmt.Sprintf("Expected pod %s to have status '%s', but it found %s", pod.Name, pm.expectedPod.Status, pod.Status.Phase)
 	}
 	return errorMsg
 }

--- a/test/kubernetes/e2e/features/http_listener_options/http_lis_opt_suite.go
+++ b/test/kubernetes/e2e/features/http_listener_options/http_lis_opt_suite.go
@@ -45,6 +45,9 @@ func (s *testingSuite) SetupSuite() {
 	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, nginxPod.ObjectMeta.GetNamespace(), metav1.ListOptions{
 		LabelSelector: "app.kubernetes.io/name=nginx",
 	})
+	s.testInstallation.Assertions.EventuallyPodsRunning(s.ctx, testdefaults.CurlPod.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app=curl",
+	})
 
 	// include gateway manifests for the tests, so we recreate it for each test run
 	s.manifests = map[string][]string{
@@ -88,6 +91,10 @@ func (s *testingSuite) AfterTest(suiteName, testName string) {
 		output, err := s.testInstallation.Actions.Kubectl().DeleteFileWithOutput(s.ctx, manifest)
 		s.testInstallation.Assertions.ExpectObjectDeleted(manifest, err, output)
 	}
+	s.testInstallation.Assertions.EventuallyObjectsNotExist(s.ctx, proxyService, proxyDeployment)
+	s.testInstallation.Assertions.EventuallyPodsNotExist(s.ctx, proxyDeployment.ObjectMeta.GetNamespace(), metav1.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=gloo-proxy-gw",
+	})
 }
 
 func (s *testingSuite) TestConfigureHttpListenerOptions() {


### PR DESCRIPTION
# Description
Backport of https://github.com/solo-io/gloo/pull/10480

The TestConfigureNotAttachedHttpListenerOptions fails after this particular log line :
`expected pod to have status Running, but it was Succeeded`
A pod will be reported as success when all the containers have successfully terminated : https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-conditions

A potential reason for this flake can be :
After deleting the gateway in the prior test, the proxy does not immediately come down while the next test begins. In doing so the terminating proxy might still be running but the condition in the TestConfigureNotAttachedHttpListenerOptions passes since the proxy is running although it will terminate soon. This could lead to the timeout where the proxy is not running when curling the endpoint.

The fix ensures the old gateway-proxy pod is down before beginning the next test. Additionally, I've also added a ready check if the pod is running

This is an educated guess at the failure but will have to merge and see if it is effective. Locally I've not been able to reproduce it

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/6617