### PR TITLE
fix glooctl install: Replace deprecated distutils 

### DIFF
--- a/changelog/v1.19.0-beta5/glooctl-install.yaml
+++ b/changelog/v1.19.0-beta5/glooctl-install.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      "Replace deprecated distutils in the glooctl install script with packaging.version"

--- a/changelog/v1.19.0-beta5/glooctl-install.yaml
+++ b/changelog/v1.19.0-beta5/glooctl-install.yaml
@@ -1,5 +1,6 @@
 changelog:
   - type: NON_USER_FACING
-    skipCI: true
     description: >-
-      "Replace deprecated distutils in the glooctl install script with packaging.version"
+      Replace deprecated distutils in the glooctl install script with packaging.version
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/changelog/v1.19.0-beta5/glooctl-install.yaml
+++ b/changelog/v1.19.0-beta5/glooctl-install.yaml
@@ -1,4 +1,5 @@
 changelog:
   - type: NON_USER_FACING
+    skipCI: true
     description: >-
       "Replace deprecated distutils in the glooctl install script with packaging.version"

--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -28,7 +28,7 @@ if [ ! $python_version ]; then
 fi
 
 if [ -z "${GLOO_VERSION:-}" ]; then
-  GLOO_VERSIONS=$(curl -sHL"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | $python_version -c "import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None and StrictVersion(release_string[1:]) < StrictVersion('2.0.0') , releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\n'.join(filtered_releases))")
+  GLOO_VERSIONS=$(curl -sHL"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | $python_version -c "import sys; from packaging.version import Version; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases]; filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and not Version(release_string[1:]).is_prerelease and Version(release_string[1:]) < Version('2.0.0') , releases)); filtered_releases.sort(key=Version, reverse=True); print('\n'.join(filtered_releases))")
 else
   GLOO_VERSIONS="${GLOO_VERSION}"
 fi

--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -2,33 +2,8 @@
 
 set -eu
 
-python_version=
-if [ -x "$(command -v python)" ]; then
-  python_version="$(command -v python)"
-  echo "Using $python_version"
-fi
-
-if [ ! $python_version ]; then
-  if [ -x "$(command -v python3)" ]; then
-    python_version="$(command -v python3)"
-    echo "Using $python_version"
-  fi
-fi
-
-if [ ! $python_version ]; then
-  if [ -x "$(command -v python2)" ]; then
-    python_version="$(command -v python2)"
-    echo "Using $python_version"
-  fi
-fi
-
-if [ ! $python_version ]; then
-  echo Python is required to install glooctl
-  exit 1
-fi
-
 if [ -z "${GLOO_VERSION:-}" ]; then
-  GLOO_VERSIONS=$(curl -sHL"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | $python_version -c "import sys; from packaging.version import Version; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases]; filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and not Version(release_string[1:]).is_prerelease and Version(release_string[1:]) < Version('2.0.0') , releases)); filtered_releases.sort(key=Version, reverse=True); print('\n'.join(filtered_releases))")
+  GLOO_VERSIONS=$(curl -sHL "Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | jq -r '[.[] | select(.tag_name | test("-") | not) | select(.tag_name | startswith("v1.")) | .tag_name] | sort_by(.) | reverse | .[0]')
 else
   GLOO_VERSIONS="${GLOO_VERSION}"
 fi

--- a/projects/gloo/cli/install.sh
+++ b/projects/gloo/cli/install.sh
@@ -3,6 +3,8 @@
 set -eu
 
 if [ -z "${GLOO_VERSION:-}" ]; then
+  # `select(.tag_name | test("-") | not)` should filter out any prerelease versions which contain hyphens (eg. 1.19.0-beta1)
+  # `select(.tag_name | startswith("v1."))` will filter out any "v2". Though we might be able to get rid of this (see https://github.com/kgateway-dev/kgateway/pull/8856)
   GLOO_VERSIONS=$(curl -sHL "Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | jq -r '[.[] | select(.tag_name | test("-") | not) | select(.tag_name | startswith("v1.")) | .tag_name] | sort_by(.) | reverse | .[0]')
 else
   GLOO_VERSIONS="${GLOO_VERSION}"

--- a/projects/gloo/cli/test.sh
+++ b/projects/gloo/cli/test.sh
@@ -2,33 +2,8 @@
 
 set -eu
 
-python_version=
-if [ -x "$(command -v python)" ]; then
-  python_version="$(command -v python)"
-  echo "Using $python_version"
-fi
-
-if [ ! $python_version ]; then
-  if [ -x "$(command -v python3)" ]; then
-    python_version="$(command -v python3)"
-    echo "Using $python_version"
-  fi
-fi
-
-if [ ! $python_version ]; then
-  if [ -x "$(command -v python2)" ]; then
-    python_version="$(command -v python2)"
-    echo "Using $python_version"
-  fi
-fi
-
-if [ ! $python_version ]; then
-  echo Python is required to install glooctl
-  exit 1
-fi
-
 if [ -z "${GLOO_VERSION:-}" ]; then
-  GLOO_VERSIONS=$(curl -sHL"Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | $python_version -c "import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None and StrictVersion(release_string[1:]) < StrictVersion('2.0.0') , releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\n'.join(filtered_releases))")
+  GLOO_VERSIONS=$(curl -sHL "Accept: application/vnd.github.v3+json" https://api.github.com/repos/solo-io/gloo/releases | jq -r '[.[] | select(.tag_name | test("-") | not) | select(.tag_name | startswith("v1.")) | .tag_name] | sort_by(.) | reverse | .[0]')
 else
   GLOO_VERSIONS="${GLOO_VERSION}"
 fi


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

distutils package used in glooctl install script is deprecated. Currently trying to install will give an error:
```
curl -sL https://run.solo.io/gloo/install | sh
Using /opt/homebrew/bin/python3
Traceback (most recent call last):
  File "<string>", line 1, in <module>
    import sys; from distutils.version import StrictVersion, LooseVersion; from json import loads as l; releases = l(sys.stdin.read()); releases = [release['tag_name'] for release in releases];  filtered_releases = list(filter(lambda release_string: len(release_string) > 0 and StrictVersion.version_re.match(release_string[1:]) != None and StrictVersion(release_string[1:]) < StrictVersion('2.0.0') , releases)); filtered_releases.sort(key=LooseVersion, reverse=True); print('\n'.join(filtered_releases))
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'distutils'
```
The replacement package [recommended by Python  ](https://peps.python.org/pep-0632/#migration-advice) is not installed by default. So we decided to drop the dependency on python and use jq instead.


## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->
run the install script and verify latest non-beta version is installed 
` projects/gloo/cli/install.sh`

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
