### PR TITLE
[backport] gateway2: reconcile on HTTPRoute annotation change

### DIFF
--- a/changelog/v1.17.19/httproute-annotation.yaml
+++ b/changelog/v1.17.19/httproute-annotation.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7514
+    resolvesIssue: false
+    description: |
+      Route delegation makes use of delegation.gateway.solo.io/*
+      annotations, so changes to annotations should reconcile HTTPRoutes.

--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -85,7 +85,6 @@ func NewBaseGatewayController(ctx context.Context, cfg GatewayConfig) error {
 		controllerBuilder.addVhOptIndexes,
 		controllerBuilder.addGwParamsIndexes,
 	)
-
 }
 
 func run(ctx context.Context, funcs ...func(ctx context.Context) error) error {
@@ -258,7 +257,7 @@ func (c *controllerBuilder) watchGwClass(ctx context.Context) error {
 
 func (c *controllerBuilder) watchHttpRoute(ctx context.Context) error {
 	err := ctrl.NewControllerManagedBy(c.cfg.Mgr).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.AnnotationChangedPredicate{})).
 		For(&apiv1.HTTPRoute{}).
 		Complete(reconcile.Func(c.reconciler.ReconcileHttpRoutes))
 	if err != nil {
@@ -414,7 +413,6 @@ func (r *controllerReconciler) ReconcileHttpRoutes(ctx context.Context, req ctrl
 }
 
 func (r *controllerReconciler) ReconcileReferenceGrants(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-
 	// reconcile all things?!
 	r.kick(ctx)
 	return ctrl.Result{}, nil


### PR DESCRIPTION
# Description
Backports https://github.com/solo-io/gloo/pull/10520 
---
Route delegation makes use of delegation.gateway.solo.io/* annotations, so changes to annotations should reconcile HTTPRoutes.
