### PR TITLE
.github/workflows: Fix the 1.18.x e2e nightly tests

### DIFF
--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -210,7 +210,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: 1.18.x
+          ref: v1.18.x
       # The dotenv action is used to load key-value pairs from files.
       # In this case, the file is specified in the matrix and will contain the versions of the tools to use
       - name: Dotenv Action

--- a/changelog/v1.19.0-beta17/fix-1.18-nightly-tests.yaml
+++ b/changelog/v1.19.0-beta17/fix-1.18-nightly-tests.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Fix the e2e 1.18.x nightly tests. Previously, the tests were attempting to checkout the 1.18.x branch
+      which doesn't exist. Now, the tests are using the v1.18.x tag and are consistent with the rest of the
+      1.18.x nightly tests (e.g. regression tests).
+
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Fix the e2e 1.18.x nightly tests. Previously, the tests were attempting to checkout the 1.18.x branchwhich doesn't exist. Now, the tests are using the v1.18.x tag and are consistent with the rest of the 1.18.x nightly tests (e.g. regression tests).

See https://github.com/solo-io/gloo/actions/runs/14301994528/job/40119014650 for an example failure.

Supersedes 10747.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
