### PR TITLE
Reduce nooneway test failures

### DIFF
--- a/changelog/v1.19.0-beta6/flake-improve-nooneway-failures.yaml
+++ b/changelog/v1.19.0-beta6/flake-improve-nooneway-failures.yaml
@@ -1,6 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: |
-      Adjusted timeout in an effort to reduce failures of these tests.
-    issueLink: https://github.com/solo-io/solo-projects/issues/7685
-    resolvesIssue: false

--- a/changelog/v1.19.0-beta6/flake-improve-nooneway-failures.yaml
+++ b/changelog/v1.19.0-beta6/flake-improve-nooneway-failures.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Adjusted timeout in an effort to reduce failures of these tests.
+    issueLink: https://github.com/solo-io/solo-projects/issues/7685
+    resolvesIssue: false

--- a/changelog/v1.19.0-beta7/flake-improve-nooneway-failures.yaml
+++ b/changelog/v1.19.0-beta7/flake-improve-nooneway-failures.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Adjusted timeout in an effort to reduce failures of these tests.
+    issueLink: https://github.com/solo-io/solo-projects/issues/7685
+    resolvesIssue: false

--- a/test/kubernetes/e2e/features/server_tls/k8s_suite.go
+++ b/test/kubernetes/e2e/features/server_tls/k8s_suite.go
@@ -131,5 +131,6 @@ func (s *k8sServerTlsTestingSuite) assertEventualError(hostHeaderValue string, c
 			Container: "curl",
 		},
 		append(curlOptions("gloo-proxy-gw", s.ns, hostHeaderValue), curl.WithPath("/status/200")),
-		code)
+		code,
+		time.Minute*2)
 }


### PR DESCRIPTION
# Description

Was able to reproduce locally. After looking at the logs and things, it appears things were getting to a working state but just not fast enough for the test. Adjusting the timeout. I was able to confirm that I no longer saw the test fail locally with 2m.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
