### PR TITLE
Updating discovery docs

### DIFF
--- a/changelog/v1.20.0-beta3/docs-discovery.yaml
+++ b/changelog/v1.20.0-beta3/docs-discovery.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update docs for discovery disabled by default.
+
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/docs/content/guides/graphql/getting_started/setup.md
+++ b/docs/content/guides/graphql/getting_started/setup.md
@@ -29,12 +29,12 @@ Enable GraphQL functionality in your Gloo Gateway installation.
 
 ## Step 2: Enable API spec discovery for upstreams
 
-To allow Gloo Gateway to automatically discover API specifications, turn on FDS discovery. When discovery is enabled, Gloo Gateway automatically creates `graphqlapi` resources based on the discovered specifications. Discovery is supported for gRPC, OpenAPI, and GraphQL server upstreams.
+To allow Gloo Gateway to automatically discover API specifications, turn on Function Discovery Service (FDS) discovery. When discovery is enabled, Gloo Gateway automatically creates `graphqlapi` resources based on the discovered specifications. Discovery is supported for gRPC, OpenAPI, and GraphQL server upstreams.
+
+Note that this setting enables discovery for all upstreams. To enable discovery for only specified upstreams, see the [FDS guide]({{< versioned_link_path fromRoot="/installation/advanced_configuration/fds_mode/" >}}).
 
 ```sh
-kubectl patch settings -n gloo-system default --type=merge --patch '{"spec":{"discovery":{"fdsMode":"BLACKLIST"}}}'
+kubectl patch settings -n gloo-system default --type=merge --patch '{"spec":{"discovery":{"fdsMode":"BLACKLIST","enabled":true}}}'
 ```
-
-Note that this setting enables discovery for all upstreams. To enable discovery for only specified upstreams, see the [Function Discovery Service (FDS) guide]({{% versioned_link_path fromRoot="/installation/advanced_configuration/fds_mode/#function-discovery-service-fds" %}}).
 
 **Up next**: [Explore basic GraphQL service discovery with the Pet Store sample application.]({{% versioned_link_path fromRoot="/guides/graphql/getting_started/simple_discovery" %}})

--- a/docs/content/installation/advanced_configuration/fds_mode.md
+++ b/docs/content/installation/advanced_configuration/fds_mode.md
@@ -1,14 +1,149 @@
 ---
-title: Configuring Function Discovery
+title: Configuring Discovery
 weight: 10
-description: Using automatic function discovery (ie, discovering and understanding Swagger/OAS docs or gRPC reflection)
+description: Set up automatic discovery for upstreams and functions. automatic function discovery.
 ---
 
