### PR TITLE
fix: gwp does not respect image variant

### DIFF
--- a/changelog/v1.19.0-beta7/fix-gwp-fips-distroless.yaml
+++ b/changelog/v1.19.0-beta7/fix-gwp-fips-distroless.yaml
@@ -2,5 +2,4 @@ changelog:
 - type: FIX
   issueLink: https://github.com/solo-io/gloo/issues/10602
   resolvesIssue: false
-  description: Fixes the gateway params image to respect the fips and distroless variants specified by global.image.variant
-
+  description: Fixes the gateway params image to respect the fips and distroless variants specified by global.image.variant. This only applies to the kubernetes gateway proxy.

--- a/changelog/v1.19.0-beta7/fix-gwp-fips-distroless.yaml
+++ b/changelog/v1.19.0-beta7/fix-gwp-fips-distroless.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/issues/10602
+  resolvesIssue: false
+  description: Fixes the gateway params image to respect the fips and distroless variants specified by global.image.variant
+

--- a/install/helm/gloo/templates/_gg-helpers.tpl
+++ b/install/helm/gloo/templates/_gg-helpers.tpl
@@ -46,11 +46,36 @@ ref Image api in projects/gateway2/api/v1alpha1/kube/container.proto
 {{- if $image.registry }}
 registry: {{ $image.registry }}
 {{- end -}}{{/* if $image.registry */}}
+
+{{- /* This has been copied from _helpers.tpl and should be kept in sync */ -}}
 {{- if $image.repository }}
-repository: {{ $image.repository }}
+{{- $repository := $image.repository -}}
+{{- /*
+for fips or fips-distroless variants: add -fips to the image repo (name)
+*/ -}}
+{{- if or $image.fips (has $image.variant (list "fips" "fips-distroless")) -}}
+{{- $fipsSupportedImages := list "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" -}}
+{{- if (has $image.repository $fipsSupportedImages) -}}
+{{- $repository = printf "%s-fips" $repository -}}
+{{- end -}}{{- /* if (has .repository $fipsSupportedImages) */ -}}
+{{- end -}}{{- /* if or .fips (has .variant (list "fips" "fips-distroless")) */ -}}
+{{ printf "\n" }}
+repository: {{ $repository }}
 {{- end -}}{{/* if $image.repository */}}
+
 {{- if $image.tag }}
-tag: {{ $image.tag }}
+{{- $tag := $image.tag -}}
+{{- /*
+for distroless or fips-distroless variants: add -distroless to the tag
+*/ -}}
+{{- if has $image.variant (list "distroless" "fips-distroless") -}}
+{{- $distrolessSupportedImages := list "gloo" "gloo-envoy-wrapper" "discovery" "sds" "certgen" "kubectl" "access-logger" "ingress" "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" "observability-ee" "caching-ee" -}}
+{{- if (has $image.repository $distrolessSupportedImages) -}}
+{{- $tag = printf "%s-distroless" $tag -}} {{- /* Add distroless suffix to the tag since it contains the same binaries in a different container */ -}}
+{{- end -}}{{- /* if (has .repository $distrolessSupportedImages) */ -}}
+{{- end }}{{- /* if and .tag (has .variant (list "distroless" "fips-distroless")) */ -}}
+{{ printf "\n" }}
+tag: {{ $tag }}
 {{- end -}}{{/* if $image.tag */}}
 {{- if $image.digest }}
 digest: {{ $image.digest }}

--- a/install/helm/gloo/templates/_gg-helpers.tpl
+++ b/install/helm/gloo/templates/_gg-helpers.tpl
@@ -42,43 +42,18 @@ Images valid for the GatewayParameters
 ref Image api in projects/gateway2/api/v1alpha1/kube/container.proto
 */}}
 {{- define "gloo-gateway.gatewayParametersImage" -}}
-{{- $image := . -}}
+{{ $image := . }}
 {{- if $image.registry }}
 registry: {{ $image.registry }}
 {{- end -}}{{/* if $image.registry */}}
-
-{{- /* This has been copied from _helpers.tpl and should be kept in sync */ -}}
 {{- if $image.repository }}
