### PR TITLE
[backport] gateway2/delegation: check cyclic reference only for valid children

### DIFF
--- a/changelog/v1.18.16/deleg-check-move.yaml
+++ b/changelog/v1.18.16/deleg-check-move.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8119
+    resolvesIssue: false
+    description: |
+      gateway2/delegation: check cyclic reference only for valid children
+
+      - Moves the cyclic reference check after ignoring unattached candidate
+        child routes to prevent an unnecessary status error when the parent delegates
+        to wildcard routes in the same namespace.
+
+      - Removes the self-reference check so that invalid references to self
+        are reported as status errors.

--- a/projects/gateway2/query/httproute.go
+++ b/projects/gateway2/query/httproute.go
@@ -268,18 +268,16 @@ func (r *gatewayQueries) getDelegatedChildren(
 			}
 			for _, childRoute := range referencedRoutes {
 				childRef := namespacedName(&childRoute)
+				// ignore routes that are not attached to the parent
+				if !utils.ChildRouteCanAttachToParentRef(&childRoute, parentRef) {
+					continue
+				}
+
+				// This is a candidate child route, check if it results in a cyclic reference
 				if visited.Has(childRef) {
 					err := fmt.Errorf("ignoring child route %s for parent %s: %w", childRef, parentRef, ErrCyclicReference)
 					children.AddError(backendRef.BackendObjectReference, err)
 					// Don't resolve invalid child route
-					continue
-				}
-				// ignore reference to self
-				if childRef == parentRef {
-					continue
-				}
-				// ignore routes that are not attached to the parent
-				if !utils.ChildRouteCanAttachToParentRef(&childRoute, parentRef) {
 					continue
 				}
 


### PR DESCRIPTION
Backports https://github.com/solo-io/gloo/pull/10773 from main
---
- Moves the cyclic reference check after ignoring unattached candidate child routes to prevent an unnecessary status error when the parent delegates to wildcard routes in the same namespace.

- Removes the self-reference check so that invalid references to self are reported as status errors.
