### PR TITLE
gateway2: skip non-Gloo Gateways

### DIFF
--- a/changelog/v1.19.0-beta5/check-gw.yaml
+++ b/changelog/v1.19.0-beta5/check-gw.yaml
@@ -1,7 +1,0 @@
-changelog:
-  - type: FIX
-    issueLink: https://github.com/solo-io/solo-projects/issues/7768
-    resolvesIssue: false
-    description: |
-      Fixes a bug where we translate Gateways that do not belong to us.
-

--- a/changelog/v1.19.0-beta5/check-gw.yaml
+++ b/changelog/v1.19.0-beta5/check-gw.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7768
+    resolvesIssue: false
+    description: |
+      Fixes a bug where we translate Gateways that do not belong to us.
+

--- a/changelog/v1.19.0-beta6/check-gw.yaml
+++ b/changelog/v1.19.0-beta6/check-gw.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/7768
+    resolvesIssue: false
+    description: |
+      Fixes a bug where we translate Gateways that do not belong to us.
+

--- a/projects/gateway2/controller/start.go
+++ b/projects/gateway2/controller/start.go
@@ -84,11 +84,12 @@ type StartConfig struct {
 // It is intended to be run in a goroutine as the function will block until the supplied
 // context is cancelled
 type ControllerBuilder struct {
-	proxySyncer     *proxy_syncer.ProxySyncer
-	inputChannels   *proxy_syncer.GatewayInputChannels
-	cfg             StartConfig
-	k8sGwExtensions ext.K8sGatewayExtensions
-	mgr             ctrl.Manager
+	proxySyncer           *proxy_syncer.ProxySyncer
+	inputChannels         *proxy_syncer.GatewayInputChannels
+	cfg                   StartConfig
+	k8sGwExtensions       ext.K8sGatewayExtensions
+	mgr                   ctrl.Manager
+	allowedGatewayClasses sets.Set[string]
 }
 
 func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuilder, error) {
@@ -170,6 +171,8 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		return nil, err
 	}
 
+	allowedGatewayClasses := sets.New(append(cfg.SetupOpts.ExtraGatewayClasses, wellknown.GatewayClassName)...)
+
 	// Create the proxy syncer for the Gateway API resources
 	setupLog.Info("initializing proxy syncer")
 	proxySyncer := proxy_syncer.NewProxySyncer(
@@ -190,6 +193,7 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 		cfg.SyncerExtensions,
 		cfg.GlooStatusReporter,
 		cfg.SetupOpts.ProxyReconcileQueue,
+		allowedGatewayClasses,
 	)
 	proxySyncer.Init(ctx, cfg.Debugger)
 	if err := mgr.Add(proxySyncer); err != nil {
@@ -198,11 +202,12 @@ func NewControllerBuilder(ctx context.Context, cfg StartConfig) (*ControllerBuil
 	}
 
 	return &ControllerBuilder{
-		proxySyncer:     proxySyncer,
-		inputChannels:   inputChannels,
-		cfg:             cfg,
-		k8sGwExtensions: k8sGwExtensions,
-		mgr:             mgr,
+		proxySyncer:           proxySyncer,
+		inputChannels:         inputChannels,
+		cfg:                   cfg,
+		k8sGwExtensions:       k8sGwExtensions,
+		mgr:                   mgr,
+		allowedGatewayClasses: allowedGatewayClasses,
 	}, nil
 }
 
@@ -246,7 +251,7 @@ func (c *ControllerBuilder) Start(ctx context.Context) error {
 
 	gwCfg := GatewayConfig{
 		Mgr:            c.mgr,
-		GWClasses:      sets.New(append(c.cfg.SetupOpts.ExtraGatewayClasses, wellknown.GatewayClassName)...),
+		GWClasses:      c.allowedGatewayClasses,
 		ControllerName: wellknown.GatewayControllerName,
 		AutoProvision:  AutoProvision,
 		ControlPlane: deployer.ControlPlaneInfo{

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -409,6 +409,9 @@ func (s *ProxySyncer) Init(ctx context.Context, dbg *krt.DebugHandler) error {
 	s.proxyTrigger = krt.NewRecomputeTrigger(true)
 
 	glooProxies := krt.NewCollection(kubeGateways, func(kctx krt.HandlerContext, gw *gwv1.Gateway) *glooProxy {
+		if gw.Spec.GatewayClassName != wellknown.GatewayClassName {
+			return nil
+		}
 		logger.Debugf("building proxy for kube gw %s version %s", client.ObjectKeyFromObject(gw), gw.GetResourceVersion())
 		s.proxyTrigger.MarkDependant(kctx)
 		proxy := s.buildProxy(ctx, gw)


### PR DESCRIPTION
Fixes a bug where we translate Gateways that do not belong to us.
Without this, we translate and update statuses on Gateways that do not belong to Gloo.