### PR TITLE
[1.18] Bump/envoy 1.31.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 # for more information, see https://github.com/solo-io/gloo/pull/9633
 # and
 # https://soloio.slab.com/posts/extended-http-methods-design-doc-40j7pjeu
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.31.5-patch2
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.31.6-patch1
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS ?=
 

--- a/changelog/v1.18.14/envoy-bump-extproc.yaml
+++ b/changelog/v1.18.14/envoy-bump-extproc.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    issueLink: https://github.com/solo-io/solo-projects/issues/8041
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: v1.31.6-patch1
+    resolvesIssue: false
+    description: >-
+      CVE-2025-30157: Fix a bug where local replies were incorrectly sent to the ext_proc server


### PR DESCRIPTION
Bump envoy for ext proc fixes  CVE-2025-30157: Fix a bug where local replies were incorrectly sent to the ext_proc server