### PR TITLE
Workaround solo-projects CI go.sum checksum mismatch on v1.20.5

### DIFF
--- a/changelog/v1.20.6/v1.20.x.yaml
+++ b/changelog/v1.20.6/v1.20.x.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    description: >-
+      dummy release to workaround sum.golang.org caching the wrong checksum for v1.20.5.
+
+      skipCI-kube-tests:true
+      skipCI-docs-build:true


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

Trying to fix the solo-projects bump CI [checksum errors](https://github.com/solo-io/solo-projects/actions/runs/20464521536/job/58875851655#step:5:1305) with v1.20.5 by release a v1.20.6.