### PR TITLE
v1.18.x CVE go 1.24.6 bump

### DIFF
--- a/changelog/v1.18.27/v1.18.x-cve-go-1.24.6.yaml
+++ b/changelog/v1.18.27/v1.18.x-cve-go-1.24.6.yaml
@@ -1,0 +1,21 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: golang
+  dependencyRepo: go
+  dependencyTag: v1.24.6
+  issueLink: https://github.com/solo-io/gloo/issues/10932
+  resolvesIssue: false
+  description: >-
+    Bump go to 1.24.6 to fix CVE-2025-47907
+- type: DEPENDENCY_BUMP
+  dependencyOwner: solo-io
+  dependencyRepo: cloud-builders
+  dependencyTag: v0.13.1
+- type: DEPENDENCY_BUMP
+  dependencyOwner: bitnami
+  dependencyRepo: kubectl
+  dependencyTag: v1.33.3
+  description: >-
+    Bump kubectl image to 1.33.3 to fix CVE-2025-22868
+  issueLink: https://github.com/solo-io/gloo/issues/10932
+  resolvesIssue: false

--- a/ci/cloudbuild/publish-artifacts.yaml
+++ b/ci/cloudbuild/publish-artifacts.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.13.1'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -59,7 +59,7 @@ steps:
     - '-c'
     - 'docker run --rm --privileged multiarch/qemu-user-static --reset -p yes -c yes'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.1'
   id: 'build-certgen-arm64-binary'
   args:
   - 'certgen-docker'
@@ -68,7 +68,7 @@ steps:
   - 'GOARCH=arm64'
 
 # Run make targets to push docker images to quay.io
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.1'
   id: 'publish-docker'
   args:
   - 'publish-docker'
@@ -94,7 +94,7 @@ steps:
   waitFor:
   - 'publish-docker'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.1'
   id: 'release-chart'
   dir: *dir
   args:
@@ -109,7 +109,7 @@ steps:
   - 'gcr-auth'
 
 # Run make targets to retag and push docker images to GCR
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.1'
   id: 'docker-push-extended-gcr'
   dir: *dir
   args:

--- a/ci/cloudbuild/run-tests.yaml
+++ b/ci/cloudbuild/run-tests.yaml
@@ -1,6 +1,6 @@
 steps:
 
-- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/prepare-go-workspace:0.13.1'
   id: 'prepare-workspace'
   args:
   - '--repo-name'
@@ -23,7 +23,7 @@ steps:
     cd /go/pkg
     gsutil cat gs://$PROJECT_ID-cache/gloo/gloo-mod.tar.gz | tar -xzf - || echo "untar mod cache failed; continuing because we can download deps as we need them"
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.1'
   id: 'prepare-envoy'
   dir: *dir
   entrypoint: 'bash'
@@ -77,7 +77,7 @@ steps:
   waitFor:
   - 'prepare-gcr-zone'
 
-- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/go-mod-make:0.13.1'
   id: 'prepare-test-tools'
   dir: *dir
   args:
@@ -88,7 +88,7 @@ steps:
   - 'prepare-gcr-zone'
   - 'prepare-test-credentials'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.1'
   id: 'run-tests'
   dir: *dir
   entrypoint: 'make'
@@ -99,7 +99,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.1'
   id: 'run-e2e-tests'
   dir: *dir
   entrypoint: 'make'
@@ -110,7 +110,7 @@ steps:
   secretEnv:
   - 'JWT_PRIVATE_KEY'
 
-- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.0'
+- name: 'gcr.io/$PROJECT_ID/e2e-go-mod-ginkgo:0.13.1'
   id: 'run-hashicorp-e2e-tests'
   dir: *dir
   entrypoint: 'make'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo
 
