### PR TITLE
[backport] gateway2: allow route delegation using well known label (#10561)

### DIFF
--- a/changelog/v1.18.4/deleg-label.yaml
+++ b/changelog/v1.18.4/deleg-label.yaml
@@ -1,0 +1,17 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7626
+    resolvesIssue: false
+    description: |
+      gateway2: allow route delegation using wellknown label
+
+      There is a product requirement to enable users to use
+      a label to select HTTPRoutes to delegate to instead
+      of GVK ref to other HTTPRoutes (includes wildcards).
+
+      To strike a balance between flexibility and performance,
+      this change implements the proposal to use a well known
+      label `delegation.gateway.solo.io/label=<value>` to
+      allow users to delegate to other HTTPRoutes using a label.
+      HTTPRoutes are indexed using this well known label key that
+      enable O(1) lookups of routes matching this label value.

--- a/projects/gateway2/controller/controller.go
+++ b/projects/gateway2/controller/controller.go
@@ -123,6 +123,10 @@ func (c *controllerBuilder) addIndexes(ctx context.Context) error {
 	if err := c.cfg.Mgr.GetFieldIndexer().IndexField(ctx, &apiv1.HTTPRoute{}, query.HttpRouteTargetField, query.IndexerByObjType); err != nil {
 		errs = append(errs, err)
 	}
+	// Index HTTPRoutes by the delegation.gateway.solo.io/label label value to lookup delegatee routes using the label
+	if err := c.cfg.Mgr.GetFieldIndexer().IndexField(ctx, &apiv1.HTTPRoute{}, query.HttpRouteDelegatedLabelSelector, query.IndexByHTTPRouteDelegationLabelSelector); err != nil {
+		errs = append(errs, err)
+	}
 
 	// Index for ReferenceGrant
 	if err := c.cfg.Mgr.GetFieldIndexer().IndexField(ctx, &apiv1beta1.ReferenceGrant{}, query.ReferenceGrantFromField, query.IndexerByObjType); err != nil {

--- a/projects/gateway2/translator/backendref/types.go
+++ b/projects/gateway2/translator/backendref/types.go
@@ -27,6 +27,18 @@ func RefIsHTTPRoute(ref gwv1.BackendObjectReference) bool {
 	return (ref.Kind != nil && *ref.Kind == wellknown.HTTPRouteKind) && (ref.Group != nil && *ref.Group == gwv1.GroupName)
 }
 
+// RefIsHTTPRouteDelegationLabelSelector checks if the BackendObjectReference is an HTTPRoute delegation label selector
+// Parent routes may delegate to child routes using an HTTPRoute backend reference.
+func RefIsHTTPRouteDelegationLabelSelector(ref gwv1.BackendObjectReference) bool {
+	return ref.Group != nil && ref.Kind != nil && (string(*ref.Group)+"/"+string(*ref.Kind)) == wellknown.RouteDelegationLabelSelector
+}
+
+// RefIsDelegatedHTTPRoute checks if the BackendObjectReference is a delegated HTTPRoute
+// selected by an HTTPRoute GVK reference or a delegation label selector.
+func RefIsDelegatedHTTPRoute(ref gwv1.BackendObjectReference) bool {
+	return RefIsHTTPRoute(ref) || RefIsHTTPRouteDelegationLabelSelector(ref)
+}
+
 // ToString returns a string representation of the BackendObjectReference
 func ToString(ref gwv1.BackendObjectReference) string {
 	var group, kind, namespace string

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -329,4 +329,5 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("RouteOptions prefer child override when allowed", "route_options_inheritance_child_override_allow.yaml"),
 	Entry("RouteOptions multi level inheritance with child override when allowed", "route_options_multi_level_inheritance_override_allow.yaml"),
 	Entry("RouteOptions multi level inheritance with partial child override", "route_options_multi_level_inheritance_override_partial.yaml"),
+	Entry("Label based delegation", "label_based.yaml"),
 )

--- a/projects/gateway2/translator/httproute/delegation_helpers.go
+++ b/projects/gateway2/translator/httproute/delegation_helpers.go
@@ -13,11 +13,6 @@ import (
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
 
-// inheritMatcherAnnotation is the annotation used on an child HTTPRoute that
-// participates in a delegation chain to indicate that child route should inherit
-// the route matcher from the parent route.
-const inheritMatcherAnnotation = "delegation.gateway.solo.io/inherit-parent-matcher"
-
 // filterDelegatedChildren filters the referenced children and their rules based
 // on parent matchers, filters their hostnames, and applies parent matcher
 // inheritance
@@ -184,7 +179,7 @@ func isDelegatedRouteMatch(
 // shouldInheritMatcher returns true if the route indicates that it should inherit
 // its parent's matcher.
 func shouldInheritMatcher(route *gwv1.HTTPRoute) bool {
-	val, ok := route.Annotations[inheritMatcherAnnotation]
+	val, ok := route.Annotations[wellknown.InheritMatcherAnnotation]
 	if !ok {
 		return false
 	}

--- a/projects/gateway2/translator/httproute/gateway_http_route_translator.go
+++ b/projects/gateway2/translator/httproute/gateway_http_route_translator.go
@@ -329,7 +329,7 @@ func setRouteAction(
 	for _, backendRef := range backendRefs {
 		// If the backend is an HTTPRoute, it implies route delegation
 		// for which delegated routes are recursively flattened and translated
-		if backendref.RefIsHTTPRoute(backendRef.BackendObjectReference) {
+		if backendref.RefIsDelegatedHTTPRoute(backendRef.BackendObjectReference) {
 			delegates = true
 			// Flatten delegated HTTPRoute references
 			err := flattenDelegatedRoutes(

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin_test.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin_test.go
@@ -773,7 +773,7 @@ var _ = DescribeTable("mergeOptionsForRoute",
 	Entry("override dst options with annotation: full override",
 		&gwv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{policyOverrideAnnotation: "*"},
+				Annotations: map[string]string{wellknown.PolicyOverrideAnnotation: "*"},
 			},
 		},
 		&v1.RouteOptions{
@@ -804,7 +804,7 @@ var _ = DescribeTable("mergeOptionsForRoute",
 	Entry("override dst options with annotation: partial override",
 		&gwv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{policyOverrideAnnotation: "*"},
+				Annotations: map[string]string{wellknown.PolicyOverrideAnnotation: "*"},
 			},
 		},
 		&v1.RouteOptions{
@@ -837,7 +837,7 @@ var _ = DescribeTable("mergeOptionsForRoute",
 	Entry("override dst options with annotation: no override",
 		&gwv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{policyOverrideAnnotation: "*"},
+				Annotations: map[string]string{wellknown.PolicyOverrideAnnotation: "*"},
 			},
 		},
 		&v1.RouteOptions{
@@ -860,7 +860,7 @@ var _ = DescribeTable("mergeOptionsForRoute",
 	Entry("override dst options with annotation: specific fields",
 		&gwv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{policyOverrideAnnotation: "faults,timeout"},
+				Annotations: map[string]string{wellknown.PolicyOverrideAnnotation: "faults,timeout"},
 			},
 		},
 		&v1.RouteOptions{
@@ -895,7 +895,7 @@ var _ = DescribeTable("mergeOptionsForRoute",
 	Entry("override and augment dst options with annotation: specific fields",
 		&gwv1.HTTPRoute{
 			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{policyOverrideAnnotation: "faults,timeout"},
+				Annotations: map[string]string{wellknown.PolicyOverrideAnnotation: "faults,timeout"},
 			},
 		},
 		&v1.RouteOptions{

--- a/projects/gateway2/translator/testutils/inputs/delegation/label_based.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/label_based.yaml
@@ -1,0 +1,179 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: delegation.gateway.solo.io
+      kind: label
+      name: a-label
+      namespace: a
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /b
+    backendRefs:
+    - group: delegation.gateway.solo.io
+      kind: label
+      name: b-label
+      # namespace defaults to parent's namespace
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /c
+    backendRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: "*"
+      namespace: c
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a1
+  namespace: a
+  labels:
+    delegation.gateway.solo.io/label: a-label
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a2
+  namespace: a
+  labels:
+    delegation.gateway.solo.io/label: a-label
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /a/2
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+# route-a3 does not match the selected label so it should be ignored
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a3
+  namespace: a
+  labels:
+    delegation.gateway.solo.io/label: not-a-label
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /a/3
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-b
+  namespace: infra
+  labels:
+    delegation.gateway.solo.io/label: b-label
+spec:
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: /b/.*
+    backendRefs:
+    - name: svc-b
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-b
+  namespace: infra
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-c
+  namespace: c
+spec:
+  rules:
+  - matches:
+    - path:
+        type: RegularExpression
+        value: /c/.*
+    backendRefs:
+    - name: svc-c
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-c
+  namespace: c
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/outputs/delegation/label_based.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/label_based.yaml
@@ -70,12 +70,6 @@ listeners:
 
   bindAddress: '::'
   bindPort: 8080
-  metadataStatic:
-    sources:
-    - resourceKind: gateway.networking.k8s.io/Gateway
-      resourceRef:
-        name: http
-        namespace: infra
   name: http
 metadata:
   labels:

--- a/projects/gateway2/translator/testutils/outputs/delegation/label_based.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/label_based.yaml
@@ -1,0 +1,85 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - exact: /a/1
+            options: {}
+            name: httproute-route-a1-a-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - exact: /a/2
+            options: {}
+            name: httproute-route-a2-a-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - regex: /b/.*
+            options: {}
+            name: httproute-route-b-infra-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-b
+                    namespace: infra
+          - matchers:
+            - regex: /c/.*
+            options: {}
+            name: httproute-route-c-c-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-c
+                    namespace: c
+          - matchers:
+            - prefix: /
+            options: {}
+            name: httproute-example-route-infra-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: example-svc
+                    namespace: infra
+
+  bindAddress: '::'
+  bindPort: 8080
+  metadataStatic:
+    sources:
+    - resourceKind: gateway.networking.k8s.io/Gateway
+      resourceRef:
+        name: http
+        namespace: infra
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system

--- a/projects/gateway2/wellknown/delegation.go
+++ b/projects/gateway2/wellknown/delegation.go
@@ -1,0 +1,15 @@
+package wellknown
+
+const (
+	// RouteDelegationLabelSelector is the label used to select delegated HTTPRoutes
+	RouteDelegationLabelSelector = "delegation.gateway.solo.io/label"
+
+	// InheritMatcherAnnotation is the annotation used on an child HTTPRoute that
+	// participates in a delegation chain to indicate that child route should inherit
+	// the route matcher from the parent route.
+	InheritMatcherAnnotation = "delegation.gateway.solo.io/inherit-parent-matcher"
+
+	// PolicyOverrideAnnotation can be set by parent routes to allow child routes to override
+	// all (wildcard *) or specific fields (comma separated field names) in RouteOptions inherited from the parent route.
+	PolicyOverrideAnnotation = "delegation.gateway.solo.io/enable-policy-overrides"
+)

--- a/test/kubernetes/e2e/features/route_delegation/testdata/basic.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/testdata/basic.yaml
@@ -35,9 +35,9 @@ spec:
         type: PathPrefix
         value: /anything/team2
     backendRefs:
-    - group: gateway.networking.k8s.io
-      kind: HTTPRoute
-      name: "*"
+    - group: delegation.gateway.solo.io
+      kind: label
+      name: team2
       namespace: team2
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -60,6 +60,8 @@ kind: HTTPRoute
 metadata:
   name: svc2
   namespace: team2
+  labels:
+    delegation.gateway.solo.io/label: team2
 spec:
   parentRefs:
   - name: root


### PR DESCRIPTION
# Description

Backports 5b5e872ce from main to v1.18.x
---
There is a product requirement to enable users to use a label to select HTTPRoutes to delegate to instead of GVK ref to other HTTPRoutes (includes wildcards).

To strike a balance between flexibility and performance, this change implements the proposal to use a well known label `delegation.gateway.solo.io/label=<value>` to allow users to delegate to other HTTPRoutes using a label. HTTPRoutes are indexed using this well known label key that enable O(1) lookups of routes matching this label value.

## API changes

New `delegation.gateway.solo.io/label` label to select HTTPRoutes to delegate to.

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation `TODO`
- [X] I have added tests that prove my fix is effective or that my feature works
