### PR TITLE
bump distroless ci image

### DIFF
--- a/changelog/v1.18.27/kubectl-image-bump-1.33.3.yaml
+++ b/changelog/v1.18.27/kubectl-image-bump-1.33.3.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: bitnami
+  dependencyRepo: kubectl
+  dependencyTag: v1.33.3
+  description: >-
+    Bump kubectl distroless image to 1.33.3 to fix CVE-2025-22868
+  issueLink: https://github.com/solo-io/gloo/issues/10932
+  resolvesIssue: false

--- a/jobs/kubectl/Dockerfile.distroless
+++ b/jobs/kubectl/Dockerfile.distroless
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM bitnami/kubectl:1.31.1 as kubectl
+FROM bitnami/kubectl:1.33.3 as kubectl
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION

# Description
Missed an image when updating for https://github.com/solo-io/gloo/pull/10960
