### PR TITLE
fix ci build

### DIFF
--- a/changelog/v1.19.0-beta12/ci-fix-build.yaml
+++ b/changelog/v1.19.0-beta12/ci-fix-build.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix broken CI build due to qemu segfault for multiarch images.
+
+      skipCI-docs-build:true

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -51,6 +51,14 @@ steps:
   - create
   - --use
 
+# Reset QEMU to avoid segfaults for multiarch images
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'reset-qemu'
+  entrypoint: 'sh'
+  args:
+    - '-c'
+    - 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes'
+
 - name: 'gcr.io/$PROJECT_ID/go-mod-make:0.12.0'
   id: 'build-certgen-arm64-binary'
   args:


### PR DESCRIPTION
# Description
Fixing broken CI build due to recent qemu segault error for building multiarch images

cloudbuilder ci [build](https://storage.googleapis.com/solo-public-build-logs/logs.html?buildid=7060fc78-3f32-4bc3-9447-95afdeb1f99f) with the fix

```
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 29.27 Segmentation fault
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 29.28 qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 29.28 Segmentation fault
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 29.29 dpkg: error processing package libc-bin (--configure):
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 29.29  installed libc-bin package post-installation script subprocess returned error exit status 139
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 29.30 Errors were encountered while processing:
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 29.30  libc-bin
Step #0 - "publish-artifacts": Step #6 - "publish-docker": : Sub-process /usr/bin/dpkg returned an error code (1)
Step #0 - "publish-artifacts": Step #6 - "publish-docker": ------
Step #0 - "publish-artifacts": Step #6 - "publish-docker": 
Step #0 - "publish-artifacts": Step #6 - "publish-docker":  [33m4 warnings found (use docker --debug to expand):
Step #0 - "publish-artifacts": Step #6 - "publish-docker": [0m - InvalidDefaultArgInFrom: Default value for ARG $PACKAGE_DONOR_IMAGE results in empty or invalid base image name (line 5)
Step #0 - "publish-artifacts": Step #6 - "publish-docker":  - InvalidDefaultArgInFrom: Default value for ARG $PACKAGE_DONOR_IMAGE results in empty or invalid base image name (line 6)
Step #0 - "publish-artifacts": Step #6 - "publish-docker":  - InvalidDefaultArgInFrom: Default value for ARG $PACKAGE_DONOR_IMAGE results in empty or invalid base image name (line 8)
Step #0 - "publish-artifacts": Step #6 - "publish-docker":  - InvalidDefaultArgInFrom: Default value for ARG $BASE_IMAGE results in empty or invalid base image name (line 15)
Step #0 - "publish-artifacts": Step #6 - "publish-docker": Dockerfile:11
Step #0 - "publish-artifacts": Step #6 - "publish-docker": --------------------
Step #0 - "publish-artifacts": Step #6 - "publish-docker":   10 |     ENV DEBIAN_FRONTEND=noninteractive
Step #0 - "publish-artifacts": Step #6 - "publish-docker":   11 | >>> RUN apt-get update \
Step #0 - "publish-artifacts": Step #6 - "publish-docker":   12 | >>>     && apt-get upgrade -y \
Step #0 - "publish-artifacts": Step #6 - "publish-docker":   13 | >>>     && apt-get install --no-install-recommends -y ca-certificates
Step #0 - "publish-artifacts": Step #6 - "publish-docker":   14 |     
Step #0 - "publish-artifacts": Step #6 - "publish-docker": --------------------
Step #0 - "publish-artifacts": Step #6 - "publish-docker": ERROR: failed to solve: process "/dev/.buildkit_qemu_emulator /bin/sh -c apt-get update     && apt-get upgrade -y     && apt-get install --no-install-recommends -y ca-certificates" did not complete successfully: exit code: 100
Step #0 - "publish-artifacts": Step #6 - "publish-docker": make: *** [Makefile:512: distroless-docker] Error 1
```

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## CI changes
- added step to reset qemu before building images to avoid segfault


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
