### PR TITLE
gateway2/delegation: use a wildcard namespace

### DIFF
--- a/changelog/v1.19.0-beta16/deleg-wildcard.yaml
+++ b/changelog/v1.19.0-beta16/deleg-wildcard.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8070
+    resolvesIssue: false
+    description: |
+      gateway2/delegation: use a wildcard namespace
+
+      Namespace type in Gateway API must be a valid RFC 1123 DNS label,
+      so we can't use '*' to wildcard the namespace. Instead, we use 'all'
+      to indicate all namespaced and return an error when the namespace 'all'
+      is actually present on the cluster.

--- a/projects/gateway2/query/httproute.go
+++ b/projects/gateway2/query/httproute.go
@@ -431,7 +431,7 @@ func (r *gatewayQueries) wildcardNamespaceExists(ctx context.Context) (bool, err
 	if err == nil {
 		// Namespace exists
 		return true, nil
-	} else if err != nil && k8serrors.IsNotFound(err) {
+	} else if k8serrors.IsNotFound(err) {
 		// Namespace does not exist
 		return false, nil
 	}

--- a/projects/gateway2/query/httproute.go
+++ b/projects/gateway2/query/httproute.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"strings"
 
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -346,6 +348,17 @@ func (r *gatewayQueries) fetchChildRoutes(
 		// If the namespace is not explicitly set to a wildcard, restrict the List to the delegated namespace
 		if delegatedNs != wellknown.RouteDelegationLabelSelectorWildcardNamespace {
 			opts = append(opts, client.InNamespace(delegatedNs))
+		} else {
+			// Wildcard namespace specified
+			// Validate that a Namespace matching the wildcard namespace does not actually exist
+			// as it would undesirably delegate to all namespaces would be a security risk if the user
+			// intended to delegate to a namespace called 'all.
+			exists, err := r.wildcardNamespaceExists(ctx)
+			if err != nil {
+				return nil, err
+			} else if exists {
+				return nil, ErrWildcardNamespaceDisallowed
+			}
 		}
 		err := r.client.List(ctx, &hrlist, opts...)
 		if err != nil {
@@ -406,6 +419,24 @@ func (r *gatewayQueries) GetRoutesForGateway(ctx context.Context, gw *gwv1.Gatew
 	}
 
 	return ret, nil
+}
+
+func (r *gatewayQueries) wildcardNamespaceExists(ctx context.Context) (bool, error) {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: wellknown.RouteDelegationLabelSelectorWildcardNamespace,
+		},
+	}
+	err := r.client.Get(ctx, types.NamespacedName{Name: ns.Name}, ns)
+	if err == nil {
+		// Namespace exists
+		return true, nil
+	} else if err != nil && k8serrors.IsNotFound(err) {
+		// Namespace does not exist
+		return false, nil
+	}
+	// Unexpected error
+	return false, err
 }
 
 // fetchRoutes is a helper function to fetch routes and add to the routes slice.

