### PR TITLE
Updates

### DIFF
--- a/changelog/v1.20.0-beta5/main.yaml
+++ b/changelog/v1.20.0-beta5/main.yaml
@@ -1,0 +1,4 @@
+changelog:
+  - type: NON_USER_FACING
+    description: >-
+      Update watch namespace test to use port 443 for upstream host to avoid inconsistent http behavior

--- a/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
+++ b/test/kubernetes/e2e/features/watch_namespace_selector/suite.go
@@ -47,23 +47,23 @@ func (s *testingSuite) TestMatchExpressions() {
 
 func (s *testingSuite) testWatchNamespaceSelector(key, value string) {
 	// Ensure the install namespace is watched even if not specified
-	s.TestInstallation.Assertions.CurlEventuallyRespondsWithStatus(s.Ctx, "install-ns/", http.StatusOK)
+	s.TestInstallation.AssertionsT(s.T()).CurlEventuallyRespondsWithStatus(s.Ctx, "install-ns/", http.StatusOK)
 
 	// Ensure the namespace is not watched
 	s.TestInstallation.Actions.Kubectl().Execute(s.Ctx, "label", "ns", "random", key+"-")
 
 	// Ensure CRs defined in non watched-namespaces are not translated
-	s.TestInstallation.Assertions.CurlEventuallyRespondsWithStatus(s.Ctx, "random/", http.StatusNotFound)
+	s.TestInstallation.AssertionsT(s.T()).CurlEventuallyRespondsWithStatus(s.Ctx, "random/", http.StatusNotFound)
 
 	s.labelSecondNamespaceAsWatched(key, value)
 
 	// The VS defined in the random namespace should be translated
-	s.TestInstallation.Assertions.CurlEventuallyRespondsWithStatus(s.Ctx, "random/", http.StatusOK)
+	s.TestInstallation.AssertionsT(s.T()).CurlEventuallyRespondsWithStatus(s.Ctx, "random/", http.StatusOK)
 
 	s.unwatchNamespace(key)
 
 	// Ensure CRs defined in non watched-namespaces are not translated
-	s.TestInstallation.Assertions.CurlConsistentlyRespondsWithStatus(s.Ctx, "random/", http.StatusNotFound)
+	s.TestInstallation.AssertionsT(s.T()).CurlConsistentlyRespondsWithStatus(s.Ctx, "random/", http.StatusNotFound)
 }
 
 func (s *testingSuite) TestUnwatchedNamespaceValidation() {
@@ -80,6 +80,7 @@ func (s *testingSuite) TestUnwatchedNamespaceValidation() {
 }
 
 func (s *testingSuite) TestWatchedNamespaceValidation() {
+	const testUrl = "postman-echo.com/get"
 	s.applyFile(unlabeledRandomNamespaceManifest)
 	s.applyFile(randomUpstreamManifest)
 
@@ -95,7 +96,7 @@ func (s *testingSuite) TestWatchedNamespaceValidation() {
 	}, time.Minute*2, time.Second*10)
 
 	// The upstream defined in the random namespace should be translated and referenced
-	s.TestInstallation.Assertions.CurlEventuallyRespondsWithStatus(s.Ctx, "/get", http.StatusOK)
+	s.TestInstallation.AssertionsT(s.T()).CurlEventuallyRespondsWithStatus(s.Ctx, testUrl, http.StatusOK)
 
 	// Trying to unwatch the namespace that has an upstream referenced in another namespace leads to an error
 	_, errOut, err := s.TestInstallation.Actions.Kubectl().Execute(s.Ctx, "label", "ns", "random", "label-")
@@ -119,7 +120,7 @@ func (s *testingSuite) TestWatchedNamespaceValidation() {
 	s.unwatchNamespace("label")
 
 	// The upstream defined in the random namespace should be translated and referenced
-	s.TestInstallation.Assertions.CurlEventuallyRespondsWithStatus(s.Ctx, "/get", http.StatusNotFound)
+	s.TestInstallation.AssertionsT(s.T()).CurlEventuallyRespondsWithStatus(s.Ctx, testUrl, http.StatusNotFound)
 
 	// Optimists invent airplanes; pessimists invent parachutes
 	s.addInconsequentialLabelToSecondNamespace()

--- a/test/kubernetes/e2e/features/watch_namespace_selector/testdata/upstream-random.yaml
+++ b/test/kubernetes/e2e/features/watch_namespace_selector/testdata/upstream-random.yaml
@@ -7,5 +7,5 @@ spec:
   static:
     hosts:
     - addr: postman-echo.com
-      port: 80
+      port: 443
 


### PR DESCRIPTION
# Description
Update `TestWatchNamespaceSelector/WatchNamespaceSelector/TestWatchedNamespaceValidation` to use https with postman-echo upstream to avoid test flakes.

Also cleaned up deprecated syntax.

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
