### PR TITLE
[Docs workflow] Add tag output to event receiver job

### DIFF
--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       dispatch_lts: ${{ steps.dispatch-receiver.outputs.dispatch_lts }}
+      dispatch_tag: ${{ steps.dispatch-receiver.outputs.dispatch_tag }}
     steps:
       - name: The glooe-release-created event is received when a relase is cut in solo-projects repo
         id: dispatch-receiver

--- a/changelog/v1.20.0-beta5/doc-fixes-1.yaml
+++ b/changelog/v1.20.0-beta5/doc-fixes-1.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Push-docs workflow fixes.
+
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
Add the tag of the release-cut event to the output of the event receiver job of the push-docs workflow. This release tag is used later in the `Bump version conrefs` step of the next job.