### PR TITLE
[1.20] switch from bitnami/kubectl to rancher/kubectl when building docker image

### DIFF
--- a/changelog/v1.20.0-rc3/fix-kubectl-docker-build.yaml
+++ b/changelog/v1.20.0-rc3/fix-kubectl-docker-build.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    description: >-
+      switch from bitnami/kubectl to rancher/kubectl when building docker image
+      skipCI-kube-tests:true
+      skipCI-docs-build:true

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,11 +1,11 @@
 ARG BASE_IMAGE
 
-FROM bitnami/kubectl:1.33.3 as kubectl
+FROM rancher/kubectl:v1.34.1 as kubectl
 
 FROM $BASE_IMAGE
 
 RUN apk upgrade --update-cache
 
-COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+COPY --from=kubectl /bin/kubectl /usr/local/bin/
 
 USER 10101

--- a/jobs/kubectl/Dockerfile.distroless
+++ b/jobs/kubectl/Dockerfile.distroless
@@ -1,9 +1,9 @@
 ARG BASE_IMAGE
 
-FROM bitnami/kubectl:1.33.3 as kubectl
+FROM rancher/kubectl:v1.34.1 as kubectl
 
 FROM $BASE_IMAGE
 
-COPY --from=kubectl /opt/bitnami/kubectl/bin/kubectl /usr/local/bin/
+COPY --from=kubectl /bin/kubectl /usr/local/bin/
 
 USER 10101


### PR DESCRIPTION
# Description

backport of #10996 

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
