### PR TITLE
[1.19] fix: gloo_solo_io_namespaces_watched metrics error

### DIFF
--- a/changelog/v1.19.1/fix-watch-ns-metric.yaml
+++ b/changelog/v1.19.1/fix-watch-ns-metric.yaml
@@ -1,0 +1,6 @@
+changelog:
+- tyoe: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/8319
+  resolvesIssue: false
+  description: Fix a bug in the gloo_solo_io_namespaces_watched metric that errors when the list of namespaces watched is large.
+

--- a/changelog/v1.19.1/fix-watch-ns-metric.yaml
+++ b/changelog/v1.19.1/fix-watch-ns-metric.yaml
@@ -1,5 +1,5 @@
 changelog:
-- tyoe: FIX
+- type: FIX
   issueLink: https://github.com/solo-io/solo-projects/issues/8319
   resolvesIssue: false
   description: Fix a bug in the gloo_solo_io_namespaces_watched metric that errors when the list of namespaces watched is large.

--- a/pkg/utils/setuputils/setup_syncer.go
+++ b/pkg/utils/setuputils/setup_syncer.go
@@ -65,14 +65,12 @@ func (s *SetupSyncer) Sync(ctx context.Context, snap *v1.SetupSnapshot) error {
 	}
 
 	watchedNamespaces := settingsutil.GetNamespacesToWatch(settings)
-	contextutils.LoggerFrom(ctx).Debugw("received updated list of namespaces to watch", zap.Any("namespaces", watchedNamespaces))
+	contextutils.LoggerFrom(ctx).Debugw("received updated list of namespaces to watch", zap.Any("namespaces", strings.Join(watchedNamespaces, ",")))
 
-	watchedNamespacesStr := strings.Join(watchedNamespaces, ",")
 	statsutils.Measure(
 		ctx,
 		mNamespacesWatched,
 		int64(len(watchedNamespaces)),
-		tag.Insert(namespacesWatchedKey, watchedNamespacesStr),
 	)
 
 	statsutils.MeasureOne(


### PR DESCRIPTION
# Description

Backport of https://github.com/solo-io/gloo/pull/10852

Fix a bug in the gloo_solo_io_namespaces_watched metric that errors when the list of namespaces watched is large.