### PR TITLE
[AI] api change to support customhost in all AI providers

### DIFF
--- a/changelog/v1.20.0-beta13/all-ai-providers-custom-host-support.yaml
+++ b/changelog/v1.20.0-beta13/all-ai-providers-custom-host-support.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/8438
+    resolvesIssue: false
+    description: >-
+      updated ai.proto to support customhost in all AI providers

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/ai/ai.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/ai/ai.proto.sk.md
@@ -236,7 +236,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
 | `authToken` | [.ai.options.gloo.solo.io.SingleAuthToken](../ai.proto.sk/#singleauthtoken) | The authorization token that the AI gateway uses to access the OpenAI API. This token is automatically sent in the `Authorization` header of the request and prefixed with `Bearer`. |
-| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port, such as to proxy the request, or to use a different backend that is API-compliant with the upstream version. |
+| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port or configure custom path override or hostname. |
 | `model` | `string` | Optional: Override the model name, such as `gpt-4o-mini`. If unset, the model name is taken from the request. This setting can be useful when setting up model failover within the same LLM provider. |
 
 
@@ -258,6 +258,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 "endpoint": string
 "deploymentName": string
 "apiVersion": string
+"customHost": .ai.options.gloo.solo.io.UpstreamSpec.CustomHost
 
 ```
 
@@ -267,6 +268,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 | `endpoint` | `string` | The endpoint for the Azure OpenAI API to use, such as `my-endpoint.openai.azure.com`. If the scheme is included, it is stripped. |
 | `deploymentName` | `string` | The name of the Azure OpenAI model deployment to use. For more information, see the [Azure OpenAI model docs](https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models). |
 | `apiVersion` | `string` | The version of the Azure OpenAI API to use. For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs). |
+| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port or configure custom path override or hostname. |
 
 
 
@@ -286,6 +288,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 "authToken": .ai.options.gloo.solo.io.SingleAuthToken
 "model": string
 "apiVersion": string
+"customHost": .ai.options.gloo.solo.io.UpstreamSpec.CustomHost
 
 ```
 
@@ -294,6 +297,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 | `authToken` | [.ai.options.gloo.solo.io.SingleAuthToken](../ai.proto.sk/#singleauthtoken) | The authorization token that the AI gateway uses to access the Gemini API. This token is automatically sent in the `x-goog-api-key` header of the request. |
 | `model` | `string` | The Gemini model to use. For more information, see the [Gemini models docs](https://ai.google.dev/gemini-api/docs/models/gemini). |
 | `apiVersion` | `string` | The version of the Gemini API to use. For more information, see the [Gemini API version docs](https://ai.google.dev/gemini-api/docs/api-versions). |
+| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port or configure custom path override or hostname. |
 
 
 
@@ -318,6 +322,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 "modelPath": string
 "publisher": .ai.options.gloo.solo.io.UpstreamSpec.VertexAI.Publisher
 "jsonSchema": .ai.options.gloo.solo.io.ApiJsonSchema
+"customHost": .ai.options.gloo.solo.io.UpstreamSpec.CustomHost
 
 ```
 
@@ -331,6 +336,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 | `modelPath` | `string` | Optional: The model path to route to. Defaults to the Gemini model path, `generateContent`. |
 | `publisher` | [.ai.options.gloo.solo.io.UpstreamSpec.VertexAI.Publisher](../ai.proto.sk/#publisher) | The type of publisher model to use. Currently, only Google is supported. |
 | `jsonSchema` | [.ai.options.gloo.solo.io.ApiJsonSchema](../ai.proto.sk/#apijsonschema) | Optional: Specify the API json schema the model uses, default to GEMINI if not set. |
+| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port or configure custom path override or hostname. |
 
 
 
@@ -370,7 +376,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
 | `authToken` | [.ai.options.gloo.solo.io.SingleAuthToken](../ai.proto.sk/#singleauthtoken) | The authorization token that the AI gateway uses to access the OpenAI API. This token is automatically sent in the `Authorization` header of the request and prefixed with `Bearer`. |
-| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port, such as to proxy the request, or to use a different backend that is API-compliant with the upstream version. |
+| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port or configure custom path override or hostname. |
 | `model` | `string` | Optional: Override the model name. If unset, the model name is taken from the request. This setting can be useful when testing model failover scenarios. |
 
 
@@ -396,7 +402,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
 | `authToken` | [.ai.options.gloo.solo.io.SingleAuthToken](../ai.proto.sk/#singleauthtoken) | The authorization token that the AI gateway uses to access the Anthropic API. This token is automatically sent in the `x-api-key` header of the request. |
-| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port, such as to proxy the request, or to use a different backend that is API-compliant with the upstream version. |
+| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port or configure custom path override or hostname. |
 | `version` | `string` | Optional: The version string used to override the `anthropic-version` header to pass to the Anthropic API. Note: This does not control the api version (eg `/v1`) in the url. For more information, see the [Anthropic API versioning docs](https://docs.anthropic.com/en/api/versioning). |
 | `model` | `string` | Optional: Override the model name. If unset, the model name is taken from the request. This setting can be useful when testing model failover scenarios. |
 
@@ -423,7 +429,7 @@ The AI API is supported only in [Gloo Gateway (Kubernetes Gateway API)](https://
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
 | `credentialProvider` | [.ai.options.gloo.solo.io.UpstreamSpec.AwsCredentialProvider](../ai.proto.sk/#awscredentialprovider) | The authorization config used to access authenticated AWS Bedrock services. |
-| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port, such as to proxy the request, or to use a different backend that is API-compliant with the upstream version. Note: For AWS Bedrock, if custom_host is set, host_rewrite will be used to override the Host header before signing the request. |
+| `customHost` | [.ai.options.gloo.solo.io.UpstreamSpec.CustomHost](../ai.proto.sk/#customhost) | Optional: Send requests to a custom host and port or configure custom path override or hostname Note: For AWS Bedrock, if custom_host is set, host_rewrite will be used to override the Host header before signing the request. |
 | `model` | `string` | Required: model string. The model field is the supported model id published by AWS. See <https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html>. |
 | `region` | `string` | Required: region string. The region is a string for the standard AWS region for the service that hosts the HTTP endpoint. The `AWS_SIGV4` signing algorithm is currently used by default. For more regions, see the AWS docs <https://docs.aws.amazon.com/general/latest/gr/rande.html> Example: us-west-2 NOTE: Multiple regions are not currently supported. |
 

--- a/install/helm/gloo/crds/gloo.solo.io_v1_Upstream.yaml
+++ b/install/helm/gloo/crds/gloo.solo.io_v1_Upstream.yaml
@@ -85,6 +85,25 @@ spec:
                                 type: string
                             type: object
                         type: object
+                      customHost:
+                        properties:
+                          host:
+                            type: string
+                          hostname:
+                            nullable: true
+                            type: string
+                          pathOverride:
+                            properties:
+                              basePath:
+                                type: string
+                              fullPath:
+                                type: string
+                            type: object
+                          port:
+                            maximum: 4294967295
+                            minimum: 0
+                            type: integer
+                        type: object
                       deploymentName:
                         type: string
                       endpoint:
@@ -152,6 +171,25 @@ spec:
                               namespace:
                                 type: string
                             type: object
+                        type: object
+                      customHost:
+                        properties:
+                          host:
+                            type: string
+                          hostname:
+                            nullable: true
+                            type: string
+                          pathOverride:
+                            properties:
+                              basePath:
+                                type: string
+                              fullPath:
+                                type: string
+                            type: object
+                          port:
+                            maximum: 4294967295
+                            minimum: 0
+                            type: integer
                         type: object
                       model:
                         type: string
@@ -260,6 +298,25 @@ spec:
                                                 type: string
                                             type: object
                                         type: object
+                                      customHost:
+                                        properties:
+                                          host:
+                                            type: string
+                                          hostname:
+                                            nullable: true
+                                            type: string
+                                          pathOverride:
+                                            properties:
+                                              basePath:
+                                                type: string
+                                              fullPath:
+                                                type: string
+                                            type: object
+                                          port:
+                                            maximum: 4294967295
+                                            minimum: 0
+                                            type: integer
+                                        type: object
                                       deploymentName:
                                         type: string
                                       endpoint:
@@ -327,6 +384,25 @@ spec:
                                               namespace:
                                                 type: string
                                             type: object
+                                        type: object
+                                      customHost:
+                                        properties:
+                                          host:
+                                            type: string
+                                          hostname:
+                                            nullable: true
+                                            type: string
+                                          pathOverride:
+                                            properties:
+                                              basePath:
+                                                type: string
+                                              fullPath:
+                                                type: string
+                                            type: object
+                                          port:
+                                            maximum: 4294967295
+                                            minimum: 0
+                                            type: integer
                                         type: object
                                       model:
                                         type: string
@@ -425,6 +501,25 @@ spec:
                                                 type: string
                                             type: object
                                         type: object
+                                      customHost:
+                                        properties:
+                                          host:
+                                            type: string
+                                          hostname:
+                                            nullable: true
+                                            type: string
+                                          pathOverride:
+                                            properties:
+                                              basePath:
+                                                type: string
+                                              fullPath:
+                                                type: string
+                                            type: object
+                                          port:
+                                            maximum: 4294967295
+                                            minimum: 0
+                                            type: integer
+                                        type: object
                                       jsonSchema:
                                         type: string
                                         x-kubernetes-int-or-string: true
@@ -500,6 +595,25 @@ spec:
                               namespace:
                                 type: string
                             type: object
+                        type: object
+                      customHost:
+                        properties:
+                          host:
+                            type: string
+                          hostname:
+                            nullable: true
+                            type: string
+                          pathOverride:
+                            properties:
+                              basePath:
+                                type: string
+                              fullPath:
+                                type: string
+                            type: object
+                          port:
+                            maximum: 4294967295
+                            minimum: 0
+                            type: integer
                         type: object
                       jsonSchema:
                         type: string

--- a/projects/gloo/api/v1/enterprise/options/ai/ai.proto
+++ b/projects/gloo/api/v1/enterprise/options/ai/ai.proto
@@ -120,8 +120,7 @@ message UpstreamSpec {
     // This token is automatically sent in the `Authorization` header of the
     // request and prefixed with `Bearer`.
     SingleAuthToken auth_token = 1;
-    // Optional: Send requests to a custom host and port, such as to proxy the request,
-    // or to use a different backend that is API-compliant with the upstream version.
+    // Optional: Send requests to a custom host and port or configure custom path override or hostname
     CustomHost custom_host = 2;
     // Optional: Override the model name, such as `gpt-4o-mini`.
     // If unset, the model name is taken from the request.
@@ -154,6 +153,8 @@ message UpstreamSpec {
     // The version of the Azure OpenAI API to use.
     // For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs).
     string api_version = 4;
+    // Optional: Send requests to a custom host and port or configure custom path override or hostname
+    CustomHost custom_host = 5;
   }
 
   // Settings for the [Gemini](https://ai.google.dev/gemini-api/docs) LLM provider.
@@ -178,6 +179,8 @@ message UpstreamSpec {
     // The version of the Gemini API to use.
     // For more information, see the [Gemini API version docs](https://ai.google.dev/gemini-api/docs/api-versions).
     string api_version = 3;
+    // Optional: Send requests to a custom host and port or configure custom path override or hostname
+    CustomHost custom_host = 4;
   }
 
   // Settings for the [Vertex AI](https://cloud.google.com/vertex-ai/docs) LLM provider.
@@ -222,6 +225,9 @@ message UpstreamSpec {
 
     // Optional: Specify the API json schema the model uses, default to GEMINI if not set
     ApiJsonSchema json_schema = 8;
+
+    // Optional: Send requests to a custom host and port or configure custom path override or hostname
+    CustomHost custom_host = 9;
   }
 
   // Settings for the [Mistral AI](https://docs.mistral.ai/getting-started/quickstart/) LLM provider.
@@ -233,8 +239,7 @@ message UpstreamSpec {
     // This token is automatically sent in the `Authorization` header of the
     // request and prefixed with `Bearer`.
     SingleAuthToken auth_token = 1;
-    // Optional: Send requests to a custom host and port, such as to proxy the request,
-    // or to use a different backend that is API-compliant with the upstream version.
+    // Optional: Send requests to a custom host and port or configure custom path override or hostname
     CustomHost custom_host = 2;
     // Optional: Override the model name.
     // If unset, the model name is taken from the request.
@@ -250,8 +255,7 @@ message UpstreamSpec {
     // The authorization token that the AI gateway uses to access the Anthropic API.
     // This token is automatically sent in the `x-api-key` header of the request.
     SingleAuthToken auth_token = 1;
-    // Optional: Send requests to a custom host and port, such as to proxy the request,
-    // or to use a different backend that is API-compliant with the upstream version.
+    // Optional: Send requests to a custom host and port or configure custom path override or hostname
     CustomHost custom_host = 2;
     // Optional: The version string used to override the `anthropic-version` header to pass to the Anthropic API.
     // Note: This does not control the api version (eg `/v1`) in the url.
@@ -270,8 +274,7 @@ message UpstreamSpec {
   message Bedrock {
     // The authorization config used to access authenticated AWS Bedrock services.
     AwsCredentialProvider credential_provider = 1;
-    // Optional: Send requests to a custom host and port, such as to proxy the request,
-    // or to use a different backend that is API-compliant with the upstream version.
+    // Optional: Send requests to a custom host and port or configure custom path override or hostname
     // Note: For AWS Bedrock, if custom_host is set, host_rewrite will be used to override the Host header before signing the request
     CustomHost custom_host = 2;
     // Required: model string.

--- a/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.clone.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.clone.go
@@ -530,6 +530,12 @@ func (m *UpstreamSpec_AzureOpenAI) Clone() proto.Message {
 
 	target.ApiVersion = m.GetApiVersion()
 
+	if h, ok := interface{}(m.GetCustomHost()).(clone.Cloner); ok {
+		target.CustomHost = h.Clone().(*UpstreamSpec_CustomHost)
+	} else {
+		target.CustomHost = proto.Clone(m.GetCustomHost()).(*UpstreamSpec_CustomHost)
+	}
+
 	switch m.AuthTokenSource.(type) {
 
 	case *UpstreamSpec_AzureOpenAI_AuthToken:
@@ -560,6 +566,12 @@ func (m *UpstreamSpec_Gemini) Clone() proto.Message {
 	target.Model = m.GetModel()
 
 	target.ApiVersion = m.GetApiVersion()
+
+	if h, ok := interface{}(m.GetCustomHost()).(clone.Cloner); ok {
+		target.CustomHost = h.Clone().(*UpstreamSpec_CustomHost)
+	} else {
+		target.CustomHost = proto.Clone(m.GetCustomHost()).(*UpstreamSpec_CustomHost)
+	}
 
 	switch m.AuthTokenSource.(type) {
 
@@ -601,6 +613,12 @@ func (m *UpstreamSpec_VertexAI) Clone() proto.Message {
 	target.Publisher = m.GetPublisher()
 
 	target.JsonSchema = m.GetJsonSchema()
+
+	if h, ok := interface{}(m.GetCustomHost()).(clone.Cloner); ok {
+		target.CustomHost = h.Clone().(*UpstreamSpec_CustomHost)
+	} else {
+		target.CustomHost = proto.Clone(m.GetCustomHost()).(*UpstreamSpec_CustomHost)
+	}
 
 	switch m.AuthTokenSource.(type) {
 

--- a/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.equal.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.equal.go
@@ -886,6 +886,16 @@ func (m *UpstreamSpec_AzureOpenAI) Equal(that interface{}) bool {
 		return false
 	}
 
+	if h, ok := interface{}(m.GetCustomHost()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetCustomHost()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetCustomHost(), target.GetCustomHost()) {
+			return false
+		}
+	}
+
 	switch m.AuthTokenSource.(type) {
 
 	case *UpstreamSpec_AzureOpenAI_AuthToken:
@@ -940,6 +950,16 @@ func (m *UpstreamSpec_Gemini) Equal(that interface{}) bool {
 
 	if strings.Compare(m.GetApiVersion(), target.GetApiVersion()) != 0 {
 		return false
+	}
+
+	if h, ok := interface{}(m.GetCustomHost()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetCustomHost()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetCustomHost(), target.GetCustomHost()) {
+			return false
+		}
 	}
 
 	switch m.AuthTokenSource.(type) {
@@ -1016,6 +1036,16 @@ func (m *UpstreamSpec_VertexAI) Equal(that interface{}) bool {
 
 	if m.GetJsonSchema() != target.GetJsonSchema() {
 		return false
+	}
+
+	if h, ok := interface{}(m.GetCustomHost()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetCustomHost()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetCustomHost(), target.GetCustomHost()) {
+			return false
+		}
 	}
 
 	switch m.AuthTokenSource.(type) {

--- a/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.go
@@ -1684,8 +1684,7 @@ type UpstreamSpec_OpenAI struct {
 	// This token is automatically sent in the `Authorization` header of the
 	// request and prefixed with `Bearer`.
 	AuthToken *SingleAuthToken `protobuf:"bytes,1,opt,name=auth_token,json=authToken,proto3" json:"auth_token,omitempty"`
-	// Optional: Send requests to a custom host and port, such as to proxy the request,
-	// or to use a different backend that is API-compliant with the upstream version.
+	// Optional: Send requests to a custom host and port or configure custom path override or hostname
 	CustomHost *UpstreamSpec_CustomHost `protobuf:"bytes,2,opt,name=custom_host,json=customHost,proto3" json:"custom_host,omitempty"`
 	// Optional: Override the model name, such as `gpt-4o-mini`.
 	// If unset, the model name is taken from the request.
@@ -1769,7 +1768,9 @@ type UpstreamSpec_AzureOpenAI struct {
 	DeploymentName string `protobuf:"bytes,3,opt,name=deployment_name,json=deploymentName,proto3" json:"deployment_name,omitempty"`
 	// The version of the Azure OpenAI API to use.
 	// For more information, see the [Azure OpenAI API version reference](https://learn.microsoft.com/en-us/azure/ai-services/openai/reference#api-specs).
-	ApiVersion    string `protobuf:"bytes,4,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	ApiVersion string `protobuf:"bytes,4,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	// Optional: Send requests to a custom host and port or configure custom path override or hostname
+	CustomHost    *UpstreamSpec_CustomHost `protobuf:"bytes,5,opt,name=custom_host,json=customHost,proto3" json:"custom_host,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1841,6 +1842,13 @@ func (x *UpstreamSpec_AzureOpenAI) GetApiVersion() string {
 	return ""
 }
 
+func (x *UpstreamSpec_AzureOpenAI) GetCustomHost() *UpstreamSpec_CustomHost {
+	if x != nil {
+		return x.CustomHost
+	}
+	return nil
+}
+
 type isUpstreamSpec_AzureOpenAI_AuthTokenSource interface {
 	isUpstreamSpec_AzureOpenAI_AuthTokenSource()
 }
@@ -1873,7 +1881,9 @@ type UpstreamSpec_Gemini struct {
 	Model string `protobuf:"bytes,2,opt,name=model,proto3" json:"model,omitempty"`
 	// The version of the Gemini API to use.
 	// For more information, see the [Gemini API version docs](https://ai.google.dev/gemini-api/docs/api-versions).
-	ApiVersion    string `protobuf:"bytes,3,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	ApiVersion string `protobuf:"bytes,3,opt,name=api_version,json=apiVersion,proto3" json:"api_version,omitempty"`
+	// Optional: Send requests to a custom host and port or configure custom path override or hostname
+	CustomHost    *UpstreamSpec_CustomHost `protobuf:"bytes,4,opt,name=custom_host,json=customHost,proto3" json:"custom_host,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1938,6 +1948,13 @@ func (x *UpstreamSpec_Gemini) GetApiVersion() string {
 	return ""
 }
 
+func (x *UpstreamSpec_Gemini) GetCustomHost() *UpstreamSpec_CustomHost {
+	if x != nil {
+		return x.CustomHost
+	}
+	return nil
+}
+
 type isUpstreamSpec_Gemini_AuthTokenSource interface {
 	isUpstreamSpec_Gemini_AuthTokenSource()
 }
@@ -1980,7 +1997,9 @@ type UpstreamSpec_VertexAI struct {
 	// The type of publisher model to use. Currently, only Google is supported.
 	Publisher UpstreamSpec_VertexAI_Publisher `protobuf:"varint,7,opt,name=publisher,proto3,enum=ai.options.gloo.solo.io.UpstreamSpec_VertexAI_Publisher" json:"publisher,omitempty"`
 	// Optional: Specify the API json schema the model uses, default to GEMINI if not set
-	JsonSchema    ApiJsonSchema `protobuf:"varint,8,opt,name=json_schema,json=jsonSchema,proto3,enum=ai.options.gloo.solo.io.ApiJsonSchema" json:"json_schema,omitempty"`
+	JsonSchema ApiJsonSchema `protobuf:"varint,8,opt,name=json_schema,json=jsonSchema,proto3,enum=ai.options.gloo.solo.io.ApiJsonSchema" json:"json_schema,omitempty"`
+	// Optional: Send requests to a custom host and port or configure custom path override or hostname
+	CustomHost    *UpstreamSpec_CustomHost `protobuf:"bytes,9,opt,name=custom_host,json=customHost,proto3" json:"custom_host,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2080,6 +2099,13 @@ func (x *UpstreamSpec_VertexAI) GetJsonSchema() ApiJsonSchema {
 	return ApiJsonSchema_NOT_SET
 }
 
+func (x *UpstreamSpec_VertexAI) GetCustomHost() *UpstreamSpec_CustomHost {
+	if x != nil {
+		return x.CustomHost
+	}
+	return nil
+}
+
 type isUpstreamSpec_VertexAI_AuthTokenSource interface {
 	isUpstreamSpec_VertexAI_AuthTokenSource()
 }
@@ -2102,8 +2128,7 @@ type UpstreamSpec_Mistral struct {
 	// This token is automatically sent in the `Authorization` header of the
 	// request and prefixed with `Bearer`.
 	AuthToken *SingleAuthToken `protobuf:"bytes,1,opt,name=auth_token,json=authToken,proto3" json:"auth_token,omitempty"`
-	// Optional: Send requests to a custom host and port, such as to proxy the request,
-	// or to use a different backend that is API-compliant with the upstream version.
+	// Optional: Send requests to a custom host and port or configure custom path override or hostname
 	CustomHost *UpstreamSpec_CustomHost `protobuf:"bytes,2,opt,name=custom_host,json=customHost,proto3" json:"custom_host,omitempty"`
 	// Optional: Override the model name.
 	// If unset, the model name is taken from the request.
@@ -2173,8 +2198,7 @@ type UpstreamSpec_Anthropic struct {
 	// The authorization token that the AI gateway uses to access the Anthropic API.
 	// This token is automatically sent in the `x-api-key` header of the request.
 	AuthToken *SingleAuthToken `protobuf:"bytes,1,opt,name=auth_token,json=authToken,proto3" json:"auth_token,omitempty"`
-	// Optional: Send requests to a custom host and port, such as to proxy the request,
-	// or to use a different backend that is API-compliant with the upstream version.
+	// Optional: Send requests to a custom host and port or configure custom path override or hostname
 	CustomHost *UpstreamSpec_CustomHost `protobuf:"bytes,2,opt,name=custom_host,json=customHost,proto3" json:"custom_host,omitempty"`
 	// Optional: The version string used to override the `anthropic-version` header to pass to the Anthropic API.
 	// Note: This does not control the api version (eg `/v1`) in the url.
@@ -2254,8 +2278,7 @@ type UpstreamSpec_Bedrock struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The authorization config used to access authenticated AWS Bedrock services.
 	CredentialProvider *UpstreamSpec_AwsCredentialProvider `protobuf:"bytes,1,opt,name=credential_provider,json=credentialProvider,proto3" json:"credential_provider,omitempty"`
-	// Optional: Send requests to a custom host and port, such as to proxy the request,
-	// or to use a different backend that is API-compliant with the upstream version.
+	// Optional: Send requests to a custom host and port or configure custom path override or hostname
 	// Note: For AWS Bedrock, if custom_host is set, host_rewrite will be used to override the Host header before signing the request
 	CustomHost *UpstreamSpec_CustomHost `protobuf:"bytes,2,opt,name=custom_host,json=customHost,proto3" json:"custom_host,omitempty"`
 	// Required: model string.
@@ -3957,7 +3980,7 @@ const file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_ai_ai
 	"secret_ref\x18\x02 \x01(\v2\x19.core.solo.io.ResourceRefH\x00R\tsecretRef\x12X\n" +
 	"\vpassthrough\x18\x03 \x01(\v24.ai.options.gloo.solo.io.SingleAuthToken.PassthroughH\x00R\vpassthrough\x1a\r\n" +
 	"\vPassthroughB\x13\n" +
-	"\x11auth_token_source\"\xd0\x1c\n" +
+	"\x11auth_token_source\"\xc9\x1e\n" +
 	"\fUpstreamSpec\x12F\n" +
 	"\x06openai\x18\x01 \x01(\v2,.ai.options.gloo.solo.io.UpstreamSpec.OpenAIH\x00R\x06openai\x12I\n" +
 	"\amistral\x18\x02 \x01(\v2-.ai.options.gloo.solo.io.UpstreamSpec.MistralH\x00R\amistral\x12O\n" +
@@ -3982,22 +4005,26 @@ const file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_ai_ai
 	"auth_token\x18\x01 \x01(\v2(.ai.options.gloo.solo.io.SingleAuthTokenR\tauthToken\x12Q\n" +
 	"\vcustom_host\x18\x02 \x01(\v20.ai.options.gloo.solo.io.UpstreamSpec.CustomHostR\n" +
 	"customHost\x12\x14\n" +
-	"\x05model\x18\x03 \x01(\tR\x05model\x1a\xd3\x01\n" +
+	"\x05model\x18\x03 \x01(\tR\x05model\x1a\xa6\x02\n" +
 	"\vAzureOpenAI\x12I\n" +
 	"\n" +
 	"auth_token\x18\x01 \x01(\v2(.ai.options.gloo.solo.io.SingleAuthTokenH\x00R\tauthToken\x12\x1a\n" +
 	"\bendpoint\x18\x02 \x01(\tR\bendpoint\x12'\n" +
 	"\x0fdeployment_name\x18\x03 \x01(\tR\x0edeploymentName\x12\x1f\n" +
 	"\vapi_version\x18\x04 \x01(\tR\n" +
-	"apiVersionB\x13\n" +
-	"\x11auth_token_source\x1a\x9f\x01\n" +
+	"apiVersion\x12Q\n" +
+	"\vcustom_host\x18\x05 \x01(\v20.ai.options.gloo.solo.io.UpstreamSpec.CustomHostR\n" +
+	"customHostB\x13\n" +
+	"\x11auth_token_source\x1a\xf2\x01\n" +
 	"\x06Gemini\x12I\n" +
 	"\n" +
 	"auth_token\x18\x01 \x01(\v2(.ai.options.gloo.solo.io.SingleAuthTokenH\x00R\tauthToken\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x1f\n" +
 	"\vapi_version\x18\x03 \x01(\tR\n" +
-	"apiVersionB\x13\n" +
-	"\x11auth_token_source\x1a\xb5\x03\n" +
+	"apiVersion\x12Q\n" +
+	"\vcustom_host\x18\x04 \x01(\v20.ai.options.gloo.solo.io.UpstreamSpec.CustomHostR\n" +
+	"customHostB\x13\n" +
+	"\x11auth_token_source\x1a\x88\x04\n" +
 	"\bVertexAI\x12I\n" +
 	"\n" +
 	"auth_token\x18\x01 \x01(\v2(.ai.options.gloo.solo.io.SingleAuthTokenH\x00R\tauthToken\x12\x14\n" +
@@ -4011,7 +4038,9 @@ const file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_ai_ai
 	"model_path\x18\x06 \x01(\tR\tmodelPath\x12V\n" +
 	"\tpublisher\x18\a \x01(\x0e28.ai.options.gloo.solo.io.UpstreamSpec.VertexAI.PublisherR\tpublisher\x12G\n" +
 	"\vjson_schema\x18\b \x01(\x0e2&.ai.options.gloo.solo.io.ApiJsonSchemaR\n" +
-	"jsonSchema\"\x17\n" +
+	"jsonSchema\x12Q\n" +
+	"\vcustom_host\x18\t \x01(\v20.ai.options.gloo.solo.io.UpstreamSpec.CustomHostR\n" +
+	"customHost\"\x17\n" +
 	"\tPublisher\x12\n" +
 	"\n" +
 	"\x06GOOGLE\x10\x00B\x13\n" +
@@ -4298,50 +4327,53 @@ var file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_ai_ai_p
 	7,  // 30: ai.options.gloo.solo.io.UpstreamSpec.OpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
 	19, // 31: ai.options.gloo.solo.io.UpstreamSpec.OpenAI.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
 	7,  // 32: ai.options.gloo.solo.io.UpstreamSpec.AzureOpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	7,  // 33: ai.options.gloo.solo.io.UpstreamSpec.Gemini.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	7,  // 34: ai.options.gloo.solo.io.UpstreamSpec.VertexAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	1,  // 35: ai.options.gloo.solo.io.UpstreamSpec.VertexAI.publisher:type_name -> ai.options.gloo.solo.io.UpstreamSpec.VertexAI.Publisher
-	0,  // 36: ai.options.gloo.solo.io.UpstreamSpec.VertexAI.json_schema:type_name -> ai.options.gloo.solo.io.ApiJsonSchema
-	7,  // 37: ai.options.gloo.solo.io.UpstreamSpec.Mistral.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	19, // 38: ai.options.gloo.solo.io.UpstreamSpec.Mistral.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
-	7,  // 39: ai.options.gloo.solo.io.UpstreamSpec.Anthropic.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	19, // 40: ai.options.gloo.solo.io.UpstreamSpec.Anthropic.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
-	27, // 41: ai.options.gloo.solo.io.UpstreamSpec.Bedrock.credential_provider:type_name -> ai.options.gloo.solo.io.UpstreamSpec.AwsCredentialProvider
-	19, // 42: ai.options.gloo.solo.io.UpstreamSpec.Bedrock.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
-	48, // 43: ai.options.gloo.solo.io.UpstreamSpec.AwsCredentialProvider.secret_ref:type_name -> core.solo.io.ResourceRef
-	28, // 44: ai.options.gloo.solo.io.UpstreamSpec.AwsCredentialProvider.inline:type_name -> ai.options.gloo.solo.io.UpstreamSpec.AWSInline
-	31, // 45: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.priorities:type_name -> ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Priority
-	20, // 46: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.openai:type_name -> ai.options.gloo.solo.io.UpstreamSpec.OpenAI
-	24, // 47: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.mistral:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Mistral
-	25, // 48: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.anthropic:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Anthropic
-	21, // 49: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.azure_openai:type_name -> ai.options.gloo.solo.io.UpstreamSpec.AzureOpenAI
-	22, // 50: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.gemini:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Gemini
-	23, // 51: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.vertex_ai:type_name -> ai.options.gloo.solo.io.UpstreamSpec.VertexAI
-	26, // 52: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.bedrock:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Bedrock
-	30, // 53: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Priority.pool:type_name -> ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend
-	7,  // 54: ai.options.gloo.solo.io.Embedding.OpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	7,  // 55: ai.options.gloo.solo.io.Embedding.AzureOpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	34, // 56: ai.options.gloo.solo.io.SemanticCache.DataStore.redis:type_name -> ai.options.gloo.solo.io.SemanticCache.Redis
-	35, // 57: ai.options.gloo.solo.io.SemanticCache.DataStore.weaviate:type_name -> ai.options.gloo.solo.io.SemanticCache.Weaviate
-	11, // 58: ai.options.gloo.solo.io.RAG.DataStore.postgres:type_name -> ai.options.gloo.solo.io.Postgres
-	44, // 59: ai.options.gloo.solo.io.AIPromptGuard.Regex.matches:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex.RegexMatch
-	4,  // 60: ai.options.gloo.solo.io.AIPromptGuard.Regex.builtins:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex.BuiltIn
-	5,  // 61: ai.options.gloo.solo.io.AIPromptGuard.Regex.action:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex.Action
-	45, // 62: ai.options.gloo.solo.io.AIPromptGuard.Webhook.forwardHeaders:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook.HeaderMatch
-	46, // 63: ai.options.gloo.solo.io.AIPromptGuard.Moderation.openai:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Moderation.OpenAI
-	47, // 64: ai.options.gloo.solo.io.AIPromptGuard.Request.custom_response:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Request.CustomResponse
-	39, // 65: ai.options.gloo.solo.io.AIPromptGuard.Request.regex:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex
-	40, // 66: ai.options.gloo.solo.io.AIPromptGuard.Request.webhook:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook
-	41, // 67: ai.options.gloo.solo.io.AIPromptGuard.Request.moderation:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Moderation
-	39, // 68: ai.options.gloo.solo.io.AIPromptGuard.Response.regex:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex
-	40, // 69: ai.options.gloo.solo.io.AIPromptGuard.Response.webhook:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook
-	6,  // 70: ai.options.gloo.solo.io.AIPromptGuard.Webhook.HeaderMatch.match_type:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook.HeaderMatch.MatchType
-	7,  // 71: ai.options.gloo.solo.io.AIPromptGuard.Moderation.OpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
-	72, // [72:72] is the sub-list for method output_type
-	72, // [72:72] is the sub-list for method input_type
-	72, // [72:72] is the sub-list for extension type_name
-	72, // [72:72] is the sub-list for extension extendee
-	0,  // [0:72] is the sub-list for field type_name
+	19, // 33: ai.options.gloo.solo.io.UpstreamSpec.AzureOpenAI.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
+	7,  // 34: ai.options.gloo.solo.io.UpstreamSpec.Gemini.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
+	19, // 35: ai.options.gloo.solo.io.UpstreamSpec.Gemini.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
+	7,  // 36: ai.options.gloo.solo.io.UpstreamSpec.VertexAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
+	1,  // 37: ai.options.gloo.solo.io.UpstreamSpec.VertexAI.publisher:type_name -> ai.options.gloo.solo.io.UpstreamSpec.VertexAI.Publisher
+	0,  // 38: ai.options.gloo.solo.io.UpstreamSpec.VertexAI.json_schema:type_name -> ai.options.gloo.solo.io.ApiJsonSchema
+	19, // 39: ai.options.gloo.solo.io.UpstreamSpec.VertexAI.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
+	7,  // 40: ai.options.gloo.solo.io.UpstreamSpec.Mistral.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
+	19, // 41: ai.options.gloo.solo.io.UpstreamSpec.Mistral.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
+	7,  // 42: ai.options.gloo.solo.io.UpstreamSpec.Anthropic.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
+	19, // 43: ai.options.gloo.solo.io.UpstreamSpec.Anthropic.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
+	27, // 44: ai.options.gloo.solo.io.UpstreamSpec.Bedrock.credential_provider:type_name -> ai.options.gloo.solo.io.UpstreamSpec.AwsCredentialProvider
+	19, // 45: ai.options.gloo.solo.io.UpstreamSpec.Bedrock.custom_host:type_name -> ai.options.gloo.solo.io.UpstreamSpec.CustomHost
+	48, // 46: ai.options.gloo.solo.io.UpstreamSpec.AwsCredentialProvider.secret_ref:type_name -> core.solo.io.ResourceRef
+	28, // 47: ai.options.gloo.solo.io.UpstreamSpec.AwsCredentialProvider.inline:type_name -> ai.options.gloo.solo.io.UpstreamSpec.AWSInline
+	31, // 48: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.priorities:type_name -> ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Priority
+	20, // 49: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.openai:type_name -> ai.options.gloo.solo.io.UpstreamSpec.OpenAI
+	24, // 50: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.mistral:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Mistral
+	25, // 51: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.anthropic:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Anthropic
+	21, // 52: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.azure_openai:type_name -> ai.options.gloo.solo.io.UpstreamSpec.AzureOpenAI
+	22, // 53: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.gemini:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Gemini
+	23, // 54: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.vertex_ai:type_name -> ai.options.gloo.solo.io.UpstreamSpec.VertexAI
+	26, // 55: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend.bedrock:type_name -> ai.options.gloo.solo.io.UpstreamSpec.Bedrock
+	30, // 56: ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Priority.pool:type_name -> ai.options.gloo.solo.io.UpstreamSpec.MultiPool.Backend
+	7,  // 57: ai.options.gloo.solo.io.Embedding.OpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
+	7,  // 58: ai.options.gloo.solo.io.Embedding.AzureOpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
+	34, // 59: ai.options.gloo.solo.io.SemanticCache.DataStore.redis:type_name -> ai.options.gloo.solo.io.SemanticCache.Redis
+	35, // 60: ai.options.gloo.solo.io.SemanticCache.DataStore.weaviate:type_name -> ai.options.gloo.solo.io.SemanticCache.Weaviate
+	11, // 61: ai.options.gloo.solo.io.RAG.DataStore.postgres:type_name -> ai.options.gloo.solo.io.Postgres
+	44, // 62: ai.options.gloo.solo.io.AIPromptGuard.Regex.matches:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex.RegexMatch
+	4,  // 63: ai.options.gloo.solo.io.AIPromptGuard.Regex.builtins:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex.BuiltIn
+	5,  // 64: ai.options.gloo.solo.io.AIPromptGuard.Regex.action:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex.Action
+	45, // 65: ai.options.gloo.solo.io.AIPromptGuard.Webhook.forwardHeaders:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook.HeaderMatch
+	46, // 66: ai.options.gloo.solo.io.AIPromptGuard.Moderation.openai:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Moderation.OpenAI
+	47, // 67: ai.options.gloo.solo.io.AIPromptGuard.Request.custom_response:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Request.CustomResponse
+	39, // 68: ai.options.gloo.solo.io.AIPromptGuard.Request.regex:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex
+	40, // 69: ai.options.gloo.solo.io.AIPromptGuard.Request.webhook:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook
+	41, // 70: ai.options.gloo.solo.io.AIPromptGuard.Request.moderation:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Moderation
+	39, // 71: ai.options.gloo.solo.io.AIPromptGuard.Response.regex:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Regex
+	40, // 72: ai.options.gloo.solo.io.AIPromptGuard.Response.webhook:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook
+	6,  // 73: ai.options.gloo.solo.io.AIPromptGuard.Webhook.HeaderMatch.match_type:type_name -> ai.options.gloo.solo.io.AIPromptGuard.Webhook.HeaderMatch.MatchType
+	7,  // 74: ai.options.gloo.solo.io.AIPromptGuard.Moderation.OpenAI.auth_token:type_name -> ai.options.gloo.solo.io.SingleAuthToken
+	75, // [75:75] is the sub-list for method output_type
+	75, // [75:75] is the sub-list for method input_type
+	75, // [75:75] is the sub-list for extension type_name
+	75, // [75:75] is the sub-list for extension extendee
+	0,  // [0:75] is the sub-list for field type_name
 }
 
 func init() { file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_ai_ai_proto_init() }

--- a/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.hash.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.hash.go
@@ -1058,6 +1058,26 @@ func (m *UpstreamSpec_AzureOpenAI) Hash(hasher hash.Hash64) (uint64, error) {
 		return 0, err
 	}
 
+	if h, ok := interface{}(m.GetCustomHost()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetCustomHost(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
 	switch m.AuthTokenSource.(type) {
 
 	case *UpstreamSpec_AzureOpenAI_AuthToken:
@@ -1110,6 +1130,26 @@ func (m *UpstreamSpec_Gemini) Hash(hasher hash.Hash64) (uint64, error) {
 
 	if _, err = hasher.Write([]byte(m.GetApiVersion())); err != nil {
 		return 0, err
+	}
+
+	if h, ok := interface{}(m.GetCustomHost()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetCustomHost(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
 	}
 
 	switch m.AuthTokenSource.(type) {
@@ -1186,6 +1226,26 @@ func (m *UpstreamSpec_VertexAI) Hash(hasher hash.Hash64) (uint64, error) {
 	err = binary.Write(hasher, binary.LittleEndian, m.GetJsonSchema())
 	if err != nil {
 		return 0, err
+	}
+
+	if h, ok := interface{}(m.GetCustomHost()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetCustomHost(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
 	}
 
 	switch m.AuthTokenSource.(type) {

--- a/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.uniquehash.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/ai/ai.pb.uniquehash.go
@@ -1117,6 +1117,26 @@ func (m *UpstreamSpec_AzureOpenAI) HashUnique(hasher hash.Hash64) (uint64, error
 		return 0, err
 	}
 
+	if h, ok := interface{}(m.GetCustomHost()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetCustomHost(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
 	switch m.AuthTokenSource.(type) {
 
 	case *UpstreamSpec_AzureOpenAI_AuthToken:
@@ -1174,6 +1194,26 @@ func (m *UpstreamSpec_Gemini) HashUnique(hasher hash.Hash64) (uint64, error) {
 	}
 	if _, err = hasher.Write([]byte(m.GetApiVersion())); err != nil {
 		return 0, err
+	}
+
+	if h, ok := interface{}(m.GetCustomHost()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetCustomHost(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
 	}
 
 	switch m.AuthTokenSource.(type) {
@@ -1270,6 +1310,26 @@ func (m *UpstreamSpec_VertexAI) HashUnique(hasher hash.Hash64) (uint64, error) {
 	err = binary.Write(hasher, binary.LittleEndian, m.GetJsonSchema())
 	if err != nil {
 		return 0, err
+	}
+
+	if h, ok := interface{}(m.GetCustomHost()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetCustomHost(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("CustomHost")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
 	}
 
 	switch m.AuthTokenSource.(type) {


### PR DESCRIPTION
# Description

This is only the api change, the actual change is in solo-projects

## API changes
Added customHost field to azure_openai, gemini and vertex_ai ai upstreams

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