--- a/projects/gateway2/query/httproute_test.go
+++ b/projects/gateway2/query/httproute_test.go
@@ -1,0 +1,123 @@
+package query
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/solo-io/gloo/pkg/schemes"
+	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+)
+
+var _ = DescribeTable("fetchChildRoutes",
+	func(parentNamespace string, backendRef gwv1.HTTPBackendRef, objects []client.Object, wantChildren int, wantErr error) {
+		scheme := schemes.GatewayScheme()
+		builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...)
+		err := IterateIndices(func(o client.Object, f string, fun client.IndexerFunc) error {
+			builder.WithIndex(o, f, fun)
+			return nil
+		})
+		fakeClient := builder.Build()
+
+		q := &gatewayQueries{
+			client: fakeClient,
+			scheme: scheme,
+		}
+
+		children, err := q.fetchChildRoutes(context.TODO(), parentNamespace, backendRef)
+		if wantErr != nil {
+			Expect(err).To(MatchError(wantErr))
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+		Expect(children).To(HaveLen(wantChildren))
+	},
+	Entry(
+		"with wildcard label selector",
+		"parent-ns",
+		gwv1.HTTPBackendRef{
+			BackendRef: gwv1.BackendRef{
+				BackendObjectReference: gwv1.BackendObjectReference{
+					Group:     ptr.To(gwv1.Group("delegation.gateway.solo.io")),
+					Kind:      ptr.To(gwv1.Kind("label")),
+					Name:      "delegate",
+					Namespace: ptr.To(gwv1.Namespace(wellknown.RouteDelegationLabelSelectorWildcardNamespace)),
+				},
+			},
+		},
+		[]client.Object{
+			&gwv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       wellknown.HTTPRouteKind,
+					APIVersion: gwv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "r1",
+					Labels: map[string]string{
+						wellknown.RouteDelegationLabelSelector: "delegate",
+					},
+				},
+			},
+			&gwv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       wellknown.HTTPRouteKind,
+					APIVersion: gwv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "r2",
+					Labels: map[string]string{
+						wellknown.RouteDelegationLabelSelector: "delegate",
+					},
+				},
+			},
+		},
+		2,
+		nil,
+	),
+	Entry(
+		"with wildcard label selector when wildcard namespace exists",
+		"parent-ns",
+		gwv1.HTTPBackendRef{
+			BackendRef: gwv1.BackendRef{
+				BackendObjectReference: gwv1.BackendObjectReference{
+					Group:     ptr.To(gwv1.Group("delegation.gateway.solo.io")),
+					Kind:      ptr.To(gwv1.Kind("label")),
+					Name:      "delegate",
+					Namespace: ptr.To(gwv1.Namespace(wellknown.RouteDelegationLabelSelectorWildcardNamespace)),
+				},
+			},
+		},
+		[]client.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: wellknown.RouteDelegationLabelSelectorWildcardNamespace,
+				},
+			},
+			&gwv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       wellknown.HTTPRouteKind,
+					APIVersion: gwv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "test",
+					Labels: map[string]string{
+						wellknown.RouteDelegationLabelSelector: "delegate",
+					},
+				},
+			},
+		},
+		0,
+		ErrWildcardNamespaceDisallowed,
+	),
+)

