### PR TITLE
Fix readiness probe

### DIFF
--- a/changelog/v1.19.0-beta3/fix-readiness-probe.yaml
+++ b/changelog/v1.19.0-beta3/fix-readiness-probe.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/10541
+  resolvesIssue: false
+  description: Fixes a bug where the envoy pod passes the readiness probe before receving the xds config.
+

--- a/projects/gateway2/helm/gloo-gateway/templates/gateway/proxy-deployment.yaml
+++ b/projects/gateway2/helm/gloo-gateway/templates/gateway/proxy-deployment.yaml
@@ -430,43 +430,6 @@ data:
         role: gloo-kube-gateway-api~{{ $gateway.gatewayNamespace }}~{{ $gateway.gatewayNamespace }}-{{ $gateway.gatewayName | default (include "gloo-gateway.gateway.fullname" .) }}
     static_resources:
       listeners:
-      - name: readiness_listener
-        address:
-          socket_address: { address: 0.0.0.0, port_value: 8082 }
-        filter_chains:
-          - filters:
-            - name: envoy.filters.network.http_connection_manager
-              typed_config:
-                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
-                stat_prefix: ingress_http
-                codec_type: AUTO
-                route_config:
-                  name: main_route
-                  virtual_hosts:
-                    - name: local_service
-                      domains: ["*"]
-                      routes:
-                        - match:
-                            path: "/ready"
-                            headers:
-                              - name: ":method"
-                                string_match:
-                                  exact: GET
-                          route:
-                            cluster: admin_port_cluster
-                http_filters:
-{{- if $gateway.readinessProbe }}
-                  - name: envoy.filters.http.health_check
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
-                      pass_through_mode: false
-                      headers:
-                      - name: ":path"
-                        exact_match: "/envoy-hc"
-{{- end }}{{/*if $gateway.readinessProbe*/}}
-                  - name: envoy.filters.http.router
-                    typed_config:
-                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 {{- if $statsConfig.enabled }}
       - name: prometheus_listener
         address:

--- a/projects/gateway2/translator/gateway_translator.go
+++ b/projects/gateway2/translator/gateway_translator.go
@@ -91,6 +91,8 @@ func (t *translator) TranslateProxy(
 		reporter,
 	)
 
