### PR TITLE
GHAs use repo variables for LTS branches

### DIFF
--- a/.github/workflows/docs-gen.yaml
+++ b/.github/workflows/docs-gen.yaml
@@ -1,16 +1,19 @@
 name: Docs
 
 env:
+    # ON_LTS_UPDATE - bump lts version in the repo variables
+    MIN_SCANNED_VERSION: ${{ vars.LATEST_STABLE_MINUS_THREE_BRANCH }}  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
+
     SLACK_DEBUG_TESTING: false      # when set to "true", send notifications to #slack-integration-testing.  Otherwise, post to #edge-team-bots
-    MIN_SCANNED_VERSION: 'v1.15.0'  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
 on:
   push:
     branches:
     - 'main'
+    # ON_LTS_UPDATE - bump version
+    - 'v1.19.x'
     - 'v1.18.x'
     - 'v1.17.x'
     - 'v1.16.x'
-    - 'v1.15.x'
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -1,5 +1,7 @@
 name: Nightly
 
+# ON_LTS_UPDATE - bump lts version in the repo variables
+
 env:
   GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }} # necessary to pass upgrade tests
   # https://github.com/solo-io/gloo/issues/10534
@@ -17,9 +19,9 @@ on:
   # Day of the week ([0,6] with 0=Sunday)
   schedule:
     - cron: "0 5 * * *" # every day @ 05:00 UTC, run tests against latest main
-    - cron: "0 6 * * 1" # monday    @ 06:00 UTC, run expanded tests against v1.18.x
-    - cron: "0 7 * * 1" # monday    @ 07:00 UTC, run expanded tests against v1.17.x
-    - cron: "0 8 * * 1" # monday    @ 08:00 UTC, run expanded tests against v1.16.x
+    - cron: "0 6 * * 1" # monday    @ 06:00 UTC, run expanded tests against LATEST_STABLE_BRANCH
+    - cron: "0 7 * * 1" # monday    @ 07:00 UTC, run expanded tests against LATEST_STABLE_MINUS_ONE_BRANCH
+    - cron: "0 8 * * 1" # monday    @ 08:00 UTC, run expanded tests against LATEST_STABLE_MINUS_TWO_BRANCH
   workflow_dispatch:
     inputs:
       branch:
@@ -27,9 +29,9 @@ on:
         type: choice
         options:
           - main
-          - v1.18.x
-          - v1.17.x
-          - v1.16.x
+          - latest_stable
+          - latest_stable_minus_one
+          - latest_stable_minus_two
           - workflow_initiating_branch
       run-regression:
         description: "Run regression tests"
@@ -182,9 +184,9 @@ jobs:
           matrix-label: ${{ matrix.version-files.label }}
 
   # Reminder: when setting up the job next release branch, copy from "end_to_end_tests_main" not the previous release job as configuration may have changed
