### PR TITLE
Test configure invalid virtual host options flake

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -60,49 +60,49 @@ jobs:
         # 2025-03-24: 23m7s
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGateway$$/^RouteDelegation$$|^TestGlooctlGlooGatewayEdgeGateway$$|^TestGlooctlK8sGateway$$|^TestK8sGateway$$/^HTTPTunnel$$|^TestListenerSet$$'
+          go-test-run-regex: '^TestK8sGatewayNoValidation$$'
 
         # 2024-12-04: 23m
         # 2025-02-13: 30m30s
         # 2025-03-24: 27m42s
         - cluster-name: 'cluster-two'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGatewayIstioRevision$$|^TestRevisionIstioRegression$$|^TestK8sGateway$$/^Deployer$$|^TestK8sGateway$$/^RouteOptions$$|^TestK8sGateway$$/^VirtualHostOptions$$|^TestK8sGateway$$/^Upstreams$$|^TestK8sGateway$$/^HeadlessSvc$$|^TestK8sGateway$$/^PortRouting$$|^TestK8sGatewayMinimalDefaultGatewayParameters$$|^TestK8sGateway$$/^DirectResponse$$|^TestK8sGateway$$/^HttpListenerOptions$$|^TestK8sGateway$$/^ListenerOptions$$|^TestK8sGateway$$/^GlooAdminServer$$'
+          go-test-run-regex: '^TestK8sGatewayNoValidation$$'
 
         # 2024-12-04: 24m
         # 2025-02-13: 31m49s
         # 2025-03-24: 30m26s
         - cluster-name: 'cluster-three'
           go-test-args: '-v -timeout=30m'
-          go-test-run-regex: '(^TestK8sGatewayIstioAutoMtls$$|^TestAutomtlsIstioEdgeApisGateway$$|^TestIstioEdgeApiGateway$$|^TestIstioRegression$$)'
+          go-test-run-regex: '^TestK8sGatewayNoValidation$$'
 
         # 2024-12-04: 21m
         # 2025-02-13: 28m3s
         # 2025-03-24: 29m15s
         - cluster-name: 'cluster-four'
           go-test-args: '-v -timeout=30m'
-          go-test-run-regex: '(^TestK8sGatewayIstio$$|^TestGlooGatewayEdgeGateway$$|^TestGlooctlIstioInjectEdgeApiGateway$$)'
+          go-test-run-regex: '^TestK8sGatewayNoValidation$$'
 
         # 2024-12-04: 24m
         # 2025-02-13: 35m21s
         # 2025-03-24: 33m39s
         - cluster-name: 'cluster-five'
           go-test-args: '-v -timeout=30m'
-          go-test-run-regex: '^TestFullEnvoyValidation$$|^TestValidationStrict$$|^TestValidationAlwaysAccept$$|^TestTransformationValidationDisabled$$'
+          go-test-run-regex: '^TestK8sGatewayNoValidation$$'
 
         # 2024-12-04: 26m
         # 2025-02-13: 33m19s
         # 2025-03-24: 31m38s
         - cluster-name: 'cluster-six'
           go-test-args: '-v -timeout=30m'
-          go-test-run-regex: '^TestDiscoveryWatchlabels$$|^TestK8sGatewayNoValidation$$|^TestHelm$$|^TestHelmSettings$$|^TestK8sGatewayAws$$|^TestK8sGateway$$/^HTTPRouteServices$$|^TestK8sGateway$$/^TCPRouteServices$$'
+          go-test-run-regex: '^TestK8sGatewayNoValidation$$'
 
         # 2024-12-04: 16m
         # 2025-02-13: 26m29s
         # 2025-03-24: 29m9s