-Gloo Gateway's **Function Discovery Service** (FDS) attempts to poll endpoints for:
+Gloo Gateway supports automatically discovering upstreams and functions. 
+
+{{% notice note %}}
+Because discovery is a resource-intensive process, both discovery services are disabled by default.
+{{% /notice %}}
+
+As a quick reference, you can enable both UDS and FDS with the following Helm values. For more options, continue to the following sections.
+
+```yaml
+settings:
+  create: true
+
+discovery:
+  enabled: true
+  fdsMode: WHITELIST
+```
+
+## Upstream Discovery Service (UDS) {#uds}
+
+Gloo Gateway can automatically create Upstream resources for Kubernetes services that it detects in your cluster. The Upstream is created in the namespace that you configure in the `discoveryNamespace` setting, which is `gloo-system` by default.
+
+### Upstream names
+
+The name of the Upstream is based on the name, namespace, and port of the service that it refers to, in the following format: 
+
+```
+<service-namespace>-<service-name>-<service-port>
+```
+
+For example, if you have a Pet Store service in the `default` namespace that listens on port `8080`, the discovered Upstream gets the follwing name:
+
+```
+default-petstore-8080
+```
+
+To list discovered Upstreams, run the following command:
+
+```
+glooctl get upstreams -n gloo-system
+```
+
+Example output:
+
+```
++-----------------------+------------+----------+-------------------------+
+|       UPSTREAM        |    TYPE    |  STATUS  |         DETAILS         |
++-----------------------+------------+----------+-------------------------+
+| default-petstore-8080 | Kubernetes | Accepted | svc name:      petstore |
+|                       |            |          | svc namespace: default  |
+|                       |            |          | port:          8080     |
+|                       |            |          | REST service:           |
+|                       |            |          | functions:              |
+|                       |            |          | - addPet                |
+|                       |            |          | - deletePet             |
+|                       |            |          | - findPetById           |
+|                       |            |          | - findPets              |
+|                       |            |          |                         |
++-----------------------+------------+----------+-------------------------+
+```
+
+
+### Enable UDS mode
+
+You can enable UDS mode with Helm or the Settings CR in the `gloo-system` namespace.
+
+{{< tabs >}} 
+{{% tab name="Helm values file" %}}
+Add the `discovery.enabled=true` setting to your Helm overrides file:
+
+```yaml
+settings:
+  create: true
+
+discovery:
+  enabled: true
+```
+{{% /tab %}}
+
+{{% tab name="Helm CLI" %}}
+Add the following CLI flags to `helm install|template` commands:
+
+```bash
+helm install|template ... --set settings.create=true --set discovery.enabled=true
+```
+{{% /tab %}}
+
+{{% tab name="Settings CR" %}}
+Enable `fdsMode` by editing the `gloo.solo.io/v1.Settings` custom resource to add the `discovery.enabled=true` setting.
+
+```bash
+kubectl edit -n gloo-system settings.gloo.solo.io
+```
+
+Example Settings CR:
+```yaml
+# Please edit the object below. Lines beginning with a '#' will be ignored,
+# and an empty file will abort the edit. If an error occurs while saving this file will be
+# reopened with the relevant failures.
+#
+apiVersion: gloo.solo.io/v1
+kind: Settings
+metadata:
+  labels:
+    app: gloo
+    gloo: settings
+  name: default
+  namespace: gloo-system
+spec:
+  bindAddr: 0.0.0.0:9977
+  discoveryNamespace: gloo-system
+  kubernetesArtifactSource: {}
+  kubernetesConfigSource: {}
+  kubernetesSecretSource: {}
+  refreshRate: 60s
+  # add the following lines
+  discovery:
+    enabled: true
+```
+{{% /tab %}} 
+{{< /tabs >}}
+
+### More information about UDS {#more-info}
+
+For more information, check out the following guides:
+
+* [Discovered Upstreams]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/discovered_upstream/" >}})
+* [Configuration via Annotations]({{< versioned_link_path fromRoot="/guides/traffic_management/destination_types/discovered_upstream/discovered-upstream-configuration/" >}})
+
+---
+
+## Function Discovery Service (FDS) {#fds}
+
+The **Function Discovery Service** (FDS) discovers and understands the OpenAPI Spec (OAS, formerly known as Swagger) or gRPC endpoints of the Upstreams in your cluster.
+
+### Evaluated endpoints
+
+When enabled, FDS attempts to poll endpoints for:
 
 * A path serving an [OpenAPI (Swagger) document](https://swagger.io/specification/).
 * gRPC Services with [gRPC Reflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) enabled.
-
 
 The default endpoints evaluated for `swagger` or `OpenAPISpec` docs are:
 
@@ -48,13 +183,7 @@ spec:
 
 {{< /highlight >}}
 
-{{% notice note %}}
-
-Note, Function Discovery needs to be enabled for this to work. See the next sections.
-
-{{% /notice %}}
-
-## Function Discovery Service (FDS)
+### How FDS works
 
 Using FDS means that the Gloo Gateway `discovery` component will make HTTP requests to all `Upstreams` known to Gloo Gateway trying to discover functions. This behavior causes increased network traffic and may be undesirable if it causes unexpected behavior or logs to appear in the services Gloo Gateway is attempting to poll. For this reason, we may want to restrict the manner in which FDS polls services.
 
@@ -62,23 +191,16 @@ Gloo Gateway allows whitelisting/blacklisting services, either by namespace or o
 
 We can use these configuration settings to restrict FDS to discover only the namespaces or individual services we choose.
 
----
+### Enable FDS mode
 
-## Configuring the `fdsMode` Setting
+You can enable FDS mode with Helm or the Settings CR in the `gloo-system` namespace.
 
-FDS can run in one of 3 modes:
+**Enterprise-only**: Automated schema generation for GraphQL is enabled by default. This can be disabled by modifying the `gloo.solo.io/v1.Settings` custom resource as shown in the following tabs.
 
-* `BLACKLIST`: The most liberal FDS polling policy. Using this mode, FDS will poll any service unless its namespace or the service itself is explicitly blacklisted.
-* `WHITELIST`: A more restricted FDS polling policy. Using this mode, FDS will poll only those services who either live in an explicitly whitelisted namespace, or themselves are are explicitly whitelisted. *`WHITELIST` is the default mode for FDS*.
-* `DISABLED`: FDS will not run. **Upstream Discovery Service** (UDS) will still run as normal.
+{{< tabs >}} 
+{{% tab name="Helm values file" %}}
+Add the `discovery.fdsMode` setting to your Helm overrides file:
 
-Setting the `fdsMode` can be done either via the Helm Chart, or by directly modifying the `default` `gloo.solo.io/v1.Settings` custom resource in Gloo Gateway's installation namespace (`gloo-system`).
-
-(Enterprise Only) Automated schema generation for GraphQL is enabled by default. This can be disabled by modifying the `gloo.solo.io/v1.Settings` custom resource as seen [below](#setting-fdsmode-by-editing-the-gloosoloiov1settings-custom-resource)
-
-### Setting `fdsMode` via the Helm chart
-
-Add the following to your Helm overrides file:
 ```yaml
 settings:
   create: true
@@ -88,19 +210,25 @@ discovery:
   # WHITELIST is the default value
   fdsMode: BLACKLIST
 ```
+{{% /tab %}}
 
-Or add the following CLI flags to `helm install|template` commands:
+{{% tab name="Helm CLI" %}}
+Add the following CLI flags to `helm install|template` commands:
 
 ```bash
 helm install|template ... --set settings.create=true --set discovery.fdsMode=BLACKLIST
 ```
+{{% /tab %}}
 
-### Setting `fdsMode` by editing the `gloo.solo.io/v1.Settings` custom resource:
+{{% tab name="Settings CR" %}}
+Enable `fdsMode` by editing the `gloo.solo.io/v1.Settings` custom resource to add the `discovery.fdsMode` setting.
 
 ```bash
 kubectl edit -n gloo-system settings.gloo.solo.io
 ```
-{{< highlight yaml "hl_lines=20-28" >}}
+
+Example Settings CR:
+```yaml
 # Please edit the object below. Lines beginning with a '#' will be ignored,
 # and an empty file will abort the edit. If an error occurs while saving this file will be
 # reopened with the relevant failures.
@@ -126,14 +254,22 @@ spec:
     # WHITELIST is the default value
     fdsMode: WHITELIST
     fdsOptions:
-      # set to false to disable automated GraphQL schema generation as part of FDS.
+      # Enterprise-only: set to false to disable automated GraphQL schema generation as part of FDS.
       # true is the default value (enabled)
       graphqlEnabled: true
-{{< /highlight >}}
+```
+{{% /tab %}} 
+{{< /tabs >}}
 
----
+### FDS modes
 
-## Blacklisting Namespaces & Upstreams
+FDS can run in one of 3 modes:
+
+* `BLACKLIST`: The most liberal FDS polling policy. Using this mode, FDS will poll any service unless its namespace or the service itself is explicitly blacklisted.
+* `WHITELIST`: A more restricted FDS polling policy. Using this mode, FDS will poll only those services who either live in an explicitly whitelisted namespace, or themselves are are explicitly whitelisted. *`WHITELIST` is the default mode for FDS*.
+* `DISABLED`: FDS will not run. **Upstream Discovery Service** (UDS) will still run as normal.
+
+### Blacklisting namespaces and upstreams
 
 When running in `BLACKLIST` mode, blacklist upstreams by adding the following label:
 
@@ -156,9 +292,7 @@ To enable FDS for specific upstreams in a blacklisted namespace:
 
 `discovery.solo.io/function_discovery=enabled`
 
----
-
-## Whitelisting Namespaces & Upstreams
+### Whitelisting namespaces and upstreams
 
 When running in `WHITELIST` mode, whitelist `Upstreams` by adding the following label:
 

--- a/docs/content/static/content/setup_notes
+++ b/docs/content/static/content/setup_notes
@@ -1,8 +1,6 @@
-This guide assumes that you have deployed Gloo to the `gloo-system` namespace and that the `glooctl` command line utility
-is installed on your machine. `glooctl` provides several convenient functions to view, manipulate, and debug Gloo resources;
-in particular, it is worth mentioning the following command, which we will use each time we need to retrieve the URL of
-the Gloo Gateway that is running inside your cluster:
+Before you begin, this guide assumes that you have the following setup.
 
-```shell
-glooctl proxy url
-```
+1. [Install Gloo Gateway]({{< versioned_link_path fromRoot="/installation/gateway/kubernetes" >}}) in the `gloo-system` namespace.
+2. Enable [discovery mode for Gloo Gateway]({{< versioned_link_path fromRoot="/installation/advanced_configuration/fds_mode/" >}}). If not, make sure that you created any Upstream resources with the appropriate functions.
+3. Install the `glooctl` command line tool.
+4. Identify the URL of the gateway proxy that you want to use for this guide, such as with the `glooctl proxy` command. Note that if you are testing in a local cluster such as Kind, you must use the custom localhost port that you configured instead of `glooctl proxy`, such as `http://localhost:31500`.


### PR DESCRIPTION
# Description

## Doc changes
In Edge 1.20+ discovery disabled by default. This PR updates several guides as well as a prereq note that is reused across other guides.

## Context

* Slack [here](https://solo-io-corp.slack.com/archives/C03MFATU265/p1747931431385549)
* Dev issue: https://github.com/solo-io/solo-projects/issues/7292 / Dev PR: https://github.com/solo-io/gloo/pull/10849

## Checklist:

- [ ] N/A - I have performed a self-review of my own code
- [ ] N/A - I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] N/A - I have added tests that prove my fix is effective or that my feature works