-{{- $repository := $image.repository -}}
-{{- /*
-for fips or fips-distroless variants: add -fips to the image repo (name)
-*/ -}}
-{{- if or $image.fips (has $image.variant (list "fips" "fips-distroless")) -}}
-{{- $fipsSupportedImages := list "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" -}}
-{{- if (has $image.repository $fipsSupportedImages) -}}
-{{- $repository = printf "%s-fips" $repository -}}
-{{- end -}}{{- /* if (has .repository $fipsSupportedImages) */ -}}
-{{- end -}}{{- /* if or .fips (has .variant (list "fips" "fips-distroless")) */ -}}
-{{ printf "\n" }}
-repository: {{ $repository }}
+repository: {{ template "gloo.image.repository" $image }}
 {{- end -}}{{/* if $image.repository */}}
-
 {{- if $image.tag }}
-{{- $tag := $image.tag -}}
-{{- /*
-for distroless or fips-distroless variants: add -distroless to the tag
-*/ -}}
-{{- if has $image.variant (list "distroless" "fips-distroless") -}}
-{{- $distrolessSupportedImages := list "gloo" "gloo-envoy-wrapper" "discovery" "sds" "certgen" "kubectl" "access-logger" "ingress" "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" "observability-ee" "caching-ee" -}}
-{{- if (has $image.repository $distrolessSupportedImages) -}}
-{{- $tag = printf "%s-distroless" $tag -}} {{- /* Add distroless suffix to the tag since it contains the same binaries in a different container */ -}}
-{{- end -}}{{- /* if (has .repository $distrolessSupportedImages) */ -}}
-{{- end }}{{- /* if and .tag (has .variant (list "distroless" "fips-distroless")) */ -}}
-{{ printf "\n" }}
-tag: {{ $tag }}
+tag: {{ template "gloo.image.tag" $image }}
 {{- end -}}{{/* if $image.tag */}}
 {{- if $image.digest }}
-digest: {{ $image.digest }}
+digest: {{ template "gloo.image.digest" $image }}
 {{- end -}}{{/* if $image.digest */}}
 {{- if $image.pullPolicy }}
 pullPolicy: {{ $image.pullPolicy }}

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -25,60 +25,76 @@ ClusterRole
 {{- end -}}
 {{- end -}}
 
-{{/*
-Construct a container image name from a registry, repository, tag, and digest.
-*/}}
-{{- define "gloo.image" -}}
-{{- $image := printf "%s/%s" .registry .repository -}}
-
-{{- /* This has been copied over to _gg-helpers.tpl and should be kept in sync */ -}}
+{{- define "gloo.image.repository" -}}
 {{- /*
 for fips or fips-distroless variants: add -fips to the image repo (name)
 */ -}}
+{{- if .repository -}}
+{{- $repository := .repository -}}
 {{- if or .fips (has .variant (list "fips" "fips-distroless")) -}}
 {{- $fipsSupportedImages := list "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" -}}
 {{- if (has .repository $fipsSupportedImages) -}}
-{{- $image = printf "%s-fips" $image -}}
+{{- $repository = printf "%s-fips" $repository -}}
 {{- end -}}{{- /* if (has .repository $fipsSupportedImages) */ -}}
 {{- end -}}{{- /* if or .fips (has .variant (list "fips" "fips-distroless")) */ -}}
+{{ $repository }}
+{{- end -}}{{- /* if .repository */ -}}
+{{- end -}}{{- /* define "gloo.image.repository" */ -}}
 
-{{- /*
-add tag, if it exists
-*/ -}}
+{{- define "gloo.image.tag" -}}
 {{- if .tag -}}
-{{- $image = printf "%s:%s" $image .tag -}}
-{{- end -}}{{- /* if .tag */ -}}
-
+{{- $tag := .tag -}}
 {{- /*
 for distroless or fips-distroless variants: add -distroless to the tag
 */ -}}
 {{- if and .tag (has .variant (list "distroless" "fips-distroless")) -}}
 {{- $distrolessSupportedImages := list "gloo" "gloo-envoy-wrapper" "discovery" "sds" "certgen" "kubectl" "access-logger" "ingress" "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" "observability-ee" "caching-ee" -}}
 {{- if (has .repository $distrolessSupportedImages) -}}