--- a/projects/gateway2/query/query.go
+++ b/projects/gateway2/query/query.go
@@ -21,14 +21,15 @@ import (
 )
 
 var (
-	ErrMissingReferenceGrant      = fmt.Errorf("missing reference grant")
-	ErrUnknownBackendKind         = fmt.Errorf("unknown backend kind")
-	ErrNoMatchingListenerHostname = fmt.Errorf("no matching listener hostname")
-	ErrNoMatchingParent           = fmt.Errorf("no matching parent")
-	ErrNotAllowedByListeners      = fmt.Errorf("not allowed by listeners")
-	ErrLocalObjRefMissingKind     = fmt.Errorf("localObjRef provided with empty kind")
-	ErrCyclicReference            = fmt.Errorf("cyclic reference detected while evaluating delegated routes")
-	ErrUnresolvedReference        = fmt.Errorf("unresolved reference")
+	ErrMissingReferenceGrant       = fmt.Errorf("missing reference grant")
+	ErrUnknownBackendKind          = fmt.Errorf("unknown backend kind")
+	ErrNoMatchingListenerHostname  = fmt.Errorf("no matching listener hostname")
+	ErrNoMatchingParent            = fmt.Errorf("no matching parent")
+	ErrNotAllowedByListeners       = fmt.Errorf("not allowed by listeners")
+	ErrLocalObjRefMissingKind      = fmt.Errorf("localObjRef provided with empty kind")
+	ErrCyclicReference             = fmt.Errorf("cyclic reference detected while evaluating delegated routes")
+	ErrUnresolvedReference         = fmt.Errorf("unresolved reference")
+	ErrWildcardNamespaceDisallowed = fmt.Errorf("wildcard namespace disallowed as namespace 'all' exists in the cluster")
 )
 
 type Error struct {

--- a/projects/gateway2/translator/testutils/inputs/delegation/label_based_wildcard_ns.yaml
+++ b/projects/gateway2/translator/testutils/inputs/delegation/label_based_wildcard_ns.yaml
@@ -32,7 +32,7 @@ spec:
     - group: delegation.gateway.solo.io
       kind: label
       name: a-label
-      namespace: '*'
+      namespace: all # implies all namespaces
 ---
 apiVersion: v1
 kind: Service

--- a/projects/gateway2/wellknown/delegation.go
+++ b/projects/gateway2/wellknown/delegation.go
@@ -1,12 +1,10 @@
 package wellknown
 
+import "github.com/solo-io/gloo/pkg/utils/envutils"
+
 const (
 	// RouteDelegationLabelSelector is the label used to select delegated HTTPRoutes
 	RouteDelegationLabelSelector = "delegation.gateway.solo.io/label"
-
-	// RouteDelegationLabelSelectorWildcard wildcards the namespace to select delegatee routes by label
-	// Note: this must be a valid RFC 1123 DNS label
-	RouteDelegationLabelSelectorWildcardNamespace = "all"
 
 	// InheritMatcherAnnotation is the annotation used on an child HTTPRoute that
 	// participates in a delegation chain to indicate that child route should inherit
@@ -17,3 +15,7 @@ const (
 	// all (wildcard *) or specific fields (comma separated field names) in RouteOptions inherited from the parent route.
 	PolicyOverrideAnnotation = "delegation.gateway.solo.io/enable-policy-overrides"
 )
+
+// RouteDelegationLabelSelectorWildcard wildcards the namespace to select delegatee routes by label
+// Note: this must be a valid RFC 1123 DNS label
+var RouteDelegationLabelSelectorWildcardNamespace = envutils.GetOrDefault("DELEGATION_WILDCARD_NAMESPACE", "all", false)

--- a/projects/gateway2/wellknown/delegation.go
+++ b/projects/gateway2/wellknown/delegation.go
@@ -5,7 +5,8 @@ const (
 	RouteDelegationLabelSelector = "delegation.gateway.solo.io/label"
 
 	// RouteDelegationLabelSelectorWildcard wildcards the namespace to select delegatee routes by label
-	RouteDelegationLabelSelectorWildcardNamespace = "*"
+	// Note: this must be a valid RFC 1123 DNS label
+	RouteDelegationLabelSelectorWildcardNamespace = "all"
 
 	// InheritMatcherAnnotation is the annotation used on an child HTTPRoute that
 	// participates in a delegation chain to indicate that child route should inherit

--- a/test/kubernetes/e2e/features/route_delegation/testdata/label_selector.yaml
+++ b/test/kubernetes/e2e/features/route_delegation/testdata/label_selector.yaml
@@ -1,0 +1,71 @@
+# Configuration:
+#
+# Parent infra/root:
+#   - Delegate /anything to wildcard namespace 'all' with label 'delegate'
+#
+# Child team1/svc1:
+#   - Route /anything/team1/foo to team1/svc1
+#   - No parentRefs
+#
+# Child team2/svc2:
+#   - Route /anything/team2/foo to team2/svc2
+#   - Parent infra/root
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: root
+  namespace: infra
+spec:
+  parentRefs:
+  - name: http-gateway
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything
+    backendRefs:
+    - group: delegation.gateway.solo.io
+      kind: label
+      name: delegate
+      namespace: all # implies all namespaces
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc1
+  namespace: team1
+  labels:
+    delegation.gateway.solo.io/label: delegate
+spec:
+  rules:
+  - matches:
+    - path:
+        type: PathPrefix
+        value: /anything/team1/foo
+    backendRefs:
+    - name: svc1
+      port: 8000
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: svc2
+  namespace: team2
+  labels:
+    delegation.gateway.solo.io/label: delegate
+spec:
+  parentRefs:
+  - name: root
+    namespace: infra
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+  rules:
+  - matches:
+    - path:
+        type: Exact
+        value: /anything/team2/foo
+    backendRefs:
+    - name: svc2
+      port: 8000
+---

--- a/test/kubernetes/e2e/features/route_delegation/types.go
+++ b/test/kubernetes/e2e/features/route_delegation/types.go
@@ -127,4 +127,5 @@ var (
 	unresolvedChildManifest             = filepath.Join(util.MustGetThisDir(), "testdata", "unresolved_child.yaml")
 	routeOptionsManifest                = filepath.Join(util.MustGetThisDir(), "testdata", "route_options.yaml")
 	matcherInheritanceManifest          = filepath.Join(util.MustGetThisDir(), "testdata", "matcher_inheritance.yaml")
+	labelSelectorManifest               = filepath.Join(util.MustGetThisDir(), "testdata", "label_selector.yaml")
 )


### PR DESCRIPTION
Namespace type in Gateway API must be a valid RFC 1123 DNS label, so we can't use '*' to wildcard the namespace. Instead, we use 'all' to indicate all namespaced and return an error when the namespace 'all' is actually present on the cluster.