-  end_to_end_tests_18:
-    name: End-to-End (branch=v1.18.x, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'v1.18.x') || github.event.schedule == '0 6 * * 1' }}
+  end_to_end_tests_latest_stable:
+    name: End-to-End (branch=${{ vars.LATEST_STABLE_BRANCH }}, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
@@ -210,7 +212,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.18.x
+          ref: ${{ vars.LATEST_STABLE_BRANCH }}
       # The dotenv action is used to load key-value pairs from files.
       # In this case, the file is specified in the matrix and will contain the versions of the tools to use
       - name: Dotenv Action
@@ -244,9 +246,71 @@ jobs:
           istio-version: ${{ steps.dotenv.outputs.istio_version }}
           matrix-label: ${{ matrix.version-files.label }}
 
-  end_to_end_tests_17:
-    name: End-to-End (branch=v1.17.x, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'v1.17.x') || github.event.schedule == '0 7 * * 1' }}
+  end_to_end_tests_latest_stable_minus_one:
+    name: End-to-End (branch=${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    strategy:
+      # Since we are running these on a schedule, there is no value in failing fast
+      # In fact, we want to ensure that all tests run, so that we have a clearer picture of which tests are prone to flaking
+      fail-fast: false
+      matrix:
+        test:
+          # When running the tests at night, there is no value in splitting the tests across multiple clusters and running them in parallel.
+          # As a result, we increase the threshold for the tests, since they all run serially on a single cluster
+          - cluster-name: 'cluster-one'
+            go-test-args: '-v -timeout=210m'
+            # Specifying an empty regex means all tests will be run.
+            go-test-run-regex: ""
+        # In our nightly tests, we run the suite of tests using the lower and upper ends of versions that we claim to support
+        # The versions should mirror: https://docs.solo.io/gloo-edge/latest/reference/support/
+        version-files:
+          - label: 'min'
+            file: './.github/workflows/.env/nightly-tests/min_versions.env'
+          - label: 'max'
+            file: './.github/workflows/.env/nightly-tests/max_versions.env'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}
+      # The dotenv action is used to load key-value pairs from files.
+      # In this case, the file is specified in the matrix and will contain the versions of the tools to use
+      - name: Dotenv Action
+        uses: falti/dotenv-action@v1.1.4
+        id: dotenv
+        with:
+          path: ${{ matrix.version-files.file }}
+          log-variables: true
+      - name: Prep Go Runner
+        uses: ./.github/workflows/composite-actions/prep-go-runner
+      # Set up the KinD cluster that the tests will use
+      - id: setup-kind-cluster
+        name: Setup KinD Cluster
+        uses: ./.github/workflows/composite-actions/setup-kind-cluster
+        with:
+          cluster-name: ${{ matrix.test.cluster-name }}
+          kind-node-version: ${{ steps.dotenv.outputs.node_version }}
+          kind-version: ${{ steps.dotenv.outputs.kind_version }}
+          kubectl-version: ${{ steps.dotenv.outputs.kubectl_version }}
+          helm-version: ${{ steps.dotenv.outputs.helm_version }}
+          istio-version: ${{ steps.dotenv.outputs.istio_version }}
+          k8sgateway-api-version: ${{ steps.dotenv.outputs.k8sgateway_api_version }}
+      # Run the tests
+      - id: run-tests
+        name: Run Kubernetes e2e Tests
+        uses: ./.github/workflows/composite-actions/kubernetes-e2e-tests
+        with:
+          cluster-name: ${{ matrix.test.cluster-name }}
+          test-args: ${{ matrix.test.go-test-args }}
+          run-regex: ${{ matrix.test.go-test-run-regex }}
+          istio-version: ${{ steps.dotenv.outputs.istio_version }}
+          matrix-label: ${{ matrix.version-files.label }}
+
+  end_to_end_tests_latest_stable_minus_two:
+    name: End-to-End (branch=${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 150
     strategy:
@@ -272,7 +336,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.17.x
+          ref: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}
       # The dotenv action is used to load key-value pairs from files.
       # In this case, the file is specified in the matrix and will contain the versions of the tools to use
       - name: Dotenv Action
@@ -306,7 +370,7 @@ jobs:
           matrix-label: ${{ matrix.version-files.label }}
 
   regression_tests_on_demand:
-    name: on demand regression tests
+    name: on demand regression tests (${{ matrix.kube-e2e-test-type }})
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'workflow_initiating_branch' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -325,7 +389,7 @@ jobs:
     - uses: ./.github/workflows/composite-actions/regression-tests
 
   regression_tests_main:
-    name: main regression tests
+    name: main regression tests (${{ matrix.kube-e2e-test-type }})
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'main') || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -353,9 +417,38 @@ jobs:
         ref: main
     - uses: ./.github/workflows/composite-actions/regression-tests
 
-  regression_tests_18:
-    name: v1.18.x regression tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.18.x') || github.event.schedule == '0 6 * * 1' }}
+  regression_tests_latest_stable:
+    name: ${{ vars.LATEST_STABLE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }})
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    # Previously, there was an environment variable, RELEASED_VERSION="LATEST" set.  This made use of some internal code:
+    #       https://github.com/solo-io/gloo/blob/main/test/kube2e/util.go#L229-L241
+    # which modified our testing process to pull the latest beta release.
+    #
+    # NOW, however, running this job is the same as normal CI.  (building a local chart, then using it)
+    strategy:
+      fail-fast: false
+      matrix:
+        # TODO:
+        #   As part of the end_to_end_tests_main job, we added support for importing versions from a .env file
+        #   We should extend the support/usage of those .env files to these other jobs.
+        #   The tests are currently in flux, and some of these regression tests are being migrated, so we decided
+        #   to limit the scope (and potentially unnecessary work) for now
+        kube-e2e-test-type: ['gateway', 'gloo', 'upgrade']
+        kube-version: [ { node: 'v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72', kubectl: 'v1.27.3', kind: 'v0.20.0', helm: 'v3.13.2' },
+                        { node: 'v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865', kubectl: 'v1.31.0', kind: 'v0.24.0', helm: 'v3.14.4' }]
+        image-variant:
+          - standard
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ vars.LATEST_STABLE_BRANCH }}
+    - uses: ./.github/workflows/composite-actions/regression-tests
+
+  regression_tests_latest_stable_minus_one:
+    name: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }})
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     # Previously, there was an environment variable, RELEASED_VERSION="LATEST" set.  This made use of some internal code:
@@ -379,12 +472,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.18.x
+          ref: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}
       - uses: ./.github/workflows/composite-actions/regression-tests
 
