### PR TITLE
gateway2/delegation: enable wildcard namespace for label selection

### DIFF
--- a/changelog/v1.19.0-beta15/deleg-label.yaml
+++ b/changelog/v1.19.0-beta15/deleg-label.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8070
+    resolvesIssue: false
+    description: |
+      gateway2/delegation: enable wildcard namespace for label selection
+
+      Allows specifying a wildcard value when using the label selector
+      API to delegate routes.

--- a/projects/gateway2/query/httproute.go
+++ b/projects/gateway2/query/httproute.go
@@ -342,7 +342,12 @@ func (r *gatewayQueries) fetchChildRoutes(
 		}
 	} else if backendref.RefIsHTTPRouteDelegationLabelSelector(backendRef.BackendObjectReference) {
 		var hrlist gwv1.HTTPRouteList
-		err := r.client.List(ctx, &hrlist, client.InNamespace(delegatedNs), client.MatchingFields{HttpRouteDelegatedLabelSelector: string(backendRef.Name)})
+		opts := []client.ListOption{client.MatchingFields{HttpRouteDelegatedLabelSelector: string(backendRef.Name)}}
+		// If the namespace is not explicitly set to a wildcard, restrict the List to the delegated namespace
+		if delegatedNs != wellknown.RouteDelegationLabelSelectorWildcardNamespace {
+			opts = append(opts, client.InNamespace(delegatedNs))
+		}
+		err := r.client.List(ctx, &hrlist, opts...)
 		if err != nil {
 			return nil, err
 		}

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -415,4 +415,5 @@ var _ = DescribeTable("Route Delegation translator",
 	Entry("RouteOptions multi level inheritance with child override when allowed", "route_options_multi_level_inheritance_override_allow.yaml"),
 	Entry("RouteOptions multi level inheritance with partial child override", "route_options_multi_level_inheritance_override_partial.yaml"),
 	Entry("Label based delegation", "label_based.yaml"),
+	Entry("Label based delegation with wildcard namespace", "label_based_wildcard_ns.yaml"),
 )

--- a/projects/gateway2/translator/testutils/inputs/delegation/label_based_wildcard_ns.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/label_based_wildcard_ns.yaml
@@ -1,0 +1,109 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+  namespace: infra
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: http
+    protocol: HTTP
+    port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+  namespace: infra
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /a
+    backendRefs:
+    - group: delegation.gateway.solo.io
+      kind: label
+      name: a-label
+      namespace: '*'
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: example-svc
+  namespace: infra
+spec:
+  selector:
+    test: test
+  ports:
+    - protocol: TCP
+      port: 80
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a1
+  namespace: a
+  labels:
+    delegation.gateway.solo.io/label: a-label
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /a/1
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a2
+  namespace: a
+  labels:
+    delegation.gateway.solo.io/label: a-label
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /a/2
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+# route-a3 does not match the selected label so it should be ignored
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: route-a3
+  namespace: a
+  labels:
+    delegation.gateway.solo.io/label: not-a-label
+spec:
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /a/3
+    backendRefs:
+    - name: svc-a
+      port: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-a
+  namespace: a
+spec:
+  ports:
+    - protocol: TCP
+      port: 8080

--- a/projects/gateway2/translator/testutils/outputs/delegation/label_based_wildcard_ns.yaml
+++ b/projects/gateway2/translator/testutils/outputs/delegation/label_based_wildcard_ns.yaml
@@ -1,0 +1,63 @@
+---
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - http~example_com
+    httpResources:
+      virtualHosts:
+        http~example_com:
+          domains:
+          - example.com
+          name: http~example_com
+          routes:
+          - matchers:
+            - exact: /a/1
+            options: {}
+            name: httproute-route-a1-a-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - exact: /a/2
+            options: {}
+            name: httproute-route-a2-a-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 8080
+                  ref:
+                    name: svc-a
+                    namespace: a
+          - matchers:
+            - prefix: /
+            options: {}
+            name: httproute-example-route-infra-0-0
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: example-svc
+                    namespace: infra
+
+  bindAddress: '::'
+  bindPort: 8080
+  metadataStatic:
+    sources:
+    - resourceKind: gateway.networking.k8s.io/Gateway
+      resourceRef:
+        name: http
+        namespace: infra
+  name: http
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: infra
+  name: infra-example-gateway
+  namespace: gloo-system

--- a/projects/gateway2/wellknown/delegation.go
+++ b/projects/gateway2/wellknown/delegation.go
@@ -4,6 +4,9 @@ const (
 	// RouteDelegationLabelSelector is the label used to select delegated HTTPRoutes
 	RouteDelegationLabelSelector = "delegation.gateway.solo.io/label"
 
+	// RouteDelegationLabelSelectorWildcard wildcards the namespace to select delegatee routes by label
+	RouteDelegationLabelSelectorWildcardNamespace = "*"
+
 	// InheritMatcherAnnotation is the annotation used on an child HTTPRoute that
 	// participates in a delegation chain to indicate that child route should inherit
 	// the route matcher from the parent route.


### PR DESCRIPTION
Allows specifying a wildcard value when using the label selector API to delegate routes.
