### PR TITLE
Dump logs for all containers when test fails

### DIFF
--- a/changelog/v1.19.0-beta3/dump-all-containers-logs-on-test-fail.yaml
+++ b/changelog/v1.19.0-beta3/dump-all-containers-logs-on-test-fail.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Added pod/container name prefix to log lines and make sure all containers are logged on test failure
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/pkg/utils/statedumputils/state_dump.go
+++ b/pkg/utils/statedumputils/state_dump.go
@@ -298,7 +298,7 @@ func recordCRs(ctx context.Context, namespaceDir string, namespace string) error
 
 // kubeLogs runs $(kubectl -n $namespace logs $pod --all-containers) and returns the string result
 func kubeLogs(namespace string, pod string) (string, string, error) {
-	args := []string{"-n", namespace, "logs", pod, "--all-containers"}
+	args := []string{"-n", namespace, "logs", pod, "--all-containers=true", "--prefix=true"}
 	return kubeExecute(args)
 }
 


### PR DESCRIPTION
# Description
- previously setting `--all-containers` does not seem to work. `--all-containers=true` works
- also added `--prefix=true` to add pod/container_name prefix to the log lines 
- this only affects the artifacts we upload when test fails

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [/] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
