### PR TITLE
fix e2e tests: gateway tls listeners must specify tls

### DIFF
--- a/changelog/v1.19.0-beta13/tls-tests.yaml
+++ b/changelog/v1.19.0-beta13/tls-tests.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      "fix e2e tls route tests that were failing on nightlies using GW API v1.0.0"

--- a/test/kubernetes/e2e/features/services/tlsroute/testdata/cross-ns-gateway-and-client.yaml
+++ b/test/kubernetes/e2e/features/services/tlsroute/testdata/cross-ns-gateway-and-client.yaml
@@ -9,6 +9,8 @@ spec:
       port: 8443
       protocol: TLS
       hostname: "example.com"
+      tls:
+        mode: Passthrough
 ---
 apiVersion: v1
 kind: Pod

--- a/test/kubernetes/e2e/features/services/tlsroute/testdata/cross-ns-no-refgrant-gateway-and-client.yaml
+++ b/test/kubernetes/e2e/features/services/tlsroute/testdata/cross-ns-no-refgrant-gateway-and-client.yaml
@@ -9,6 +9,8 @@ spec:
       port: 8443
       protocol: TLS
       hostname: "example.com"
+      tls:
+        mode: Passthrough
 ---
 apiVersion: v1
 kind: Pod

--- a/test/kubernetes/e2e/features/services/tlsroute/testdata/multi-listener-gateway-and-client.yaml
+++ b/test/kubernetes/e2e/features/services/tlsroute/testdata/multi-listener-gateway-and-client.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   gatewayClassName: gloo-gateway
   listeners:
-  - name: listener-6443 # do one listener with multiple hostnames? 
+  - name: listener-6443  
     protocol: TLS
     port: 6443
     hostname: "example.com"
@@ -17,6 +17,9 @@ spec:
   - name: listener-8443
     protocol: TLS
     port: 8443
+    hostname: "example.com"
+    tls:
+      mode: Passthrough
     allowedRoutes:
       kinds:
       - kind: TLSRoute


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->
[nightlies](https://github.com/solo-io/gloo/actions/runs/13514021560) running GW API v1.0.0 were failing with : 
```
The Gateway "<gateway created for test>" is invalid: spec.listeners: Invalid value: "array": tls must be specified for protocols ['HTTPS', 'TLS']
```

this PR adds the tls field for the listeners, which should be explicitly defined in the tests anyway, for clarity

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
