### PR TITLE
dont create gatewayproxy HPA when disabled is true

### DIFF
--- a/changelog/v1.20.0-beta11/solo-projects-8520.yaml
+++ b/changelog/v1.20.0-beta11/solo-projects-8520.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/solo-projects/issues/8520
+    resolvesIssue: true
+    description: Prevent HPA creation when a gateway proxy is disabled.

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -34,8 +34,8 @@ spec:
   behavior:
   {{ toYaml $spec.horizontalPodAutoscaler.behavior | nindent 4 }}
   {{- end }}
-{{- end }} {{/* if $spec.kind.deployment */}}
 {{- end }} {{/* if $spec.horizontalPodAutoscaler */}}
+{{- end }} {{/* if $spec.kind.deployment */}}
 {{- end }} {{/* if not $spec.disabled */}}
 {{- end }} {{/* with */}}
 {{- end }} {{/* define gatewayProxy.autoscalerSpec*/}}

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -4,6 +4,7 @@
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
+{{- if not $spec.disabled }}
 {{- if $spec.kind.deployment }}
 {{- if $spec.horizontalPodAutoscaler }}
 apiVersion: {{ $spec.horizontalPodAutoscaler.apiVersion }}
@@ -35,6 +36,7 @@ spec:
   {{- end }}
 {{- end }} {{/* if $spec.kind.deployment */}}
 {{- end }} {{/* if $spec.horizontalPodAutoscaler */}}
+{{- end }} {{/* if not $spec.disabled */}}
 {{- end }} {{/* with */}}
 {{- end }} {{/* define gatewayProxy.autoscalerSpec*/}}
 {{- if .Values.gateway.enabled }}


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

If helm values included config for additional proxy an HPA was always created, even when:

gloo:
  gatewayProxies:
    dummy-gatewayProxy:
          disabled: true

There was an if statement missing in the helmchart.

# Change Type

<!--
Select one or more of the following by including the corresponding slash-command:
```
/kind breaking_change
/kind bug_fix
/kind design
/kind cleanup
/kind deprecation
/kind documentation
/kind flake
/kind new_feature
```

/kind bug_fix
-->

# Changelog

<!--
Provide the exact line to appear in release notes for the chosen changelog type.

If no, just write "NONE" in the release-note block below.
If yes, a release note is required:

Fixes erroneous creation of HPA for a disbled GatewayProxy
-->

```release-note

```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/8520