### PR TITLE
switch from bitnami/kubectl to rancher/kubectl when building docker image

### DIFF
--- a/changelog/v1.21.0-beta2/fix-kubectl-docker-build.yaml
+++ b/changelog/v1.21.0-beta2/fix-kubectl-docker-build.yaml
@@ -1,0 +1,5 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    description: >-
+      switch from bitnami/kubectl to rancher/kubectl when building docker image

--- a/changelog/v1.21.0-beta2/fix-kubectl-docker-build.yaml
+++ b/changelog/v1.21.0-beta2/fix-kubectl-docker-build.yaml
@@ -3,3 +3,5 @@ changelog:
     resolvesIssue: false
     description: >-
       switch from bitnami/kubectl to rancher/kubectl when building docker image
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,11 +1,11 @@
 ARG BASE_IMAGE
 
-FROM bitnami/kubectl:1.33.3 as kubectl
+FROM rancher/kubectl:v1.34.1 as kubectl
 
 FROM $BASE_IMAGE
 
 RUN apk upgrade --update-cache
 
-COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+COPY --from=kubectl /bin/kubectl /usr/local/bin/
 
 USER 10101

--- a/jobs/kubectl/Dockerfile.distroless
+++ b/jobs/kubectl/Dockerfile.distroless
@@ -1,9 +1,9 @@
 ARG BASE_IMAGE
 
-FROM bitnami/kubectl:1.33.3 as kubectl
+FROM rancher/kubectl:v1.34.1 as kubectl
 
 FROM $BASE_IMAGE
 
-COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+COPY --from=kubectl /bin/kubectl /usr/local/bin/
 
 USER 10101


### PR DESCRIPTION
# Description

The bitnami image is no longer available. Also updated to 1.34.1 while we are there as we already updated our support matrix to cover k8s 1.34. 

skipping tests because the tests do not use the Dockerfiles. They are only used when we publish a release. 
## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
