### PR TITLE
Fix glooctl check test flake

### DIFF
--- a/changelog/v1.19.0-beta8/fix_glooctl-check_test-flake.yaml
+++ b/changelog/v1.19.0-beta8/fix_glooctl-check_test-flake.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/6619
+  description: fixes flaky enterprise glooctl check tests
+  resolvesIssue: false

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
@@ -34,7 +34,7 @@ var (
 	customGlooDeploymentName = helpers.GlooDeploymentName
 )
 
-func ResourcesSyncedOverXds(stats, deploymentName string) bool {
+func ResourcesSyncedOverXds(printer printers.P, stats, deploymentName string) bool {
 	var outOfSyncResources []string
 	metrics := parseMetrics(stats, []string{glooeTotalEntites, glooeInSyncEntities}, deploymentName)
 	for metric, val := range metrics {
@@ -53,9 +53,9 @@ func ResourcesSyncedOverXds(stats, deploymentName string) bool {
 	}
 
 	if len(metrics) == 0 {
-		fmt.Println("No xds metrics to check")
+		printer.AppendStatus("xds metrics", "No xds metrics to check")
 	} else {
-		fmt.Println("OK")
+		printer.AppendStatus("xds metrics", "OK")
 	}
 	return true
 }
@@ -110,7 +110,7 @@ func checkXdsMetrics(ctx context.Context, printer printers.P, opts *options.Opti
 		return fmt.Errorf(err)
 	}
 
-	if !ResourcesSyncedOverXds(stats, customGlooDeploymentName) {
+	if !ResourcesSyncedOverXds(printer, stats, customGlooDeploymentName) {
 		fmt.Println(errMessage)
 		return fmt.Errorf(errMessage)
 	}

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats.go
@@ -51,6 +51,12 @@ func ResourcesSyncedOverXds(stats, deploymentName string) bool {
 		fmt.Println(resourcesOutOfSyncMessage(outOfSyncResources))
 		return false
 	}
+
+	if len(metrics) == 0 {
+		fmt.Println("No xds metrics to check")
+	} else {
+		fmt.Println("OK")
+	}
 	return true
 }
 
@@ -69,6 +75,7 @@ func RateLimitIsConnected(stats string) bool {
 }
 
 func checkXdsMetrics(ctx context.Context, printer printers.P, opts *options.Options, deployments *appsv1.DeploymentList) error {
+	printer.AppendCheck("Checking xds metrics... ")
 	errMessage := "Problem while checking for gloo xds errors"
 	if deployments == nil {
 		fmt.Println("Skipping due to an error in checking deployments")

--- a/projects/gloo/cli/pkg/cmd/check/gloo_stats_test.go
+++ b/projects/gloo/cli/pkg/cmd/check/gloo_stats_test.go
@@ -4,6 +4,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/solo-io/gloo/projects/gloo/cli/pkg/cmd/check"
+	"github.com/solo-io/gloo/projects/gloo/cli/pkg/printers"
 )
 
 var _ = Describe("Gloo Stats", func() {
@@ -14,7 +15,7 @@ var _ = Describe("Gloo Stats", func() {
 
 	Context("check resources in sync", func() {
 		It("returns true when there are no stats", func() {
-			result := check.ResourcesSyncedOverXds("", deploymentName)
+			result := check.ResourcesSyncedOverXds(printers.P{}, "", deploymentName)
 			Expect(result).To(BeTrue())
 		})
 
@@ -38,7 +39,7 @@ glooe_solo_io_xds_total_entities{resource="type.googleapis.com/envoy.api.v2.List
 glooe_solo_io_xds_total_entities{resource="type.googleapis.com/envoy.api.v2.RouteConfiguration"} 1
 glooe_solo_io_xds_total_entities{resource="type.googleapis.com/glooe.solo.io.RateLimitConfig"} 1
 `
-			result := check.ResourcesSyncedOverXds(stats, deploymentName)
+			result := check.ResourcesSyncedOverXds(printers.P{}, stats, deploymentName)
 			Expect(result).To(BeFalse())
 		})
 
@@ -59,7 +60,7 @@ glooe_solo_io_xds_total_entities{resource="type.googleapis.com/envoy.api.v2.List
 glooe_solo_io_xds_total_entities{resource="type.googleapis.com/envoy.api.v2.RouteConfiguration"} 1
 glooe_solo_io_xds_total_entities{resource="type.googleapis.com/glooe.solo.io.RateLimitConfig"} 1
 `
-			result := check.ResourcesSyncedOverXds(stats, deploymentName)
+			result := check.ResourcesSyncedOverXds(printers.P{}, stats, deploymentName)
 			Expect(result).To(BeTrue())
 		})
 	})

--- a/projects/gloo/cli/pkg/cmd/check/root.go
+++ b/projects/gloo/cli/pkg/cmd/check/root.go
@@ -952,7 +952,7 @@ func checkSecrets(ctx context.Context, printer printers.P, _ *options.Options, n
 	client, err := helpers.GetSecretClient(ctx, namespaces)
 	if err != nil {
 		multiErr = multierror.Append(multiErr, err)
-		printer.AppendStatus("secrets", fmt.Sprintf("%v Errors!", multiErr.Len()))
+		printer.AppendStatus("Secrets", fmt.Sprintf("%v Errors!", multiErr.Len()))
 		return multiErr
 	}
 


### PR DESCRIPTION
# Description

This PR excludes the xds-metrics check from glooctl check runs in the e2e glooctl check tests suite to fix enterprise tests that are flaking due to an [Envoy bug](https://github.com/envoyproxy/envoy/issues/7529).

An in-depth explanation and additional context can be found [here](https://github.com/solo-io/solo-projects/issues/6619#issuecomment-2657843057).

## Testing steps

I verified this fix by running the failing enterprise tests on my local and seeing them pass consistently with the fix.

## Additional changes

I also made a small improvement to the user-facing `glooctl check` output.

If the deployments are not all healthy, the previous output would include:
```
Checking Proxies... Skipping due to an error in checking deployments
Skipping due to an error in checking deployments
```

With this change, it will instead include:
```
Checking Proxies... Skipping due to an error in checking deployments
Checking xds metrics... Skipping due to an error in checking deployments
```

If the check has no issues, it will include:
```
Checking Proxies... OK
Checking xds metrics... OK
```

With an open source installation, it will instead include:
```
Checking Proxies... OK
Checking xds metrics... No xds metrics to check
```

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have made corresponding changes to the documentation~
- [ ] ~I have added tests that prove my fix is effective or that my feature works~