### PR TITLE
Unique artifact names

### DIFF
--- a/.github/workflows/composite-actions/regression-tests/action.yaml
+++ b/.github/workflows/composite-actions/regression-tests/action.yaml
@@ -34,9 +34,12 @@ runs:
       IMAGE_VARIANT: ${{ matrix.image-variant }}
     shell: bash
     run: make install-test-tools run-kube-e2e-tests
+  - id: timestamp
+    uses: ./.github/workflows/composite-actions/timestamp
+    if: ${{ failure() }}
   - uses: actions/upload-artifact@v4
     if: ${{ failure() }}
     with:
-      name: ${{matrix.kube-e2e-test-type}}-attempt-${{ github.run_attempt }}@k8s${{matrix.kube-version.kubectl}}-kube-dump
+      name: ${{matrix.kube-e2e-test-type}}--attempt-${{ github.run_attempt }}@k8s${{matrix.kube-version.kubectl}}-kube-dump-${{steps.timestamp.outputs.timestamp}}
       path: "_output/kube2e-artifacts"
       if-no-files-found: warn

--- a/.github/workflows/composite-actions/timestamp/action.yaml
+++ b/.github/workflows/composite-actions/timestamp/action.yaml
@@ -1,0 +1,17 @@
+name: Timestamp
+
+description: Action that outputs a timestamp
+
+outputs:
+  timestamp:
+    description: "The timestamp"
+    value: ${{ steps.generate-timestamp.outputs.timestamp }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Generate timestamp
+      id: generate-timestamp
+      run: |
+        echo "timestamp=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+

--- a/test/kube2e/gateway/gateway_suite_test.go
+++ b/test/kube2e/gateway/gateway_suite_test.go
@@ -58,6 +58,8 @@ var _ = BeforeSuite(StartTestHelper)
 var _ = AfterSuite(TearDownTestHelper)
 
 func StartTestHelper() {
+	Fail("INTENTIONALLY FAILING")
+
 	var err error
 	ctx, cancel = context.WithCancel(context.Background())
 

--- a/test/kube2e/gloo/gloo_suite_test.go
+++ b/test/kube2e/gloo/gloo_suite_test.go
@@ -59,6 +59,8 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	Fail("INTENTIONALLY FAILING")
+
 	var err error
 
 	// This line prevents controller-runtime from complaining about log.SetLogger never being called

--- a/test/kube2e/upgrade/upgrade_suite_test.go
+++ b/test/kube2e/upgrade/upgrade_suite_test.go
@@ -47,6 +47,8 @@ var (
 )
 
 var _ = BeforeSuite(func() {
+	Fail("INTENTIONALLY FAILING")
+
 	suiteCtx, suiteCancel = context.WithCancel(context.Background())
 
 	testHelper, err := kube2e.GetTestHelper(suiteCtx, namespace)


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
