### PR TITLE
[1.18] mod: go@v1.24.4

### DIFF
--- a/changelog/v1.18.22/v1.18.x-go-cloudbuild-update.yaml
+++ b/changelog/v1.18.22/v1.18.x-go-cloudbuild-update.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.24.4
+    description: Update go to version v1.24.4.
+    issueLink: https://github.com/solo-io/solo-projects/issues/8392
+    resolvesIssue: false

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.13.0'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -59,7 +59,7 @@ steps:
     - '-c'
     - 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
   id: 'build-certgen-arm64-binary'
   args:
   - 'certgen-docker'
@@ -68,7 +68,7 @@ steps:
   - 'GOARCH=arm64'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
   id: 'publish-docker'
   args:
   - 'publish-docker'
@@ -94,7 +94,7 @@ steps:
   waitFor:
   - 'publish-docker'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
   id: 'release-chart'
   dir: *dir
   args:
@@ -109,7 +109,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.13.0'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -23,7 +23,7 @@ steps:
     cd /go/pkg
     gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
   id: 'prepare-envoy'
   dir: *dir
   entrypoint: 'bash'
@@ -77,7 +77,7 @@ steps:
   waitFor:
   - 'prepare-gcr-zone'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
   id: 'prepare-test-tools'
   dir: *dir
   args:
@@ -88,7 +88,7 @@ steps:
   - 'prepare-gcr-zone'
   - 'prepare-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.0'
   id: 'run-tests'
   dir: *dir
   entrypoint: 'make'
@@ -99,7 +99,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.0'
   id: 'run-e2e-tests'
   dir: *dir
   entrypoint: 'make'
@@ -110,7 +110,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.12.1'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.0'
   id: 'run-hashicorp-e2e-tests'
   dir: *dir
   entrypoint: 'make'

--- a/cloudbuild-cache.yaml
+++ b/cloudbuild-cache.yaml
@@ -1,6 +1,6 @@
 options:
   env:
-    - "_GO_VERSION=1.24.1"
+    - "_GO_VERSION=1.24.4"
 
 steps:
 - name: gcr.io/cloud-builders/gsutil

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo
 
-go 1.24.1
+go 1.24.4
 
 // Note for developers: upgrading go will also require upgrading go in the following files:
 // ./cloudbuild-cache.yaml,


### PR DESCRIPTION
# Description

Update go to v1.24.4

# Context
A partial backport of https://github.com/solo-io/gloo/pull/10899, to stay on the latest patch release of go

## Interesting decisions
-

## Testing steps
- CI passes

## Notes for reviewers
-

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
