### PR TITLE
gateway2/delegation: ignore child routes with mismatched parentRef early

### DIFF
--- a/changelog/v1.19.0-beta19/deleg-fix-mem.yaml
+++ b/changelog/v1.19.0-beta19/deleg-fix-mem.yaml
@@ -1,0 +1,29 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8119
+    resolvesIssue: false
+    description: |
+      gateway2/delegation: ignore child routes with mismatched parentRef early
+
+      After the refactor to decouple querying of routes from translation
+      to enable KRT integration, the resolution of child routes for a
+      delegating route became too permissive, leading to massive amount
+      of memory usage when there are cyclic references to namespaces,
+      i.e., a parent route delegating to wildcard routes in the parent
+      route's namespace. This happens even if a child route does not
+      attach to the parent because this check was omitted during the
+      initial route chain construction. Without this check, the recursive
+      nature of evaluating a delegation chain can consume massive amount
+      of memory.
+
+      This change prunes the routes in the chain early on to avoid
+      this problem, as this is a regression from 1.17.x. While we could
+      prune the child route list further, it would degrade the performance
+      due to O(N^2) computation required to match all the rules in a child
+      route with all the rules on the parent, which already happens later
+      in the translation. To reduce the risk of introducing new bugs,
+      we defer other optimizations for the future.
+
+      Testing done:
+      Verified that the memory usage remains stable with the
+      repro config provided in solo-io/solo-projects#8119

--- a/projects/gateway2/query/httproute_test.go
+++ b/projects/gateway2/query/httproute_test.go
@@ -5,6 +5,8 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -17,8 +19,8 @@ import (
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 )
 
