### PR TITLE
Bump base image to alpine to 3.21.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ endif
 GOOS ?= $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 GO_BUILD_FLAGS := GO111MODULE=on CGO_ENABLED=0 GOARCH=$(GOARCH)
-GOLANG_ALPINE_IMAGE_NAME = golang:$(shell go version | egrep -o '([0-9]+\.[0-9]+)')-alpine3.18
+GOLANG_ALPINE_IMAGE_NAME = golang:$(shell go version | egrep -o '([0-9]+\.[0-9]+)')-alpine3.21
 
 TEST_ASSET_DIR ?= $(ROOTDIR)/_test
 
@@ -121,7 +121,7 @@ GLOO_DISTROLESS_BASE_IMAGE ?= $(IMAGE_REGISTRY)/distroless-base:$(VERSION)
 # GLOO_DISTROLESS_BASE_IMAGE + utility binaries (sh, wget, sleep, nc, echo, ls, cat, vi)
 GLOO_DISTROLESS_BASE_WITH_UTILS_IMAGE ?= $(IMAGE_REGISTRY)/distroless-base-with-utils:$(VERSION)
 # BASE_IMAGE used in non distroless variants
-ALPINE_BASE_IMAGE ?= alpine:3.17.6
+ALPINE_BASE_IMAGE ?= alpine:3.21.3
 
 #----------------------------------------------------------------------------------
 # Macros
@@ -685,6 +685,7 @@ $(GLOO_RACE_OUT_DIR)/.gloo-race-docker-build: $(GLOO_SOURCES) $(GLOO_RACE_OUT_DI
 	docker buildx build --load $(PLATFORM) -t $(IMAGE_REGISTRY)/gloo-race-build-container:$(VERSION) \
 		-f $(GLOO_RACE_OUT_DIR)/Dockerfile.build \
 		--build-arg GO_BUILD_IMAGE=$(GOLANG_ALPINE_IMAGE_NAME) \
+		--build-arg BASE_IMAGE=$(ALPINE_BASE_IMAGE) \
 		--build-arg VERSION=$(VERSION) \
 		--build-arg GCFLAGS=$(GCFLAGS) \
 		--build-arg LDFLAGS=$(LDFLAGS) \

--- a/changelog/v1.19.0-beta13/bump-alpine.yaml
+++ b/changelog/v1.19.0-beta13/bump-alpine.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/7956
+  resolvesIssue: false
+  description: Bump the alpine base container image to 3.21.3

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.6
+FROM alpine:3.21.3
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.6
+FROM alpine:3.21.3
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/projects/gloo/Dockerfile
+++ b/projects/gloo/Dockerfile
@@ -8,6 +8,8 @@
 #
 #####################################################################################################################
 ARG GO_BUILD_IMAGE
+ARG BASE_IMAGE
+
 FROM $GO_BUILD_IMAGE as build-env
 
 ARG VERSION
@@ -34,6 +36,6 @@ RUN CGO_ENABLED=1 GOARCH=${GOARCH} GOOS=linux go build \
     projects/gloo/cmd/main.go
 
 
-FROM alpine:3.17.6
+FROM $BASE_IMAGE
 ARG GOARCH
 COPY --from=build-env /go/src/github.com/solo-io/gloo/gloo-linux-${GOARCH} /


### PR DESCRIPTION
# Description

Bump the alpine base container image to 3.21.3 since alpine 3.17 is EOL

# Context

https://github.com/solo-io/solo-projects/issues/7956

## Testing steps
CI passes

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
- If upgrading Gloo, review the kubernetes e2e tests against the guide in `test/kubernetes/e2e/README.md to see if additional steps need to be taken.
-->
