### PR TITLE
Adding TestInstallation.AssertionsT

### DIFF
--- a/changelog/v1.19.0-beta6/tests-introducing-assertionst.yaml
+++ b/changelog/v1.19.0-beta6/tests-introducing-assertionst.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    description: |
+      Introducing TestInstallation.AssertionsT method that provides a better 
+      scoped assertions provider.

--- a/test/kubernetes/e2e/features/server_tls/k8s_suite.go
+++ b/test/kubernetes/e2e/features/server_tls/k8s_suite.go
@@ -108,9 +108,8 @@ func (s *k8sServerTlsTestingSuite) TestOneWayServerTlsWorksWithOneWayTls() {
 }
 
 func (s *k8sServerTlsTestingSuite) assertEventualResponse(hostHeaderValue string, matcher *matchers.HttpResponse) {
-
 	// Check curl works against expected response
-	s.testInstallation.Assertions.AssertEventualCurlResponse(
+	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
 		s.ctx,
 		kubectl.PodExecOptions{
 			Name:      "curl",
@@ -123,7 +122,7 @@ func (s *k8sServerTlsTestingSuite) assertEventualResponse(hostHeaderValue string
 
 func (s *k8sServerTlsTestingSuite) assertEventualError(hostHeaderValue string, code int) {
 	// Check curl works against expected response
-	s.testInstallation.Assertions.AssertEventualCurlError(
+	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlError(
 		s.ctx,
 		kubectl.PodExecOptions{
 			Name:      "curl",

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -142,7 +142,7 @@ type TestInstallation struct {
 	// DEPRECATED: Use AssertionsT instead (which is scoped to a specific test and not the root suite)
 	Assertions *assertions.Provider
 
-	// AssertionsT creates an assertion provide that is scoped to the provided test
+	// AssertionsT creates an assertion provider that is scoped to the provided test
 	AssertionsT func(*testing.T) *assertions.Provider
 
 	// GeneratedFiles is the collection of directories and files that this test installation _may_ create

--- a/test/kubernetes/e2e/test.go
+++ b/test/kubernetes/e2e/test.go
@@ -102,6 +102,12 @@ func CreateTestInstallationForCluster(
 			WithClusterContext(clusterContext).
 			WithGlooGatewayContext(glooGatewayContext),
 
+		AssertionsT: func(t *testing.T) *assertions.Provider {
+			return assertions.NewProvider(t).
+				WithClusterContext(clusterContext).
+				WithGlooGatewayContext(glooGatewayContext)
+		},
+
 		// GeneratedFiles contains the unique location where files generated during the execution
 		// of tests against this installation will be stored
 		// By creating a unique location, per TestInstallation and per Cluster.Name we guarantee isolation
@@ -133,7 +139,11 @@ type TestInstallation struct {
 	Actions *actions.Provider
 
 	// Assertions is the entity that creates assertions that can be executed by the Operator
+	// DEPRECATED: Use AssertionsT instead (which is scoped to a specific test and not the root suite)
 	Assertions *assertions.Provider
+
+	// AssertionsT creates an assertion provide that is scoped to the provided test
+	AssertionsT func(*testing.T) *assertions.Provider
 
 	// GeneratedFiles is the collection of directories and files that this test installation _may_ create
 	GeneratedFiles GeneratedFiles


### PR DESCRIPTION
# Description

While looking into a flakey test I noticed that trying to check if the test failed in the `AfterTest` method wasn't working as expected; The `Failed` method was reporting false when there was a failure, preventing me from making a test-level cluster dump in the `_test` artifacts. 

It turns out that `TestInstallation.Assertions` is created when the suite runs and uses the suite's `testing.T`. That leads to the issue and the framework calls it out in the log with `testing.go:1577: test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test`. 

This PR introduces a new method that takes the current `testing.T` and returns an appropriately scoped assertions provider. The previous method has been flagged in a way that VSC (and likely other IDEs) will call it out.

> After we finish abating this issue, we should be able implement test-level dumps across our `kubernetes/e2e` tests. Making test failures easier to debug. 

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
