### PR TITLE
gateway2/status: use SetStatusCondition to prevent duplicate conditions

### DIFF
--- a/changelog/v1.18.14/set-condition.yaml
+++ b/changelog/v1.18.14/set-condition.yaml
@@ -1,0 +1,12 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8098
+    resolvesIssue: false
+    description: |
+      gateway2/status: use SetStatusCondition to prevent duplicate conditions
+
+      Currently, we append() Conditions while building the status reports.
+      This can result in duplicate Condition.Type in the list that is
+      incorrect and will lead to API errors. This change uses
+      SetStatusCondition API that correctly updates the condition if the
+      same Type already exists in the list.

--- a/projects/gateway2/reports/reporter.go
+++ b/projects/gateway2/reports/reporter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/solo-io/go-utils/contextutils"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
@@ -147,7 +148,7 @@ func (g *GatewayReport) SetCondition(gc GatewayCondition) {
 		Reason:  string(gc.Reason),
 		Message: gc.Message,
 	}
-	g.conditions = append(g.conditions, condition)
+	meta.SetStatusCondition(&g.conditions, condition)
 }
 
 func NewListenerReport(name string) *ListenerReport {
@@ -163,7 +164,7 @@ func (l *ListenerReport) SetCondition(lc ListenerCondition) {
 		Reason:  string(lc.Reason),
 		Message: lc.Message,
 	}
-	l.Status.Conditions = append(l.Status.Conditions, condition)
+	meta.SetStatusCondition(&l.Status.Conditions, condition)
 }
 
 func (l *ListenerReport) SetSupportedKinds(rgks []gwv1.RouteGroupKind) {
@@ -260,7 +261,7 @@ func (prr *ParentRefReport) SetCondition(rc RouteCondition) {
 		Reason:  string(rc.Reason),
 		Message: rc.Message,
 	}
-	prr.Conditions = append(prr.Conditions, condition)
+	meta.SetStatusCondition(&prr.Conditions, condition)
 }
 
 func NewReporter(reportMap *ReportMap) Reporter {

--- a/projects/gateway2/reports/reporter_test.go
+++ b/projects/gateway2/reports/reporter_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Reporting Infrastructure", func() {
 
 		It("should preserve conditions set externally", func() {
 			gw := gw()
-			gw.Status.Conditions = append(gw.Status.Conditions, metav1.Condition{
+			meta.SetStatusCondition(&gw.Status.Conditions, metav1.Condition{
 				Type:   "gloo.solo.io/SomeCondition",
 				Status: metav1.ConditionFalse,
 			})

--- a/projects/gateway2/reports/status.go
+++ b/projects/gateway2/reports/status.go
@@ -37,7 +37,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 			if oldLisStatusIndex != -1 {
 				if cond := meta.FindStatusCondition(gw.Status.Listeners[oldLisStatusIndex].Conditions, lisCondition.Type); cond != nil {
-					finalConditions = append(finalConditions, *cond)
+					meta.SetStatusCondition(&finalConditions, *cond)
 				}
 			}
 			meta.SetStatusCondition(&finalConditions, lisCondition)
@@ -54,7 +54,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 
 		// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
 		if cond := meta.FindStatusCondition(gw.Status.Conditions, gwCondition.Type); cond != nil {
-			finalConditions = append(finalConditions, *cond)
+			meta.SetStatusCondition(&finalConditions, *cond)
 		}
 		meta.SetStatusCondition(&finalConditions, gwCondition)
 	}
@@ -62,7 +62,7 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 	// them in the final list of conditions to preseve conditions we do not own
 	for _, condition := range gw.Status.Conditions {
 		if meta.FindStatusCondition(finalConditions, condition.Type) == nil {
-			finalConditions = append(finalConditions, condition)
+			meta.SetStatusCondition(&finalConditions, condition)
 		}
 	}
 
@@ -135,7 +135,7 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 
 			// Copy old condition to preserve LastTransitionTime, if it exists
 			if cond := meta.FindStatusCondition(currentParentRefConditions, pCondition.Type); cond != nil {
-				finalConditions = append(finalConditions, *cond)
+				meta.SetStatusCondition(&finalConditions, *cond)
 			}
 			meta.SetStatusCondition(&finalConditions, pCondition)
 		}
@@ -143,7 +143,7 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 		// them in the final list of conditions to preseve conditions we do not own
 		for _, condition := range currentParentRefConditions {
 			if meta.FindStatusCondition(finalConditions, condition.Type) == nil {
-				finalConditions = append(finalConditions, condition)
+				meta.SetStatusCondition(&finalConditions, condition)
 			}
 		}
 


### PR DESCRIPTION
Backports https://github.com/solo-io/gloo/pull/10734 to 1.18.x
---
Currently, we append() Conditions while building the status reports. This can result in duplicate Condition.Type in the list that is incorrect and will lead to API errors. This change uses SetStatusCondition API that correctly updates the condition if the same Type already exists in the list.