-  regression_tests_17:
-    name: v1.17.x regression tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.17.x') || github.event.schedule == '0 7 * * 1' }}
+  regression_tests_latest_stable_minus_two:
+    name: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }})
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -397,24 +490,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.17.x
-      - uses: ./.github/workflows/composite-actions/regression-tests
-
-  regression_tests_16:
-    name: v1.16.x regression tests
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'v1.16.x') || github.event.schedule == '0 8 * * 1' }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 60
-    strategy:
-      fail-fast: false
-      matrix:
-        kube-e2e-test-type: ['gateway', 'gloo', 'ingress', 'helm', 'gloomtls', 'glooctl', 'upgrade']
-        kube-version: [ { node: 'v1.25.16@sha256:5da57dfc290ac3599e775e63b8b6c49c0c85d3fec771cd7d55b45fae14b38d3b', kubectl: 'v1.25.16', kind: 'v0.20.0', helm: 'v3.13.2' },
-                        { node: 'v1.28.0@sha256:b7a4cad12c197af3ba43202d3efe03246b3f0793f162afb40a33c923952d5b31', kubectl: 'v1.28.4', kind: 'v0.20.0', helm: 'v3.14.4' }]
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: v1.16.x
+          ref: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}
       - uses: ./.github/workflows/composite-actions/regression-tests
 
   performance_tests_on_demand:
@@ -446,45 +522,45 @@ jobs:
       - uses: ./.github/workflows/composite-actions/prep-go-runner
       - uses: ./.github/workflows/composite-actions/performance-tests
 
-  performance_tests_18:
-    name: v1.18.x performance tests
+  performance_tests_latest_stable:
+    name: ${{ vars.LATEST_STABLE_BRANCH }} performance tests"
     # Instead of false, we would want to define: env.ENABLE_PERFORMANCE_TESTS == 'true'
     # Due to https://github.com/actions/runner/issues/1189#issuecomment-880110759, we cannot use env variables in job.if
-    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.18.x') || github.event.schedule == '0 6 * * 1') }}
+    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.18.x
+          ref: ${{ vars.LATEST_STABLE_BRANCH }}
       - uses: ./.github/workflows/composite-actions/prep-go-runner
       - uses: ./.github/workflows/composite-actions/performance-tests
 
-  performance_tests_17:
-    name: v1.17.x performance tests
+  performance_tests_latest_stable_minus_one:
+    name: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }} performance tests"
     # Instead of false, we would want to define: env.ENABLE_PERFORMANCE_TESTS == 'true'
     # Due to https://github.com/actions/runner/issues/1189#issuecomment-880110759, we cannot use env variables in job.if
-    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.17.x') || github.event.schedule == '0 7 * * 1') }}
+    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.17.x
+          ref: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}
       - uses: ./.github/workflows/composite-actions/prep-go-runner
       - uses: ./.github/workflows/composite-actions/performance-tests
 
-  performance_tests_16:
-    name: v1.16.x performance tests
+  performance_tests_latest_stable_minus_two:
+    name: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }} performance tests"
     # Instead of false, we would want to define: env.ENABLE_PERFORMANCE_TESTS == 'true'
     # Due to https://github.com/actions/runner/issues/1189#issuecomment-880110759, we cannot use env variables in job.if
-    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'v1.16.x') || github.event.schedule == '0 8 * * 1') }}
+    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.16.x
+          ref: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}
       - uses: ./.github/workflows/composite-actions/prep-go-runner
       - uses: ./.github/workflows/composite-actions/performance-tests
 
@@ -506,9 +582,27 @@ jobs:
         ref: main
     - uses: ./.github/workflows/composite-actions/kube-gateway-api-conformance-tests
 
