### PR TITLE
Fix 1.18 e2e test ref

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: main
+          ref: 1.18.x
       # The dotenv action is used to load key-value pairs from files.
       # In this case, the file is specified in the matrix and will contain the versions of the tools to use
       - name: Dotenv Action

--- a/changelog/v1.19.0-beta16/1.18-nightly-ref-fix.yaml
+++ b/changelog/v1.19.0-beta16/1.18-nightly-ref-fix.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix the ref used for the scheduled weekly run of 1.18 e2e tests
+      
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

Fix the ref used for 1.18.x weekly e2e test runs, changing it from `main` to `1.18.x`

# Context

When investigating [this failure](https://github.com/solo-io/gloo/actions/runs/14165125165/job/39676885957) I realized that the ref that was checked out was `main` and not `1.18.x` as expected

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works