### PR TITLE
Pin FirebaseExtended/action-hosting-deploy version

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -114,7 +114,7 @@ jobs:
       # Do not publish docs if this workflow was triggered by a pull request
       # Only deploy if this was triggered by a push to main, or a successful trivy workflow_run
       if: ${{ github.event_name != 'pull_request' }}
-      uses: FirebaseExtended/action-hosting-deploy@main
+      uses: FirebaseExtended/action-hosting-deploy@v0.7.2
       with:
         repoToken: ${{ secrets.GITHUB_TOKEN }}
         firebaseServiceAccount: ${{ secrets.GC_FIREBASE_GHA_SA_JSON_KEY }}
@@ -124,7 +124,7 @@ jobs:
     - name: Deploy to Firebase (preview)
       # Generate live preview of docs for PRs to main
       if: ${{ github.event_name == 'pull_request' }}
-      uses: FirebaseExtended/action-hosting-deploy@main
+      uses: FirebaseExtended/action-hosting-deploy@v0.7.2
       with:
         repoToken: ${{ secrets.GITHUB_TOKEN }}
         firebaseServiceAccount: ${{ secrets.GC_FIREBASE_GHA_SA_JSON_KEY }}

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -114,7 +114,7 @@ jobs:
       # Do not publish docs if this workflow was triggered by a pull request
       # Only deploy if this was triggered by a push to main, or a successful trivy workflow_run
       if: ${{ github.event_name != 'pull_request' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+      uses: FirebaseExtended/action-hosting-deploy@v0
       with:
         repoToken: ${{ secrets.GITHUB_TOKEN }}
         firebaseServiceAccount: ${{ secrets.GC_FIREBASE_GHA_SA_JSON_KEY }}
@@ -125,7 +125,7 @@ jobs:
     - name: Deploy to Firebase (preview)
       # Generate live preview of docs for PRs to main
       if: ${{ github.event_name == 'pull_request' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
+      uses: FirebaseExtended/action-hosting-deploy@v0
       with:
         repoToken: ${{ secrets.GITHUB_TOKEN }}
         firebaseServiceAccount: ${{ secrets.GC_FIREBASE_GHA_SA_JSON_KEY }}

--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -114,22 +114,24 @@ jobs:
       # Do not publish docs if this workflow was triggered by a pull request
       # Only deploy if this was triggered by a push to main, or a successful trivy workflow_run
       if: ${{ github.event_name != 'pull_request' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.7.2
+      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
       with:
         repoToken: ${{ secrets.GITHUB_TOKEN }}
         firebaseServiceAccount: ${{ secrets.GC_FIREBASE_GHA_SA_JSON_KEY }}
         projectId: ${{ secrets.GC_FIREBASE_GHA_PROJECT_ID }}
         channelId: live
         entryPoint: ./docs/ci
+        firebaseToolsVersion: v13
     - name: Deploy to Firebase (preview)
       # Generate live preview of docs for PRs to main
       if: ${{ github.event_name == 'pull_request' }}
-      uses: FirebaseExtended/action-hosting-deploy@v0.7.2
+      uses: FirebaseExtended/action-hosting-deploy@v0.9.0
       with:
         repoToken: ${{ secrets.GITHUB_TOKEN }}
         firebaseServiceAccount: ${{ secrets.GC_FIREBASE_GHA_SA_JSON_KEY }}
         projectId: ${{ secrets.GC_FIREBASE_GHA_PROJECT_ID }}
         entryPoint: ./docs/ci
+        firebaseToolsVersion: v13
     - name: Notify On Failure
       id: notify-on-failure
       if: ${{ github.event_name != 'pull_request' && failure() }}

--- a/changelog/v1.19.0-beta16/ci-check.yaml
+++ b/changelog/v1.19.0-beta16/ci-check.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Pin the version of the FirebaseExtended/action-hosting-deploy action to v0.7.2, as the latest version is not compatible with our node version.

--- a/changelog/v1.19.0-beta16/ci-check.yaml
+++ b/changelog/v1.19.0-beta16/ci-check.yaml
@@ -1,4 +1,5 @@
 changelog:
   - type: NON_USER_FACING
     description: >-
-      Pin the version of the FirebaseExtended/action-hosting-deploy action to v0.7.2, as the latest version is not compatible with our node version.
+      Pin the version of the FirebaseExtended/action-hosting-deploy action to v0 to avoid unintended changes to the action.
+      Add the firebaseToolsVersion: v13 parameter to the action to avoid unintended changes to node version in the tools used by the action.


### PR DESCRIPTION
# Description
Pin `FirebaseExtended/action-hosting-deploy` to `v0` and the parameter `firebaseToolsVersion` to `v13` to prevent CI failures.

Passing jobs:
* https://github.com/solo-io/gloo/actions/runs/14177308755/job/39715224928?pr=10727
* https://github.com/solo-io/gloo/pull/10727/checks?check_run_id=39715878498
