### PR TITLE
dummy release

### DIFF
--- a/changelog/v1.21.0-beta3/dummy-release.yaml
+++ b/changelog/v1.21.0-beta3/dummy-release.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    description: >-
+      dummy release to workaround sum.golang.org caching the wrong checksum for v1.21.0-beta2.
+      The initial release build failed because of the bitnami docker image no longer exists. Fixed 
+      that removed the tag and re-release but sum.golang.org already cache the checksum of the old 
+      failed release tag. 
+ 
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description
dummy release to workaround sum.golang.org caching the wrong checksum for v1.21.0-beta2.
The initial release build failed because of the bitnami docker image no longer exists. Fixed 
that, removed the tag and re-release but sum.golang.org already cache the checksum of the old 
failed release tag. 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
