### PR TITLE
Update static-analysis.yaml

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -45,7 +45,7 @@ jobs:
       uses: actions/checkout@v4
     - name: Prep Go Runner
       uses: ./.github/workflows/composite-actions/prep-go-runner
-    - uses: golangci/golangci-lint-action@v6
+    - uses: golangci/golangci-lint-action@v6.4.1
       # `make analyze` runs the linter with similar arguments to what we use here.
       # If this action fails, try running `make analyze` locally.
       with:

--- a/changelog/v1.19.0-beta9/pin-linter.yaml
+++ b/changelog/v1.19.0-beta9/pin-linter.yaml
@@ -3,3 +3,5 @@ changelog:
     resolvesIssue: false
     description: >-
       Pin golangci-lint-action to `6.4.1` to avoid breaking changes in `6.5.0`
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/changelog/v1.19.0-beta9/pin-linter.yaml
+++ b/changelog/v1.19.0-beta9/pin-linter.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    description: >-
+      Pin golangci-lint-action to `6.4.1` to avoid breaking changes in `6.5.0`


### PR DESCRIPTION
# Description
Pin golangci-lint-action to `6.4.1` to avoid breaking changes in `6.5.0`
