### PR TITLE
Ignore CVE-2025-53547

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -93,3 +93,11 @@ CVE-2025-46569
 # https://github.com/advisories/GHSA-wq9g-9vfc-cfq9
 # This CVE has been addressed in v1.18.x and later. We have opted to ignore it in v1.17.x because it only affects Portal, which is no longer has any known users on this branch. We will remove this CVE from .trivyignore when v1.17.x is no longer supported. ([issue link](https://github.com/solo-io/gloo/issues/10925))
 CVE-2025-30153
+
+# https://github.com/advisories/GHSA-557j-xg8c-q2mm
+# This CVE does not affect Gloo. Nevertheless, the update to fix this CVE has
+# been adopted in v.18.x and later (see
+# [here](https://github.com/solo-io/gloo/pull/10914)), so we will remove it as
+# a part of our clean-up when 1.17.x is EOL. ([issue
+# link](https://github.com/solo-io/gloo/issues/10925))
+CVE-2025-53547

--- a/changelog/v1.20.0-beta9/ignore-cve-2025-53547.yaml
+++ b/changelog/v1.20.0-beta9/ignore-cve-2025-53547.yaml
@@ -1,0 +1,10 @@
+changelog:
+  - type: NON_USER_FACING
+    issueLink: https://github.com/solo-io/solo-projects/issues/8472
+    description: >-
+      Ignore CVE-2025-53547. See issue link for details. We will revert this change later in https://github.com/solo-io/gloo/issues/10925
+
+      skipCI-kube-tests:true
+      skipCI-storybook-tests:true
+      skipCI-in-memory-e2e-tests:true
+


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
