### PR TITLE
gateway2: reconcile on HTTPRoute annotation change

### DIFF
--- a/changelog/v1.19.0-beta3/httproute-annotation.yaml
+++ b/changelog/v1.19.0-beta3/httproute-annotation.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7514
+    resolvesIssue: false
+    description: |
+      Route delegation makes use of delegation.gateway.solo.io/*
+      annotations, so changes to annotations should reconcile HTTPRoutes.

--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -311,7 +311,7 @@ func (c *controllerBuilder) watchCustomResourceDefinitions(_ context.Context) er
 
 func (c *controllerBuilder) watchHttpRoute(_ context.Context) error {
 	return ctrl.NewControllerManagedBy(c.cfg.Mgr).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		For(&apiv1.HTTPRoute{}).
 		Complete(reconcile.Func(c.reconciler.ReconcileHttpRoutes))
 }


### PR DESCRIPTION
# Description
Route delegation makes use of delegation.gateway.solo.io/* annotations, so changes to annotations should reconcile HTTPRoutes.