-{{- $image = printf "%s-distroless" $image -}} {{- /* Add distroless suffix to the tag since it contains the same binaries in a different container */ -}}
+{{- $tag = printf "%s-distroless" $tag -}} {{- /* Add distroless suffix to the tag since it contains the same binaries in a different container */ -}}
 {{- end -}}{{- /* if (has .repository $distrolessSupportedImages) */ -}}
 {{- end -}}{{- /* if and .tag (has .variant (list "distroless" "fips-distroless")) */ -}}
+{{ $tag }}
+{{- end -}}{{- /* if .tag */ -}}
+{{- end -}}{{- /* define "gloo.image.tag" */ -}}
 
-{{- /*
-add digest for the chosen variant, if it exists
-*/ -}}
+{{- define "gloo.image.digest" -}}
+{{- $digest := "" -}}
 {{- if or .fips (eq .variant "fips") -}}
   {{- if .fipsDigest -}}
-    {{- $image = printf "%s@%s" $image .fipsDigest -}}
+    {{- $digest = .fipsDigest -}}
   {{- end -}}{{- /* if .fipsDigest */ -}}
 {{- else if eq .variant "distroless" -}}
   {{- if .distrolessDigest -}}
-    {{- $image = printf "%s@%s" $image .distrolessDigest -}}
+    {{- $digest = .distrolessDigest -}}
   {{- end -}}{{- /* if .distrolessDigest */ -}}
 {{- else if eq .variant "fips-distroless" -}}
   {{- if .fipsDistrolessDigest -}}
-    {{- $image = printf "%s@%s" $image .fipsDistrolessDigest -}}
+    {{- $digest = .fipsDistrolessDigest -}}
   {{- end -}}{{- /* if .fipsDistrolessDigest */ -}}
 {{- else -}}
   {{- if .digest -}}{{- /* standard image digest */ -}}
-    {{- $image = printf "%s@%s" $image .digest -}}
+    {{- $image = .digest -}}
   {{- end -}}{{- /* if .digest */ -}}
+{{ $digest }}
 {{- end -}}
+
+{{- end -}}{{- /* define "gloo.image.digest" */ -}}
+
+
+{{/*
+Construct a container image name from a registry, repository, tag, and digest.
+*/}}
+{{- define "gloo.image" -}}
+{{- $repository := include  "gloo.image.repository" . -}}
+{{- $image := printf "%s/%s" .registry $repository -}}
+{{- $tag := include  "gloo.image.tag" . -}}
+{{- if $tag -}}
+{{- $image = printf "%s:%s" $image $tag -}}
+{{- end -}}{{- /* if .tag */ -}}
+{{- $digest := include  "gloo.image.digest" . -}}
+{{- if $digest -}}
+{{- $image = printf "%s@%s" $image $digest -}}
+{{- end -}}{{- /* if .digest */ -}}
 {{ $image }}
 {{- end -}}{{- /* define "gloo.image" */ -}}
 

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Construct a container image name from a registry, repository, tag, and digest.
 {{- if $tag -}}
 {{- $image = printf "%s:%s" $image $tag -}}
 {{- end -}}{{- /* if .tag */ -}}
-{{- $digest = include  "gloo.image.digest" . -}}
+{{- $digest := include  "gloo.image.digest" . -}}
 {{- if $digest -}}
 {{- $image = printf "%s@%s" $image $digest -}}
 {{- end -}}{{- /* if .digest */ -}}

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -73,11 +73,10 @@ for distroless or fips-distroless variants: add -distroless to the tag
   {{- end -}}{{- /* if .fipsDistrolessDigest */ -}}
 {{- else -}}
   {{- if .digest -}}{{- /* standard image digest */ -}}
-    {{- $image = .digest -}}
+    {{- $digest = .digest -}}
   {{- end -}}{{- /* if .digest */ -}}
-{{ $digest }}
 {{- end -}}
-
+{{ $digest }}
 {{- end -}}{{- /* define "gloo.image.digest" */ -}}
 
 

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -31,6 +31,7 @@ Construct a container image name from a registry, repository, tag, and digest.
 {{- define "gloo.image" -}}
 {{- $image := printf "%s/%s" .registry .repository -}}
 
