### PR TITLE
tests: Potentially fix flaky ValidtionStrict test

### DIFF
--- a/changelog/v1.19.0-beta6/fix-validation-strict.yaml
+++ b/changelog/v1.19.0-beta6/fix-validation-strict.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Potentially fix the flaky ValidationStrct test by ensuring the kubeCoreFailurePolicy is set to Fail
+

--- a/test/kubernetes/e2e/tests/manifests/validation-strict-helm.yaml
+++ b/test/kubernetes/e2e/tests/manifests/validation-strict-helm.yaml
@@ -3,6 +3,7 @@ gateway:
   validation:
     enabled: true
     failurePolicy: Fail # For "strict" validation mode, fail the validation if webhook server is not available
+    kubeCoreFailurePolicy: Fail # For "strict" validation mode, fail the validation if webhook server is not available
     allowWarnings: false # For "strict" validation mode, webhook will also reject warnings
     alwaysAcceptResources: false
     # added to preserve behavior tested by this suite.


### PR DESCRIPTION
# Description

Potentially fix the flaky ValidationStrct test by ensuring the kubeCoreFailurePolicy is set to Fail

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