-        - cluster-name: 'cluster-seven'
-          go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGateway$$/^CRDCategories$$|^TestK8sGateway$$/^Metrics$$|^TestGloomtlsGatewayEdgeGateway$$|^TestGloomtlsGatewayK8sGateway$$|^TestGlooGatewayEdgeGatewayClearMetrics$$|^TestWatchNamespaceSelector$$|^TestK8sGateway$$/^TLSRouteServices$$'
+        # - cluster-name: 'cluster-seven'
+        #   go-test-args: '-v -timeout=25m'
+        #   go-test-run-regex: '^TestK8sGateway$$/^CRDCategories$$|^TestK8sGateway$$/^Metrics$$|^TestGloomtlsGatewayEdgeGateway$$|^TestGloomtlsGatewayK8sGateway$$|^TestGlooGatewayEdgeGatewayClearMetrics$$|^TestWatchNamespaceSelector$$|^TestK8sGateway$$/^TLSRouteServices$$'
 
         # In our PR tests, we run the suite of tests using the upper ends of versions that we claim to support
         # The versions should mirror: https://docs.solo.io/gloo-edge/latest/reference/support/

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -51,7 +51,7 @@ func (p *Provider) EventuallyResourceStatusMatchesRejectedReasons(getter helpers
 		status, err := getResourceNamespacedStatus(getter)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("EventuallyResourceStatusMatchesRejectedReasons failed: %s", err))
 		g.Expect(status).ToNot(gomega.BeNil())
-		g.Expect(status).To(gomega.HaveValue(statusRejectionsMatcher))
+		g.Expect(status).To(gomega.HaveValue(statusRejectionsMatcher), fmt.Sprintf("status %v does not match expected reasons %v", status, desiredStatusReasons))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
 }
 
@@ -70,7 +70,7 @@ func (p *Provider) EventuallyResourceStatusMatchesState(
 		status, err := getResourceNamespacedStatus(getter)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("EventuallyResourceStatusMatchesState failed: %s", err))
 		g.Expect(status).ToNot(gomega.BeNil())
-		g.Expect(status).To(gomega.HaveValue(statusStateMatcher))
+		g.Expect(status).To(gomega.HaveValue(statusStateMatcher), fmt.Sprintf("status %v does not match expected state %v", status, desiredState))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
 }
 
@@ -86,7 +86,7 @@ func (p *Provider) EventuallyResourceStatusMatchesSubResource(
 		status, err := getResourceNamespacedStatus(getter)
 		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("EventuallyResourceStatusMatchesSubResource failed: %s", err))
 		g.Expect(status).ToNot(gomega.BeNil())
-		g.Expect(status).To(gomega.HaveValue(subResourceStatusMatcher))
+		g.Expect(status).To(gomega.HaveValue(subResourceStatusMatcher), fmt.Sprintf("subresource status %v does not match expected subresource %v", status, desiredSubresource))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
 }
 

--- a/test/kubernetes/testutils/assertions/status.go
+++ b/test/kubernetes/testutils/assertions/status.go
@@ -32,7 +32,7 @@ func (p *Provider) EventuallyResourceStatusMatchesWarningReasons(getter helpers.
 		)
 
 		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("EventuallyResourceStatusMatchesWarningReasons failed: %s", err))
 		g.Expect(status).ToNot(gomega.BeNil())
 		g.Expect(status).To(gomega.HaveValue(statusWarningsMatcher))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
@@ -49,7 +49,7 @@ func (p *Provider) EventuallyResourceStatusMatchesRejectedReasons(getter helpers
 		)
 
 		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("EventuallyResourceStatusMatchesRejectedReasons failed: %s", err))
 		g.Expect(status).ToNot(gomega.BeNil())
 		g.Expect(status).To(gomega.HaveValue(statusRejectionsMatcher))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
@@ -68,7 +68,7 @@ func (p *Provider) EventuallyResourceStatusMatchesState(
 			gomega.And(matchers.HaveState(desiredState), matchers.HaveReportedBy(desiredReporter)),
 		)
 		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("EventuallyResourceStatusMatchesState failed: %s", err))
 		g.Expect(status).ToNot(gomega.BeNil())
 		g.Expect(status).To(gomega.HaveValue(statusStateMatcher))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())
@@ -84,7 +84,7 @@ func (p *Provider) EventuallyResourceStatusMatchesSubResource(
 	p.Gomega.Eventually(func(g gomega.Gomega) {
 		subResourceStatusMatcher := matchers.HaveSubResourceStatusState(desiredSubresourceName, desiredSubresource)
 		status, err := getResourceNamespacedStatus(getter)
-		g.Expect(err).NotTo(gomega.HaveOccurred(), "failed to get resource namespaced status")
+		g.Expect(err).NotTo(gomega.HaveOccurred(), fmt.Sprintf("EventuallyResourceStatusMatchesSubResource failed: %s", err))
 		g.Expect(status).ToNot(gomega.BeNil())
 		g.Expect(status).To(gomega.HaveValue(subResourceStatusMatcher))
 	}, currentTimeout, pollingInterval).Should(gomega.Succeed())


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
