### PR TITLE
gateway2/status: correctly merge parentRefs for routes

### DIFF
--- a/changelog/v1.20.0-beta2/fix-status-merge.yaml
+++ b/changelog/v1.20.0-beta2/fix-status-merge.yaml
@@ -1,0 +1,14 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8230
+    resolvesIssue: false
+    description: |
+      gateway2/status: correctly merge parentRefs for routes
+
+      When a route has multiple parentRefs, the exitsing status
+      merging code does not correctly merge parentRefs belonging
+      to different proxies. As a result, a route with multiple
+      parents does not have both parents in their status during
+      merging of status reports.
+
+      This change fixes it.

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -475,53 +475,7 @@ func (s *ProxySyncer) Init(ctx context.Context, dbg *krt.DebugHandler) error {
 	// here we will merge reports that are per-Proxy to a singleton Report used to persist to k8s on a timer
 	s.statusReport = krt.NewSingleton(func(kctx krt.HandlerContext) *report {
 		proxies := krt.Fetch(kctx, glooProxies)
-		merged := reports.NewReportMap()
-		for _, p := range proxies {
-			// 1. merge GW Reports for all Proxies' status reports
-			maps.Copy(merged.Gateways, p.reportMap.Gateways)
-
-			// 2. merge LS Reports for all Proxies' status reports
-			maps.Copy(merged.ListenerSets, p.reportMap.ListenerSets)
-
-			// 3. merge httproute parentRefs into RouteReports
-			for rnn, rr := range p.reportMap.HTTPRoutes {
-				// if we haven't encountered this route, just copy it over completely
-				old := merged.HTTPRoutes[rnn]
-				if old == nil {
-					merged.HTTPRoutes[rnn] = rr
-					continue
-				}
-				// else, let's merge our parentRefs into the existing map
-				// obsGen will stay as-is...
-				maps.Copy(p.reportMap.HTTPRoutes[rnn].Parents, rr.Parents)
-			}
-
-			// 4. merge tcproute parentRefs into RouteReports
-			for rnn, rr := range p.reportMap.TCPRoutes {
-				// if we haven't encountered this route, just copy it over completely
-				old := merged.TCPRoutes[rnn]
-				if old == nil {
-					merged.TCPRoutes[rnn] = rr
-					continue
-				}
-				// else, let's merge our parentRefs into the existing map
-				// obsGen will stay as-is...
-				maps.Copy(p.reportMap.TCPRoutes[rnn].Parents, rr.Parents)
-			}
-
-			// 5. merge tlsroute parentRefs into RouteReports
-			for rnn, rr := range p.reportMap.TLSRoutes {
-				// if we haven't encountered this route, just copy it over completely
-				old := merged.TLSRoutes[rnn]
-				if old == nil {
-					merged.TLSRoutes[rnn] = rr
-					continue
-				}
-				// else, let's merge our parentRefs into the existing map
-				// obsGen will stay as-is...
-				maps.Copy(p.reportMap.TLSRoutes[rnn].Parents, rr.Parents)
-			}
-		}
+		merged := mergeProxyReports(proxies)
 		return &report{merged}
 	})
 
@@ -549,6 +503,56 @@ func (s *ProxySyncer) Init(ctx context.Context, dbg *krt.DebugHandler) error {
 		s.k8sGwExtensions.KRTExtensions().HasSynced,
 	}
 	return nil
+}
+
+func mergeProxyReports(
+	proxies []glooProxy,
+) reports.ReportMap {
+	merged := reports.NewReportMap()
+	for _, p := range proxies {
+		// 1. merge GW Reports for all Proxies' status reports
+		maps.Copy(merged.Gateways, p.reportMap.Gateways)
+
+		// 2. merge httproute parentRefs into RouteReports
+		for rnn, rr := range p.reportMap.HTTPRoutes {
+			// if we haven't encountered this route, just copy it over completely
+			old := merged.HTTPRoutes[rnn]
+			if old == nil {
+				merged.HTTPRoutes[rnn] = rr
+				continue
+			}
+			// else, this route has already been seen for a proxy, merge this proxy's parents
+			// into the merged report
+			maps.Copy(merged.HTTPRoutes[rnn].Parents, rr.Parents)
+		}
+
+		// 3. merge tcproute parentRefs into RouteReports
+		for rnn, rr := range p.reportMap.TCPRoutes {
+			// if we haven't encountered this route, just copy it over completely
+			old := merged.TCPRoutes[rnn]
+			if old == nil {
+				merged.TCPRoutes[rnn] = rr
+				continue
+			}
+			// else, this route has already been seen for a proxy, merge this proxy's parents
+			// into the merged report
+			maps.Copy(merged.TCPRoutes[rnn].Parents, rr.Parents)
+		}
+
+		for rnn, rr := range p.reportMap.TLSRoutes {
+			// if we haven't encountered this route, just copy it over completely
+			old := merged.TLSRoutes[rnn]
+			if old == nil {
+				merged.TLSRoutes[rnn] = rr
+				continue
+			}
+			// else, this route has already been seen for a proxy, merge this proxy's parents
+			// into the merged report
+			maps.Copy(merged.TLSRoutes[rnn].Parents, rr.Parents)
+		}
+	}
+
+	return merged
 }
 
 func (s *ProxySyncer) Start(ctx context.Context) error {

--- a/projects/gateway2/proxy_syncer/proxy_syncer_test.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer_test.go
@@ -3,10 +3,13 @@ package proxy_syncer
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 
+	"github.com/solo-io/gloo/projects/gateway2/reports"
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 )
 
