### PR TITLE
Add DFP circuit breakers to 1.19

### DIFF
--- a/changelog/v1.19.2/doc-circuit-breaker.yaml
+++ b/changelog/v1.19.2/doc-circuit-breaker.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  description: >-
+    Adds docs for configuring circuit breakers on DFP. 
+    skipCI-kube-tests:true

--- a/docs/content/guides/traffic_management/listener_configuration/http_connection_manager/dfp/_index.md
+++ b/docs/content/guides/traffic_management/listener_configuration/http_connection_manager/dfp/_index.md
@@ -57,6 +57,68 @@ spec:
             autoHostRewriteHeader: "x-rewrite-me" # host header will be rewritten to the value of this header
 ```
 
+## Set circuit breakers for dynamically discovered upstreams {#dfp-circuit-breakers}
+
+By default, Envoy allows a maximum of 1024 connections to dynamically discovered upstreams. Starting in Gloo Gateway Enterprise version 1.19.3, you can override these settings by defining custom circuit breakers for your dynamic forward proxy. 
+
+1. Update your gateway proxy to add custom circuit breaker settings for your dynamic forward proxy. The following example overrides the default number of connections, requests, pending requests, and retries to 40,000. For more information, see the [Circuit breaker configuration]({{% versioned_link_path fromRoot="/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/circuit_breaker/circuit_breaker.proto.sk/#circuitbreakerconfig" %}})
+
+   ```bash
+   kubectl -n gloo-system patch gw/gateway-proxy --type merge -p "
+   spec:
+     httpGateway:
+       options:
+         dynamicForwardProxy: 
+           circuitBreakers:
+             maxConnections: 40000
+             maxPendingRequests: 40000
+             maxRequests: 40000
+             maxRetries: 40000
+             trackRemaining: true
+   "
+   ```
+
+   | Setting | Description | 
+   | -- | -- | 
+   | `maxConnections` | The maximum number of connections that Envoy makes to the upstream cluster. If not specified, the default is 1024. | 
+   | `maxPendingRequests` | The maximum number of pending requests that Envoy allows to the upstream cluster. If not specified, the default is 1024.| 
+   | `maxRequests` | The maximum number of parallel requests that Envoy makes to the upstream cluster. If not specified, the default is 1024.| 
+   | `maxRetries` | The maximum number of parallel retries that Envoy allows to the upstream cluster. If not specified, the default is 3. | 
+   | `trackRemaining` | If set to `true`, then stats are published that expose the number of resources remaining until the circuit breakers open. If not specified, the default is `false`.| 
+
+2. Verify that your circuit breaker settings were applied. 
+   1. Port-forward your gateway proxy on port 19000. 
+      ```sh
+      kubectl port-forward deploy/gateway-proxy 19000:19000 -n gloo-system
+      ```
+   2. Get the config dump for your gateway proxy. 
+      ```sh
+      curl http://localhost:19000/config_dump | jq -r '.configs[] | select(.["@type"]=="type.googleapis.com/envoy.admin.v3.ClustersConfigDump") | .dynamic_active_clusters | map(select(.cluster.name | startswith("solo_io_generated_dfp")))'
+      ```
+      
+      Example output: 
+      ```
+      ...
+      "version_info": "5428280815645392517",
+       "cluster": {
+         "@type": "type.googleapis.com/envoy.config.cluster.v3.Cluster",
+         "name": "solo_io_generated_dfp:8973398522796813204",
+         "connect_timeout": "5s",
+         "lb_policy": "CLUSTER_PROVIDED",
+         "circuit_breakers": {
+           "thresholds": [
+             {
+               "max_connections": 40000,
+               "max_pending_requests": 40000,
+               "max_requests": 40000,
+               "max_retries": 40000,
+               "track_remaining": true
+             }
+           ]
+        },
+      ...
+      ```
+
 
 
 

--- a/docs/content/operations/upgrading/faq.md
+++ b/docs/content/operations/upgrading/faq.md
@@ -60,6 +60,12 @@ The Envoy dependency in Gloo Gateway 1.19 was upgraded from 1.31.x to 1.33.x. Th
 
 ## New features
 
+#### Set circuit breakers for dynamic forward proxies
+
+When using a dynamic forward proxy, Envoy sets a limit of 1024 connections for dynamically discovered upstreams. Starting in Gloo Gateway Enterprise version 1.19.3, you can override this setting by setting custom circuit breakers for your dynamic forward proxy. 
+
+For more information, see [Set circuit breakers for dynamically discovered upstreams]({{% versioned_link_path fromRoot="/guides/traffic_management/listener_configuration/http_connection_manager/dfp/#dfp-circuit-breakers" %}}). 
+
 ### Set authority header for gRPC OpenTelemetry collectors
 
 When referencing a gRPC OpenTelemetry collector in your Gateway, Gloo Gateway automatically generates an Envoy configuration that sets the cluster name as the `:authority` pseudo-header. If your collector expects a different `:authority` header, you can specify that by setting the `spec.httpGateway.options.httpConnectionManagerSettings.tracing.openTelemetryConfig.grpcService.authority` value on your Gateway as shown in the following example. 


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