-  kube_gateway_api_conformance_tests_18:
-    name: Conformance (branch=v1.18.x, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'v1.18.x') || github.event.schedule == '0 6 * * 1' }}
+  kube_gateway_api_conformance_tests_latest_stable:
+    name: Conformance (branch=${{ vars.LATEST_STABLE_BRANCH }}, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        kube-version: [ { node: 'v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72', kubectl: 'v1.27.3', kind: 'v0.20.0', helm: 'v3.13.2' },
+                        { node: 'v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865', kubectl: 'v1.31.0', kind: 'v0.24.0', helm: 'v3.14.4' }]
+        image-variant:
+          - standard
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ vars.LATEST_STABLE_BRANCH }}
+    - uses: ./.github/workflows/composite-actions/kube-gateway-api-conformance-tests
+
+  kube_gateway_api_conformance_tests_latest_stable_minus_one:
+    name: Conformance (branch=${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -521,13 +615,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.18.x
+          ref: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}
       - uses: ./.github/workflows/composite-actions/kube-gateway-api-conformance-tests
 
-
-  kube_gateway_api_conformance_tests_17:
-    name: Conformance (branch=v1.17.x, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'v1.17.x') || github.event.schedule == '0 7 * * 1' }}
+  kube_gateway_api_conformance_tests_latest_stable_minus_two:
+    name: Conformance (branch=${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -540,7 +633,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: v1.17.x
+          ref: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}
       - uses: ./.github/workflows/composite-actions/kube-gateway-api-conformance-tests
 
   publish_results:
@@ -549,19 +642,21 @@ jobs:
     if: ${{ always() }}
     needs:
       - end_to_end_tests_main
-      - end_to_end_tests_18
-      - end_to_end_tests_17
+      - end_to_end_tests_latest_stable
+      - end_to_end_tests_latest_stable_minus_one
+      - end_to_end_tests_latest_stable_minus_two
       - regression_tests_main
-      - regression_tests_18
-      - regression_tests_17
-      - regression_tests_16
+      - regression_tests_latest_stable
+      - regression_tests_latest_stable_minus_one
+      - regression_tests_latest_stable_minus_two
       - performance_tests_main
-      - performance_tests_18
-      - performance_tests_17
-      - performance_tests_16
+      - performance_tests_latest_stable
+      - performance_tests_latest_stable_minus_one
+      - performance_tests_latest_stable_minus_two
       - kube_gateway_api_conformance_tests_main
-      - kube_gateway_api_conformance_tests_18
-      - kube_gateway_api_conformance_tests_17
+      - kube_gateway_api_conformance_tests_latest_stable
+      - kube_gateway_api_conformance_tests_latest_stable_minus_one
+      - kube_gateway_api_conformance_tests_latest_stable_minus_two
       - end_to_end_tests_on_demand
       - regression_tests_on_demand
       - performance_tests_on_demand
@@ -581,13 +676,13 @@ jobs:
             branch="main"
           elif [[ ${{github.event.schedule == '0 6 * * 1'}} = true ]]; then
             trigger="Gloo OSS weeklies"
-            branch="v1.18.x"
+            branch="${{ vars.LATEST_STABLE_BRANCH }}"
           elif [[ ${{github.event.schedule == '0 7 * * 1'}} = true ]]; then
             trigger="Gloo OSS weeklies"
-            branch="v1.17.x"
+            branch="${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}"
           elif [[ ${{github.event.schedule == '0 8 * * 1'}} = true ]]; then
             trigger="Gloo OSS nightlies"
-            branch="v1.16.x"
+            branch="${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}"
           fi
           preamble="$trigger ($branch)"
           echo "Setting PREAMBLE as $preamble"

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -370,7 +370,7 @@ jobs:
           matrix-label: ${{ matrix.version-files.label }}
 
   regression_tests_on_demand:
-    name: on demand regression tests (${{ matrix.kube-e2e-test-type }})
+    name: on demand regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'workflow_initiating_branch' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -389,7 +389,7 @@ jobs:
     - uses: ./.github/workflows/composite-actions/regression-tests
 
   regression_tests_main:
-    name: main regression tests (${{ matrix.kube-e2e-test-type }})
+    name: main regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'main') || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -418,7 +418,7 @@ jobs:
     - uses: ./.github/workflows/composite-actions/regression-tests
 
   regression_tests_latest_stable:
