### PR TITLE
plugins/hcm: resolve UuidRequestIdConfig leading to NACK

### DIFF
--- a/changelog/v1.20.0-beta4/uuid-request.yaml
+++ b/changelog/v1.20.0-beta4/uuid-request.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink:
+    resolvesIssue: false
+    description: >-
+      ""

--- a/changelog/v1.20.0-beta4/uuid-request.yaml
+++ b/changelog/v1.20.0-beta4/uuid-request.yaml
@@ -1,6 +1,8 @@
 changelog:
   - type: FIX
-    issueLink:
+    issueLink: https://github.com/solo-io/solo-projects/issues/8354
     resolvesIssue: false
     description: >-
-      ""
+      Setting the `uuidRequestIdConfig` in the `HttpConnectionManagerSettings` now correctly sets the `RequestIdExtension` in the `HttpConnectionManager` filter.
+
+      Previously, setting the `uuidRequestIdConfig` in the `HttpConnectionManagerSettings` would lead to the listener being rejected with the error `Didn't find a registered implementation for type: 'hcm.options.gloo.solo.io.HttpConnectionManagerSettings.UuidRequestIdConfigSettings'`.

--- a/projects/gloo/pkg/plugins/hcm/plugin_test.go
+++ b/projects/gloo/pkg/plugins/hcm/plugin_test.go
@@ -189,7 +189,6 @@ var _ = Describe("Plugin", func() {
 		typedConfigOutput := &envoyuuid.UuidRequestIdConfig{}
 		err = cfg.RequestIdExtension.GetTypedConfig().UnmarshalTo(typedConfigOutput)
 		Expect(err).NotTo(HaveOccurred())
-		// Expect(typedConfigOutput).To(MatchProto(settings.UuidRequestIdConfig))
 		Expect(typedConfigOutput.GetPackTraceReason().GetValue()).To(Equal(settings.UuidRequestIdConfig.GetPackTraceReason().GetValue()))
 		Expect(typedConfigOutput.GetUseRequestIdForTraceSampling().GetValue()).To(Equal(settings.UuidRequestIdConfig.GetUseRequestIdForTraceSampling().GetValue()))
 

--- a/projects/gloo/pkg/plugins/hcm/plugin_test.go
+++ b/projects/gloo/pkg/plugins/hcm/plugin_test.go
@@ -14,6 +14,7 @@ import (
 
 	envoycore "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	envoyuuid "github.com/envoyproxy/go-control-plane/envoy/extensions/request_id/uuid/v3"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -185,10 +186,12 @@ var _ = Describe("Plugin", func() {
 		Expect(cfg.Tracing).To(BeNil())
 
 		// Expect the UUID request ID config to be set through request_id_extension
-		typedConfigOutput := &hcm.HttpConnectionManagerSettings_UuidRequestIdConfigSettings{}
+		typedConfigOutput := &envoyuuid.UuidRequestIdConfig{}
 		err = cfg.RequestIdExtension.GetTypedConfig().UnmarshalTo(typedConfigOutput)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(typedConfigOutput).To(MatchProto(settings.UuidRequestIdConfig))
+		// Expect(typedConfigOutput).To(MatchProto(settings.UuidRequestIdConfig))
+		Expect(typedConfigOutput.GetPackTraceReason().GetValue()).To(Equal(settings.UuidRequestIdConfig.GetPackTraceReason().GetValue()))
+		Expect(typedConfigOutput.GetUseRequestIdForTraceSampling().GetValue()).To(Equal(settings.UuidRequestIdConfig.GetUseRequestIdForTraceSampling().GetValue()))
 
 		Expect(cfg.UpgradeConfigs).To(HaveLen(1))
 		Expect(cfg.UpgradeConfigs[0].UpgradeType).To(Equal("websocket"))

--- a/test/e2e/hcm_test.go
+++ b/test/e2e/hcm_test.go
@@ -59,7 +59,7 @@ var _ = Describe("HttpConnectionManagerSettings", func() {
 				logs, err := testContext.EnvoyInstance().Logs()
 				g.Expect(err).NotTo(HaveOccurred())
 				g.Expect(logs).NotTo(ContainSubstring("Didn't find a registered implementation"))
-			})
+			}).Should(Succeed())
 		})
 	})
 })

--- a/test/e2e/hcm_test.go
+++ b/test/e2e/hcm_test.go
@@ -1,0 +1,65 @@
+package e2e_test
+
+import (
+	"github.com/golang/protobuf/ptypes/wrappers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	gatewaydefaults "github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/hcm"
+
+	"github.com/solo-io/gloo/test/e2e"
+)
+
+var _ = Describe("HttpConnectionManagerSettings", func() {
+
+	var (
+		testContext *e2e.TestContext
+	)
+
+	BeforeEach(func() {
+		testContext = testContextFactory.NewTestContext()
+		testContext.BeforeEach()
+	})
+
+	AfterEach(func() {
+		testContext.AfterEach()
+	})
+
+	JustBeforeEach(func() {
+		testContext.JustBeforeEach()
+	})
+
+	JustAfterEach(func() {
+		testContext.JustAfterEach()
+	})
+
+	Context("UuidRequestIdConfig", func() {
+
+		BeforeEach(func() {
+			gw := gatewaydefaults.DefaultGateway(writeNamespace)
+			gw.GetHttpGateway().Options = &gloov1.HttpListenerOptions{
+				HttpConnectionManagerSettings: &hcm.HttpConnectionManagerSettings{
+					UuidRequestIdConfig: &hcm.HttpConnectionManagerSettings_UuidRequestIdConfigSettings{
+						PackTraceReason:              &wrappers.BoolValue{Value: true},
+						UseRequestIdForTraceSampling: &wrappers.BoolValue{Value: true},
+					},
+				},
+			}
+
+			testContext.ResourcesToCreate().Gateways = gatewayv1.GatewayList{
+				gw,
+			}
+		})
+
+		It("does not lead to error in logs", func() {
+			Consistently(func(g Gomega) {
+				logs, err := testContext.EnvoyInstance().Logs()
+				g.Expect(err).NotTo(HaveOccurred())
+				g.Expect(logs).NotTo(ContainSubstring("Didn't find a registered implementation"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
# Description
Setting the UuidRequestIdConfig on the HCM configuration should result in the values properly updated according to Envoy

# Context
The original PR that added this is: https://github.com/kgateway-dev/kgateway/pull/6140

The issue is that the Envoy API expects an Any type. This means that the typed URL is baked into that object, and Envoy relies on that type URL to unmarshal the resource at runtime. As indicated by the error, the type we were creating was one that was specific to Solo, and not Envoy. 

To resolve this, I used the proper upstream type.

## Interesting decisions
-

## Testing steps
- I updated  the unit tests to prove this works. This alone doesn't guarantee the fix, it just proves that we're not converting the output config to an envoy type
- I also wrote a basic integration test to prove that configuring the API does not lead to NACK's

## Notes for reviewers
-


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works