### PR TITLE
fix child route portal transformation being overriden by parent route option if set

### DIFF
--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
@@ -115,7 +115,10 @@ func (p *plugin) ApplyRoutePlugin(
 	} // In case OptionsMergedFull, the correct sources are already set on the outputRoute
 
 	// merge portal specific transformations into the destination route options post merge
-	mergePortalTransformations(merged, outputRoute.GetOptions())
+	err = mergePortalTransformations(merged, outputRoute.GetOptions())
+	if err != nil {
+		contextutils.LoggerFrom(ctx).Errorf("error merging portal transformations: %v", err)
+	}
 
 	// Set the merged RouteOptions on the outputRoute
 	outputRoute.Options = merged
@@ -380,7 +383,7 @@ func mergePortalTransformations(dst, src *gloov1.RouteOptions) error {
 				// extract portal specific transformations and add them to the destination route options
 				srcDynamicMetadataTransformations := transformation.GetRequestTransformation().GetTransformationTemplate().GetDynamicMetadataValues()
 				for _, srcDynamicMetadataTransformation := range srcDynamicMetadataTransformations {
-					if srcDynamicMetadataTransformation.GetKey() == PortalMetadataNamespace || srcDynamicMetadataTransformation.GetKey() == PortalCustomMetadataNamespace {
+					if srcDynamicMetadataTransformation.GetMetadataNamespace() == PortalMetadataNamespace || srcDynamicMetadataTransformation.GetMetadataNamespace() == PortalCustomMetadataNamespace {
 						portalDynamicMetadataTransformations = append(portalDynamicMetadataTransformations, srcDynamicMetadataTransformation)
 					}
 				}

--- a/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
+++ b/projects/gateway2/translator/plugins/routeoptions/route_options_plugin.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	transformation1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
 	"sort"
 	"strings"
+
+	transformation1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/rotisserie/eris"
@@ -403,11 +404,11 @@ func mergePortalTransformations(dst, src *gloov1.RouteOptions) error {
 
 	// if there are no staged early request transformations in the destination route option, we can add the portal metadata transformation as-is
 	if dst.GetStagedTransformations().GetEarly().GetRequestTransforms() == nil {
-		if dst.StagedTransformations == nil {
+		if dst.GetStagedTransformations() == nil {
 			dst.StagedTransformations = &transformation1.TransformationStages{}
 		}
-		if dst.StagedTransformations.Early == nil {
-			dst.StagedTransformations.Early = &transformation1.RequestResponseTransformations{}
+		if dst.GetStagedTransformations().GetEarly() == nil {
+			dst.GetStagedTransformations().Early = &transformation1.RequestResponseTransformations{}
 		}
 
 		dst.GetStagedTransformations().GetEarly().RequestTransforms = []*transformation1.RequestMatch{{
@@ -436,7 +437,7 @@ func setMetadataOnMatch(match *transformation1.RequestMatch, transform *transfor
 	}
 
 	// add the portal transformation to the existing request transformation, if it exists
-	if requestTransform := match.RequestTransformation; requestTransform != nil {
+	if requestTransform := match.GetRequestTransformation(); requestTransform != nil {
 		err := mergePortalTransformation(requestTransform, transform)
 		if err != nil {
 			return err
@@ -499,5 +500,5 @@ func mergePortalTransformation(dest, src *transformation1.Transformation) error 
 
 // getDynamicMetadataKey returns a unique key for a dynamic metadata value.
 func getDynamicMetadataKey(v *transformation1.TransformationTemplate_DynamicMetadataValue) string {
-	return v.MetadataNamespace + "." + v.Key
+	return v.GetMetadataNamespace() + "." + v.GetKey()
 }


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