-var _ = DescribeTable("fetchChildRoutes",
-	func(parentNamespace string, backendRef gwv1.HTTPBackendRef, objects []client.Object, wantChildren int, wantErr error) {
+var _ = DescribeTable("getDelegatedChildren",
+	func(parentRef types.NamespacedName, backendRef gwv1.HTTPBackendRef, objects []client.Object, wantChildren int, wantErr error) {
 		scheme := schemes.GatewayScheme()
 		builder := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...)
 		err := IterateIndices(func(o client.Object, f string, fun client.IndexerFunc) error {
@@ -32,17 +34,35 @@ var _ = DescribeTable("fetchChildRoutes",
 			scheme: scheme,
 		}
 
-		children, err := q.fetchChildRoutes(context.TODO(), parentNamespace, backendRef)
+		parentRoute := &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: parentRef.Namespace,
+				Name:      parentRef.Name,
+			},
+			Spec: gwv1.HTTPRouteSpec{
+				Rules: []gwv1.HTTPRouteRule{
+					{
+						BackendRefs: []gwv1.HTTPBackendRef{
+							backendRef,
+						},
+					},
+				},
+			},
+		}
+
+		backendMap := q.getDelegatedChildren(context.TODO(), parentRoute, sets.New[types.NamespacedName]())
+		backendKey := backendToRefKey(backendRef.BackendObjectReference)
+		err = backendMap.errors[backendKey]
+		children := backendMap.items[backendKey]
+
 		if wantErr != nil {
 			Expect(err).To(MatchError(wantErr))
-			return
 		}
-		Expect(err).NotTo(HaveOccurred())
 		Expect(children).To(HaveLen(wantChildren))
 	},
 	Entry(
 		"with wildcard label selector",
-		"parent-ns",
+		types.NamespacedName{Namespace: "parent-ns", Name: "parent"},
 		gwv1.HTTPBackendRef{
 			BackendRef: gwv1.BackendRef{
 				BackendObjectReference: gwv1.BackendObjectReference{
@@ -86,7 +106,7 @@ var _ = DescribeTable("fetchChildRoutes",
 	),
 	Entry(
 		"with wildcard label selector when wildcard namespace exists",
-		"parent-ns",
+		types.NamespacedName{Namespace: "parent-ns", Name: "parent"},
 		gwv1.HTTPBackendRef{
 			BackendRef: gwv1.BackendRef{
 				BackendObjectReference: gwv1.BackendObjectReference{
@@ -119,5 +139,116 @@ var _ = DescribeTable("fetchChildRoutes",
 		},
 		0,
 		ErrWildcardNamespaceDisallowed,
+	),
+	Entry(
+		"filter self reference and mismatched parentRef",
+		types.NamespacedName{Namespace: "parent-ns", Name: "parent"},
+		gwv1.HTTPBackendRef{
+			BackendRef: gwv1.BackendRef{
+				BackendObjectReference: gwv1.BackendObjectReference{
+					Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+					Kind:      ptr.To(gwv1.Kind("HTTPRoute")),
+					Name:      "*",
+					Namespace: ptr.To(gwv1.Namespace("parent-ns")),
+				},
+			},
+		},
+		[]client.Object{
+			&corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: wellknown.RouteDelegationLabelSelectorWildcardNamespace,
+				},
+			},
+			// self reference
+			&gwv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       wellknown.HTTPRouteKind,
+					APIVersion: gwv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "parent-ns",
+					Name:      "parent",
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{
+								Group: ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+								Kind:  ptr.To(gwv1.Kind("HTTPRoute")),
+								Name:  "parent",
+							},
+						},
+					},
+				},
+			},
+			// ParentRef mismatch
+			&gwv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       wellknown.HTTPRouteKind,
+					APIVersion: gwv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "parent-ns",
+					Name:      "invalid-ref",
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{
+								Group: ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+								Kind:  ptr.To(gwv1.Kind("HTTPRoute")),
+								Name:  "invalid", // mismatched parentRef
+							},
+						},
+					},
+				},
+			},
+			// valid child
+			&gwv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       wellknown.HTTPRouteKind,
+					APIVersion: gwv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "parent-ns",
+					Name:      "child-1",
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{
+								Group: ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+								Kind:  ptr.To(gwv1.Kind("HTTPRoute")),
+								Name:  "parent",
+							},
+						},
+					},
+				},
+			},
+			// valid child
+			&gwv1.HTTPRoute{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       wellknown.HTTPRouteKind,
+					APIVersion: gwv1.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "parent-ns",
+					Name:      "child-2",
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{
+								Group: ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+								Kind:  ptr.To(gwv1.Kind("HTTPRoute")),
+								Name:  "parent",
+							},
+						},
+					},
+				},
+			},
+		},
+		2,
+		nil,
 	),
 )