-    name: ${{ vars.LATEST_STABLE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }})
+    name: ${{ vars.LATEST_STABLE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -447,7 +447,7 @@ jobs:
     - uses: ./.github/workflows/composite-actions/regression-tests
 
   regression_tests_latest_stable_minus_one:
-    name: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }})
+    name: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
@@ -476,7 +476,7 @@ jobs:
       - uses: ./.github/workflows/composite-actions/regression-tests
 
   regression_tests_latest_stable_minus_two:
-    name: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }})
+    name: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
     if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60

--- a/.github/workflows/nightly-tests.yaml
+++ b/.github/workflows/nightly-tests.yaml
@@ -186,7 +186,7 @@ jobs:
   # Reminder: when setting up the job next release branch, copy from "end_to_end_tests_main" not the previous release job as configuration may have changed
   end_to_end_tests_latest_stable:
     name: End-to-End (branch=${{ vars.LATEST_STABLE_BRANCH }}, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
@@ -248,7 +248,7 @@ jobs:
 
   end_to_end_tests_latest_stable_minus_one:
     name: End-to-End (branch=${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 180
     strategy:
@@ -310,7 +310,7 @@ jobs:
 
   end_to_end_tests_latest_stable_minus_two:
     name: End-to-End (branch=${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}, cluster=${{ matrix.test.cluster-name }}, version=${{ matrix.version-files.label }} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-kubernetes-end-to-end && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 8 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 150
     strategy:
@@ -419,7 +419,7 @@ jobs:
 
   regression_tests_latest_stable:
     name: ${{ vars.LATEST_STABLE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     # Previously, there was an environment variable, RELEASED_VERSION="LATEST" set.  This made use of some internal code:
@@ -448,7 +448,7 @@ jobs:
 
   regression_tests_latest_stable_minus_one:
     name: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     # Previously, there was an environment variable, RELEASED_VERSION="LATEST" set.  This made use of some internal code:
@@ -477,7 +477,7 @@ jobs:
 
   regression_tests_latest_stable_minus_two:
     name: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }} regression tests (${{ matrix.kube-e2e-test-type }} - ${{ matrix.kube-version.kubectl }})
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-regression && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 8 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -526,7 +526,7 @@ jobs:
     name: ${{ vars.LATEST_STABLE_BRANCH }} performance tests"
     # Instead of false, we would want to define: env.ENABLE_PERFORMANCE_TESTS == 'true'
     # Due to https://github.com/actions/runner/issues/1189#issuecomment-880110759, we cannot use env variables in job.if
-    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *') }}
+    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 6 * * 1') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -540,7 +540,7 @@ jobs:
     name: ${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }} performance tests"
     # Instead of false, we would want to define: env.ENABLE_PERFORMANCE_TESTS == 'true'
     # Due to https://github.com/actions/runner/issues/1189#issuecomment-880110759, we cannot use env variables in job.if
-    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1') }}
+    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 7 * * 1') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -554,7 +554,7 @@ jobs:
     name: ${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }} performance tests"
     # Instead of false, we would want to define: env.ENABLE_PERFORMANCE_TESTS == 'true'
     # Due to https://github.com/actions/runner/issues/1189#issuecomment-880110759, we cannot use env variables in job.if
-    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1') }}
+    if: ${{ false && ((github.event_name == 'workflow_dispatch' && inputs.run-performance && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 8 * * 1') }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     steps:
@@ -584,7 +584,7 @@ jobs:
 
   kube_gateway_api_conformance_tests_latest_stable:
     name: Conformance (branch=${{ vars.LATEST_STABLE_BRANCH }}, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 5 * * *' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable' ) || github.event.schedule == '0 6 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -602,7 +602,7 @@ jobs:
 
   kube_gateway_api_conformance_tests_latest_stable_minus_one:
     name: Conformance (branch=${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 6 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable_minus_one' ) || github.event.schedule == '0 7 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -620,7 +620,7 @@ jobs:
 
   kube_gateway_api_conformance_tests_latest_stable_minus_two:
     name: Conformance (branch=${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}, type=Kubernetes Gateway API, version=${{matrix.kube-version.node}} )
-    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 7 * * 1' }}
+    if: ${{ (github.event_name == 'workflow_dispatch' && inputs.run-conformance && inputs.branch == 'latest_stable_minus_two' ) || github.event.schedule == '0 8 * * 1' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -44,25 +44,26 @@ jobs:
           version=${{ inputs.branch }}
         fi
         echo "lts=$version" >> $GITHUB_OUTPUT
+    # ON_LTS_UPDATE - bump version
     - name: Set version variables
       id: version-variables
       run: |
         minor=""
         directory=""
         if [[ "${{ steps.lts-version.outputs.lts }}" == "main" ]]; then
-          minor="1.19"
+          minor="1.20"
           directory="main"
-        elif [[ "${{ steps.lts-version.outputs.lts }}" == "v1.19.x" ]]; then
+        elif [[ "${{ steps.lts-version.outputs.lts }}" == "${{ vars.LATEST_STABLE_BRANCH }}" ]]; then
           minor="1.19"
-          directory="main"
-        elif [[ "${{ steps.lts-version.outputs.lts }}" == "v1.18.x" ]]; then
-          minor="1.18"
           directory="latest"
-        elif [[ "${{ steps.lts-version.outputs.lts }}" == "v1.17.x" ]]; then
+        elif [[ "${{ steps.lts-version.outputs.lts }}" == "${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}" ]]; then
+          minor="1.18"
+          directory="${{ vars.LATEST_STABLE_MINUS_ONE_BRANCH }}"
+        elif [[ "${{ steps.lts-version.outputs.lts }}" == "${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}" ]]; then
           minor="1.17"
-          directory="1.17.x"
+          directory="${{ vars.LATEST_STABLE_MINUS_TWO_BRANCH }}"
         else
-          minor="1.19"
+          minor="1.20"
           directory="main"
         fi
         echo "minor=${minor}" >> $GITHUB_OUTPUT

--- a/.github/workflows/trivy-analysis-scheduled.yaml
+++ b/.github/workflows/trivy-analysis-scheduled.yaml
@@ -4,7 +4,7 @@ on:
   # allow for version to be manually specified under actions page
   workflow_dispatch: {}
   schedule:
-    # Monday 4am EST so as to hope for this to complete prior to a 9 AM check 
+    # Monday 4am EST so as to hope for this to complete prior to a 9 AM check
     - cron: "0 8 * * 1"
 
 env:
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Install Trivy (latest)
         run: |
-          TRIVY_VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/') 
+          TRIVY_VERSION=$(curl --silent "https://api.github.com/repos/aquasecurity/trivy/releases/latest" | grep '"tag_name":' | sed -E 's/.*"v([^"]+)".*/\1/')
           echo Using Trivy v${TRIVY_VERSION}
           wget https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb
           sudo dpkg -i trivy_${TRIVY_VERSION}_Linux-64bit.deb
@@ -37,8 +37,8 @@ jobs:
         env:
           SCAN_DIR: _output/scans
           IMAGE_REGISTRY: quay.io/solo-io
-          # ON_LTS_UPDATE - bump version
-          MIN_SCANNED_VERSION: 'v1.15.0' # ⚠️ you should also change docs-gen.yaml ⚠️
+          # ON_LTS_UPDATE - bump lts version in the repo variables
+          MIN_SCANNED_VERSION: ${{ vars.LATEST_STABLE_MINUS_THREE_BRANCH }}  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
         run: |
           mkdir -p $SCAN_DIR
           make run-security-scan

--- a/changelog/v1.20.0-beta1/bump-lts-in-gha.yaml
+++ b/changelog/v1.20.0-beta1/bump-lts-in-gha.yaml
@@ -1,4 +1,7 @@
 changelog:
 - type: NON_USER_FACING
-  description: GHAs use repo variables for LTS branches
+  description: >-
+    GHAs use repo variables for LTS branches
 
+    skipCI-kube-tests:true
+    skipCI-docs-build:true

--- a/changelog/v1.20.0-beta1/bump-lts-in-gha.yaml
+++ b/changelog/v1.20.0-beta1/bump-lts-in-gha.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: GHAs use repo variables for LTS branches
+


### PR DESCRIPTION
# Description

Github Actions use Repo variables when referencing LTS branches
This makes life easier for devs by just changing the repo variable whenever a new lts branch is cut rather than modifying individual GHAs

1.19 -> https://github.com/solo-io/gloo/actions/runs/14581616584
1.18 -> https://github.com/solo-io/gloo/actions/runs/14581617969
1.17 -> https://github.com/solo-io/gloo/actions/runs/14581619328 