-go 1.24.4
+go 1.24.6
 
 // Note for developers: upgrading go will also require upgrading go in the following files:
 // ./cloudbuild-cache.yaml,

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM bitnami/kubectl:1.31.1 as kubectl
+FROM bitnami/kubectl:1.33.3 as kubectl
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
# Description
Updating go version to 1.24.6, relying on the toolchain to update dependencies. This addresses [CVE-2025-47907](https://github.com/advisories/GHSA-j5pm-7495-qmr3), though it doesn't apply to this codebase as it is a SQL vulnerability
Updating kubctl image to 1.33.3 to address [CVE-2025-22868](https://github.com/advisories/GHSA-6v2p-p543-phr9)] , which is an OAuth2 vulnerability and is unlikely to be a security risk in our codebase as that image is used only during application install.

## Testing steps
Local scans of local builds:
```
 for image in access-logger certgen discovery gloo gloo-envoy-wrapper ingress kubectl sds; do trivy image --severity HIGH,CRITICAL quay.io/solo-io/${image}:1.0.0-ci1; done
2025-08-13T10:16:55-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:16:55-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:16:55-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:16:55-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:16:57-04:00	INFO	Detected OS	family="alpine" version="3.21.3"
2025-08-13T10:16:57-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.21" repository="3.21" pkg_num=16
2025-08-13T10:16:57-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:16:57-04:00	INFO	[gobinary] Detecting vulnerabilities...
2025-08-13T10:16:57-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

Report Summary

┌─────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                         Target                          │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/access-logger:1.0.0-ci1 (alpine 3.21.3) │  alpine  │        0        │    -    │
├─────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/access-logger                             │ gobinary │        0        │    -    │
└─────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

2025-08-13T10:16:57-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:16:57-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:16:57-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:16:57-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:16:58-04:00	INFO	Detected OS	family="alpine" version="3.21.3"
2025-08-13T10:16:58-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.21" repository="3.21" pkg_num=16
2025-08-13T10:16:58-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:16:58-04:00	INFO	[gobinary] Detecting vulnerabilities...

Report Summary

┌───────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                      Target                       │   Type   │ Vulnerabilities │ Secrets │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/certgen:1.0.0-ci1 (alpine 3.21.3) │  alpine  │        0        │    -    │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/certgen                             │ gobinary │        0        │    -    │
└───────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

2025-08-13T10:16:58-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:16:58-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:16:58-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:16:58-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:17:00-04:00	INFO	Detected OS	family="alpine" version="3.21.3"
2025-08-13T10:17:00-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.21" repository="3.21" pkg_num=16
2025-08-13T10:17:00-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:17:00-04:00	INFO	[gobinary] Detecting vulnerabilities...
2025-08-13T10:17:00-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

Report Summary

┌─────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                       Target                        │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/discovery:1.0.0-ci1 (alpine 3.21.3) │  alpine  │        0        │    -    │
├─────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/discovery                             │ gobinary │        0        │    -    │
└─────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

2025-08-13T10:17:00-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:17:00-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:17:00-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:17:00-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:17:05-04:00	INFO	Detected OS	family="ubuntu" version="20.04"
2025-08-13T10:17:05-04:00	INFO	[ubuntu] Detecting vulnerabilities...	os_version="20.04" pkg_num=98
2025-08-13T10:17:05-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:17:05-04:00	INFO	[gobinary] Detecting vulnerabilities...
2025-08-13T10:17:05-04:00	WARN	This OS version is no longer supported by the distribution	family="ubuntu" version="20.04"
2025-08-13T10:17:05-04:00	WARN	The vulnerability detection may be insufficient because security updates are not provided
2025-08-13T10:17:05-04:00	INFO	Some vulnerabilities have been ignored/suppressed. Use the "--show-suppressed" flag to display them.

Report Summary

┌───────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                    Target                     │   Type   │ Vulnerabilities │ Secrets │
├───────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/gloo:1.0.0-ci1 (ubuntu 20.04) │  ubuntu  │        0        │    -    │
├───────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/gloo                            │ gobinary │        0        │    -    │
└───────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

2025-08-13T10:17:05-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:17:05-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:17:05-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:17:05-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:17:07-04:00	INFO	Detected OS	family="ubuntu" version="20.04"
2025-08-13T10:17:07-04:00	INFO	[ubuntu] Detecting vulnerabilities...	os_version="20.04" pkg_num=98
2025-08-13T10:17:07-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:17:07-04:00	INFO	[gobinary] Detecting vulnerabilities...
2025-08-13T10:17:07-04:00	WARN	This OS version is no longer supported by the distribution	family="ubuntu" version="20.04"
2025-08-13T10:17:07-04:00	WARN	The vulnerability detection may be insufficient because security updates are not provided

Report Summary

┌─────────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                           Target                            │   Type   │ Vulnerabilities │ Secrets │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/gloo-envoy-wrapper:1.0.0-ci1 (ubuntu 20.04) │  ubuntu  │        0        │    -    │
├─────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/envoyinit                                     │ gobinary │        0        │    -    │
└─────────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

2025-08-13T10:17:07-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:17:07-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:17:07-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:17:07-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:17:08-04:00	INFO	Detected OS	family="alpine" version="3.21.3"
2025-08-13T10:17:08-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.21" repository="3.21" pkg_num=15
2025-08-13T10:17:08-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:17:08-04:00	INFO	[gobinary] Detecting vulnerabilities...

Report Summary

┌───────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                      Target                       │   Type   │ Vulnerabilities │ Secrets │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/ingress:1.0.0-ci1 (alpine 3.21.3) │  alpine  │        0        │    -    │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/ingress                             │ gobinary │        0        │    -    │
└───────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

2025-08-13T10:17:09-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:17:09-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:17:09-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:17:09-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:17:09-04:00	INFO	Detected OS	family="alpine" version="3.21.3"
2025-08-13T10:17:09-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.21" repository="3.21" pkg_num=15
2025-08-13T10:17:09-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:17:09-04:00	INFO	[gobinary] Detecting vulnerabilities...

Report Summary

┌───────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                      Target                       │   Type   │ Vulnerabilities │ Secrets │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/kubectl:1.0.0-ci1 (alpine 3.21.3) │  alpine  │        0        │    -    │
├───────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/kubectl                             │ gobinary │        0        │    -    │
└───────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)

2025-08-13T10:17:09-04:00	INFO	[vuln] Vulnerability scanning is enabled
2025-08-13T10:17:09-04:00	INFO	[secret] Secret scanning is enabled
2025-08-13T10:17:09-04:00	INFO	[secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-08-13T10:17:09-04:00	INFO	[secret] Please see also https://trivy.dev/v0.65/docs/scanner/secret#recommendation for faster secret detection
2025-08-13T10:17:09-04:00	INFO	Detected OS	family="alpine" version="3.21.3"
2025-08-13T10:17:09-04:00	INFO	[alpine] Detecting vulnerabilities...	os_version="3.21" repository="3.21" pkg_num=15
2025-08-13T10:17:09-04:00	INFO	Number of language-specific files	num=1
2025-08-13T10:17:09-04:00	INFO	[gobinary] Detecting vulnerabilities...

Report Summary

┌───────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                    Target                     │   Type   │ Vulnerabilities │ Secrets │
├───────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/solo-io/sds:1.0.0-ci1 (alpine 3.21.3) │  alpine  │        0        │    -    │
├───────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ usr/local/bin/sds                             │ gobinary │        0        │    -    │
└───────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
```

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