+{{- /* This has been copied over to _gg-helpers.tpl and should be kept in sync */ -}}
 {{- /*
 for fips or fips-distroless variants: add -fips to the image repo (name)
 */ -}}
@@ -170,7 +171,7 @@ It takes 4 values:
   .defaults - the default securityContext for the pod or container
   .globalSec - global security settings, usually from .Values.global.securitySettings
   .indent - the number of spaces to indent the output. If not set, the output will not be indented.
-    The indentation argument is necessary because it is possible that no output will be rendered. 
+    The indentation argument is necessary because it is possible that no output will be rendered.
     If that happens and the caller handles the indentation the result will be a line of whitespace, which gets caught by the whitespace tests
 
   Depending upon the value of .values.merge, the securityContext will be merged with the defaults or completely replaced.
@@ -234,7 +235,7 @@ It takes 4 values:
   .podSecurityStandards - podSecurityStandard from values.yaml
   .globalSec - global security settings, usually from .Values.global.securitySettings
   .indent - the number of spaces to indent the output. If not set, the output will not be indented.
-    The indentation argument is necessary because it is possible that no output will be rendered. 
+    The indentation argument is necessary because it is possible that no output will be rendered.
     If that happens and the caller handles the indentation the result will be a line of whitespace, which gets caught by the whitespace tests
 
   If .podSecurityStandards.container.enableRestrictedContainerDefaults is true, the defaults will be set to a restricted set of values.
@@ -260,7 +261,7 @@ It takes 4 values:
 {{- end -}}
 {{- /* set default seccompProfileType */ -}}
 