@@ -64,18 +67,18 @@ func TestIsRouteStatusEqual(t *testing.T) {
 		Parents: []gwv1.RouteParentStatus{
 			{
 				ParentRef: gwv1.ParentReference{
-					Group:     ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:      ptr.To[gwv1.Kind](gwv1.Kind(wellknown.HTTPRouteKind)),
+					Group:     ptr.To(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      ptr.To(gwv1.Kind(wellknown.HTTPRouteKind)),
 					Name:      "parent",
-					Namespace: ptr.To[gwv1.Namespace](gwv1.Namespace("default")),
+					Namespace: ptr.To(gwv1.Namespace("default")),
 				},
 			},
 			{
 				ParentRef: gwv1.ParentReference{
-					Group:     ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:      ptr.To[gwv1.Kind](gwv1.Kind(wellknown.TCPRouteKind)),
+					Group:     ptr.To(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      ptr.To(gwv1.Kind(wellknown.TCPRouteKind)),
 					Name:      "parent",
-					Namespace: ptr.To[gwv1.Namespace](gwv1.Namespace("default")),
+					Namespace: ptr.To(gwv1.Namespace("default")),
 				},
 			},
 		},
@@ -85,18 +88,18 @@ func TestIsRouteStatusEqual(t *testing.T) {
 		Parents: []gwv1.RouteParentStatus{
 			{
 				ParentRef: gwv1.ParentReference{
-					Group:     ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:      ptr.To[gwv1.Kind](gwv1.Kind(wellknown.HTTPRouteKind)),
+					Group:     ptr.To(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      ptr.To(gwv1.Kind(wellknown.HTTPRouteKind)),
 					Name:      "parent",
-					Namespace: ptr.To[gwv1.Namespace](gwv1.Namespace("default")),
+					Namespace: ptr.To(gwv1.Namespace("default")),
 				},
 			},
 			{
 				ParentRef: gwv1.ParentReference{
-					Group:     ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:      ptr.To[gwv1.Kind](gwv1.Kind(wellknown.TCPRouteKind)),
+					Group:     ptr.To(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      ptr.To(gwv1.Kind(wellknown.TCPRouteKind)),
 					Name:      "parent",
-					Namespace: ptr.To[gwv1.Namespace](gwv1.Namespace("default")),
+					Namespace: ptr.To(gwv1.Namespace("default")),
 				},
 			},
 		},
@@ -106,18 +109,18 @@ func TestIsRouteStatusEqual(t *testing.T) {
 		Parents: []gwv1.RouteParentStatus{
 			{
 				ParentRef: gwv1.ParentReference{
-					Group:     ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:      ptr.To[gwv1.Kind](gwv1.Kind(wellknown.HTTPRouteKind)),
+					Group:     ptr.To(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      ptr.To(gwv1.Kind(wellknown.HTTPRouteKind)),
 					Name:      "parent",
-					Namespace: ptr.To[gwv1.Namespace](gwv1.Namespace("my-other-ns")),
+					Namespace: ptr.To(gwv1.Namespace("my-other-ns")),
 				},
 			},
 			{
 				ParentRef: gwv1.ParentReference{
-					Group:     ptr.To[gwv1.Group](gwv1.Group(wellknown.GatewayGroup)),
-					Kind:      ptr.To[gwv1.Kind](gwv1.Kind(wellknown.TCPRouteKind)),
+					Group:     ptr.To(gwv1.Group(wellknown.GatewayGroup)),
+					Kind:      ptr.To(gwv1.Kind(wellknown.TCPRouteKind)),
 					Name:      "parent",
-					Namespace: ptr.To[gwv1.Namespace](gwv1.Namespace("my-other-ns")),
+					Namespace: ptr.To(gwv1.Namespace("my-other-ns")),
 				},
 			},
 		},
@@ -184,6 +187,143 @@ func TestIsListenerSetStatusEqual(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := isListenerSetStatusEqual(tt.objA, tt.objB); got != tt.want {
 				t.Errorf("isListenerSetStatusEqual() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMergeProxyReports(t *testing.T) {
+	tests := []struct {
+		name     string
+		proxies  []glooProxy
+		expected reports.ReportMap
+	}{
+		{
+			name: "Merge HTTPRoute reports for different parents",
+			proxies: []glooProxy{
+				{
+					reportMap: reports.ReportMap{
+						HTTPRoutes: map[types.NamespacedName]*reports.RouteReport{
+							{Name: "route1", Namespace: "default"}: {
+								Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+									{NamespacedName: types.NamespacedName{Name: "gw-1", Namespace: "default"}}: {},
+								},
+							},
+						},
+					},
+				},
+				{
+					reportMap: reports.ReportMap{
+						HTTPRoutes: map[types.NamespacedName]*reports.RouteReport{
+							{Name: "route1", Namespace: "default"}: {
+								Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+									{NamespacedName: types.NamespacedName{Name: "gw-2", Namespace: "default"}}: {},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: reports.ReportMap{
+				HTTPRoutes: map[types.NamespacedName]*reports.RouteReport{
+					{Name: "route1", Namespace: "default"}: {
+						Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+							{NamespacedName: types.NamespacedName{Name: "gw-1", Namespace: "default"}}: {},
+							{NamespacedName: types.NamespacedName{Name: "gw-2", Namespace: "default"}}: {},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Merge TCPRoute reports for different parents",
+			proxies: []glooProxy{
+				{
+					reportMap: reports.ReportMap{
+						TCPRoutes: map[types.NamespacedName]*reports.RouteReport{
+							{Name: "route1", Namespace: "default"}: {
+								Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+									{NamespacedName: types.NamespacedName{Name: "gw-1", Namespace: "default"}}: {},
+								},
+							},
+						},
+					},
+				},
+				{
+					reportMap: reports.ReportMap{
+						TCPRoutes: map[types.NamespacedName]*reports.RouteReport{
+							{Name: "route1", Namespace: "default"}: {
+								Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+									{NamespacedName: types.NamespacedName{Name: "gw-2", Namespace: "default"}}: {},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: reports.ReportMap{
+				TCPRoutes: map[types.NamespacedName]*reports.RouteReport{
+					{Name: "route1", Namespace: "default"}: {
+						Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+							{NamespacedName: types.NamespacedName{Name: "gw-1", Namespace: "default"}}: {},
+							{NamespacedName: types.NamespacedName{Name: "gw-2", Namespace: "default"}}: {},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "Merge TLSRoute reports for different parents",
+			proxies: []glooProxy{
+				{
+					reportMap: reports.ReportMap{
+						TLSRoutes: map[types.NamespacedName]*reports.RouteReport{
+							{Name: "route1", Namespace: "default"}: {
+								Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+									{NamespacedName: types.NamespacedName{Name: "gw-1", Namespace: "default"}}: {},
+								},
+							},
+						},
+					},
+				},
+				{
+					reportMap: reports.ReportMap{
+						TLSRoutes: map[types.NamespacedName]*reports.RouteReport{
+							{Name: "route1", Namespace: "default"}: {
+								Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+									{NamespacedName: types.NamespacedName{Name: "gw-2", Namespace: "default"}}: {},
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: reports.ReportMap{
+				TLSRoutes: map[types.NamespacedName]*reports.RouteReport{
+					{Name: "route1", Namespace: "default"}: {
+						Parents: map[reports.ParentRefKey]*reports.ParentRefReport{
+							{NamespacedName: types.NamespacedName{Name: "gw-1", Namespace: "default"}}: {},
+							{NamespacedName: types.NamespacedName{Name: "gw-2", Namespace: "default"}}: {},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := assert.New(t)
+
+			actual := mergeProxyReports(tt.proxies)
+			if tt.expected.HTTPRoutes != nil {
+				a.Equal(tt.expected.HTTPRoutes, actual.HTTPRoutes)
+			}
+			if tt.expected.TCPRoutes != nil {
+				a.Equal(tt.expected.TCPRoutes, actual.TCPRoutes)
+			}
+			if tt.expected.TLSRoutes != nil {
+				a.Equal(tt.expected.TLSRoutes, actual.TLSRoutes)
 			}
 		})
 	}

--- a/projects/gateway2/reports/reporter.go
+++ b/projects/gateway2/reports/reporter.go
@@ -299,6 +299,17 @@ func getParentRefKey(parentRef *gwv1.ParentReference) ParentRefKey {
 	}
 }
 
+// getParentRefOrNil returns a ParentRefReport for the given parentRef if and only if
+// that parentRef exists in the report (i.e. the parentRef was encountered during translation)
+// If no report is found, nil is returned, signaling this parentRef is unknown to the report
+func (r *RouteReport) getParentRefOrNil(parentRef *gwv1.ParentReference) *ParentRefReport {
+	key := getParentRefKey(parentRef)
+	if r.Parents == nil {
+		r.Parents = make(map[ParentRefKey]*ParentRefReport)
+	}
+	return r.Parents[key]
+}
+
 func (r *RouteReport) parentRef(parentRef *gwv1.ParentReference) *ParentRefReport {
 	key := getParentRefKey(parentRef)
 	if r.Parents == nil {


### PR DESCRIPTION
Crossport of https://github.com/kgateway-dev/kgateway/pull/11130
---
When a route has multiple parentRefs, the exitsing status merging code does not correctly merge parentRefs belonging to different proxies. As a result, a route with multiple parents does not have both parents in their status during merging of status reports.
This change fixes it.

It also ensures we do not generate status reports for refs not in ReportsMap as the ref could contain parentRef pointing to Gateways we do not manage.
