### PR TITLE
correcting replacementText key

### DIFF
--- a/docs/content/guides/traffic_management/request_processing/transformations/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/transformations/_index.md
@@ -276,9 +276,9 @@ Starting with Gloo Gateway 1.15, extractors support multiple different modes of 
 
 |Mode|Description|Configuration validation|
 |--|--|--|
-|`EXTRACT` (default)|Extract the value of the specified capturing group from the source. This is the standard behavior of extractors prior to this version. The `regex` expression must match the entire source. Only the value in the specified `subgroup` is extracted. |If the extractor mode is set to `Extract`, the `replacement_text` must not be set. If set, the configuration is rejected.|
-|`SINGLE_REPLACE`|Replace the value of the n-th capturing group, where n is the value selected by `subgroup`, with the text specified in `replacement_text`. The `regex` expression must match the entire source for the replacement to work. The `subgroup` specifies which part of the match to replace.|The `replacement_text` must be set. If not set, the configuration is rejected.|
-|`REPLACE_ALL`|Replace all occurrences of the pattern specified in the `regex` field within the source with the text specified in `replacement_text`. The `regex` can match any part of the source. All matches are replaced.|The `subgroup` field must not be set. If set, the configuration is rejected. In addition, the `replacement_text` must be set. If not set, the configuration is rejected.  |
+|`EXTRACT` (default)|Extract the value of the specified capturing group from the source. This is the standard behavior of extractors prior to this version. The `regex` expression must match the entire source. Only the value in the specified `subgroup` is extracted. |If the extractor mode is set to `Extract`, the `replacementText` must not be set. If set, the configuration is rejected.|
+|`SINGLE_REPLACE`|Replace the value of the n-th capturing group, where n is the value selected by `subgroup`, with the text specified in `replacementText`. The `regex` expression must match the entire source for the replacement to work. The `subgroup` specifies which part of the match to replace.|The `replacementText` must be set. If not set, the configuration is rejected.|
+|`REPLACE_ALL`|Replace all occurrences of the pattern specified in the `regex` field within the source with the text specified in `replacementText`. The `regex` can match any part of the source. All matches are replaced.|The `subgroup` field must not be set. If set, the configuration is rejected. In addition, the `replacementText` must be set. If not set, the configuration is rejected.  |
 
 ##### Extractor Example - Single Replace Mode
 
@@ -290,7 +290,7 @@ extractors:
   BananaToOrange:
     body: {}
     mode: SINGLE_REPLACE
-    replacement_text: 'orange'
+    replacementText: 'orange'
     regex: '.*(banana).*'
     subgroup: 1
 body: 
@@ -302,9 +302,9 @@ In this configuration:
  - `body: {}` indicates that the request/response body will be used as input to the extractor.
  - `regex: '.*(banana).*'` is designed to match the entire source, and capture the word `banana` in the first capturing group.
  - `mode: SINGLE_REPLACE` specifies the operation mode, indicating a single replace operation.
- - `replacement_text: 'orange'` replaces the content in the first capturing group with the text `orange`.
+ - `replacementText: 'orange'` replaces the content in the first capturing group with the text `orange`.
  - `subgroup: 1` specifies that the replacement should only apply to the first captured group, which is banana in this case.
- - `body.text` adds the string with the `replacement_text` text back to the body.
+ - `body.text` adds the string with the `replacementText` text back to the body.
 
 In this case, if the extractor processes a body containing the text `Fruits: [apple, pear, banana, pineapple]`
 
@@ -319,7 +319,7 @@ extractors:
     body: {}
     regex: 'foo'
     mode: REPLACE_ALL
-    replacement_text: 'bar'
+    replacementText: 'bar'
 body: 
   text: '{{ FooToBar }}'
 ```
@@ -329,8 +329,8 @@ In this configuration:
  - `body: {}` indicates that the request/response body will be used as input to the extractor.
  - `regex: 'foo'` specifies the pattern to match.
  - `mode: REPLACE_ALL` specifies the mode of operation.
- - `replacement_text: 'bar'` specifies the text to replace the matched pattern with.
- - `body.text` adds the string with the `replacement_text` text back to the body.
+ - `replacementText: 'bar'` specifies the text to replace the matched pattern with.
+ - `body.text` adds the string with the `replacementText` text back to the body.
 
 In this case, if the extractor processes a body containing the text `foo foo foo`, the result will be `bar bar bar`.
 


### PR DESCRIPTION
replacing all occurrences of replacement_text with replacementText

# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
