### PR TITLE
[v1.20.x] fix oneWayTls

### DIFF
--- a/changelog/v1.20.8/onewaytls.yaml
+++ b/changelog/v1.20.8/onewaytls.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/8654
+  resolvesIssue: false
+  description: When oneWayTls is set to true, the ValidationContext is removed to prevent Envoy from requesting a client certificate during the TLS handshake.

--- a/projects/gloo/pkg/utils/ssl.go
+++ b/projects/gloo/pkg/utils/ssl.go
@@ -104,6 +104,14 @@ func (s *sslConfigTranslator) ResolveDownstreamSslConfig(secrets v1.SecretList, 
 	var requireClientCert *wrappers.BoolValue
 	if common.GetValidationContextType() != nil {
 		requireClientCert = &wrappers.BoolValue{Value: !dc.GetOneWayTls().GetValue()}
+		// When oneWayTls is true, remove the ValidationContext to prevent Envoy from
+		// requesting a client certificate during the TLS handshake. The presence of
+		// a ValidationContext causes Envoy to request client certificates even when
+		// RequireClientCertificate is false (which only controls whether the cert is
+		// required, not whether it's requested).
+		if dc.GetOneWayTls().GetValue() {
+			common.ValidationContextType = nil
+		}
 	}
 
 	// default alpn for downstreams.

--- a/projects/gloo/pkg/utils/ssl_test.go
+++ b/projects/gloo/pkg/utils/ssl_test.go
@@ -233,6 +233,15 @@ Header: 1
 			Expect(cfg.RequireClientCertificate.GetValue()).To(BeFalse())
 		})
 
+		It("should remove validation context if oneWayTls enabled for downstream config", func() {
+			downstreamCfg.OneWayTls = &wrappers.BoolValue{Value: true}
+			cfg, err := configTranslator.ResolveDownstreamSslConfig(secrets, downstreamCfg)
+			Expect(err).NotTo(HaveOccurred())
+			// When oneWayTls is true, ValidationContext should be removed to prevent Envoy
+			// from requesting client certificates during the TLS handshake
+			Expect(cfg.CommonTlsContext.GetValidationContext()).To(BeNil(), "Validation context should be removed to prevent client certificate requests")
+		})
+
 		It("should remove client certificates but keep validation context if oneWayTls enabled for upstream config", func() {
 			upstreamCfg.OneWayTls = &wrappers.BoolValue{Value: true}
 			cfg, err := configTranslator.ResolveUpstreamSslConfig(secrets, upstreamCfg)

--- a/test/kubernetes/e2e/features/client_tls/testdata/vs-oneway-downstream-tls.yaml
+++ b/test/kubernetes/e2e/features/client_tls/testdata/vs-oneway-downstream-tls.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.solo.io/v1
+kind: VirtualService
+metadata:
+  name: vs-oneway-downstream-tls
+spec:
+  sslConfig:
+    oneWayTls: true
+    secretRef:
+      name: nginx-tls
+      namespace: nginx
+  virtualHost:
+    domains:
+      - oneway-downstream.example.com
+    routes:
+      - matchers:
+          - exact: /
+        routeAction:
+          single:
+            upstream:
+              name: nginx
+              namespace: nginx
+        options:
+          prefixRewrite: /
+

--- a/test/kubernetes/e2e/features/client_tls/types.go
+++ b/test/kubernetes/e2e/features/client_tls/types.go
@@ -6,7 +6,9 @@ import (
 
 	"github.com/onsi/gomega"
 
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	kubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
 	"github.com/solo-io/gloo/test/gomega/matchers"
@@ -23,6 +25,9 @@ var VSTargetingUpstreamYaml []byte
 
 //go:embed testdata/vs-targeting-kube.yaml
 var VSTargetingKubeYaml []byte
+
+//go:embed testdata/vs-oneway-downstream-tls.yaml
+var VSOnewayDownstreamTlsYaml []byte
 
 var (
 	vSTargetingUpstreamObject = func(ns string) *kubev1.VirtualService {
@@ -43,6 +48,15 @@ var (
 		}
 	}
 
+	vSOnewayDownstreamTlsObject = func(ns string) *kubev1.VirtualService {
+		return &kubev1.VirtualService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "vs-oneway-downstream-tls",
+				Namespace: ns,
+			},
+		}
+	}
+
 	expectedHealthyResponse = &matchers.HttpResponse{
 		StatusCode: http.StatusOK,
 		Body:       gomega.ContainSubstring("Welcome to nginx!"),
@@ -51,5 +65,20 @@ var (
 	expectedCertVerifyFailedResponse = &matchers.HttpResponse{
 		StatusCode: http.StatusServiceUnavailable,
 		Body:       gomega.ContainSubstring("CERTIFICATE_VERIFY_FAILED"),
+	}
+
+	nginxTlsSecret = func(ns string) *corev1.Secret {
+		return &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "nginx-tls",
+				Namespace: ns,
+			},
+		}
+	}
+
+	coreSecretGVK = schema.GroupVersionKind{
+		Version: "v1",
+		Group:   "",
+		Kind:    "Secret",
 	}
 )


### PR DESCRIPTION
# Description

<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

envoy will still request a Client cert if validation context is set. This can cause an issue with some clients. In order to avoid requesting the client cert, set validation context to nil if one way tls is enabled.

Even though we set `RequireClientCertificate` to false, Envoy still _requests_ the cert if validation context is set. 

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
