### PR TITLE
[main] CVE fix bump kubectl to 1.34.3

### DIFF
--- a/.github/workflows/.env/nightly-tests/max_versions.env
+++ b/.github/workflows/.env/nightly-tests/max_versions.env
@@ -1,5 +1,5 @@
 node_version='v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a'
-kubectl_version='v1.34.0'
+kubectl_version='v1.34.3'
 kind_version='v0.30.0'
 helm_version='v3.18.6'
 argocd_version='v3.1.1'

--- a/.github/workflows/.env/pr-tests/versions.env
+++ b/.github/workflows/.env/pr-tests/versions.env
@@ -1,5 +1,5 @@
 node_version='v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a'
-kubectl_version='v1.34.0'
+kubectl_version='v1.34.3'
 kind_version='v0.30.0'
 helm_version='v3.18.6'
 argocd_version='v3.1.1'

--- a/changelog/v1.21.0-beta12/bump-kubectl-1.34.3.yaml
+++ b/changelog/v1.21.0-beta12/bump-kubectl-1.34.3.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: rancher
+  dependencyRepo: kubectl
+  dependencyTag: v1.34.3
+  description: >-
+    Bump kubectl distroless image to 1.34.3 to fix CVE-2025-58183 and CVE-2025-61729
+  issueLink: https://github.com/solo-io/gloo/issues/11089
+  resolvesIssue: false

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM rancher/kubectl:v1.34.1 as kubectl
+FROM rancher/kubectl:v1.34.3 as kubectl
 
 FROM $BASE_IMAGE
 

--- a/jobs/kubectl/Dockerfile.distroless
+++ b/jobs/kubectl/Dockerfile.distroless
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM rancher/kubectl:v1.34.1 as kubectl
+FROM rancher/kubectl:v1.34.3 as kubectl
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

- Update kubectl image to 1.34.3 to resolve CVE-2025-58183 and CVE-2025-61729
- Update nightly test max version and pr test version of kubectl image to 1.34.3

# Context

## Testing steps

```
 make scan-version
GO111MODULE=on go run github.com/solo-io/go-utils/securityscanutils/cli scan-version -v \
                -r quay.io/solo-io\
                -t 1.0.1-dev\
                --images gloo,gloo-envoy-wrapper,discovery,ingress,sds,certgen,access-logger,kubectl
{"level":"info","ts":"2026-01-12T00:50:17.918-0800","caller":"commands/scan_version.go:73","msg":"Starting ScanVersion with version=1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:28.283-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 10.364838375s on quay.io/solo-io/gloo:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:28.283-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/gloo:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T00:50:29.198-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 914.85475ms on quay.io/solo-io/gloo-envoy-wrapper:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:29.198-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/gloo-envoy-wrapper:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T00:50:30.296-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 1.098014s on quay.io/solo-io/discovery:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:30.296-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/discovery:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T00:50:31.106-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 810.13575ms on quay.io/solo-io/ingress:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:31.106-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/ingress:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T00:50:31.698-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 591.78375ms on quay.io/solo-io/sds:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:31.698-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/sds:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T00:50:32.432-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 733.401333ms on quay.io/solo-io/certgen:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:32.432-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/certgen:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T00:50:33.259-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 827.6795ms on quay.io/solo-io/access-logger:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:33.259-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/access-logger:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T00:50:33.762-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 502.952583ms on quay.io/solo-io/kubectl:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T00:50:33.762-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/kubectl:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"info","ts":"2026-01-12T00:50:33.763-0800","caller":"commands/scan_version.go:31","msg":"No vulnerabilities found"}
```

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
