### PR TITLE
add missing tests for external traffic policy gateway params

### DIFF
--- a/changelog/v1.19.0-beta3/add-missing-tests.yaml
+++ b/changelog/v1.19.0-beta3/add-missing-tests.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: > 
+    Add missing e2e suite test for checking gateway param eternal traffic policy


### PR DESCRIPTION
external traffic policy support was added here https://github.com/solo-io/gloo/pull/10420
additional tests were added in the backport to 1.18 here https://github.com/solo-io/gloo/pull/10552

this PR ports these tests forward to 1.19