### PR TITLE
[1.18] CVE fix bump kubectl to 1.34.3

### DIFF
--- a/.github/workflows/.env/nightly-tests/max_versions.env
+++ b/.github/workflows/.env/nightly-tests/max_versions.env
@@ -1,5 +1,5 @@
 node_version='v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865'
-kubectl_version='v1.31.0'
+kubectl_version='v1.34.3'
 kind_version='v0.24.0'
 helm_version='v3.14.4'
 argocd_version='v2.8.4'

--- a/.github/workflows/.env/pr-tests/versions.env
+++ b/.github/workflows/.env/pr-tests/versions.env
@@ -1,5 +1,5 @@
 node_version='v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865'
-kubectl_version='v1.31.0'
+kubectl_version='v1.34.3'
 kind_version='v0.24.0'
 helm_version='v3.14.4'
 argocd_version='v2.8.4'

--- a/changelog/v1.18.32/bump-kubectl-1.34.3.yaml
+++ b/changelog/v1.18.32/bump-kubectl-1.34.3.yaml
@@ -1,0 +1,9 @@
+changelog:
+- type: DEPENDENCY_BUMP
+  dependencyOwner: rancher
+  dependencyRepo: kubectl
+  dependencyTag: v1.34.3
+  description: >-
+    Bump kubectl distroless image to 1.34.3 to fix CVE-2025-58183 and CVE-2025-61729
+  issueLink: https://github.com/solo-io/gloo/issues/11090
+  resolvesIssue: false

--- a/jobs/kubectl/Dockerfile
+++ b/jobs/kubectl/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM rancher/kubectl:v1.34.1 as kubectl
+FROM rancher/kubectl:v1.34.3 as kubectl
 
 FROM $BASE_IMAGE
 

--- a/jobs/kubectl/Dockerfile.distroless
+++ b/jobs/kubectl/Dockerfile.distroless
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE
 
-FROM rancher/kubectl:v1.34.1 as kubectl
+FROM rancher/kubectl:v1.34.3 as kubectl
 
 FROM $BASE_IMAGE
 


### PR DESCRIPTION
# Description

<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

- Update kubectl image to 1.34.3 to resolve CVE-2025-58183 and CVE-2025-61729
- Update nightly test max version and pr test version of kubectl image to 1.34.3

# Context

## Testing steps

```
make scan-version
GO111MODULE=on go run github.com/solo-io/go-utils/securityscanutils/cli scan-version -v \
                -r quay.io/solo-io\
                -t 1.0.1-dev\
                --images gloo,gloo-envoy-wrapper,discovery,ingress,sds,certgen,access-logger,kubectl
{"level":"info","ts":"2026-01-12T17:36:25.840-0800","caller":"commands/scan_version.go:73","msg":"Starting ScanVersion with version=1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:25.936-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 95.673791ms on quay.io/solo-io/gloo:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:25.936-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/gloo:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T17:36:26.018-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 82.594958ms on quay.io/solo-io/gloo-envoy-wrapper:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:26.018-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/gloo-envoy-wrapper:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T17:36:26.093-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 74.334667ms on quay.io/solo-io/discovery:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:26.093-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/discovery:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T17:36:26.179-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 85.732667ms on quay.io/solo-io/ingress:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:26.179-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/ingress:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T17:36:26.259-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 80.860459ms on quay.io/solo-io/sds:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:26.260-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/sds:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T17:36:26.347-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 87.275167ms on quay.io/solo-io/certgen:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:26.347-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/certgen:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T17:36:26.424-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 76.656458ms on quay.io/solo-io/access-logger:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:26.424-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/access-logger:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"debug","ts":"2026-01-12T17:36:26.507-0800","caller":"securityscanutils/trivy_scanner.go:89","msg":"Trivy returned 0 after 83.7135ms on quay.io/solo-io/kubectl:1.0.1-dev"}
{"level":"debug","ts":"2026-01-12T17:36:26.507-0800","caller":"commands/scan_version.go:100","msg":"Scanned Image: quay.io/solo-io/kubectl:1.0.1-dev, ScanCompleted: true, VulnerabilityFound: false, Error: <nil>"}
{"level":"info","ts":"2026-01-12T17:36:26.508-0800","caller":"commands/scan_version.go:31","msg":"No vulnerabilities found"}
```

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->


# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->
