### PR TITLE
fix: don't assume kind in AppendSourceToListener

### DIFF
--- a/changelog/v1.21.0-beta9/fix-gk.yaml
+++ b/changelog/v1.21.0-beta9/fix-gk.yaml
@@ -1,0 +1,6 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/solo-projects/issues/8681
+  resolvesIssue: false
+  description: >-
+    fix: don't assume source is listeneroption when appending source to listener in AppendSourceToListener

--- a/projects/gateway2/translator/listenerutils/utils.go
+++ b/projects/gateway2/translator/listenerutils/utils.go
@@ -1,7 +1,6 @@
 package listenerutils
 
 import (
-	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -19,8 +18,8 @@ func SetListenerSources(listener *v1.Listener, sources []*v1.SourceMetadata_Sour
 	}
 }
 
-// AppendSourceToListener appends a source ListenerOption to the Listener's metadata static
-func AppendSourceToListener(listener *v1.Listener, source client.Object) {
+// AppendSourceToListener appends a source object to the Listener's static metadata
+func AppendSourceToListener(listener *v1.Listener, source client.Object, resourceKind string) {
 	meta := listener.GetMetadataStatic()
 	if meta == nil {
 		meta = &v1.SourceMetadata{}
@@ -31,7 +30,7 @@ func AppendSourceToListener(listener *v1.Listener, source client.Object) {
 			Name:      source.GetName(),
 			Namespace: source.GetNamespace(),
 		},
-		ResourceKind:       sologatewayv1.ListenerOptionGVK.Kind,
+		ResourceKind:       resourceKind,
 		ObservedGeneration: source.GetGeneration(),
 	})
 	listener.OpaqueMetadata = &v1.Listener_MetadataStatic{

--- a/projects/gateway2/translator/plugins/listeneroptions/listener_options_plugin.go
+++ b/projects/gateway2/translator/plugins/listeneroptions/listener_options_plugin.go
@@ -98,7 +98,7 @@ func (p *plugin) ApplyListenerPlugin(
 		outListener.Options = optionUsed.Spec.GetOptions()
 	}
 
-	listenerutils.AppendSourceToListener(outListener, optionUsed)
+	listenerutils.AppendSourceToListener(outListener, optionUsed, sologatewayv1.ListenerOptionGVK.Kind)
 
 	nn := client.ObjectKeyFromObject(optionUsed)
 	p.legacyStatusCache[nn] = newLegacyStatus()

--- a/projects/gateway2/translator/plugins/virtualhostoptions/virtualhost_options_plugin.go
+++ b/projects/gateway2/translator/plugins/virtualhostoptions/virtualhost_options_plugin.go
@@ -141,7 +141,7 @@ func (p *plugin) ApplyListenerPlugin(
 			v.Options = merged.Spec.GetOptions()
 			vhostutils.AppendSourceToVirtualHost(v, opt)
 		}
-		listenerutils.AppendSourceToListener(outListener, opt)
+		listenerutils.AppendSourceToListener(outListener, opt, sologatewayv1.VirtualHostOptionGVK.Kind)
 
 		// track that we used this VirtualHostOption in our status cache
 		// we do this so we can persist status later for all attached VirtualHostOptions


### PR DESCRIPTION
# Description

the assumption in https://github.com/solo-io/gloo/pull/11076 wasn't true. AppendSourceToListener can append either a ListenerOption or VirtualHostOption. 

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
