### PR TITLE
[1.19] ci: Add missing tests to PR runs

### DIFF
--- a/.github/workflows/pr-kubernetes-tests.yaml
+++ b/.github/workflows/pr-kubernetes-tests.yaml
@@ -60,7 +60,7 @@ jobs:
         # 2025-03-24: 23m7s
         - cluster-name: 'cluster-one'
           go-test-args: '-v -timeout=25m'
-          go-test-run-regex: '^TestK8sGateway$$/^RouteDelegation$$|^TestGlooctlGlooGatewayEdgeGateway$$|^TestGlooctlK8sGateway$$|^TestK8sGateway$$/^HTTPTunnel$$|^TestListenerSet$$|^TestK8sGateway$$/^AccessLog$$'
+          go-test-run-regex: '^TestK8sGateway$$/^RouteDelegation$$|^TestGlooctlGlooGatewayEdgeGateway$$|^TestGlooctlK8sGateway$$|^TestK8sGateway$$/^HTTPTunnel$$|^TestListenerSet$$|^TestK8sGateway$$/^AccessLog$$|^TestK8sGateway$$/^ServerTls$$|^TestK8sGateway$$/^Tracing$$'
 
         # 2024-12-04: 23m
         # 2025-02-13: 30m30s

--- a/changelog/v1.19.0-rc6/add-missing-pr-tests.yaml
+++ b/changelog/v1.19.0-rc6/add-missing-pr-tests.yaml
@@ -1,0 +1,4 @@
+changelog:
+- type: NON_USER_FACING
+  description: Add missing test to PR runs
+


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/10829

Add missing test to PR runs. This was done by comparing the tests run in our nightlies vs. on PRs
I couldn't find a reason why they were removed from PR runs so I assume that they were never added when written