+	listener.AppendHealthCheckListener(listeners)
+
 	return &v1.Proxy{
 		Metadata:  proxyMetadata(gateway, writeNamespace),
 		Listeners: listeners,

--- a/projects/gateway2/translator/gateway_translator.go
+++ b/projects/gateway2/translator/gateway_translator.go
@@ -91,7 +91,7 @@ func (t *translator) TranslateProxy(
 		reporter,
 	)
 
-	listener.AppendHealthCheckListener(listeners)
+	listeners = listener.AppendHealthCheckListener(listeners)
 
 	return &v1.Proxy{
 		Metadata:  proxyMetadata(gateway, writeNamespace),

--- a/projects/gateway2/translator/listener/gateway_listener_translator.go
+++ b/projects/gateway2/translator/listener/gateway_listener_translator.go
@@ -800,7 +800,7 @@ func AppendHealthCheckListener(listeners []*v1.Listener) []*v1.Listener {
 	httpOptionsRef := edgegwutils.HashAndStoreHttpOptions(healthCheckOption, httpOptionsByName)
 
 	listeners = append(listeners, &v1.Listener{
-		Name:        "health_check",
+		Name:        "readiness_listener",
 		BindAddress: "::",
 		BindPort:    8082,
 

--- a/projects/gateway2/translator/listener/gateway_listener_translator.go
+++ b/projects/gateway2/translator/listener/gateway_listener_translator.go
@@ -15,6 +15,7 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	edgegwutils "github.com/solo-io/gloo/projects/gateway/pkg/translator/utils"
 	"github.com/solo-io/gloo/projects/gateway2/ports"
 	"github.com/solo-io/gloo/projects/gateway2/query"
 	"github.com/solo-io/gloo/projects/gateway2/reports"
@@ -26,6 +27,8 @@ import (
 	"github.com/solo-io/gloo/projects/gateway2/translator/sslutils"
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/healthcheck"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
 	"github.com/solo-io/gloo/projects/gloo/pkg/utils"
 )
@@ -785,4 +788,73 @@ func makeVhostName(
 	domain string,
 ) string {
 	return utils.SanitizeForEnvoy(ctx, parentName+"~"+domain, "vHost")
+}
+
+// AppendHealthCheckListener adds a listener with the health check plugin
+func AppendHealthCheckListener(listeners []*v1.Listener) {
+	healthCheckOption := &v1.HttpListenerOptions{
+		HealthCheck: &healthcheck.HealthCheck{
+			Path: "/envoy-hc",
+		},
+	}
+	httpOptionsByName := map[string]*v1.HttpListenerOptions{}
+	httpOptionsRef := edgegwutils.HashAndStoreHttpOptions(healthCheckOption, httpOptionsByName)
+
+	listeners = append(listeners, &v1.Listener{
+		Name:        "health_check",
+		BindAddress: "::",
+		BindPort:    8082,
+
+		ListenerType: &v1.Listener_AggregateListener{
+			AggregateListener: &v1.AggregateListener{
+				HttpResources: &v1.AggregateListener_HttpResources{
+					VirtualHosts: map[string]*v1.VirtualHost{
+						"local_service": {
+							Name:    "local_service",
+							Domains: []string{"*"},
+							Routes: []*v1.Route{{
+								Matchers: []*matchers.Matcher{{
+									PathSpecifier: &matchers.Matcher_Exact{
+										Exact: "/ready",
+									},
+									Headers: []*matchers.HeaderMatcher{{
+										Name:  ":method",
+										Value: "GET",
+									}},
+								}},
+								Action: &v1.Route_DirectResponseAction{
+									DirectResponseAction: &v1.DirectResponseAction{
+										Body: "ready",
+									},
+								},
+							}},
+						},
+					},
+					HttpOptions: httpOptionsByName,
+				},
+				HttpFilterChains: []*v1.AggregateListener_HttpFilterChain{{
+					VirtualHostRefs: []string{"local_service"},
+					HttpOptionsRef:  httpOptionsRef,
+				}},
+				TcpListeners: nil,
+			},
+		},
+		// Used for tracing to create service_name
+		OpaqueMetadata: &v1.Listener_MetadataStatic{
+			MetadataStatic: &v1.SourceMetadata{
+				Sources: []*v1.SourceMetadata_SourceRef{
+					{
+						ResourceRef: &core.ResourceRef{
+							Name:      "health_check",
+							Namespace: "default",
+						},
+						ResourceKind: wellknown.GatewayGroup + "/" + wellknown.GatewayKind,
+					},
+				},
+			},
+		},
+		Options:      nil, // Listener options will be added by policy plugins
+		RouteOptions: nil,
+	})
+
 }


### PR DESCRIPTION
# Description

When the readiness listener is defined in the bootstrap config, the pod can be considered ready before it receives any config over XDS that can lead to downtime during an upgrade. This fixes the issue by defining the readiness listener during translation, ensuring that the envoy pod will be ready only when it receives the XDS config

## API changes
N/A

# Context
This fixes the flaky Zero Downtime tests

## Testing steps
```
  Gloo was successfully uninstalled.
--- PASS: TestUpgradeFromLastPatchPreviousMinor (215.47s)
    --- PASS: TestUpgradeFromLastPatchPreviousMinor/Upgrade (214.39s)
        --- PASS: TestUpgradeFromLastPatchPreviousMinor/Upgrade/TestZeroDowntimeUpgrade (214.38s)
PASS
ok  	github.com/solo-io/gloo/test/kubernetes/e2e/tests	217.020s

```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
