### PR TITLE
[1.19] Expose ecdh-curves TLS settings for listeners (#10913)

### DIFF
--- a/changelog/v1.19.3/expose-ecdh-curves-tls-setting-for-listener.yaml
+++ b/changelog/v1.19.3/expose-ecdh-curves-tls-setting-for-listener.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8456
+    resolvesIssue: false
+    description: >-
+      Expose ecdh-curves TLS settings for listeners

--- a/projects/gateway2/translator/sslutils/ssl_utils.go
+++ b/projects/gateway2/translator/sslutils/ssl_utils.go
@@ -22,6 +22,7 @@ const (
 	GatewaySslOptionsPrefix = wellknown.GatewayAnnotationPrefix + "/ssl"
 
 	GatewaySslCipherSuites         = GatewaySslOptionsPrefix + "/cipher-suites"
+	GatewaySslEcdhCurves           = GatewaySslOptionsPrefix + "/ecdh-curves"
 	GatewaySslMinimumTlsVersion    = GatewaySslOptionsPrefix + "/minimum-tls-version"
 	GatewaySslMaximumTlsVersion    = GatewaySslOptionsPrefix + "/maximum-tls-version"
 	GatewaySslOneWayTls            = GatewaySslOptionsPrefix + "/one-way-tls"
@@ -90,6 +91,15 @@ func ApplyCipherSuites(ctx context.Context, in string, out *ssl.SslConfig) error
 	return nil
 }
 
+func ApplyEcdhCurves(ctx context.Context, in string, out *ssl.SslConfig) error {
+	if out.GetParameters() == nil {
+		out.Parameters = &ssl.SslParameters{}
+	}
+	ecdhCurves := strings.Split(in, ",")
+	out.GetParameters().EcdhCurves = ecdhCurves
+	return nil
+}
+
 func ApplyMinimumTlsVersion(ctx context.Context, in string, out *ssl.SslConfig) error {
 	if out.GetParameters() == nil {
 		out.Parameters = &ssl.SslParameters{}
@@ -145,6 +155,7 @@ func ApplyVerifySubjectAltName(ctx context.Context, in string, out *ssl.SslConfi
 
 var SslExtensionOptionFuncs = map[string]SslExtensionOptionFunc{
 	GatewaySslCipherSuites:         ApplyCipherSuites,
+	GatewaySslEcdhCurves:           ApplyEcdhCurves,
 	GatewaySslMinimumTlsVersion:    ApplyMinimumTlsVersion,
 	GatewaySslMaximumTlsVersion:    ApplyMaximumTlsVersion,
 	GatewaySslOneWayTls:            ApplyOneWayTls,

--- a/projects/gateway2/translator/sslutils/ssl_utils_test.go
+++ b/projects/gateway2/translator/sslutils/ssl_utils_test.go
@@ -91,6 +91,19 @@ func TestApplySslExtensionOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "ecdh_curves",
+			out: &ssl.SslConfig{
+				Parameters: &ssl.SslParameters{
+					EcdhCurves: []string{"X25519MLKEM768", "X25519", "P-256"},
+				},
+			},
+			in: &gwv1.GatewayTLSConfig{
+				Options: map[gwv1.AnnotationKey]gwv1.AnnotationValue{
+					GatewaySslEcdhCurves: "X25519MLKEM768,X25519,P-256",
+				},
+			},
+		},
+		{
 			name: "subject_alt_names",
 			out: &ssl.SslConfig{
 				VerifySubjectAltName: []string{"foo", "bar"},
@@ -169,6 +182,7 @@ func TestApplySslExtensionOptions(t *testing.T) {
 					MaximumProtocolVersion: ssl.SslParameters_TLSv1_3,
 					MinimumProtocolVersion: ssl.SslParameters_TLSv1_2,
 					CipherSuites:           []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"},
+					EcdhCurves:             []string{"X25519MLKEM768", "X25519", "P-256"},
 				},
 			},
 			in: &gwv1.GatewayTLSConfig{
@@ -178,6 +192,7 @@ func TestApplySslExtensionOptions(t *testing.T) {
 					GatewaySslVerifySubjectAltName: "foo,bar",
 					GatewaySslOneWayTls:            "true",
 					GatewaySslCipherSuites:         "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+					GatewaySslEcdhCurves:           "X25519MLKEM768,X25519,P-256",
 				},
 			},
 		},

--- a/test/kubernetes/e2e/features/server_tls/k8s_suite.go
+++ b/test/kubernetes/e2e/features/server_tls/k8s_suite.go
@@ -96,7 +96,9 @@ func (s *k8sServerTlsTestingSuite) TearDownSuite() {
 // is provided in the TLS secret. This is because the Gloo translation loop assumes that mTLS is desired
 // if the secret contains a CA cert.
 func (s *k8sServerTlsTestingSuite) TestOneWayServerTlsFailsWithoutOneWayTls() {
-	s.assertEventualError("nooneway.example.com", expectedFailedResponseCodeInvalidVs)
+	// The expected error code is observed by experiment. When upgrading from curl 7.x to 8.x,
+	// the code for the error changed from 16 (Http/2 Frame Error) to 55 (Send Error)
+	s.assertEventualError("nooneway.example.com", expectedFailedResponseSendError)
 }
 
 // TestOneWayServerTlsWorksWithOneWayTls validates that one-way server TLS traffic succeeds when CA data
@@ -117,7 +119,17 @@ func (s *k8sServerTlsTestingSuite) TestTlsWorksWithMultipleHostNames() {
 	})
 }
 
-func (s *k8sServerTlsTestingSuite) assertEventualResponse(hostHeaderValue string, matcher *matchers.HttpResponse) {
+// TestServerPQTlsWorksWithCustomEcdhCurves validates that server TLS traffic succeeds when X25519MLKEM768
+// key exchange mechanism is used. This is part of PQ-TLS (post-quantum TLS) support
+// Upgraded the curl image version (8.14.1) to support X25519MLKEM768 in
+// test/kubernetes/e2e/features/server_tls/testdata/k8s/setup.yaml
+func (s *k8sServerTlsTestingSuite) TestServerPQTlsWorksWithCustomEcdhCurves() {
+	s.assertEventualResponse("pq-tls.example.com", &matchers.HttpResponse{
+		StatusCode: http.StatusOK,
+	}, "--curves", "X25519MLKEM768")
+}
+
+func (s *k8sServerTlsTestingSuite) assertEventualResponse(hostHeaderValue string, matcher *matchers.HttpResponse, curlArgs ...string) {
 	// Check curl works against expected response
 	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlResponse(
 		s.ctx,
@@ -126,11 +138,11 @@ func (s *k8sServerTlsTestingSuite) assertEventualResponse(hostHeaderValue string
 			Namespace: s.ns,
 			Container: "curl",
 		},
-		append(curlOptions("gloo-proxy-gw", s.ns, hostHeaderValue), curl.WithPath("/status/200")),
+		append(curlOptions("gloo-proxy-gw", s.ns, hostHeaderValue), curl.WithArgs(curlArgs), curl.WithPath("/status/200")),
 		matcher)
 }
 
-func (s *k8sServerTlsTestingSuite) assertEventualError(hostHeaderValue string, code int) {
+func (s *k8sServerTlsTestingSuite) assertEventualError(hostHeaderValue string, code int, curlArgs ...string) {
 	// Check curl works against expected response
 	s.testInstallation.AssertionsT(s.T()).AssertEventualCurlError(
 		s.ctx,
@@ -139,7 +151,7 @@ func (s *k8sServerTlsTestingSuite) assertEventualError(hostHeaderValue string, c
 			Namespace: s.ns,
 			Container: "curl",
 		},
-		append(curlOptions("gloo-proxy-gw", s.ns, hostHeaderValue), curl.WithPath("/status/200")),
+		append(curlOptions("gloo-proxy-gw", s.ns, hostHeaderValue), curl.WithArgs(curlArgs), curl.WithPath("/status/200")),
 		code,
 		time.Minute*2)
 }

--- a/test/kubernetes/e2e/features/server_tls/testdata/k8s/gateway.yaml
+++ b/test/kubernetes/e2e/features/server_tls/testdata/k8s/gateway.yaml
@@ -55,3 +55,17 @@ spec:
       allowedRoutes:
         namespaces:
           from: All
+    - protocol: HTTPS
+      port: 443
+      name: pqtls
+      hostname: "pq-tls.example.com"
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: tls-secret-1
+            kind: Secret
+        options:
+          "gateway.gloo.solo.io/ssl/ecdh-curves": "X25519MLKEM768"
+      allowedRoutes:
+        namespaces:
+          from: All

--- a/test/kubernetes/e2e/features/server_tls/testdata/k8s/setup.yaml
+++ b/test/kubernetes/e2e/features/server_tls/testdata/k8s/setup.yaml
@@ -65,7 +65,7 @@ metadata:
 spec:
   containers:
     - name: curl
-      image: curlimages/curl:7.83.1
+      image: curlimages/curl:8.14.1
       imagePullPolicy: IfNotPresent
       command:
         - "tail"

--- a/test/kubernetes/e2e/features/server_tls/types.go
+++ b/test/kubernetes/e2e/features/server_tls/types.go
@@ -127,6 +127,7 @@ const (
 	// These were determined experimentally.
 	expectedFailedResponseCodeInvalidVs = 16
 	expectedFailedResponseCertRequested = 35
+	expectedFailedResponseSendError     = 55
 )
 
 func manifestFromFile(fname string) ([]byte, error) {


### PR DESCRIPTION
# Description
backport of https://github.com/solo-io/gloo/pull/10913
