### PR TITLE
bump envoy-gloo to v1.35.2-patch2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SOURCES := $(shell find . -name "*.go" | grep -v test.go)
 # for more information, see https://github.com/solo-io/gloo/pull/9633
 # and
 # https://soloio.slab.com/posts/extended-http-methods-design-doc-40j7pjeu
-ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.35.2-patch1
+ENVOY_GLOO_IMAGE ?= quay.io/solo-io/envoy-gloo:1.35.2-patch2
 LDFLAGS := "-X github.com/solo-io/gloo/pkg/version.Version=$(VERSION)"
 GCFLAGS ?=
 

--- a/changelog/v1.21.0-beta2/bump-envoy-gloo-v1.35.2-patch2.yaml
+++ b/changelog/v1.21.0-beta2/bump-envoy-gloo-v1.35.2-patch2.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    issueLink: https://github.com/solo-io/solo-projects/issues/8562
+    dependencyOwner: solo-io
+    dependencyRepo: envoy-gloo
+    dependencyTag: v1.35.2-patch2
+    resolvesIssue: false
+    description: >-
+      bump envoy-gloo to bring in OpenAI Responses API passthrough changes


### PR DESCRIPTION
# Description

bump envoy-gloo to v1.35.2-patch2 to bring in the OpenAI Responses API passthrough support


# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