-{{- $pss_restricted_defaults := dict 
+{{- $pss_restricted_defaults := dict
     "runAsNonRoot" true
     "capabilities" (dict "drop" (list "ALL"))
     "allowPrivilegeEscalation" false }}
@@ -280,7 +281,7 @@ It takes 4 values:
   {{- end -}}
 {{- end -}}
 {{- /* call general securityContext template */ -}}
-{{- include "gloo.securityContext" (dict 
+{{- include "gloo.securityContext" (dict
             "values" $values
             "defaults" $defaults
             "indent" $indent

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Construct a container image name from a registry, repository, tag, and digest.
 {{- if $tag -}}
 {{- $image = printf "%s:%s" $image $tag -}}
 {{- end -}}{{- /* if .tag */ -}}
-{{- $digest := include  "gloo.image.digest" . -}}
+{{- $digest = include  "gloo.image.digest" . -}}
 {{- if $digest -}}
 {{- $image = printf "%s@%s" $image $digest -}}
 {{- end -}}{{- /* if .digest */ -}}

--- a/install/test/k8sgateway_test.go
+++ b/install/test/k8sgateway_test.go
@@ -487,6 +487,57 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 					})
 				})
 			})
+
+			FContext("distroless and fips", func() {
+				DescribeTable("Uses the correct image for the sds-ee container", func(variant string, expectedImage string) {
+					extraValueArgs := []string{
+						"kubeGateway.gatewayParameters.glooGateway.sdsContainer.image.registry=my-sds-reg",
+						"kubeGateway.gatewayParameters.glooGateway.sdsContainer.image.tag=my-sds-tag",
+						"kubeGateway.gatewayParameters.glooGateway.sdsContainer.image.repository=sds-ee",
+						"global.image.variant=" + variant,
+					}
+					valuesArgs = append(valuesArgs, extraValueArgs...)
+					// Updated values so need to re-render
+					prepareHelmManifest(namespace, glootestutils.HelmValues{ValuesArgs: valuesArgs})
+
+					gwp := getDefaultGatewayParameters(testManifest)
+					gwpKube := gwp.Spec.Kube
+					Expect(gwpKube).ToNot(BeNil())
+					sdsContainer := gwpKube.SdsContainer.Image
+					image := fmt.Sprintf("%s/%s:%s", *sdsContainer.Registry, *sdsContainer.Repository, *sdsContainer.Tag)
+					Expect(image).To(Equal(expectedImage))
+				},
+					Entry("No variant specified", "", "my-sds-reg/sds-ee:my-sds-tag"),
+					Entry("Standard variant", "standard", "my-sds-reg/sds-ee:my-sds-tag"),
+					Entry("Fips variant", "fips", "my-sds-reg/sds-ee-fips:my-sds-tag"),
+					Entry("Distroless variant", "distroless", "my-sds-reg/sds-ee:my-sds-tag-distroless"),
+					Entry("Fips-Distroless variant", "fips-distroless", "my-sds-reg/sds-ee-fips:my-sds-tag-distroless"))
+
+				DescribeTable("Uses the correct image for the gloo-ee-envoy-wrapper container", func(variant string, expectedImage string) {
+					extraValueArgs := []string{
+						"kubeGateway.gatewayParameters.glooGateway.envoyContainer.image.registry=my-gloo-ee-envoy-wrapper-reg",
+						"kubeGateway.gatewayParameters.glooGateway.envoyContainer.image.tag=my-gloo-ee-envoy-wrapper-tag",
+						"kubeGateway.gatewayParameters.glooGateway.envoyContainer.image.repository=gloo-ee-envoy-wrapper",
+						"global.image.variant=" + variant,
+					}
+					valuesArgs = append(valuesArgs, extraValueArgs...)
+					// Updated values so need to re-render
+					prepareHelmManifest(namespace, glootestutils.HelmValues{ValuesArgs: valuesArgs})
+
+					gwp := getDefaultGatewayParameters(testManifest)
+					gwpKube := gwp.Spec.Kube
+					Expect(gwpKube).ToNot(BeNil())
+					envoyContainer := gwpKube.EnvoyContainer.Image
+					image := fmt.Sprintf("%s/%s:%s", *envoyContainer.Registry, *envoyContainer.Repository, *envoyContainer.Tag)
+					Expect(image).To(Equal(expectedImage))
+				},
+					Entry("No variant specified", "", "my-gloo-ee-envoy-wrapper-reg/gloo-ee-envoy-wrapper:my-gloo-ee-envoy-wrapper-tag"),
+					Entry("Standard variant", "standard", "my-gloo-ee-envoy-wrapper-reg/gloo-ee-envoy-wrapper:my-gloo-ee-envoy-wrapper-tag"),
+					Entry("Fips variant", "fips", "my-gloo-ee-envoy-wrapper-reg/gloo-ee-envoy-wrapper-fips:my-gloo-ee-envoy-wrapper-tag"),
+					Entry("Distroless variant", "distroless", "my-gloo-ee-envoy-wrapper-reg/gloo-ee-envoy-wrapper:my-gloo-ee-envoy-wrapper-tag-distroless"),
+					Entry("Fips-Distroless variant", "fips-distroless", "my-gloo-ee-envoy-wrapper-reg/gloo-ee-envoy-wrapper-fips:my-gloo-ee-envoy-wrapper-tag-distroless"))
+
+			})
 		})
 
 		When("kube gateway integration is disabled (default)", func() {

--- a/install/test/k8sgateway_test.go
+++ b/install/test/k8sgateway_test.go
@@ -488,7 +488,7 @@ var _ = Describe("Kubernetes Gateway API integration", func() {
 				})
 			})
 
-			FContext("distroless and fips", func() {
+			Context("distroless and fips", func() {
 				DescribeTable("Uses the correct image for the sds-ee container", func(variant string, expectedImage string) {
 					extraValueArgs := []string{
 						"kubeGateway.gatewayParameters.glooGateway.sdsContainer.image.registry=my-sds-reg",


### PR DESCRIPTION
# Description
Ensures the images generated in the gatewayparams via helm respect the global.image.variant

# Context
https://github.com/solo-io/solo-projects/issues/7803

## Testing steps
Before :
```
helm-template-oss --set kubeGateway.enabled=true --set global.image.variant=fips-distroless

# Source: gloo/templates/43-gatewayparameters.yaml
kind: GatewayParameters
...
    sdsContainer:
      image:
        registry: quay.io/solo-io
        repository: sds-ee
        tag: 1.0.0-ci1
```

After :
```
helm-template-oss --set kubeGateway.enabled=true --set global.image.variant=fips-distroless

# Source: gloo/templates/43-gatewayparameters.yaml
kind: GatewayParameters
...
    sdsContainer:
      image:
        registry: quay.io/solo-io
        repository: sds-ee-fips
        tag: 1.0.0-ci1-distroless
```
## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
