### PR TITLE
trivy: ignore CVE-2024-45338

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -77,3 +77,12 @@ CVE-2022-30635
 # Ref: https://solo-io-corp.slack.com/archives/C03MFATU265/p1733926775760049?thread_ts=1733429266.473749&cid=C03MFATU265
 CVE-2024-36621
 CVE-2024-36623
+
+# https://github.com/kubernetes/kubernetes/issues/129347
+# We have updated our direct dependencies to use version of x/net that are not affected
+# However, our kubectl image, which is based on the upstream one, still warns of this
+# vulnerability. Per the linked issue above, there is agreement that Kubernetes is
+# not affected, and thus we are skipping that vulnerability for Gloo as well
+CVE-2024-45338
+
+

--- a/changelog/v1.19.0-beta3/kubectl-cve.yaml
+++ b/changelog/v1.19.0-beta3/kubectl-cve.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/gloo/issues/10527
+    resolvesIssue: false
+    description: >-
+      Update the trivyignore to exclude CVE-2024-45338
+      
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

Update the trivyignore to not report on CVE-2024-45338


# Context
See the comment in the trivyignore for more details

## Interesting decisions
-

## Testing steps
-

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works