### PR TITLE
Allows per test directory for generated files on failure

### DIFF
--- a/changelog/v1.19.0-beta4/allow-per-test-directory-for-generated-files.yaml
+++ b/changelog/v1.19.0-beta4/allow-per-test-directory-for-generated-files.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/7634
+    resolvesIssue: false
+    description: >-
+      Added optional option for PreFailHandler for dumping into per test directory

--- a/test/kubernetes/e2e/example/info_logging_test.go
+++ b/test/kubernetes/e2e/example/info_logging_test.go
@@ -46,6 +46,11 @@ func TestInstallationWithInfoLogLevel(t *testing.T) {
 		if !nsEnvPredefined {
 			os.Unsetenv(testutils.InstallNamespace)
 		}
+
+		// This clean up function is called only once after all the tests in all the registered suites are done.
+		// Moreover, PreFailHandler() will wipe out the output directory before dumping out the stats and
+		// logs of the cluster. If PreFailHandler() is called in the suite's AfterTest() function already,
+		// The following should be removed.
 		if t.Failed() {
 			testInstallation.PreFailHandler(ctx)
 		}

--- a/test/kubernetes/e2e/features/example/suite.go
+++ b/test/kubernetes/e2e/features/example/suite.go
@@ -50,11 +50,12 @@ func (s *testingSuite) AfterTest(suiteName, testName string) {
 	// it afterward, PreFailHandler() should be called here (before the resources are deleted) so we can
 	// capture the log before the pod is destroyed.
 
-	// WARNING: In this example test, another place calling PreFailHandler() is in main _test.go file where it
-	// setup the go test cleanup function with t.Cleanup(). That clean up function is only called once
-	// after all the tests in all registered suites finished. If PreFailHandler() is called here, the one in the cleanup
-	// function should be removed as it would wipe out the entire output directory (including these per-test logs).
-	// before dumping out the logs at the very end
+	// WARNING: In this example test, another place calling PreFailHandler() is in the main _test.go file
+	// (test/kubernetes/e2e/example/info_logging_test.go) where it sets up the go test cleanup function with t.Cleanup().
+	// That clean up function is only called once/ after all the tests in all registered suites finished.
+	// If PreFailHandler() is called here, the one in the cleanup function should be removed as it would wipe out the
+	// entire output directory (including these per-test logs) before dumping out the logs at the very end.
+	// If you only need to dump the logs once at the very end, the following should be removed.
 	if s.T().Failed() {
 		// Calling PreFailHandler() with optional TestName so that the logs would go into
 		// a per test directory

--- a/test/kubernetes/e2e/features/example/suite.go
+++ b/test/kubernetes/e2e/features/example/suite.go
@@ -44,6 +44,22 @@ func (s *testingSuite) BeforeTest(suiteName, testName string) {
 
 func (s *testingSuite) AfterTest(suiteName, testName string) {
 	// This is code that will be executed after each test is run
+
+	// PreFailHandler() logs the states of the clusters and dump out logs from various pods for debugging
+	// when the test fails. If the test create and remove resources that will spin up the pod and delete
+	// it afterward, PreFailHandler() should be called here (before the resources are deleted) so we can
+	// capture the log before the pod is destroyed.
+
+	// WARNING: In this example test, another place calling PreFailHandler() is in main _test.go file where it
+	// setup the go test cleanup function with t.Cleanup(). That clean up function is only called once
+	// after all the tests in all registered suites finished. If PreFailHandler() is called here, the one in the cleanup
+	// function should be removed as it would wipe out the entire output directory (including these per-test logs).
+	// before dumping out the logs at the very end
+	if s.T().Failed() {
+		// Calling PreFailHandler() with optional TestName so that the logs would go into
+		// a per test directory
+		s.testInstallation.PreFailHandler(s.ctx, e2e.PreFailHandlerOption{TestName: testName})
+	}
 }
 
 func (s *testingSuite) TestExampleAssertion() {

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -235,12 +236,19 @@ func (i *TestInstallation) UninstallGlooGateway(ctx context.Context, uninstallFn
 	i.Assertions.EventuallyUninstallationSucceeded(ctx)
 }
 
+type PreFailHandlerOption struct {
+	TestName string
+}
+
 // PreFailHandler is the function that is invoked if a test in the given TestInstallation fails
-func (i *TestInstallation) PreFailHandler(ctx context.Context) {
+func (i *TestInstallation) PreFailHandler(ctx context.Context, options ...PreFailHandlerOption) {
 	// The idea here is we want to accumulate ALL information about this TestInstallation into a single directory
 	// That way we can upload it in CI, or inspect it locally
 
 	failureDir := i.GeneratedFiles.FailureDir
+	if len(options) > 0 && len(options[0].TestName) > 0 {
+		failureDir = path.Join(failureDir, options[0].TestName)
+	}
 	err := os.Mkdir(failureDir, os.ModePerm)
 	// We don't want to fail on the output directory already existing. This could occur
 	// if multiple tests running in the same cluster from the same installation namespace


### PR DESCRIPTION
# Description

For some test suites (eg. AI Extension TestSuite), the envoy proxy pod will spin up and get shut down on each individual test, so it would be a lot easier to troubleshoot flakes if the log dumps to a per test directory. 

Not sure which tests would need this, so I am making this an optional parameter to minimize changes. I can update all tests to dump into per test directory if desired. 

This solo-projects [PR](https://github.com/solo-io/solo-projects/pull/7726) depends on this PR.
<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
