### PR TITLE
Bump nightly e2e test timeout

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -133,7 +133,7 @@ jobs:
           # When running the tests at night, there is no value in splitting the tests across multiple clusters and running them in parallel.
           # As a result, we increase the threshold for the tests, since they all run serially on a single cluster
           - cluster-name: 'cluster-one'
-            go-test-args: '-v -timeout=150m'
+            go-test-args: '-v -timeout=210m'
             # Specifying an empty regex means all tests will be run.
             go-test-run-regex: ""
         # In our nightly tests, we run the suite of tests using the lower and upper ends of versions that we claim to support
@@ -196,7 +196,7 @@ jobs:
           # When running the tests at night, there is no value in splitting the tests across multiple clusters and running them in parallel.
           # As a result, we increase the threshold for the tests, since they all run serially on a single cluster
           - cluster-name: 'cluster-one'
-            go-test-args: '-v -timeout=150m'
+            go-test-args: '-v -timeout=210m'
             # Specifying an empty regex means all tests will be run.
             go-test-run-regex: ""
         # In our nightly tests, we run the suite of tests using the lower and upper ends of versions that we claim to support

--- a/changelog/v1.19.0-beta10/bump-nightly-timeouts.yaml
+++ b/changelog/v1.19.0-beta10/bump-nightly-timeouts.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Bump timeouts for nightly e2e tests.

--- a/changelog/v1.19.0-beta9/bump-nightly-timeouts.yaml
+++ b/changelog/v1.19.0-beta9/bump-nightly-timeouts.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Bump timeouts for nightly e2e tests.

--- a/changelog/v1.19.0-beta9/bump-nightly-timeouts.yaml
+++ b/changelog/v1.19.0-beta9/bump-nightly-timeouts.yaml
@@ -1,4 +1,0 @@
-changelog:
-  - type: NON_USER_FACING
-    description: >-
-      Bump timeouts for nightly e2e tests.


### PR DESCRIPTION
# Description
1.18.x e2e tests were failing [here](https://github.com/solo-io/gloo/actions/runs/13363924901) due to hitting the timeout.

Bumping the timeout for 1.18 and also proactively for main

Non-timing out run: https://github.com/solo-io/gloo/actions/runs/13378922584