### PR TITLE
release v1.21.1

### DIFF
--- a/changelog/v1.21.1/bump-release.yaml
+++ b/changelog/v1.21.1/bump-release.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    description: >-
+      bump release
+      skipCI-kube-tests:true
+      skipCI-storybook-tests:true
+      skipCI-in-memory-e2e-tests:true


### PR DESCRIPTION
# Description

v1.21.0 failed to release initially and it's in a very early stage, I thought it was ok to remove the tag and re-release but the go sum is already out there somehow. So, need to burn a release to get things right.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