--- a/projects/gateway2/translator/httproute/delegation_helpers.go
+++ b/projects/gateway2/translator/httproute/delegation_helpers.go
@@ -2,12 +2,11 @@ package httproute
 
 import (
 	"path"
-	"reflect"
 	"slices"
 	"strings"
 
 	"github.com/solo-io/gloo/projects/gateway2/query"
-	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+	"github.com/solo-io/gloo/projects/gateway2/utils"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
@@ -44,8 +43,9 @@ func filterDelegatedChildren(
 			continue
 		}
 
-		// Check if the child route is allowed to be delegated to by the parent
-		if !isAllowedParent(parentRef, origChild.GetNamespace(), origChild.Spec.ParentRefs) {
+		// This check is redundant as it is already done in fetchRoutesByRef in projects/gateway2/query/httproute.go,
+		// so this is just to be extra careful if there is a bug when the child routes are resolved earlier.
+		if !utils.ChildRouteCanAttachToParentRef(origChild, parentRef) {
 			continue
 		}
 
@@ -57,7 +57,7 @@ func filterDelegatedChildren(
 			continue
 		}
 
-		inheritMatcher := shouldInheritMatcher(child)
+		inheritMatcher := utils.ShouldChildRouteInheritParentMatcher(child)
 
 		// Check if the child route has a prefix that matches the parent.
 		// Only rules matching the parent prefix are considered.
@@ -83,7 +83,7 @@ func filterDelegatedChildren(
 					// the parent's matcher with the child's.
 					mergeParentChildRouteMatch(&parentMatch, &match)
 					validMatches = append(validMatches, match)
-				} else if ok := isDelegatedRouteMatch(parentMatch, match); ok {
+				} else if ok := utils.IsDelegatedRouteMatch(parentMatch, match); ok {
 					// Non-inherited matcher delegation requires matching child matcher to parent matcher
 					// to delegate from the parent route to the child.
 					validMatches = append(validMatches, match)
@@ -107,109 +107,6 @@ func filterDelegatedChildren(
 	}
 
 	return selected
-}
-
-// isAllowedParent returns whether the parent specified by `parentRef` is allowed to delegate
-// to the child.
-//   - `childNs` is the namespace of the child route.
-//   - `childParentRefs` is the list of parent references on the child route. If this is empty, then
-//     there are no restrictions on which parents can delegate to this child. If it is not empty,
-//     then `parentRef` must be in this list in order for the parent to delegate to the child.
-func isAllowedParent(
-	parentRef types.NamespacedName,
-	childNs string,
-	childParentRefs []gwv1.ParentReference,
-) bool {
-	// no explicit parentRefs, so any parent is allowed
-	if len(childParentRefs) == 0 {
-		return true
-	}
-
-	// validate that the child's parentRefs contains the specified parentRef
-	for _, ref := range childParentRefs {
-		// default to the child's namespace if not specified
-		refNs := childNs
-		if ref.Namespace != nil {
-			refNs = string(*ref.Namespace)
-		}
-		// check if the ref matches the desired parentRef
-		if ref.Group != nil && *ref.Group == wellknown.GatewayGroup &&
-			ref.Kind != nil && *ref.Kind == wellknown.HTTPRouteKind &&
-			string(ref.Name) == parentRef.Name &&
-			refNs == parentRef.Namespace {
-			return true
-		}
-	}
-	return false
-}
-
-func isDelegatedRouteMatch(
-	parent gwv1.HTTPRouteMatch,
-	child gwv1.HTTPRouteMatch,
-) bool {
-	// Validate path
-	if parent.Path == nil || parent.Path.Type == nil || *parent.Path.Type != gwv1.PathMatchPathPrefix {
-		return false
-	}
-	parentPath := *parent.Path.Value
-	if child.Path == nil || child.Path.Type == nil {
-		return false
-	}
-	childPath := *child.Path.Value
-	if !strings.HasPrefix(childPath, parentPath) {
-		return false
-	}
-
-	// Validate that the child headers are a superset of the parent headers
-	for _, parentHeader := range parent.Headers {
-		found := false
-		for _, childHeader := range child.Headers {
-			if reflect.DeepEqual(parentHeader, childHeader) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	// Validate that the child query parameters are a superset of the parent headers
-	for _, parentQuery := range parent.QueryParams {
-		found := false
-		for _, childQuery := range child.QueryParams {
-			if reflect.DeepEqual(parentQuery, childQuery) {
-				found = true
-				break
-			}
-		}
-		if !found {
-			return false
-		}
-	}
-
-	// Validate that the child method matches the parent method
-	if parent.Method != nil && (child.Method == nil || *parent.Method != *child.Method) {
-		return false
-	}
-
-	return true
-}
-
-// shouldInheritMatcher returns true if the route indicates that it should inherit
-// its parent's matcher.
-func shouldInheritMatcher(route *gwv1.HTTPRoute) bool {
-	val, ok := route.Annotations[wellknown.InheritMatcherAnnotation]
-	if !ok {
-		return false
-	}
-	switch strings.ToLower(val) {
-	case "true", "yes", "enabled":
-		return true
-
-	default:
-		return false
-	}
 }
 
 // mergeParentChildRouteMatch merges the parent route match into the child.

--- a/projects/gateway2/utils/delegation.go
+++ b/projects/gateway2/utils/delegation.go
@@ -1,0 +1,122 @@
+package utils
+
+import (
+	"reflect"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	"github.com/solo-io/gloo/projects/gateway2/wellknown"
+)
+
+// ChildRouteCanAttachToParentRef returns a boolean indicating whether the given delegatee/child
+// route can attach to a parent referenced by its NamespacedName.
+//
+// A delegatee route can attach to a parent if either of the following conditions are true:
+//   - the child does not specify ParentRefs (implicit attachment)
+//   - the child has an HTTPRoute ParentReference that matches parentRef
+func ChildRouteCanAttachToParentRef(
+	route *gwv1.HTTPRoute,
+	parentRef types.NamespacedName,
+) bool {
+	if route == nil {
+		return false
+	}
+
+	childParentRefs := route.Spec.ParentRefs
+
+	// no explicit parentRefs, so any parent is allowed
+	if len(childParentRefs) == 0 {
+		return true
+	}
+
+	// validate that the child's parentRefs contains the specified parentRef
+	for _, ref := range childParentRefs {
+		// default to the child's namespace if not specified
+		refNs := route.Namespace
+		if ref.Namespace != nil {
+			refNs = string(*ref.Namespace)
+		}
+		// check if the ref matches the desired parentRef
+		if ref.Group != nil && *ref.Group == wellknown.GatewayGroup &&
+			ref.Kind != nil && *ref.Kind == wellknown.HTTPRouteKind &&
+			string(ref.Name) == parentRef.Name &&
+			refNs == parentRef.Namespace {
+			return true
+		}
+	}
+	return false
+}
+
+// ShouldChildRouteInheritParentMatcher returns true if the child HTTPRoute should inherit the parent HTTPRoute's matcher
+func ShouldChildRouteInheritParentMatcher(route *gwv1.HTTPRoute) bool {
+	if route == nil {
+		return false
+	}
+	val, ok := route.Annotations[wellknown.InheritMatcherAnnotation]
+	if !ok {
+		return false
+	}
+	switch strings.ToLower(val) {
+	case "true", "yes", "enabled":
+		return true
+
+	default:
+		return false
+	}
+}
+
+// IsDelegatedRouteMatch returns true if the child HTTPRouteMatch matches (is a subset) of the parent HTTPRouteMatch.
+func IsDelegatedRouteMatch(
+	parent gwv1.HTTPRouteMatch,
+	child gwv1.HTTPRouteMatch,
+) bool {
+	// Validate path
+	if parent.Path == nil || parent.Path.Type == nil || *parent.Path.Type != gwv1.PathMatchPathPrefix {
+		return false
+	}
+	parentPath := *parent.Path.Value
+	if child.Path == nil || child.Path.Type == nil {
+		return false
+	}
+	childPath := *child.Path.Value
+	if !strings.HasPrefix(childPath, parentPath) {
+		return false
+	}
+
+	// Validate that the child headers are a superset of the parent headers
+	for _, parentHeader := range parent.Headers {
+		found := false
+		for _, childHeader := range child.Headers {
+			if reflect.DeepEqual(parentHeader, childHeader) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Validate that the child query parameters are a superset of the parent headers
+	for _, parentQuery := range parent.QueryParams {
+		found := false
+		for _, childQuery := range child.QueryParams {
+			if reflect.DeepEqual(parentQuery, childQuery) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+
+	// Validate that the child method matches the parent method
+	if parent.Method != nil && (child.Method == nil || *parent.Method != *child.Method) {
+		return false
+	}
+
+	return true
+}

--- a/projects/gateway2/utils/delegation_test.go
+++ b/projects/gateway2/utils/delegation_test.go
@@ -1,13 +1,106 @@
-package httproute
+package utils
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 )
+
+func TestChildRouteCanAttachToParentRef(t *testing.T) {
+	testCases := []struct {
+		name      string
+		route     *gwv1.HTTPRoute
+		parentRef types.NamespacedName
+		expected  bool
+	}{
+		{
+			name: "no ParentRefs, should allow attachment",
+			route: &gwv1.HTTPRoute{
+				Spec: gwv1.HTTPRouteSpec{},
+			},
+			parentRef: types.NamespacedName{Name: "parent", Namespace: "default"},
+			expected:  true,
+		},
+		{
+			name: "ParentRefs match, should allow attachment",
+			route: &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{
+								Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+								Kind:      ptr.To(gwv1.Kind("HTTPRoute")),
+								Name:      "parent",
+								Namespace: ptr.To(gwv1.Namespace("default")),
+							},
+						},
+					},
+				},
+			},
+			parentRef: types.NamespacedName{Name: "parent", Namespace: "default"},
+			expected:  true,
+		},
+		{
+			name: "ParentRef doesn't match Name, should not allow attachment",
+			route: &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{
+								Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+								Kind:      ptr.To(gwv1.Kind("HTTPRoute")),
+								Name:      "invalid",
+								Namespace: ptr.To(gwv1.Namespace("default")),
+							},
+						},
+					},
+				},
+			},
+			parentRef: types.NamespacedName{Name: "parent", Namespace: "default"},
+			expected:  false,
+		},
+		{
+			name: "ParentRef doesn't match Namespace, should not allow attachment",
+			route: &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+				},
+				Spec: gwv1.HTTPRouteSpec{
+					CommonRouteSpec: gwv1.CommonRouteSpec{
+						ParentRefs: []gwv1.ParentReference{
+							{
+								Group:     ptr.To(gwv1.Group("gateway.networking.k8s.io")),
+								Kind:      ptr.To(gwv1.Kind("HTTPRoute")),
+								Name:      "parent",
+								Namespace: ptr.To(gwv1.Namespace("invalid")),
+							},
+						},
+					},
+				},
+			},
+			parentRef: types.NamespacedName{Name: "parent", Namespace: "default"},
+			expected:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			a := assert.New(t)
+			result := ChildRouteCanAttachToParentRef(tc.route, tc.parentRef)
+			a.Equal(tc.expected, result)
+		})
+	}
+}
 
 func TestIsDelegatedRouteMatch(t *testing.T) {
 	testCases := []struct {
@@ -526,7 +619,7 @@ func TestIsDelegatedRouteMatch(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			a := assert.New(t)
-			actual := isDelegatedRouteMatch(tc.parent, tc.child)
+			actual := IsDelegatedRouteMatch(tc.parent, tc.child)
 
 			a.Equal(tc.expected, actual)
 		})

--- a/projects/gateway2/wellknown/delegation.go
+++ b/projects/gateway2/wellknown/delegation.go
@@ -1,6 +1,8 @@
 package wellknown
 
-import "github.com/solo-io/gloo/pkg/utils/envutils"
+import (
+	"github.com/solo-io/gloo/pkg/utils/envutils"
+)
 
 const (
 	// RouteDelegationLabelSelector is the label used to select delegated HTTPRoutes


### PR DESCRIPTION
After the refactor to decouple querying of routes from translation to enable KRT integration, the resolution of child routes for a delegating route became too permissive, leading to massive amount of memory usage when there are cyclic references to namespaces, i.e., a parent route delegating to wildcard routes in the parent route's namespace. This happens even if a child route does not attach to the parent because this check was omitted during the initial route chain construction. Without this check, the recursive nature of evaluating a delegation chain can consume massive amount of memory.

This change prunes the routes in the chain early on to avoid this problem, as this is a regression from 1.17.x. While we could prune the child route list further, it would degrade the performance due to O(N^2) computation required to match all the rules in a child route with all the rules on the parent, which already happens later in the translation. To reduce the risk of introducing new bugs, we defer other optimizations for the future.

Testing done:
Verified that the memory usage remains stable with the repro config provided in solo-io/solo-projects#8119
