### PR TITLE
Add listenerset generic query

### DIFF
--- a/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1/types.go
+++ b/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1/types.go
@@ -509,6 +509,14 @@ type VirtualHostOptionList struct {
 	Items       []VirtualHostOption `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
+func (o *VirtualHostOptionList) GetItems() []api.VirtualHostOption {
+	items := make([]api.VirtualHostOption, len(o.Items))
+	for i, item := range o.Items {
+		items[i] = item.Spec
+	}
+	return items
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +resourceName=virtualservices
 // +genclient

--- a/projects/gateway2/translator/plugins/httplisteneroptions/query/query.go
+++ b/projects/gateway2/translator/plugins/httplisteneroptions/query/query.go
@@ -2,14 +2,10 @@ package query
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/utils"
-	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	skv2corev1 "github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1"
-	"k8s.io/apimachinery/pkg/fields"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -59,74 +55,40 @@ func NewQuery(c client.Client) HttpListenerOptionQueries {
 	return &queries{c}
 }
 
-func (q *queries) GetAttachedHttpListenerOptions(
+func (r *queries) GetAttachedHttpListenerOptions(
 	ctx context.Context,
 	listener *gwv1.Listener,
 	parentGw *gwv1.Gateway,
 	parentListenerSet *apixv1a1.XListenerSet,
 ) ([]*solokubev1.HttpListenerOption, error) {
-	if parentGw == nil {
-		return nil, errors.New("nil parent gateway")
-	}
-	if parentGw.GetName() == "" || parentGw.GetNamespace() == "" {
-		return nil, fmt.Errorf("parent gateway must have name and namespace; received name: %s, namespace: %s", parentGw.GetName(), parentGw.GetNamespace())
+	createList := func() *solokubev1.HttpListenerOptionList {
+		return &solokubev1.HttpListenerOptionList{}
 	}
 
-	nnk := utils.NamespacedNameKind{
-		Namespace: parentGw.Namespace,
-		Name:      parentGw.Name,
-		Kind:      wellknown.GatewayKind,
-	}
-
-	listGw := &solokubev1.HttpListenerOptionList{}
-	if err := q.c.List(
-		ctx,
-		listGw,
-		client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(HttpListenerOptionTargetField, nnk.String())},
-		client.InNamespace(parentGw.GetNamespace()),
-	); err != nil {
-		return nil, err
-	}
-
-	listListenerSet := &solokubev1.HttpListenerOptionList{}
-	if parentListenerSet != nil {
-		nnkListenerSet := utils.NamespacedNameKind{
-			Namespace: parentListenerSet.GetNamespace(),
-			Name:      parentListenerSet.GetName(),
-			Kind:      wellknown.XListenerSetKind,
+	// Can't just do this in the function because we need to call `list.Items`
+	extractItems := func(list *solokubev1.HttpListenerOptionList) []*solokubev1.HttpListenerOption {
+		items := make([]*solokubev1.HttpListenerOption, len(list.Items))
+		for i, item := range list.Items {
+			items[i] = &item
 		}
-
-		if err := q.c.List(
-			ctx,
-			listListenerSet,
-			client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(HttpListenerOptionTargetField, nnkListenerSet.String())},
-			client.InNamespace(parentListenerSet.GetNamespace()),
-		); err != nil {
-			return nil, err
-		}
+		return items
 	}
 
-	allItems := append(listGw.Items, listListenerSet.Items...)
-	if len(allItems) == 0 {
-		return nil, nil
-	}
-
-	policies := buildWrapperType(allItems)
-	orderedPolicies := utils.GetPrioritizedListenerPolicies(policies, listener, parentGw.Name, parentListenerSet)
-	return orderedPolicies, nil
-}
-
-func buildWrapperType(
-	list []solokubev1.HttpListenerOption,
-) []utils.PolicyWithSectionedTargetRefs[*solokubev1.HttpListenerOption] {
-	policies := []utils.PolicyWithSectionedTargetRefs[*solokubev1.HttpListenerOption]{}
-	for i := range list {
-		item := &list[i]
-
-		policy := httpListenerOptionPolicy{
+	wrapPolicy := func(item *solokubev1.HttpListenerOption) utils.PolicyWithSectionedTargetRefs[*solokubev1.HttpListenerOption] {
+		return httpListenerOptionPolicy{
 			obj: item,
 		}
-		policies = append(policies, policy)
 	}
-	return policies
+
+	return utils.GetOptionsForListener(
+		context.Background(),
+		listener,
+		parentGw,
+		parentListenerSet,
+		r.c,
+		HttpListenerOptionTargetField,
+		createList,
+		extractItems,
+		wrapPolicy,
+	)
 }

--- a/projects/gateway2/translator/plugins/listeneroptions/query/query.go
+++ b/projects/gateway2/translator/plugins/listeneroptions/query/query.go
@@ -2,13 +2,10 @@ package query
 
 import (
 	"context"
-	"fmt"
 
 	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
 	"github.com/solo-io/gloo/projects/gateway2/translator/plugins/utils"
-	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	skv2corev1 "github.com/solo-io/skv2/pkg/api/core.skv2.solo.io/v1"
-	"k8s.io/apimachinery/pkg/fields"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -61,64 +58,34 @@ func (r *listenerOptionQueries) GetAttachedListenerOptions(
 	parentGw *gwv1.Gateway,
 	parentListenerSet *apixv1a1.XListenerSet,
 ) ([]*solokubev1.ListenerOption, error) {
-	if parentGw.GetName() == "" || parentGw.GetNamespace() == "" {
-		return nil, fmt.Errorf("parent gateway must have name and namespace; received name: %s, namespace: %s", parentGw.GetName(), parentGw.GetNamespace())
+	createList := func() *solokubev1.ListenerOptionList {
+		return &solokubev1.ListenerOptionList{}
 	}
 
-	nnk := utils.NamespacedNameKind{
-		Namespace: parentGw.Namespace,
-		Name:      parentGw.Name,
-		Kind:      wellknown.GatewayKind,
-	}
-
-	list := &solokubev1.ListenerOptionList{}
-	if err := r.c.List(
-		ctx,
-		list,
-		client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(ListenerOptionTargetField, nnk.String())},
-		client.InNamespace(parentGw.GetNamespace()),
-	); err != nil {
-		return nil, err
-	}
-
-	listListenerSet := &solokubev1.ListenerOptionList{}
-	if parentListenerSet != nil {
-		nnkListenerSet := utils.NamespacedNameKind{
-			Namespace: parentListenerSet.GetNamespace(),
-			Name:      parentListenerSet.GetName(),
-			Kind:      wellknown.XListenerSetKind,
+	// Can't just do this in the function because we need to call `list.Items`
+	extractItems := func(list *solokubev1.ListenerOptionList) []*solokubev1.ListenerOption {
+		items := make([]*solokubev1.ListenerOption, len(list.Items))
+		for i, item := range list.Items {
+			items[i] = &item
 		}
-		if err := r.c.List(
-			ctx,
-			listListenerSet,
-			client.MatchingFieldsSelector{Selector: fields.OneTermEqualSelector(ListenerOptionTargetField, nnkListenerSet.String())},
-			client.InNamespace(parentListenerSet.GetNamespace()),
-		); err != nil {
-			return nil, err
-		}
+		return items
 	}
 
-	allItems := append(list.Items, listListenerSet.Items...)
-	if len(allItems) == 0 {
-		return nil, nil
-	}
-
-	policies := buildWrapperType(allItems)
-	orderedPolicies := utils.GetPrioritizedListenerPolicies(policies, listener, parentGw.Name, parentListenerSet)
-	return orderedPolicies, nil
-}
-
-func buildWrapperType(
-	items []solokubev1.ListenerOption,
-) []utils.PolicyWithSectionedTargetRefs[*solokubev1.ListenerOption] {
-	policies := []utils.PolicyWithSectionedTargetRefs[*solokubev1.ListenerOption]{}
-	for i := range items {
-		item := &items[i]
-
-		policy := listenerOptionPolicy{
+	wrapPolicy := func(item *solokubev1.ListenerOption) utils.PolicyWithSectionedTargetRefs[*solokubev1.ListenerOption] {
+		return listenerOptionPolicy{
 			obj: item,
 		}
-		policies = append(policies, policy)
 	}
-	return policies
+
+	return utils.GetOptionsForListener(
+		context.Background(),
+		listener,
+		parentGw,
+		parentListenerSet,
+		r.c,
+		ListenerOptionTargetField,
+		createList,
+		extractItems,
+		wrapPolicy,
+	)
 }


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
