### PR TITLE
uniqueclients test flake fix

### DIFF
--- a/changelog/v1.19.0-beta16/improve-http-tunneling-docs.yaml
+++ b/changelog/v1.19.0-beta16/improve-http-tunneling-docs.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Fix a test flake for TestUniqueClients (not a bug).
+  issueLink: https://github.com/solo-io/solo-projects/issues/10720
+  resolvesIssue: true

--- a/projects/gateway2/krtcollections/uniqueclients_test.go
+++ b/projects/gateway2/krtcollections/uniqueclients_test.go
@@ -130,12 +130,19 @@ func TestUniqueClients(t *testing.T) {
 			}
 			g.Expect(fetchNames).To(Equal(tc.result))
 			g.Expect(names).To(Equal(tc.result))
+
+			// loop through i client
 			for i := range tc.requests {
+				// before calling OnStreamClosed we should still have n - i
+				// then we close the 10 connections we made for client `i`
 				for j := 0; j < 10; j++ {
 					g.Expect(ucc.List()).To(HaveLen(len(allUcc) - i))
 					cb.OnStreamClosed(int64(i*10 + j))
 				}
-				// propagating the event happens async
+
+				// now we've called OnStreamClosed for all 10 connections
+				// so we should have n - i - 1 remaining UCCs
+				// propagating the event happens async so use Eventually
 				g.Eventually(func() []krtcollections.UniqlyConnectedClient {
 					allUcc = ucc.List()
 					return allUcc

--- a/projects/gateway2/krtcollections/uniqueclients_test.go
+++ b/projects/gateway2/krtcollections/uniqueclients_test.go
@@ -139,7 +139,7 @@ func TestUniqueClients(t *testing.T) {
 				g.Eventually(func() []krtcollections.UniqlyConnectedClient {
 					allUcc = ucc.List()
 					return allUcc
-				}, "1s").Should(HaveLen(len(tc.result)))
+				}, "1s").Should(HaveLen(len(tc.result) - (i + 1)))
 			}
 		})
 	}


### PR DESCRIPTION
This test is checking that an item is removed from the list. I updated the assertion to actually check that. 

see the kgateway version of this test:

https://github.com/kgateway-dev/kgateway/blob/main/internal/kgateway/krtcollections/uniqueclients_test.go#L235

The check _was_ saying: "make sure the list length == the max list length" which is wrong.

We just get lucky and hit it >99.9% of the time because of the async propagation. We fail 100% of the time if we wait between `onStreamClosed` and the changed check.

```
1 runs so far, 0 failures (100.00% pass rate). 91.645326ms avg, 91.645326ms max, 91.645326ms min
256 runs so far, 0 failures (100.00% pass rate). 91.865846ms avg, 127.168747ms max, 68.094213ms min
519 runs so far, 0 failures (100.00% pass rate). 91.041281ms avg, 127.168747ms max, 68.094213ms min
787 runs so far, 0 failures (100.00% pass rate). 90.850392ms avg, 127.168747ms max, 68.094213ms min
1049 runs so far, 0 failures (100.00% pass rate). 90.941727ms avg, 127.168747ms max, 68.094213ms min
1316 runs so far, 0 failures (100.00% pass rate). 90.841477ms avg, 127.168747ms max, 66.854818ms min
1581 runs so far, 0 failures (100.00% pass rate). 90.758995ms avg, 127.168747ms max, 66.854818ms min
1843 runs so far, 0 failures (100.00% pass rate). 90.780157ms avg, 127.168747ms max, 66.854818ms min
2109 runs so far, 0 failures (100.00% pass rate). 90.770928ms avg, 127.168747ms max, 66.854818ms min
2375 runs so far, 0 failures (100.00% pass rate). 90.751654ms avg, 127.168747ms max, 63.525805ms min
2636 runs so far, 0 failures (100.00% pass rate). 90.828904ms avg, 127.168747ms max, 63.525805ms min
2844 runs so far, 0 failures (100.00% pass rate). 92.609022ms avg, 144.059699ms max, 63.525805ms min
3054 runs so far, 0 failures (100.00% pass rate). 94.065937ms avg, 145.37661ms max, 63.525805ms min
3270 runs so far, 0 failures (100.00% pass rate). 95.25815ms avg, 154.901255ms max, 63.525805ms min
3486 runs so far, 0 failures (100.00% pass rate). 96.200993ms avg, 154.901255ms max, 63.525805ms min
3697 runs so far, 0 failures (100.00% pass rate). 97.171261ms avg, 169.77808ms max, 63.525805ms min
3911 runs so far, 0 failures (100.00% pass rate). 97.970595ms avg, 169.77808ms max, 63.525805ms min
4124 runs so far, 0 failures (100.00% pass rate). 98.733741ms avg, 169.77808ms max, 63.525805ms min
```
BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/10720