### PR TITLE
extauth: add API key digest config to AuthConfig

### DIFF
--- a/changelog/v1.22.0-beta1/issue-1581-digest-api.yaml
+++ b/changelog/v1.22.0-beta1/issue-1581-digest-api.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/gloo-gateway/issues/1581
+    resolvesIssue: false
+    description: >-
+      Add enterprise ExtAuth AuthConfig API/CRD support for API-key SHA256 digest
+      configuration via `apiKeyAuth.digest` and same-name header matching via
+      `apiKeyAuth.match`. This PR adds the proto/schema/generated API surface only;
+      runtime verification behavior is implemented in downstream ext-auth-service.

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk.md
@@ -1498,8 +1498,8 @@ added to the `AuthorizationRequest` state under the "api_key_value" key name.
 | `aerospikeApikeyStorage` | [.enterprise.gloo.solo.io.AerospikeApiKeyStorage](../extauth.proto.sk/#aerospikeapikeystorage) | <b>Deprecated</b>: Support for Aerospike is deprecated and will be removed in a future release. Use of this feature is not recommended. Only one of `aerospikeApikeyStorage` or `k8sSecretApikeyStorage` can be set. |
 | `skipMetadataValidation` | `bool` | API key metadata may contain data is is invalid for a header, such as a newline. By default, this data will be validated in the data plane and mitigated in a way that provides a consistent experience for the user and visibility for the operator. This validation comes with a performance cost, and can be disabled by setting this field to `true`. |
 | `hmac` | [.enterprise.gloo.solo.io.ApiKeyHmac](../extauth.proto.sk/#apikeyhmac) | Optional HMAC digest verification mode for API key validation. When configured, stored API key values are treated as HMAC digests and the request API key is transformed prior to comparison. |
-| `digest` | [.enterprise.gloo.solo.io.ApiKeyDigest](../extauth.proto.sk/#apikeydigest) | Optional digest verification mode for API key validation. When configured, stored API key values are treated as digests and the request API key is transformed prior to comparison. |
-| `match` | [.enterprise.gloo.solo.io.ApiKeyMatch](../extauth.proto.sk/#apikeymatch) | Optional additional request header matching for API key validation. When configured, each header must match a same-named data key on the matched API key secret. |
+| `digest` | [.enterprise.gloo.solo.io.ApiKeyDigest](../extauth.proto.sk/#apikeydigest) | Optional digest verification mode for API key validation. When configured, stored API key values are treated as digests and the request API key is transformed prior to comparison. When omitted, existing raw API key comparison behavior remains unchanged. |
+| `match` | [.enterprise.gloo.solo.io.ApiKeyMatch](../extauth.proto.sk/#apikeymatch) | Optional additional request header matching for digest-based API key validation. This field is only valid when digest is configured. ext-auth-service should reject configs that set match without digest. When configured, each header must match a same-named data key on the matched API key secret. |
 
 
 
@@ -1616,6 +1616,7 @@ Supported digest algorithms for API key verification.
 
  
 Additional request headers that must match same-named data keys on the matched API key secret.
+This message is only valid when ApiKeyAuth.digest is configured.
 
 ```yaml
 "headers": []enterprise.gloo.solo.io.HeaderMatch
@@ -1642,7 +1643,7 @@ A request header that must match the same-named data key on the matched API key 
 
 | Field | Type | Description |
 | ----- | ---- | ----------- | 
-| `name` | `string` |  |
+| `name` | `string` | Header name to match. Request headers are case-insensitive, but this configured name is also used as the Secret data key for same-name matching, so operators should use a canonical lowercase name. |
 
 
 

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk.md
@@ -74,6 +74,10 @@ weight: 5
 - [MetadataEntry](#metadataentry)
 - [ApiKeyHmac](#apikeyhmac)
 - [Algorithm](#algorithm)
+- [ApiKeyDigest](#apikeydigest)
+- [Algorithm](#algorithm-1)
+- [ApiKeyMatch](#apikeymatch)
+- [HeaderMatch](#headermatch-1)
 - [K8sSecretApiKeyStorage](#k8ssecretapikeystorage)
 - [AerospikeApiKeyStorage](#aerospikeapikeystorage)
 - [readModeSc](#readmodesc)
@@ -1478,6 +1482,8 @@ added to the `AuthorizationRequest` state under the "api_key_value" key name.
 "aerospikeApikeyStorage": .enterprise.gloo.solo.io.AerospikeApiKeyStorage
 "skipMetadataValidation": bool
 "hmac": .enterprise.gloo.solo.io.ApiKeyHmac
+"digest": .enterprise.gloo.solo.io.ApiKeyDigest
+"match": .enterprise.gloo.solo.io.ApiKeyMatch
 
 ```
 
@@ -1492,6 +1498,8 @@ added to the `AuthorizationRequest` state under the "api_key_value" key name.
 | `aerospikeApikeyStorage` | [.enterprise.gloo.solo.io.AerospikeApiKeyStorage](../extauth.proto.sk/#aerospikeapikeystorage) | <b>Deprecated</b>: Support for Aerospike is deprecated and will be removed in a future release. Use of this feature is not recommended. Only one of `aerospikeApikeyStorage` or `k8sSecretApikeyStorage` can be set. |
 | `skipMetadataValidation` | `bool` | API key metadata may contain data is is invalid for a header, such as a newline. By default, this data will be validated in the data plane and mitigated in a way that provides a consistent experience for the user and visibility for the operator. This validation comes with a performance cost, and can be disabled by setting this field to `true`. |
 | `hmac` | [.enterprise.gloo.solo.io.ApiKeyHmac](../extauth.proto.sk/#apikeyhmac) | Optional HMAC digest verification mode for API key validation. When configured, stored API key values are treated as HMAC digests and the request API key is transformed prior to comparison. |
+| `digest` | [.enterprise.gloo.solo.io.ApiKeyDigest](../extauth.proto.sk/#apikeydigest) | Optional digest verification mode for API key validation. When configured, stored API key values are treated as digests and the request API key is transformed prior to comparison. |
+| `match` | [.enterprise.gloo.solo.io.ApiKeyMatch](../extauth.proto.sk/#apikeymatch) | Optional additional request header matching for API key validation. When configured, each header must match a same-named data key on the matched API key secret. |
 
 
 
@@ -1567,6 +1575,74 @@ Supported HMAC algorithms for API key digest verification.
 | ----- | ----------- | 
 | `ALGORITHM_UNSPECIFIED` | When unspecified, ext-auth-service should default to HMAC_SHA256. |
 | `HMAC_SHA256` |  |
+
+
+
+
+---
+### ApiKeyDigest {#apikeydigest}
+
+ 
+Configuration for digest-based API key verification.
+
+```yaml
+"algorithm": .enterprise.gloo.solo.io.ApiKeyDigest.Algorithm
+
+```
+
+| Field | Type | Description |
+| ----- | ---- | ----------- | 
+| `algorithm` | [.enterprise.gloo.solo.io.ApiKeyDigest.Algorithm](../extauth.proto.sk/#algorithm-1) | Algorithm used to compute the digest for comparison against stored API key values. |
+
+
+
+
+---
+### Algorithm {#algorithm-1}
+
+ 
+Supported digest algorithms for API key verification.
+
+| Name | Description |
+| ----- | ----------- | 
+| `ALGORITHM_UNSPECIFIED` | When unspecified, ext-auth-service should default to SHA256. |
+| `SHA256` |  |
+
+
+
+
+---
+### ApiKeyMatch {#apikeymatch}
+
+ 
+Additional request headers that must match same-named data keys on the matched API key secret.
+
+```yaml
+"headers": []enterprise.gloo.solo.io.HeaderMatch
+
+```
+
+| Field | Type | Description |
+| ----- | ---- | ----------- | 
+| `headers` | [[]enterprise.gloo.solo.io.HeaderMatch](../extauth.proto.sk/#headermatch-1) |  |
+
+
+
+
+---
+### HeaderMatch {#headermatch-1}
+
+ 
+A request header that must match the same-named data key on the matched API key secret.
+
+```yaml
+"name": string
+
+```
+
+| Field | Type | Description |
+| ----- | ---- | ----------- | 
+| `name` | `string` |  |
 
 
 

--- a/docs/data/ProtoMap.yaml
+++ b/docs/data/ProtoMap.yaml
@@ -248,8 +248,14 @@ apis:
   enterprise.gloo.solo.io.ApiKeyDeleteResponse:
     relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth-internal.proto.sk/#ApiKeyDeleteResponse
     package: enterprise.gloo.solo.io
+  enterprise.gloo.solo.io.ApiKeyDigest:
+    relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk/#ApiKeyDigest
+    package: enterprise.gloo.solo.io
   enterprise.gloo.solo.io.ApiKeyHmac:
     relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk/#ApiKeyHmac
+    package: enterprise.gloo.solo.io
+  enterprise.gloo.solo.io.ApiKeyMatch:
+    relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk/#ApiKeyMatch
     package: enterprise.gloo.solo.io
   enterprise.gloo.solo.io.ApiKeyReadRequest:
     relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth-internal.proto.sk/#ApiKeyReadRequest
@@ -310,6 +316,9 @@ apis:
     package: enterprise.gloo.solo.io
   enterprise.gloo.solo.io.HeaderConfiguration:
     relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk/#HeaderConfiguration
+    package: enterprise.gloo.solo.io
+  enterprise.gloo.solo.io.HeaderMatch:
+    relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk/#HeaderMatch
     package: enterprise.gloo.solo.io
   enterprise.gloo.solo.io.HmacAuth:
     relativepath: reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto.sk/#HmacAuth

--- a/generate.go
+++ b/generate.go
@@ -131,6 +131,9 @@ func fixExtauthCrossReferences() error {
 		return err
 	}
 	content = []byte(strings.ReplaceAll(string(content), "extauth-internal.proto.sk/#config", "extauth.proto.sk/#config"))
+	// The docs generator already emits the ApiKeyMatch and HeaderMatch sections correctly. These rewrites
+	// only fix duplicate-anchor collisions introduced by the second nested Algorithm section and the second
+	// HeaderMatch symbol in extauth.proto.
 	content = []byte(strings.ReplaceAll(
 		string(content),
 		"[.enterprise.gloo.solo.io.ApiKeyDigest.Algorithm](../extauth.proto.sk/#algorithm)",

--- a/generate.go
+++ b/generate.go
@@ -131,6 +131,16 @@ func fixExtauthCrossReferences() error {
 		return err
 	}
 	content = []byte(strings.ReplaceAll(string(content), "extauth-internal.proto.sk/#config", "extauth.proto.sk/#config"))
+	content = []byte(strings.ReplaceAll(
+		string(content),
+		"[.enterprise.gloo.solo.io.ApiKeyDigest.Algorithm](../extauth.proto.sk/#algorithm)",
+		"[.enterprise.gloo.solo.io.ApiKeyDigest.Algorithm](../extauth.proto.sk/#algorithm-1)",
+	))
+	content = []byte(strings.ReplaceAll(
+		string(content),
+		"[[]enterprise.gloo.solo.io.HeaderMatch](../extauth.proto.sk/#headermatch)",
+		"[[]enterprise.gloo.solo.io.HeaderMatch](../extauth.proto.sk/#headermatch-1)",
+	))
 	err = os.WriteFile(extauthDocPath, content, 0644)
 	if err != nil {
 		return err

--- a/install/helm/gloo/crds/enterprise.gloo.solo.io_v1_AuthConfig.yaml
+++ b/install/helm/gloo/crds/enterprise.gloo.solo.io_v1_AuthConfig.yaml
@@ -132,6 +132,12 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        digest:
+                          properties:
+                            algorithm:
+                              type: string
+                              x-kubernetes-int-or-string: true
+                          type: object
                         headerName:
                           type: string
                         headersFromMetadata:
@@ -184,6 +190,16 @@ spec:
                         labelSelector:
                           additionalProperties:
                             type: string
+                          type: object
+                        match:
+                          properties:
+                            headers:
+                              items:
+                                properties:
+                                  name:
+                                    type: string
+                                type: object
+                              type: array
                           type: object
                         skipMetadataValidation:
                           type: boolean

--- a/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto
+++ b/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto
@@ -1202,10 +1202,12 @@ message ApiKeyAuth {
 
     // Optional digest verification mode for API key validation. When configured, stored API key values
     // are treated as digests and the request API key is transformed prior to comparison.
+    // When omitted, existing raw API key comparison behavior remains unchanged.
     ApiKeyDigest digest = 10;
 
-    // Optional additional request header matching for API key validation. When configured, each header
-    // must match a same-named data key on the matched API key secret.
+    // Optional additional request header matching for digest-based API key validation. This field is only
+    // valid when digest is configured. ext-auth-service should reject configs that set match without digest.
+    // When configured, each header must match a same-named data key on the matched API key secret.
     ApiKeyMatch match = 11;
 }
 
@@ -1239,12 +1241,15 @@ message ApiKeyDigest {
 }
 
 // Additional request headers that must match same-named data keys on the matched API key secret.
+// This message is only valid when ApiKeyAuth.digest is configured.
 message ApiKeyMatch {
     repeated HeaderMatch headers = 1;
 }
 
 // A request header that must match the same-named data key on the matched API key secret.
 message HeaderMatch {
+    // Header name to match. Request headers are case-insensitive, but this configured name is also used
+    // as the Secret data key for same-name matching, so operators should use a canonical lowercase name.
     string name = 1;
 }
 

--- a/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto
+++ b/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto
@@ -1199,6 +1199,14 @@ message ApiKeyAuth {
     // Optional HMAC digest verification mode for API key validation. When configured, stored API key values
     // are treated as HMAC digests and the request API key is transformed prior to comparison.
     ApiKeyHmac hmac = 9;
+
+    // Optional digest verification mode for API key validation. When configured, stored API key values
+    // are treated as digests and the request API key is transformed prior to comparison.
+    ApiKeyDigest digest = 10;
+
+    // Optional additional request header matching for API key validation. When configured, each header
+    // must match a same-named data key on the matched API key secret.
+    ApiKeyMatch match = 11;
 }
 
 // Configuration for HMAC-based API key digest verification.
@@ -1216,6 +1224,30 @@ message ApiKeyHmac {
     // Reference to the shared secret used to compute request-time HMAC digests.
     core.solo.io.ResourceRef shared_secret_ref = 2;
 }
+
+// Configuration for digest-based API key verification.
+message ApiKeyDigest {
+    // Supported digest algorithms for API key verification.
+    enum Algorithm {
+        // When unspecified, ext-auth-service should default to SHA256.
+        ALGORITHM_UNSPECIFIED = 0;
+        SHA256 = 1;
+    }
+
+    // Algorithm used to compute the digest for comparison against stored API key values.
+    Algorithm algorithm = 1;
+}
+
+// Additional request headers that must match same-named data keys on the matched API key secret.
+message ApiKeyMatch {
+    repeated HeaderMatch headers = 1;
+}
+
+// A request header that must match the same-named data key on the matched API key secret.
+message HeaderMatch {
+    string name = 1;
+}
+
 message K8sSecretApiKeyStorage {
     // Identify all valid API key secrets that match the provided label selector.<br/>
     // API key secrets must be in one of the watch namespaces for gloo to locate them.

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.clone.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.clone.go
@@ -1300,6 +1300,18 @@ func (m *ApiKeyAuth) Clone() proto.Message {
 		target.Hmac = proto.Clone(m.GetHmac()).(*ApiKeyHmac)
 	}
 
+	if h, ok := interface{}(m.GetDigest()).(clone.Cloner); ok {
+		target.Digest = h.Clone().(*ApiKeyDigest)
+	} else {
+		target.Digest = proto.Clone(m.GetDigest()).(*ApiKeyDigest)
+	}
+
+	if h, ok := interface{}(m.GetMatch()).(clone.Cloner); ok {
+		target.Match = h.Clone().(*ApiKeyMatch)
+	} else {
+		target.Match = proto.Clone(m.GetMatch()).(*ApiKeyMatch)
+	}
+
 	switch m.StorageBackend.(type) {
 
 	case *ApiKeyAuth_K8SSecretApikeyStorage:
@@ -1346,6 +1358,56 @@ func (m *ApiKeyHmac) Clone() proto.Message {
 	} else {
 		target.SharedSecretRef = proto.Clone(m.GetSharedSecretRef()).(*github_com_solo_io_solo_kit_pkg_api_v1_resources_core.ResourceRef)
 	}
+
+	return target
+}
+
+// Clone function
+func (m *ApiKeyDigest) Clone() proto.Message {
+	var target *ApiKeyDigest
+	if m == nil {
+		return target
+	}
+	target = &ApiKeyDigest{}
+
+	target.Algorithm = m.GetAlgorithm()
+
+	return target
+}
+
+// Clone function
+func (m *ApiKeyMatch) Clone() proto.Message {
+	var target *ApiKeyMatch
+	if m == nil {
+		return target
+	}
+	target = &ApiKeyMatch{}
+
+	if m.GetHeaders() != nil {
+		target.Headers = make([]*HeaderMatch, len(m.GetHeaders()))
+		for idx, v := range m.GetHeaders() {
+
+			if h, ok := interface{}(v).(clone.Cloner); ok {
+				target.Headers[idx] = h.Clone().(*HeaderMatch)
+			} else {
+				target.Headers[idx] = proto.Clone(v).(*HeaderMatch)
+			}
+
+		}
+	}
+
+	return target
+}
+
+// Clone function
+func (m *HeaderMatch) Clone() proto.Message {
+	var target *HeaderMatch
+	if m == nil {
+		return target
+	}
+	target = &HeaderMatch{}
+
+	target.Name = m.GetName()
 
 	return target
 }

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.equal.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.equal.go
@@ -2161,6 +2161,26 @@ func (m *ApiKeyAuth) Equal(that interface{}) bool {
 		}
 	}
 
+	if h, ok := interface{}(m.GetDigest()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetDigest()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetDigest(), target.GetDigest()) {
+			return false
+		}
+	}
+
+	if h, ok := interface{}(m.GetMatch()).(equality.Equalizer); ok {
+		if !h.Equal(target.GetMatch()) {
+			return false
+		}
+	} else {
+		if !proto.Equal(m.GetMatch(), target.GetMatch()) {
+			return false
+		}
+	}
+
 	switch m.StorageBackend.(type) {
 
 	case *ApiKeyAuth_K8SSecretApikeyStorage:
@@ -2236,6 +2256,103 @@ func (m *ApiKeyHmac) Equal(that interface{}) bool {
 		if !proto.Equal(m.GetSharedSecretRef(), target.GetSharedSecretRef()) {
 			return false
 		}
+	}
+
+	return true
+}
+
+// Equal function
+func (m *ApiKeyDigest) Equal(that interface{}) bool {
+	if that == nil {
+		return m == nil
+	}
+
+	target, ok := that.(*ApiKeyDigest)
+	if !ok {
+		that2, ok := that.(ApiKeyDigest)
+		if ok {
+			target = &that2
+		} else {
+			return false
+		}
+	}
+	if target == nil {
+		return m == nil
+	} else if m == nil {
+		return false
+	}
+
+	if m.GetAlgorithm() != target.GetAlgorithm() {
+		return false
+	}
+
+	return true
+}
+
+// Equal function
+func (m *ApiKeyMatch) Equal(that interface{}) bool {
+	if that == nil {
+		return m == nil
+	}
+
+	target, ok := that.(*ApiKeyMatch)
+	if !ok {
+		that2, ok := that.(ApiKeyMatch)
+		if ok {
+			target = &that2
+		} else {
+			return false
+		}
+	}
+	if target == nil {
+		return m == nil
+	} else if m == nil {
+		return false
+	}
+
+	if len(m.GetHeaders()) != len(target.GetHeaders()) {
+		return false
+	}
+	for idx, v := range m.GetHeaders() {
+
+		if h, ok := interface{}(v).(equality.Equalizer); ok {
+			if !h.Equal(target.GetHeaders()[idx]) {
+				return false
+			}
+		} else {
+			if !proto.Equal(v, target.GetHeaders()[idx]) {
+				return false
+			}
+		}
+
+	}
+
+	return true
+}
+
+// Equal function
+func (m *HeaderMatch) Equal(that interface{}) bool {
+	if that == nil {
+		return m == nil
+	}
+
+	target, ok := that.(*HeaderMatch)
+	if !ok {
+		that2, ok := that.(HeaderMatch)
+		if ok {
+			target = &that2
+		} else {
+			return false
+		}
+	}
+	if target == nil {
+		return m == nil
+	} else if m == nil {
+		return false
+	}
+
+	if strings.Compare(m.GetName(), target.GetName()) != 0 {
+		return false
 	}
 
 	return true

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
@@ -3508,9 +3508,11 @@ type ApiKeyAuth struct {
 	Hmac *ApiKeyHmac `protobuf:"bytes,9,opt,name=hmac,proto3" json:"hmac,omitempty"`
 	// Optional digest verification mode for API key validation. When configured, stored API key values
 	// are treated as digests and the request API key is transformed prior to comparison.
+	// When omitted, existing raw API key comparison behavior remains unchanged.
 	Digest *ApiKeyDigest `protobuf:"bytes,10,opt,name=digest,proto3" json:"digest,omitempty"`
-	// Optional additional request header matching for API key validation. When configured, each header
-	// must match a same-named data key on the matched API key secret.
+	// Optional additional request header matching for digest-based API key validation. This field is only
+	// valid when digest is configured. ext-auth-service should reject configs that set match without digest.
+	// When configured, each header must match a same-named data key on the matched API key secret.
 	Match         *ApiKeyMatch `protobuf:"bytes,11,opt,name=match,proto3" json:"match,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -3757,6 +3759,7 @@ func (x *ApiKeyDigest) GetAlgorithm() ApiKeyDigest_Algorithm {
 }
 
 // Additional request headers that must match same-named data keys on the matched API key secret.
+// This message is only valid when ApiKeyAuth.digest is configured.
 type ApiKeyMatch struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	Headers       []*HeaderMatch         `protobuf:"bytes,1,rep,name=headers,proto3" json:"headers,omitempty"`
@@ -3803,8 +3806,10 @@ func (x *ApiKeyMatch) GetHeaders() []*HeaderMatch {
 
 // A request header that must match the same-named data key on the matched API key secret.
 type HeaderMatch struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Header name to match. Request headers are case-insensitive, but this configured name is also used
+	// as the Secret data key for same-name matching, so operators should use a canonical lowercase name.
+	Name          string `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.go
@@ -284,6 +284,54 @@ func (ApiKeyHmac_Algorithm) EnumDescriptor() ([]byte, []int) {
 	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{30, 0}
 }
 
+// Supported digest algorithms for API key verification.
+type ApiKeyDigest_Algorithm int32
+
+const (
+	// When unspecified, ext-auth-service should default to SHA256.
+	ApiKeyDigest_ALGORITHM_UNSPECIFIED ApiKeyDigest_Algorithm = 0
+	ApiKeyDigest_SHA256                ApiKeyDigest_Algorithm = 1
+)
+
+// Enum value maps for ApiKeyDigest_Algorithm.
+var (
+	ApiKeyDigest_Algorithm_name = map[int32]string{
+		0: "ALGORITHM_UNSPECIFIED",
+		1: "SHA256",
+	}
+	ApiKeyDigest_Algorithm_value = map[string]int32{
+		"ALGORITHM_UNSPECIFIED": 0,
+		"SHA256":                1,
+	}
+)
+
+func (x ApiKeyDigest_Algorithm) Enum() *ApiKeyDigest_Algorithm {
+	p := new(ApiKeyDigest_Algorithm)
+	*p = x
+	return p
+}
+
+func (x ApiKeyDigest_Algorithm) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ApiKeyDigest_Algorithm) Descriptor() protoreflect.EnumDescriptor {
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes[5].Descriptor()
+}
+
+func (ApiKeyDigest_Algorithm) Type() protoreflect.EnumType {
+	return &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes[5]
+}
+
+func (x ApiKeyDigest_Algorithm) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ApiKeyDigest_Algorithm.Descriptor instead.
+func (ApiKeyDigest_Algorithm) EnumDescriptor() ([]byte, []int) {
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{31, 0}
+}
+
 type SslParameters_ProtocolVersion int32
 
 const (
@@ -324,11 +372,11 @@ func (x SslParameters_ProtocolVersion) String() string {
 }
 
 func (SslParameters_ProtocolVersion) Descriptor() protoreflect.EnumDescriptor {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes[5].Descriptor()
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes[6].Descriptor()
 }
 
 func (SslParameters_ProtocolVersion) Type() protoreflect.EnumType {
-	return &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes[5]
+	return &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes[6]
 }
 
 func (x SslParameters_ProtocolVersion) Number() protoreflect.EnumNumber {
@@ -337,7 +385,7 @@ func (x SslParameters_ProtocolVersion) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use SslParameters_ProtocolVersion.Descriptor instead.
 func (SslParameters_ProtocolVersion) EnumDescriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{48, 0}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{51, 0}
 }
 
 // This is the user-facing auth configuration. When processed by Gloo, certain configuration types (i.a. oauth, opa)
@@ -3457,7 +3505,13 @@ type ApiKeyAuth struct {
 	SkipMetadataValidation bool `protobuf:"varint,8,opt,name=skip_metadata_validation,json=skipMetadataValidation,proto3" json:"skip_metadata_validation,omitempty"`
 	// Optional HMAC digest verification mode for API key validation. When configured, stored API key values
 	// are treated as HMAC digests and the request API key is transformed prior to comparison.
-	Hmac          *ApiKeyHmac `protobuf:"bytes,9,opt,name=hmac,proto3" json:"hmac,omitempty"`
+	Hmac *ApiKeyHmac `protobuf:"bytes,9,opt,name=hmac,proto3" json:"hmac,omitempty"`
+	// Optional digest verification mode for API key validation. When configured, stored API key values
+	// are treated as digests and the request API key is transformed prior to comparison.
+	Digest *ApiKeyDigest `protobuf:"bytes,10,opt,name=digest,proto3" json:"digest,omitempty"`
+	// Optional additional request header matching for API key validation. When configured, each header
+	// must match a same-named data key on the matched API key secret.
+	Match         *ApiKeyMatch `protobuf:"bytes,11,opt,name=match,proto3" json:"match,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -3569,6 +3623,20 @@ func (x *ApiKeyAuth) GetHmac() *ApiKeyHmac {
 	return nil
 }
 
+func (x *ApiKeyAuth) GetDigest() *ApiKeyDigest {
+	if x != nil {
+		return x.Digest
+	}
+	return nil
+}
+
+func (x *ApiKeyAuth) GetMatch() *ApiKeyMatch {
+	if x != nil {
+		return x.Match
+	}
+	return nil
+}
+
 type isApiKeyAuth_StorageBackend interface {
 	isApiKeyAuth_StorageBackend()
 }
@@ -3642,6 +3710,142 @@ func (x *ApiKeyHmac) GetSharedSecretRef() *core.ResourceRef {
 	return nil
 }
 
+// Configuration for digest-based API key verification.
+type ApiKeyDigest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Algorithm used to compute the digest for comparison against stored API key values.
+	Algorithm     ApiKeyDigest_Algorithm `protobuf:"varint,1,opt,name=algorithm,proto3,enum=enterprise.gloo.solo.io.ApiKeyDigest_Algorithm" json:"algorithm,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ApiKeyDigest) Reset() {
+	*x = ApiKeyDigest{}
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ApiKeyDigest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ApiKeyDigest) ProtoMessage() {}
+
+func (x *ApiKeyDigest) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ApiKeyDigest.ProtoReflect.Descriptor instead.
+func (*ApiKeyDigest) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *ApiKeyDigest) GetAlgorithm() ApiKeyDigest_Algorithm {
+	if x != nil {
+		return x.Algorithm
+	}
+	return ApiKeyDigest_ALGORITHM_UNSPECIFIED
+}
+
+// Additional request headers that must match same-named data keys on the matched API key secret.
+type ApiKeyMatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Headers       []*HeaderMatch         `protobuf:"bytes,1,rep,name=headers,proto3" json:"headers,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ApiKeyMatch) Reset() {
+	*x = ApiKeyMatch{}
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[32]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ApiKeyMatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ApiKeyMatch) ProtoMessage() {}
+
+func (x *ApiKeyMatch) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[32]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ApiKeyMatch.ProtoReflect.Descriptor instead.
+func (*ApiKeyMatch) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{32}
+}
+
+func (x *ApiKeyMatch) GetHeaders() []*HeaderMatch {
+	if x != nil {
+		return x.Headers
+	}
+	return nil
+}
+
+// A request header that must match the same-named data key on the matched API key secret.
+type HeaderMatch struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Name          string                 `protobuf:"bytes,1,opt,name=name,proto3" json:"name,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *HeaderMatch) Reset() {
+	*x = HeaderMatch{}
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *HeaderMatch) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*HeaderMatch) ProtoMessage() {}
+
+func (x *HeaderMatch) ProtoReflect() protoreflect.Message {
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use HeaderMatch.ProtoReflect.Descriptor instead.
+func (*HeaderMatch) Descriptor() ([]byte, []int) {
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *HeaderMatch) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
 type K8SSecretApiKeyStorage struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// Identify all valid API key secrets that match the provided label selector.<br/>
@@ -3656,7 +3860,7 @@ type K8SSecretApiKeyStorage struct {
 
 func (x *K8SSecretApiKeyStorage) Reset() {
 	*x = K8SSecretApiKeyStorage{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[31]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[34]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3668,7 +3872,7 @@ func (x *K8SSecretApiKeyStorage) String() string {
 func (*K8SSecretApiKeyStorage) ProtoMessage() {}
 
 func (x *K8SSecretApiKeyStorage) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[31]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[34]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3681,7 +3885,7 @@ func (x *K8SSecretApiKeyStorage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use K8SSecretApiKeyStorage.ProtoReflect.Descriptor instead.
 func (*K8SSecretApiKeyStorage) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{31}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{34}
 }
 
 func (x *K8SSecretApiKeyStorage) GetLabelSelector() map[string]string {
@@ -3751,7 +3955,7 @@ type AerospikeApiKeyStorage struct {
 
 func (x *AerospikeApiKeyStorage) Reset() {
 	*x = AerospikeApiKeyStorage{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[32]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3763,7 +3967,7 @@ func (x *AerospikeApiKeyStorage) String() string {
 func (*AerospikeApiKeyStorage) ProtoMessage() {}
 
 func (x *AerospikeApiKeyStorage) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[32]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3776,7 +3980,7 @@ func (x *AerospikeApiKeyStorage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AerospikeApiKeyStorage.ProtoReflect.Descriptor instead.
 func (*AerospikeApiKeyStorage) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{32}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *AerospikeApiKeyStorage) GetHostname() string {
@@ -3936,7 +4140,7 @@ type ServerDefaultApiKeyStorage struct {
 
 func (x *ServerDefaultApiKeyStorage) Reset() {
 	*x = ServerDefaultApiKeyStorage{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[33]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3948,7 +4152,7 @@ func (x *ServerDefaultApiKeyStorage) String() string {
 func (*ServerDefaultApiKeyStorage) ProtoMessage() {}
 
 func (x *ServerDefaultApiKeyStorage) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[33]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -3961,7 +4165,7 @@ func (x *ServerDefaultApiKeyStorage) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerDefaultApiKeyStorage.ProtoReflect.Descriptor instead.
 func (*ServerDefaultApiKeyStorage) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{33}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{36}
 }
 
 type ApiKey struct {
@@ -3981,7 +4185,7 @@ type ApiKey struct {
 
 func (x *ApiKey) Reset() {
 	*x = ApiKey{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[34]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -3993,7 +4197,7 @@ func (x *ApiKey) String() string {
 func (*ApiKey) ProtoMessage() {}
 
 func (x *ApiKey) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[34]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4006,7 +4210,7 @@ func (x *ApiKey) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApiKey.ProtoReflect.Descriptor instead.
 func (*ApiKey) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{34}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *ApiKey) GetApiKey() string {
@@ -4053,7 +4257,7 @@ type ApiKeySecret struct {
 
 func (x *ApiKeySecret) Reset() {
 	*x = ApiKeySecret{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[35]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4065,7 +4269,7 @@ func (x *ApiKeySecret) String() string {
 func (*ApiKeySecret) ProtoMessage() {}
 
 func (x *ApiKeySecret) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[35]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4078,7 +4282,7 @@ func (x *ApiKeySecret) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApiKeySecret.ProtoReflect.Descriptor instead.
 func (*ApiKeySecret) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{35}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *ApiKeySecret) GetApiKey() string {
@@ -4127,7 +4331,7 @@ type OpaAuth struct {
 
 func (x *OpaAuth) Reset() {
 	*x = OpaAuth{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[36]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4139,7 +4343,7 @@ func (x *OpaAuth) String() string {
 func (*OpaAuth) ProtoMessage() {}
 
 func (x *OpaAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[36]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4152,7 +4356,7 @@ func (x *OpaAuth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpaAuth.ProtoReflect.Descriptor instead.
 func (*OpaAuth) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{36}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *OpaAuth) GetModules() []*core.ResourceRef {
@@ -4203,7 +4407,7 @@ type OpaAuthOptions struct {
 
 func (x *OpaAuthOptions) Reset() {
 	*x = OpaAuthOptions{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[37]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4215,7 +4419,7 @@ func (x *OpaAuthOptions) String() string {
 func (*OpaAuthOptions) ProtoMessage() {}
 
 func (x *OpaAuthOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[37]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4228,7 +4432,7 @@ func (x *OpaAuthOptions) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpaAuthOptions.ProtoReflect.Descriptor instead.
 func (*OpaAuthOptions) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{37}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *OpaAuthOptions) GetFastInputConversion() bool {
@@ -4275,7 +4479,7 @@ type OpaServerAuth struct {
 
 func (x *OpaServerAuth) Reset() {
 	*x = OpaServerAuth{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[38]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4287,7 +4491,7 @@ func (x *OpaServerAuth) String() string {
 func (*OpaServerAuth) ProtoMessage() {}
 
 func (x *OpaServerAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[38]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4300,7 +4504,7 @@ func (x *OpaServerAuth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OpaServerAuth.ProtoReflect.Descriptor instead.
 func (*OpaServerAuth) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{38}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{41}
 }
 
 func (x *OpaServerAuth) GetPackage() string {
@@ -4372,7 +4576,7 @@ type Ldap struct {
 
 func (x *Ldap) Reset() {
 	*x = Ldap{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[39]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[42]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4384,7 +4588,7 @@ func (x *Ldap) String() string {
 func (*Ldap) ProtoMessage() {}
 
 func (x *Ldap) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[39]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[42]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4397,7 +4601,7 @@ func (x *Ldap) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Ldap.ProtoReflect.Descriptor instead.
 func (*Ldap) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{39}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{42}
 }
 
 func (x *Ldap) GetAddress() string {
@@ -4468,7 +4672,7 @@ type LdapServiceAccount struct {
 
 func (x *LdapServiceAccount) Reset() {
 	*x = LdapServiceAccount{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[40]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[43]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4480,7 +4684,7 @@ func (x *LdapServiceAccount) String() string {
 func (*LdapServiceAccount) ProtoMessage() {}
 
 func (x *LdapServiceAccount) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[40]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[43]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4493,7 +4697,7 @@ func (x *LdapServiceAccount) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LdapServiceAccount.ProtoReflect.Descriptor instead.
 func (*LdapServiceAccount) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{40}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{43}
 }
 
 func (x *LdapServiceAccount) GetCredentialsSecretRef() *core.ResourceRef {
@@ -4532,7 +4736,7 @@ type PassThroughAuth struct {
 
 func (x *PassThroughAuth) Reset() {
 	*x = PassThroughAuth{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[41]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[44]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4544,7 +4748,7 @@ func (x *PassThroughAuth) String() string {
 func (*PassThroughAuth) ProtoMessage() {}
 
 func (x *PassThroughAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[41]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[44]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4557,7 +4761,7 @@ func (x *PassThroughAuth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PassThroughAuth.ProtoReflect.Descriptor instead.
 func (*PassThroughAuth) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{41}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{44}
 }
 
 func (x *PassThroughAuth) GetProtocol() isPassThroughAuth_Protocol {
@@ -4630,7 +4834,7 @@ type BackoffStrategy struct {
 
 func (x *BackoffStrategy) Reset() {
 	*x = BackoffStrategy{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[42]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[45]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4642,7 +4846,7 @@ func (x *BackoffStrategy) String() string {
 func (*BackoffStrategy) ProtoMessage() {}
 
 func (x *BackoffStrategy) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[42]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[45]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4655,7 +4859,7 @@ func (x *BackoffStrategy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BackoffStrategy.ProtoReflect.Descriptor instead.
 func (*BackoffStrategy) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{42}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{45}
 }
 
 func (x *BackoffStrategy) GetBaseInterval() *durationpb.Duration {
@@ -4688,7 +4892,7 @@ type RetryPolicy struct {
 
 func (x *RetryPolicy) Reset() {
 	*x = RetryPolicy{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[43]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[46]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4700,7 +4904,7 @@ func (x *RetryPolicy) String() string {
 func (*RetryPolicy) ProtoMessage() {}
 
 func (x *RetryPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[43]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[46]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4713,7 +4917,7 @@ func (x *RetryPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RetryPolicy.ProtoReflect.Descriptor instead.
 func (*RetryPolicy) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{43}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{46}
 }
 
 func (x *RetryPolicy) GetNumRetries() *wrapperspb.UInt32Value {
@@ -4778,7 +4982,7 @@ type PassThroughGrpc struct {
 
 func (x *PassThroughGrpc) Reset() {
 	*x = PassThroughGrpc{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[44]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[47]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4790,7 +4994,7 @@ func (x *PassThroughGrpc) String() string {
 func (*PassThroughGrpc) ProtoMessage() {}
 
 func (x *PassThroughGrpc) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[44]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[47]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4803,7 +5007,7 @@ func (x *PassThroughGrpc) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PassThroughGrpc.ProtoReflect.Descriptor instead.
 func (*PassThroughGrpc) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{44}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{47}
 }
 
 func (x *PassThroughGrpc) GetAddress() string {
@@ -4864,7 +5068,7 @@ type PassThroughHttp struct {
 
 func (x *PassThroughHttp) Reset() {
 	*x = PassThroughHttp{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[45]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[48]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4876,7 +5080,7 @@ func (x *PassThroughHttp) String() string {
 func (*PassThroughHttp) ProtoMessage() {}
 
 func (x *PassThroughHttp) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[45]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[48]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4889,7 +5093,7 @@ func (x *PassThroughHttp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PassThroughHttp.ProtoReflect.Descriptor instead.
 func (*PassThroughHttp) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{45}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{48}
 }
 
 func (x *PassThroughHttp) GetUrl() string {
@@ -4942,7 +5146,7 @@ type PassThroughGrpcTLSConfig struct {
 
 func (x *PassThroughGrpcTLSConfig) Reset() {
 	*x = PassThroughGrpcTLSConfig{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[46]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[49]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -4954,7 +5158,7 @@ func (x *PassThroughGrpcTLSConfig) String() string {
 func (*PassThroughGrpcTLSConfig) ProtoMessage() {}
 
 func (x *PassThroughGrpcTLSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[46]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[49]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -4967,7 +5171,7 @@ func (x *PassThroughGrpcTLSConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PassThroughGrpcTLSConfig.ProtoReflect.Descriptor instead.
 func (*PassThroughGrpcTLSConfig) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{46}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{49}
 }
 
 func (x *PassThroughGrpcTLSConfig) GetSecretRef() *core.ResourceRef {
@@ -4999,7 +5203,7 @@ type PassThroughHttpTLSConfig struct {
 
 func (x *PassThroughHttpTLSConfig) Reset() {
 	*x = PassThroughHttpTLSConfig{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[47]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[50]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5011,7 +5215,7 @@ func (x *PassThroughHttpTLSConfig) String() string {
 func (*PassThroughHttpTLSConfig) ProtoMessage() {}
 
 func (x *PassThroughHttpTLSConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[47]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[50]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5024,7 +5228,7 @@ func (x *PassThroughHttpTLSConfig) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PassThroughHttpTLSConfig.ProtoReflect.Descriptor instead.
 func (*PassThroughHttpTLSConfig) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{47}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{50}
 }
 
 func (x *PassThroughHttpTLSConfig) GetSecretRef() *core.ResourceRef {
@@ -5056,7 +5260,7 @@ type SslParameters struct {
 
 func (x *SslParameters) Reset() {
 	*x = SslParameters{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[48]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[51]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5068,7 +5272,7 @@ func (x *SslParameters) String() string {
 func (*SslParameters) ProtoMessage() {}
 
 func (x *SslParameters) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[48]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[51]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5081,7 +5285,7 @@ func (x *SslParameters) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SslParameters.ProtoReflect.Descriptor instead.
 func (*SslParameters) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{48}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{51}
 }
 
 func (x *SslParameters) GetMinimumProtocolVersion() SslParameters_ProtocolVersion {
@@ -5120,7 +5324,7 @@ type PortalAuth struct {
 
 func (x *PortalAuth) Reset() {
 	*x = PortalAuth{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[49]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[52]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5132,7 +5336,7 @@ func (x *PortalAuth) String() string {
 func (*PortalAuth) ProtoMessage() {}
 
 func (x *PortalAuth) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[49]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[52]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5145,7 +5349,7 @@ func (x *PortalAuth) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PortalAuth.ProtoReflect.Descriptor instead.
 func (*PortalAuth) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{49}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{52}
 }
 
 func (x *PortalAuth) GetUrl() string {
@@ -5211,7 +5415,7 @@ type AuthConfig_Config struct {
 
 func (x *AuthConfig_Config) Reset() {
 	*x = AuthConfig_Config{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[50]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[53]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5223,7 +5427,7 @@ func (x *AuthConfig_Config) String() string {
 func (*AuthConfig_Config) ProtoMessage() {}
 
 func (x *AuthConfig_Config) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[50]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[53]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5468,7 +5672,7 @@ type HttpService_Request struct {
 
 func (x *HttpService_Request) Reset() {
 	*x = HttpService_Request{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[51]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[54]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5480,7 +5684,7 @@ func (x *HttpService_Request) String() string {
 func (*HttpService_Request) ProtoMessage() {}
 
 func (x *HttpService_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[51]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[54]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5536,7 +5740,7 @@ type HttpService_Response struct {
 
 func (x *HttpService_Response) Reset() {
 	*x = HttpService_Response{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[52]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[55]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5548,7 +5752,7 @@ func (x *HttpService_Response) String() string {
 func (*HttpService_Response) ProtoMessage() {}
 
 func (x *HttpService_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[52]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[55]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5596,7 +5800,7 @@ type BasicAuth_Apr struct {
 
 func (x *BasicAuth_Apr) Reset() {
 	*x = BasicAuth_Apr{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[55]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[58]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5608,7 +5812,7 @@ func (x *BasicAuth_Apr) String() string {
 func (*BasicAuth_Apr) ProtoMessage() {}
 
 func (x *BasicAuth_Apr) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[55]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[58]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5645,7 +5849,7 @@ type BasicAuth_EncryptionType struct {
 
 func (x *BasicAuth_EncryptionType) Reset() {
 	*x = BasicAuth_EncryptionType{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[56]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[59]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5657,7 +5861,7 @@ func (x *BasicAuth_EncryptionType) String() string {
 func (*BasicAuth_EncryptionType) ProtoMessage() {}
 
 func (x *BasicAuth_EncryptionType) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[56]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[59]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5727,7 +5931,7 @@ type BasicAuth_User struct {
 
 func (x *BasicAuth_User) Reset() {
 	*x = BasicAuth_User{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[57]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[60]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5739,7 +5943,7 @@ func (x *BasicAuth_User) String() string {
 func (*BasicAuth_User) ProtoMessage() {}
 
 func (x *BasicAuth_User) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[57]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[60]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5779,7 +5983,7 @@ type BasicAuth_UserList struct {
 
 func (x *BasicAuth_UserList) Reset() {
 	*x = BasicAuth_UserList{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[58]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[61]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5791,7 +5995,7 @@ func (x *BasicAuth_UserList) String() string {
 func (*BasicAuth_UserList) ProtoMessage() {}
 
 func (x *BasicAuth_UserList) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[58]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[61]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5827,7 +6031,7 @@ type BasicAuth_Apr_SaltedHashedPassword struct {
 
 func (x *BasicAuth_Apr_SaltedHashedPassword) Reset() {
 	*x = BasicAuth_Apr_SaltedHashedPassword{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[59]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[62]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5839,7 +6043,7 @@ func (x *BasicAuth_Apr_SaltedHashedPassword) String() string {
 func (*BasicAuth_Apr_SaltedHashedPassword) ProtoMessage() {}
 
 func (x *BasicAuth_Apr_SaltedHashedPassword) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[59]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[62]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5879,7 +6083,7 @@ type BasicAuth_EncryptionType_Sha1 struct {
 
 func (x *BasicAuth_EncryptionType_Sha1) Reset() {
 	*x = BasicAuth_EncryptionType_Sha1{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[61]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[64]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5891,7 +6095,7 @@ func (x *BasicAuth_EncryptionType_Sha1) String() string {
 func (*BasicAuth_EncryptionType_Sha1) ProtoMessage() {}
 
 func (x *BasicAuth_EncryptionType_Sha1) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[61]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[64]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5916,7 +6120,7 @@ type BasicAuth_EncryptionType_Apr struct {
 
 func (x *BasicAuth_EncryptionType_Apr) Reset() {
 	*x = BasicAuth_EncryptionType_Apr{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[62]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[65]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5928,7 +6132,7 @@ func (x *BasicAuth_EncryptionType_Apr) String() string {
 func (*BasicAuth_EncryptionType_Apr) ProtoMessage() {}
 
 func (x *BasicAuth_EncryptionType_Apr) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[62]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[65]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -5963,7 +6167,7 @@ type UserSession_InternalSession struct {
 
 func (x *UserSession_InternalSession) Reset() {
 	*x = UserSession_InternalSession{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[65]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[68]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -5975,7 +6179,7 @@ func (x *UserSession_InternalSession) String() string {
 func (*UserSession_InternalSession) ProtoMessage() {}
 
 func (x *UserSession_InternalSession) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[65]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[68]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6041,7 +6245,7 @@ type UserSession_RedisSession struct {
 
 func (x *UserSession_RedisSession) Reset() {
 	*x = UserSession_RedisSession{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[66]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[69]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6053,7 +6257,7 @@ func (x *UserSession_RedisSession) String() string {
 func (*UserSession_RedisSession) ProtoMessage() {}
 
 func (x *UserSession_RedisSession) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[66]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[69]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6142,7 +6346,7 @@ type UserSession_CookieOptions struct {
 
 func (x *UserSession_CookieOptions) Reset() {
 	*x = UserSession_CookieOptions{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[67]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[70]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6154,7 +6358,7 @@ func (x *UserSession_CookieOptions) String() string {
 func (*UserSession_CookieOptions) ProtoMessage() {}
 
 func (x *UserSession_CookieOptions) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[67]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[70]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6228,7 +6432,7 @@ type UserSession_CipherConfig struct {
 
 func (x *UserSession_CipherConfig) Reset() {
 	*x = UserSession_CipherConfig{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[68]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[71]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6240,7 +6444,7 @@ func (x *UserSession_CipherConfig) String() string {
 func (*UserSession_CipherConfig) ProtoMessage() {}
 
 func (x *UserSession_CipherConfig) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[68]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[71]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6298,7 +6502,7 @@ type OidcAuthorizationCode_AccessToken struct {
 
 func (x *OidcAuthorizationCode_AccessToken) Reset() {
 	*x = OidcAuthorizationCode_AccessToken{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[72]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[75]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6310,7 +6514,7 @@ func (x *OidcAuthorizationCode_AccessToken) String() string {
 func (*OidcAuthorizationCode_AccessToken) ProtoMessage() {}
 
 func (x *OidcAuthorizationCode_AccessToken) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[72]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[75]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6345,7 +6549,7 @@ type OidcAuthorizationCode_IdentityToken struct {
 
 func (x *OidcAuthorizationCode_IdentityToken) Reset() {
 	*x = OidcAuthorizationCode_IdentityToken{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[73]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[76]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6357,7 +6561,7 @@ func (x *OidcAuthorizationCode_IdentityToken) String() string {
 func (*OidcAuthorizationCode_IdentityToken) ProtoMessage() {}
 
 func (x *OidcAuthorizationCode_IdentityToken) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[73]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[76]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6396,7 +6600,7 @@ type OidcAuthorizationCode_ClientAuthentication struct {
 
 func (x *OidcAuthorizationCode_ClientAuthentication) Reset() {
 	*x = OidcAuthorizationCode_ClientAuthentication{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[74]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[77]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6408,7 +6612,7 @@ func (x *OidcAuthorizationCode_ClientAuthentication) String() string {
 func (*OidcAuthorizationCode_ClientAuthentication) ProtoMessage() {}
 
 func (x *OidcAuthorizationCode_ClientAuthentication) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[74]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[77]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6480,7 +6684,7 @@ type OidcAuthorizationCode_Default struct {
 
 func (x *OidcAuthorizationCode_Default) Reset() {
 	*x = OidcAuthorizationCode_Default{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[75]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[78]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6492,7 +6696,7 @@ func (x *OidcAuthorizationCode_Default) String() string {
 func (*OidcAuthorizationCode_Default) ProtoMessage() {}
 
 func (x *OidcAuthorizationCode_Default) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[75]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[78]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6519,7 +6723,7 @@ type OidcAuthorizationCode_FrontChannelLogout struct {
 
 func (x *OidcAuthorizationCode_FrontChannelLogout) Reset() {
 	*x = OidcAuthorizationCode_FrontChannelLogout{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[76]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[79]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6531,7 +6735,7 @@ func (x *OidcAuthorizationCode_FrontChannelLogout) String() string {
 func (*OidcAuthorizationCode_FrontChannelLogout) ProtoMessage() {}
 
 func (x *OidcAuthorizationCode_FrontChannelLogout) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[76]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[79]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6570,7 +6774,7 @@ type OidcAuthorizationCode_ClientAuthentication_ClientSecret struct {
 
 func (x *OidcAuthorizationCode_ClientAuthentication_ClientSecret) Reset() {
 	*x = OidcAuthorizationCode_ClientAuthentication_ClientSecret{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[77]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[80]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6582,7 +6786,7 @@ func (x *OidcAuthorizationCode_ClientAuthentication_ClientSecret) String() strin
 func (*OidcAuthorizationCode_ClientAuthentication_ClientSecret) ProtoMessage() {}
 
 func (x *OidcAuthorizationCode_ClientAuthentication_ClientSecret) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[77]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[80]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6628,7 +6832,7 @@ type OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt struct {
 
 func (x *OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt) Reset() {
 	*x = OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[78]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[81]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6640,7 +6844,7 @@ func (x *OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt) String() stri
 func (*OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt) ProtoMessage() {}
 
 func (x *OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[78]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[81]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6687,7 +6891,7 @@ type JwtValidation_RemoteJwks struct {
 
 func (x *JwtValidation_RemoteJwks) Reset() {
 	*x = JwtValidation_RemoteJwks{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[81]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[84]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6699,7 +6903,7 @@ func (x *JwtValidation_RemoteJwks) String() string {
 func (*JwtValidation_RemoteJwks) ProtoMessage() {}
 
 func (x *JwtValidation_RemoteJwks) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[81]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[84]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6743,7 +6947,7 @@ type JwtValidation_LocalJwks struct {
 
 func (x *JwtValidation_LocalJwks) Reset() {
 	*x = JwtValidation_LocalJwks{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[82]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[85]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6755,7 +6959,7 @@ func (x *JwtValidation_LocalJwks) String() string {
 func (*JwtValidation_LocalJwks) ProtoMessage() {}
 
 func (x *JwtValidation_LocalJwks) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[82]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[85]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6787,7 +6991,7 @@ type AccessTokenValidation_Default struct {
 
 func (x *AccessTokenValidation_Default) Reset() {
 	*x = AccessTokenValidation_Default{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[84]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[87]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6799,7 +7003,7 @@ func (x *AccessTokenValidation_Default) String() string {
 func (*AccessTokenValidation_Default) ProtoMessage() {}
 
 func (x *AccessTokenValidation_Default) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[84]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[87]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6824,7 +7028,7 @@ type AccessTokenValidation_ScopeList struct {
 
 func (x *AccessTokenValidation_ScopeList) Reset() {
 	*x = AccessTokenValidation_ScopeList{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[85]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[88]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6836,7 +7040,7 @@ func (x *AccessTokenValidation_ScopeList) String() string {
 func (*AccessTokenValidation_ScopeList) ProtoMessage() {}
 
 func (x *AccessTokenValidation_ScopeList) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[85]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[88]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6876,7 +7080,7 @@ type ApiKeyAuth_SecretKey struct {
 
 func (x *ApiKeyAuth_SecretKey) Reset() {
 	*x = ApiKeyAuth_SecretKey{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[89]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[92]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6888,7 +7092,7 @@ func (x *ApiKeyAuth_SecretKey) String() string {
 func (*ApiKeyAuth_SecretKey) ProtoMessage() {}
 
 func (x *ApiKeyAuth_SecretKey) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[89]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[92]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6934,7 +7138,7 @@ type ApiKeyAuth_MetadataEntry struct {
 
 func (x *ApiKeyAuth_MetadataEntry) Reset() {
 	*x = ApiKeyAuth_MetadataEntry{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[90]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[93]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -6946,7 +7150,7 @@ func (x *ApiKeyAuth_MetadataEntry) String() string {
 func (*ApiKeyAuth_MetadataEntry) ProtoMessage() {}
 
 func (x *ApiKeyAuth_MetadataEntry) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[90]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[93]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -6991,7 +7195,7 @@ type AerospikeApiKeyStorageReadModeSc struct {
 
 func (x *AerospikeApiKeyStorageReadModeSc) Reset() {
 	*x = AerospikeApiKeyStorageReadModeSc{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[92]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[95]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7003,7 +7207,7 @@ func (x *AerospikeApiKeyStorageReadModeSc) String() string {
 func (*AerospikeApiKeyStorageReadModeSc) ProtoMessage() {}
 
 func (x *AerospikeApiKeyStorageReadModeSc) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[92]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[95]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7016,7 +7220,7 @@ func (x *AerospikeApiKeyStorageReadModeSc) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AerospikeApiKeyStorageReadModeSc.ProtoReflect.Descriptor instead.
 func (*AerospikeApiKeyStorageReadModeSc) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{32, 0}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{35, 0}
 }
 
 func (x *AerospikeApiKeyStorageReadModeSc) GetReadModeSc() isAerospikeApiKeyStorageReadModeSc_ReadModeSc {
@@ -7115,7 +7319,7 @@ type AerospikeApiKeyStorageReadModeAp struct {
 
 func (x *AerospikeApiKeyStorageReadModeAp) Reset() {
 	*x = AerospikeApiKeyStorageReadModeAp{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[93]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[96]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7127,7 +7331,7 @@ func (x *AerospikeApiKeyStorageReadModeAp) String() string {
 func (*AerospikeApiKeyStorageReadModeAp) ProtoMessage() {}
 
 func (x *AerospikeApiKeyStorageReadModeAp) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[93]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[96]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7140,7 +7344,7 @@ func (x *AerospikeApiKeyStorageReadModeAp) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AerospikeApiKeyStorageReadModeAp.ProtoReflect.Descriptor instead.
 func (*AerospikeApiKeyStorageReadModeAp) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{32, 1}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{35, 1}
 }
 
 func (x *AerospikeApiKeyStorageReadModeAp) GetReadModeAp() isAerospikeApiKeyStorageReadModeAp_ReadModeAp {
@@ -7204,7 +7408,7 @@ type AerospikeApiKeyStorageTlsCurveID struct {
 
 func (x *AerospikeApiKeyStorageTlsCurveID) Reset() {
 	*x = AerospikeApiKeyStorageTlsCurveID{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[94]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[97]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7216,7 +7420,7 @@ func (x *AerospikeApiKeyStorageTlsCurveID) String() string {
 func (*AerospikeApiKeyStorageTlsCurveID) ProtoMessage() {}
 
 func (x *AerospikeApiKeyStorageTlsCurveID) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[94]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[97]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7229,7 +7433,7 @@ func (x *AerospikeApiKeyStorageTlsCurveID) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AerospikeApiKeyStorageTlsCurveID.ProtoReflect.Descriptor instead.
 func (*AerospikeApiKeyStorageTlsCurveID) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{32, 2}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{35, 2}
 }
 
 func (x *AerospikeApiKeyStorageTlsCurveID) GetCurveId() isAerospikeApiKeyStorageTlsCurveID_CurveId {
@@ -7317,7 +7521,7 @@ type Ldap_ConnectionPool struct {
 
 func (x *Ldap_ConnectionPool) Reset() {
 	*x = Ldap_ConnectionPool{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[98]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[101]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7329,7 +7533,7 @@ func (x *Ldap_ConnectionPool) String() string {
 func (*Ldap_ConnectionPool) ProtoMessage() {}
 
 func (x *Ldap_ConnectionPool) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[98]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[101]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7342,7 +7546,7 @@ func (x *Ldap_ConnectionPool) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Ldap_ConnectionPool.ProtoReflect.Descriptor instead.
 func (*Ldap_ConnectionPool) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{39, 0}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{42, 0}
 }
 
 func (x *Ldap_ConnectionPool) GetMaxSize() *wrapperspb.UInt32Value {
@@ -7412,7 +7616,7 @@ type PassThroughHttp_Request struct {
 
 func (x *PassThroughHttp_Request) Reset() {
 	*x = PassThroughHttp_Request{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[99]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[102]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7424,7 +7628,7 @@ func (x *PassThroughHttp_Request) String() string {
 func (*PassThroughHttp_Request) ProtoMessage() {}
 
 func (x *PassThroughHttp_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[99]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[102]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7437,7 +7641,7 @@ func (x *PassThroughHttp_Request) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PassThroughHttp_Request.ProtoReflect.Descriptor instead.
 func (*PassThroughHttp_Request) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{45, 0}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{48, 0}
 }
 
 func (x *PassThroughHttp_Request) GetAllowedHeaders() []string {
@@ -7508,7 +7712,7 @@ type PassThroughHttp_Response struct {
 
 func (x *PassThroughHttp_Response) Reset() {
 	*x = PassThroughHttp_Response{}
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[100]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[103]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -7520,7 +7724,7 @@ func (x *PassThroughHttp_Response) String() string {
 func (*PassThroughHttp_Response) ProtoMessage() {}
 
 func (x *PassThroughHttp_Response) ProtoReflect() protoreflect.Message {
-	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[100]
+	mi := &file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[103]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -7533,7 +7737,7 @@ func (x *PassThroughHttp_Response) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PassThroughHttp_Response.ProtoReflect.Descriptor instead.
 func (*PassThroughHttp_Response) Descriptor() ([]byte, []int) {
-	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{45, 1}
+	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescGZIP(), []int{48, 1}
 }
 
 func (x *PassThroughHttp_Response) GetAllowedUpstreamHeaders() []string {
@@ -7935,7 +8139,8 @@ const file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extau
 	"\n" +
 	"\bProvider\"2\n" +
 	"\vOauthSecret\x12#\n" +
-	"\rclient_secret\x18\x01 \x01(\tR\fclientSecret\"\xef\t\n" +
+	"\rclient_secret\x18\x01 \x01(\tR\fclientSecret\"\xea\n" +
+	"\n" +
 	"\n" +
 	"ApiKeyAuth\x12a\n" +
 	"\x0elabel_selector\x18\x01 \x03(\v26.enterprise.gloo.solo.io.ApiKeyAuth.LabelSelectorEntryB\x02\x18\x01R\rlabelSelector\x12L\n" +
@@ -7947,7 +8152,10 @@ const file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extau
 	"\x19k8s_secret_apikey_storage\x18\x06 \x01(\v2/.enterprise.gloo.solo.io.K8sSecretApiKeyStorageH\x00R\x16k8sSecretApikeyStorage\x12k\n" +
 	"\x18aerospike_apikey_storage\x18\a \x01(\v2/.enterprise.gloo.solo.io.AerospikeApiKeyStorageH\x00R\x16aerospikeApikeyStorage\x128\n" +
 	"\x18skip_metadata_validation\x18\b \x01(\bR\x16skipMetadataValidation\x127\n" +
-	"\x04hmac\x18\t \x01(\v2#.enterprise.gloo.solo.io.ApiKeyHmacR\x04hmac\x1a@\n" +
+	"\x04hmac\x18\t \x01(\v2#.enterprise.gloo.solo.io.ApiKeyHmacR\x04hmac\x12=\n" +
+	"\x06digest\x18\n" +
+	" \x01(\v2%.enterprise.gloo.solo.io.ApiKeyDigestR\x06digest\x12:\n" +
+	"\x05match\x18\v \x01(\v2$.enterprise.gloo.solo.io.ApiKeyMatchR\x05match\x1a@\n" +
 	"\x12LabelSelectorEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\x1au\n" +
@@ -7970,7 +8178,17 @@ const file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extau
 	"\x11shared_secret_ref\x18\x02 \x01(\v2\x19.core.solo.io.ResourceRefR\x0fsharedSecretRef\"7\n" +
 	"\tAlgorithm\x12\x19\n" +
 	"\x15ALGORITHM_UNSPECIFIED\x10\x00\x12\x0f\n" +
-	"\vHMAC_SHA256\x10\x01\"\x8f\x02\n" +
+	"\vHMAC_SHA256\x10\x01\"\x91\x01\n" +
+	"\fApiKeyDigest\x12M\n" +
+	"\talgorithm\x18\x01 \x01(\x0e2/.enterprise.gloo.solo.io.ApiKeyDigest.AlgorithmR\talgorithm\"2\n" +
+	"\tAlgorithm\x12\x19\n" +
+	"\x15ALGORITHM_UNSPECIFIED\x10\x00\x12\n" +
+	"\n" +
+	"\x06SHA256\x10\x01\"M\n" +
+	"\vApiKeyMatch\x12>\n" +
+	"\aheaders\x18\x01 \x03(\v2$.enterprise.gloo.solo.io.HeaderMatchR\aheaders\"!\n" +
+	"\vHeaderMatch\x12\x12\n" +
+	"\x04name\x18\x01 \x01(\tR\x04name\"\x8f\x02\n" +
 	"\x16K8sSecretApiKeyStorage\x12i\n" +
 	"\x0elabel_selector\x18\x01 \x03(\v2B.enterprise.gloo.solo.io.K8sSecretApiKeyStorage.LabelSelectorEntryR\rlabelSelector\x12H\n" +
 	"\x13api_key_secret_refs\x18\x02 \x03(\v2\x19.core.solo.io.ResourceRefR\x10apiKeySecretRefs\x1a@\n" +
@@ -8154,295 +8372,303 @@ func file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extaut
 	return file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDescData
 }
 
-var file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes = make([]protoimpl.EnumInfo, 6)
-var file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes = make([]protoimpl.MessageInfo, 102)
+var file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_enumTypes = make([]protoimpl.EnumInfo, 7)
+var file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes = make([]protoimpl.MessageInfo, 105)
 var file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_goTypes = []any{
 	(Settings_ApiVersion)(0),                   // 0: enterprise.gloo.solo.io.Settings.ApiVersion
 	(RedisOptions_SocketType)(0),               // 1: enterprise.gloo.solo.io.RedisOptions.SocketType
 	(UserSession_CookieOptions_SameSite)(0),    // 2: enterprise.gloo.solo.io.UserSession.CookieOptions.SameSite
 	(EndSessionProperties_MethodType)(0),       // 3: enterprise.gloo.solo.io.EndSessionProperties.MethodType
 	(ApiKeyHmac_Algorithm)(0),                  // 4: enterprise.gloo.solo.io.ApiKeyHmac.Algorithm
-	(SslParameters_ProtocolVersion)(0),         // 5: enterprise.gloo.solo.io.SslParameters.ProtocolVersion
-	(*AuthConfig)(nil),                         // 6: enterprise.gloo.solo.io.AuthConfig
-	(*ExtAuthExtension)(nil),                   // 7: enterprise.gloo.solo.io.ExtAuthExtension
-	(*Settings)(nil),                           // 8: enterprise.gloo.solo.io.Settings
-	(*GrpcService)(nil),                        // 9: enterprise.gloo.solo.io.GrpcService
-	(*HttpService)(nil),                        // 10: enterprise.gloo.solo.io.HttpService
-	(*BufferSettings)(nil),                     // 11: enterprise.gloo.solo.io.BufferSettings
-	(*CustomAuth)(nil),                         // 12: enterprise.gloo.solo.io.CustomAuth
-	(*AuthPlugin)(nil),                         // 13: enterprise.gloo.solo.io.AuthPlugin
-	(*BasicAuth)(nil),                          // 14: enterprise.gloo.solo.io.BasicAuth
-	(*HmacAuth)(nil),                           // 15: enterprise.gloo.solo.io.HmacAuth
-	(*SecretRefList)(nil),                      // 16: enterprise.gloo.solo.io.SecretRefList
-	(*HmacParametersInHeaders)(nil),            // 17: enterprise.gloo.solo.io.HmacParametersInHeaders
-	(*OAuth)(nil),                              // 18: enterprise.gloo.solo.io.OAuth
-	(*OAuth2)(nil),                             // 19: enterprise.gloo.solo.io.OAuth2
-	(*RedisOptions)(nil),                       // 20: enterprise.gloo.solo.io.RedisOptions
-	(*UserSession)(nil),                        // 21: enterprise.gloo.solo.io.UserSession
-	(*HeaderConfiguration)(nil),                // 22: enterprise.gloo.solo.io.HeaderConfiguration
-	(*DiscoveryOverride)(nil),                  // 23: enterprise.gloo.solo.io.DiscoveryOverride
-	(*JwksOnDemandCacheRefreshPolicy)(nil),     // 24: enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy
-	(*AutoMapFromMetadata)(nil),                // 25: enterprise.gloo.solo.io.AutoMapFromMetadata
-	(*EndSessionProperties)(nil),               // 26: enterprise.gloo.solo.io.EndSessionProperties
-	(*ClaimToHeader)(nil),                      // 27: enterprise.gloo.solo.io.ClaimToHeader
-	(*Azure)(nil),                              // 28: enterprise.gloo.solo.io.Azure
-	(*OidcAuthorizationCode)(nil),              // 29: enterprise.gloo.solo.io.OidcAuthorizationCode
-	(*PlainOAuth2)(nil),                        // 30: enterprise.gloo.solo.io.PlainOAuth2
-	(*JwtValidation)(nil),                      // 31: enterprise.gloo.solo.io.JwtValidation
-	(*IntrospectionValidation)(nil),            // 32: enterprise.gloo.solo.io.IntrospectionValidation
-	(*AccessTokenValidation)(nil),              // 33: enterprise.gloo.solo.io.AccessTokenValidation
-	(*OauthSecret)(nil),                        // 34: enterprise.gloo.solo.io.OauthSecret
-	(*ApiKeyAuth)(nil),                         // 35: enterprise.gloo.solo.io.ApiKeyAuth
-	(*ApiKeyHmac)(nil),                         // 36: enterprise.gloo.solo.io.ApiKeyHmac
-	(*K8SSecretApiKeyStorage)(nil),             // 37: enterprise.gloo.solo.io.K8sSecretApiKeyStorage
-	(*AerospikeApiKeyStorage)(nil),             // 38: enterprise.gloo.solo.io.AerospikeApiKeyStorage
-	(*ServerDefaultApiKeyStorage)(nil),         // 39: enterprise.gloo.solo.io.ServerDefaultApiKeyStorage
-	(*ApiKey)(nil),                             // 40: enterprise.gloo.solo.io.ApiKey
-	(*ApiKeySecret)(nil),                       // 41: enterprise.gloo.solo.io.ApiKeySecret
-	(*OpaAuth)(nil),                            // 42: enterprise.gloo.solo.io.OpaAuth
-	(*OpaAuthOptions)(nil),                     // 43: enterprise.gloo.solo.io.OpaAuthOptions
-	(*OpaServerAuth)(nil),                      // 44: enterprise.gloo.solo.io.OpaServerAuth
-	(*Ldap)(nil),                               // 45: enterprise.gloo.solo.io.Ldap
-	(*LdapServiceAccount)(nil),                 // 46: enterprise.gloo.solo.io.LdapServiceAccount
-	(*PassThroughAuth)(nil),                    // 47: enterprise.gloo.solo.io.PassThroughAuth
-	(*BackoffStrategy)(nil),                    // 48: enterprise.gloo.solo.io.BackoffStrategy
-	(*RetryPolicy)(nil),                        // 49: enterprise.gloo.solo.io.RetryPolicy
-	(*PassThroughGrpc)(nil),                    // 50: enterprise.gloo.solo.io.PassThroughGrpc
-	(*PassThroughHttp)(nil),                    // 51: enterprise.gloo.solo.io.PassThroughHttp
-	(*PassThroughGrpcTLSConfig)(nil),           // 52: enterprise.gloo.solo.io.PassThroughGrpcTLSConfig
-	(*PassThroughHttpTLSConfig)(nil),           // 53: enterprise.gloo.solo.io.PassThroughHttpTLSConfig
-	(*SslParameters)(nil),                      // 54: enterprise.gloo.solo.io.SslParameters
-	(*PortalAuth)(nil),                         // 55: enterprise.gloo.solo.io.PortalAuth
-	(*AuthConfig_Config)(nil),                  // 56: enterprise.gloo.solo.io.AuthConfig.Config
-	(*HttpService_Request)(nil),                // 57: enterprise.gloo.solo.io.HttpService.Request
-	(*HttpService_Response)(nil),               // 58: enterprise.gloo.solo.io.HttpService.Response
-	nil,                                        // 59: enterprise.gloo.solo.io.HttpService.Request.HeadersToAddEntry
-	nil,                                        // 60: enterprise.gloo.solo.io.CustomAuth.ContextExtensionsEntry
-	(*BasicAuth_Apr)(nil),                      // 61: enterprise.gloo.solo.io.BasicAuth.Apr
-	(*BasicAuth_EncryptionType)(nil),           // 62: enterprise.gloo.solo.io.BasicAuth.EncryptionType
-	(*BasicAuth_User)(nil),                     // 63: enterprise.gloo.solo.io.BasicAuth.User
-	(*BasicAuth_UserList)(nil),                 // 64: enterprise.gloo.solo.io.BasicAuth.UserList
-	(*BasicAuth_Apr_SaltedHashedPassword)(nil), // 65: enterprise.gloo.solo.io.BasicAuth.Apr.SaltedHashedPassword
-	nil,                                   // 66: enterprise.gloo.solo.io.BasicAuth.Apr.UsersEntry
-	(*BasicAuth_EncryptionType_Sha1)(nil), // 67: enterprise.gloo.solo.io.BasicAuth.EncryptionType.Sha1
-	(*BasicAuth_EncryptionType_Apr)(nil),  // 68: enterprise.gloo.solo.io.BasicAuth.EncryptionType.Apr
-	nil,                                   // 69: enterprise.gloo.solo.io.BasicAuth.UserList.UsersEntry
-	nil,                                   // 70: enterprise.gloo.solo.io.OAuth.AuthEndpointQueryParamsEntry
-	(*UserSession_InternalSession)(nil),   // 71: enterprise.gloo.solo.io.UserSession.InternalSession
-	(*UserSession_RedisSession)(nil),      // 72: enterprise.gloo.solo.io.UserSession.RedisSession
-	(*UserSession_CookieOptions)(nil),     // 73: enterprise.gloo.solo.io.UserSession.CookieOptions
-	(*UserSession_CipherConfig)(nil),      // 74: enterprise.gloo.solo.io.UserSession.CipherConfig
-	nil,                                   // 75: enterprise.gloo.solo.io.OidcAuthorizationCode.AuthEndpointQueryParamsEntry
-	nil,                                   // 76: enterprise.gloo.solo.io.OidcAuthorizationCode.TokenEndpointQueryParamsEntry
-	nil,                                   // 77: enterprise.gloo.solo.io.OidcAuthorizationCode.DynamicMetadataFromClaimsEntry
-	(*OidcAuthorizationCode_AccessToken)(nil),                        // 78: enterprise.gloo.solo.io.OidcAuthorizationCode.AccessToken
-	(*OidcAuthorizationCode_IdentityToken)(nil),                      // 79: enterprise.gloo.solo.io.OidcAuthorizationCode.IdentityToken
-	(*OidcAuthorizationCode_ClientAuthentication)(nil),               // 80: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication
-	(*OidcAuthorizationCode_Default)(nil),                            // 81: enterprise.gloo.solo.io.OidcAuthorizationCode.Default
-	(*OidcAuthorizationCode_FrontChannelLogout)(nil),                 // 82: enterprise.gloo.solo.io.OidcAuthorizationCode.FrontChannelLogout
-	(*OidcAuthorizationCode_ClientAuthentication_ClientSecret)(nil),  // 83: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret
-	(*OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt)(nil), // 84: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt
-	nil,                                      // 85: enterprise.gloo.solo.io.PlainOAuth2.AuthEndpointQueryParamsEntry
-	nil,                                      // 86: enterprise.gloo.solo.io.PlainOAuth2.TokenEndpointQueryParamsEntry
-	(*JwtValidation_RemoteJwks)(nil),         // 87: enterprise.gloo.solo.io.JwtValidation.RemoteJwks
-	(*JwtValidation_LocalJwks)(nil),          // 88: enterprise.gloo.solo.io.JwtValidation.LocalJwks
-	nil,                                      // 89: enterprise.gloo.solo.io.AccessTokenValidation.DynamicMetadataFromClaimsEntry
-	(*AccessTokenValidation_Default)(nil),    // 90: enterprise.gloo.solo.io.AccessTokenValidation.Default
-	(*AccessTokenValidation_ScopeList)(nil),  // 91: enterprise.gloo.solo.io.AccessTokenValidation.ScopeList
-	nil,                                      // 92: enterprise.gloo.solo.io.ApiKeyAuth.LabelSelectorEntry
-	nil,                                      // 93: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntry
-	nil,                                      // 94: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntryEntry
-	(*ApiKeyAuth_SecretKey)(nil),             // 95: enterprise.gloo.solo.io.ApiKeyAuth.SecretKey
-	(*ApiKeyAuth_MetadataEntry)(nil),         // 96: enterprise.gloo.solo.io.ApiKeyAuth.MetadataEntry
-	nil,                                      // 97: enterprise.gloo.solo.io.K8sSecretApiKeyStorage.LabelSelectorEntry
-	(*AerospikeApiKeyStorageReadModeSc)(nil), // 98: enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeSc
-	(*AerospikeApiKeyStorageReadModeAp)(nil), // 99: enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeAp
-	(*AerospikeApiKeyStorageTlsCurveID)(nil), // 100: enterprise.gloo.solo.io.AerospikeApiKeyStorage.tlsCurveID
-	nil,                                      // 101: enterprise.gloo.solo.io.AerospikeApiKeyStorage.LabelSelectorEntry
-	nil,                                      // 102: enterprise.gloo.solo.io.ApiKey.MetadataEntry
-	nil,                                      // 103: enterprise.gloo.solo.io.ApiKeySecret.MetadataEntry
-	(*Ldap_ConnectionPool)(nil),              // 104: enterprise.gloo.solo.io.Ldap.ConnectionPool
-	(*PassThroughHttp_Request)(nil),          // 105: enterprise.gloo.solo.io.PassThroughHttp.Request
-	(*PassThroughHttp_Response)(nil),         // 106: enterprise.gloo.solo.io.PassThroughHttp.Response
-	nil,                                      // 107: enterprise.gloo.solo.io.PassThroughHttp.Request.HeadersToAddEntry
-	(*core.NamespacedStatuses)(nil),          // 108: core.solo.io.NamespacedStatuses
-	(*core.Metadata)(nil),                    // 109: core.solo.io.Metadata
-	(*wrapperspb.StringValue)(nil),           // 110: google.protobuf.StringValue
-	(*core.ResourceRef)(nil),                 // 111: core.solo.io.ResourceRef
-	(*durationpb.Duration)(nil),              // 112: google.protobuf.Duration
-	(*structpb.Struct)(nil),                  // 113: google.protobuf.Struct
-	(*wrapperspb.BoolValue)(nil),             // 114: google.protobuf.BoolValue
-	(*emptypb.Empty)(nil),                    // 115: google.protobuf.Empty
-	(*wrapperspb.UInt32Value)(nil),           // 116: google.protobuf.UInt32Value
+	(ApiKeyDigest_Algorithm)(0),                // 5: enterprise.gloo.solo.io.ApiKeyDigest.Algorithm
+	(SslParameters_ProtocolVersion)(0),         // 6: enterprise.gloo.solo.io.SslParameters.ProtocolVersion
+	(*AuthConfig)(nil),                         // 7: enterprise.gloo.solo.io.AuthConfig
+	(*ExtAuthExtension)(nil),                   // 8: enterprise.gloo.solo.io.ExtAuthExtension
+	(*Settings)(nil),                           // 9: enterprise.gloo.solo.io.Settings
+	(*GrpcService)(nil),                        // 10: enterprise.gloo.solo.io.GrpcService
+	(*HttpService)(nil),                        // 11: enterprise.gloo.solo.io.HttpService
+	(*BufferSettings)(nil),                     // 12: enterprise.gloo.solo.io.BufferSettings
+	(*CustomAuth)(nil),                         // 13: enterprise.gloo.solo.io.CustomAuth
+	(*AuthPlugin)(nil),                         // 14: enterprise.gloo.solo.io.AuthPlugin
+	(*BasicAuth)(nil),                          // 15: enterprise.gloo.solo.io.BasicAuth
+	(*HmacAuth)(nil),                           // 16: enterprise.gloo.solo.io.HmacAuth
+	(*SecretRefList)(nil),                      // 17: enterprise.gloo.solo.io.SecretRefList
+	(*HmacParametersInHeaders)(nil),            // 18: enterprise.gloo.solo.io.HmacParametersInHeaders
+	(*OAuth)(nil),                              // 19: enterprise.gloo.solo.io.OAuth
+	(*OAuth2)(nil),                             // 20: enterprise.gloo.solo.io.OAuth2
+	(*RedisOptions)(nil),                       // 21: enterprise.gloo.solo.io.RedisOptions
+	(*UserSession)(nil),                        // 22: enterprise.gloo.solo.io.UserSession
+	(*HeaderConfiguration)(nil),                // 23: enterprise.gloo.solo.io.HeaderConfiguration
+	(*DiscoveryOverride)(nil),                  // 24: enterprise.gloo.solo.io.DiscoveryOverride
+	(*JwksOnDemandCacheRefreshPolicy)(nil),     // 25: enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy
+	(*AutoMapFromMetadata)(nil),                // 26: enterprise.gloo.solo.io.AutoMapFromMetadata
+	(*EndSessionProperties)(nil),               // 27: enterprise.gloo.solo.io.EndSessionProperties
+	(*ClaimToHeader)(nil),                      // 28: enterprise.gloo.solo.io.ClaimToHeader
+	(*Azure)(nil),                              // 29: enterprise.gloo.solo.io.Azure
+	(*OidcAuthorizationCode)(nil),              // 30: enterprise.gloo.solo.io.OidcAuthorizationCode
+	(*PlainOAuth2)(nil),                        // 31: enterprise.gloo.solo.io.PlainOAuth2
+	(*JwtValidation)(nil),                      // 32: enterprise.gloo.solo.io.JwtValidation
+	(*IntrospectionValidation)(nil),            // 33: enterprise.gloo.solo.io.IntrospectionValidation
+	(*AccessTokenValidation)(nil),              // 34: enterprise.gloo.solo.io.AccessTokenValidation
+	(*OauthSecret)(nil),                        // 35: enterprise.gloo.solo.io.OauthSecret
+	(*ApiKeyAuth)(nil),                         // 36: enterprise.gloo.solo.io.ApiKeyAuth
+	(*ApiKeyHmac)(nil),                         // 37: enterprise.gloo.solo.io.ApiKeyHmac
+	(*ApiKeyDigest)(nil),                       // 38: enterprise.gloo.solo.io.ApiKeyDigest
+	(*ApiKeyMatch)(nil),                        // 39: enterprise.gloo.solo.io.ApiKeyMatch
+	(*HeaderMatch)(nil),                        // 40: enterprise.gloo.solo.io.HeaderMatch
+	(*K8SSecretApiKeyStorage)(nil),             // 41: enterprise.gloo.solo.io.K8sSecretApiKeyStorage
+	(*AerospikeApiKeyStorage)(nil),             // 42: enterprise.gloo.solo.io.AerospikeApiKeyStorage
+	(*ServerDefaultApiKeyStorage)(nil),         // 43: enterprise.gloo.solo.io.ServerDefaultApiKeyStorage
+	(*ApiKey)(nil),                             // 44: enterprise.gloo.solo.io.ApiKey
+	(*ApiKeySecret)(nil),                       // 45: enterprise.gloo.solo.io.ApiKeySecret
+	(*OpaAuth)(nil),                            // 46: enterprise.gloo.solo.io.OpaAuth
+	(*OpaAuthOptions)(nil),                     // 47: enterprise.gloo.solo.io.OpaAuthOptions
+	(*OpaServerAuth)(nil),                      // 48: enterprise.gloo.solo.io.OpaServerAuth
+	(*Ldap)(nil),                               // 49: enterprise.gloo.solo.io.Ldap
+	(*LdapServiceAccount)(nil),                 // 50: enterprise.gloo.solo.io.LdapServiceAccount
+	(*PassThroughAuth)(nil),                    // 51: enterprise.gloo.solo.io.PassThroughAuth
+	(*BackoffStrategy)(nil),                    // 52: enterprise.gloo.solo.io.BackoffStrategy
+	(*RetryPolicy)(nil),                        // 53: enterprise.gloo.solo.io.RetryPolicy
+	(*PassThroughGrpc)(nil),                    // 54: enterprise.gloo.solo.io.PassThroughGrpc
+	(*PassThroughHttp)(nil),                    // 55: enterprise.gloo.solo.io.PassThroughHttp
+	(*PassThroughGrpcTLSConfig)(nil),           // 56: enterprise.gloo.solo.io.PassThroughGrpcTLSConfig
+	(*PassThroughHttpTLSConfig)(nil),           // 57: enterprise.gloo.solo.io.PassThroughHttpTLSConfig
+	(*SslParameters)(nil),                      // 58: enterprise.gloo.solo.io.SslParameters
+	(*PortalAuth)(nil),                         // 59: enterprise.gloo.solo.io.PortalAuth
+	(*AuthConfig_Config)(nil),                  // 60: enterprise.gloo.solo.io.AuthConfig.Config
+	(*HttpService_Request)(nil),                // 61: enterprise.gloo.solo.io.HttpService.Request
+	(*HttpService_Response)(nil),               // 62: enterprise.gloo.solo.io.HttpService.Response
+	nil,                                        // 63: enterprise.gloo.solo.io.HttpService.Request.HeadersToAddEntry
+	nil,                                        // 64: enterprise.gloo.solo.io.CustomAuth.ContextExtensionsEntry
+	(*BasicAuth_Apr)(nil),                      // 65: enterprise.gloo.solo.io.BasicAuth.Apr
+	(*BasicAuth_EncryptionType)(nil),           // 66: enterprise.gloo.solo.io.BasicAuth.EncryptionType
+	(*BasicAuth_User)(nil),                     // 67: enterprise.gloo.solo.io.BasicAuth.User
+	(*BasicAuth_UserList)(nil),                 // 68: enterprise.gloo.solo.io.BasicAuth.UserList
+	(*BasicAuth_Apr_SaltedHashedPassword)(nil), // 69: enterprise.gloo.solo.io.BasicAuth.Apr.SaltedHashedPassword
+	nil,                                   // 70: enterprise.gloo.solo.io.BasicAuth.Apr.UsersEntry
+	(*BasicAuth_EncryptionType_Sha1)(nil), // 71: enterprise.gloo.solo.io.BasicAuth.EncryptionType.Sha1
+	(*BasicAuth_EncryptionType_Apr)(nil),  // 72: enterprise.gloo.solo.io.BasicAuth.EncryptionType.Apr
+	nil,                                   // 73: enterprise.gloo.solo.io.BasicAuth.UserList.UsersEntry
+	nil,                                   // 74: enterprise.gloo.solo.io.OAuth.AuthEndpointQueryParamsEntry
+	(*UserSession_InternalSession)(nil),   // 75: enterprise.gloo.solo.io.UserSession.InternalSession
+	(*UserSession_RedisSession)(nil),      // 76: enterprise.gloo.solo.io.UserSession.RedisSession
+	(*UserSession_CookieOptions)(nil),     // 77: enterprise.gloo.solo.io.UserSession.CookieOptions
+	(*UserSession_CipherConfig)(nil),      // 78: enterprise.gloo.solo.io.UserSession.CipherConfig
+	nil,                                   // 79: enterprise.gloo.solo.io.OidcAuthorizationCode.AuthEndpointQueryParamsEntry
+	nil,                                   // 80: enterprise.gloo.solo.io.OidcAuthorizationCode.TokenEndpointQueryParamsEntry
+	nil,                                   // 81: enterprise.gloo.solo.io.OidcAuthorizationCode.DynamicMetadataFromClaimsEntry
+	(*OidcAuthorizationCode_AccessToken)(nil),                        // 82: enterprise.gloo.solo.io.OidcAuthorizationCode.AccessToken
+	(*OidcAuthorizationCode_IdentityToken)(nil),                      // 83: enterprise.gloo.solo.io.OidcAuthorizationCode.IdentityToken
+	(*OidcAuthorizationCode_ClientAuthentication)(nil),               // 84: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication
+	(*OidcAuthorizationCode_Default)(nil),                            // 85: enterprise.gloo.solo.io.OidcAuthorizationCode.Default
+	(*OidcAuthorizationCode_FrontChannelLogout)(nil),                 // 86: enterprise.gloo.solo.io.OidcAuthorizationCode.FrontChannelLogout
+	(*OidcAuthorizationCode_ClientAuthentication_ClientSecret)(nil),  // 87: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret
+	(*OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt)(nil), // 88: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt
+	nil,                                      // 89: enterprise.gloo.solo.io.PlainOAuth2.AuthEndpointQueryParamsEntry
+	nil,                                      // 90: enterprise.gloo.solo.io.PlainOAuth2.TokenEndpointQueryParamsEntry
+	(*JwtValidation_RemoteJwks)(nil),         // 91: enterprise.gloo.solo.io.JwtValidation.RemoteJwks
+	(*JwtValidation_LocalJwks)(nil),          // 92: enterprise.gloo.solo.io.JwtValidation.LocalJwks
+	nil,                                      // 93: enterprise.gloo.solo.io.AccessTokenValidation.DynamicMetadataFromClaimsEntry
+	(*AccessTokenValidation_Default)(nil),    // 94: enterprise.gloo.solo.io.AccessTokenValidation.Default
+	(*AccessTokenValidation_ScopeList)(nil),  // 95: enterprise.gloo.solo.io.AccessTokenValidation.ScopeList
+	nil,                                      // 96: enterprise.gloo.solo.io.ApiKeyAuth.LabelSelectorEntry
+	nil,                                      // 97: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntry
+	nil,                                      // 98: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntryEntry
+	(*ApiKeyAuth_SecretKey)(nil),             // 99: enterprise.gloo.solo.io.ApiKeyAuth.SecretKey
+	(*ApiKeyAuth_MetadataEntry)(nil),         // 100: enterprise.gloo.solo.io.ApiKeyAuth.MetadataEntry
+	nil,                                      // 101: enterprise.gloo.solo.io.K8sSecretApiKeyStorage.LabelSelectorEntry
+	(*AerospikeApiKeyStorageReadModeSc)(nil), // 102: enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeSc
+	(*AerospikeApiKeyStorageReadModeAp)(nil), // 103: enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeAp
+	(*AerospikeApiKeyStorageTlsCurveID)(nil), // 104: enterprise.gloo.solo.io.AerospikeApiKeyStorage.tlsCurveID
+	nil,                                      // 105: enterprise.gloo.solo.io.AerospikeApiKeyStorage.LabelSelectorEntry
+	nil,                                      // 106: enterprise.gloo.solo.io.ApiKey.MetadataEntry
+	nil,                                      // 107: enterprise.gloo.solo.io.ApiKeySecret.MetadataEntry
+	(*Ldap_ConnectionPool)(nil),              // 108: enterprise.gloo.solo.io.Ldap.ConnectionPool
+	(*PassThroughHttp_Request)(nil),          // 109: enterprise.gloo.solo.io.PassThroughHttp.Request
+	(*PassThroughHttp_Response)(nil),         // 110: enterprise.gloo.solo.io.PassThroughHttp.Response
+	nil,                                      // 111: enterprise.gloo.solo.io.PassThroughHttp.Request.HeadersToAddEntry
+	(*core.NamespacedStatuses)(nil),          // 112: core.solo.io.NamespacedStatuses
+	(*core.Metadata)(nil),                    // 113: core.solo.io.Metadata
+	(*wrapperspb.StringValue)(nil),           // 114: google.protobuf.StringValue
+	(*core.ResourceRef)(nil),                 // 115: core.solo.io.ResourceRef
+	(*durationpb.Duration)(nil),              // 116: google.protobuf.Duration
+	(*structpb.Struct)(nil),                  // 117: google.protobuf.Struct
+	(*wrapperspb.BoolValue)(nil),             // 118: google.protobuf.BoolValue
+	(*emptypb.Empty)(nil),                    // 119: google.protobuf.Empty
+	(*wrapperspb.UInt32Value)(nil),           // 120: google.protobuf.UInt32Value
 }
 var file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_depIdxs = []int32{
-	108, // 0: enterprise.gloo.solo.io.AuthConfig.namespaced_statuses:type_name -> core.solo.io.NamespacedStatuses
-	109, // 1: enterprise.gloo.solo.io.AuthConfig.metadata:type_name -> core.solo.io.Metadata
-	56,  // 2: enterprise.gloo.solo.io.AuthConfig.configs:type_name -> enterprise.gloo.solo.io.AuthConfig.Config
-	110, // 3: enterprise.gloo.solo.io.AuthConfig.boolean_expr:type_name -> google.protobuf.StringValue
-	111, // 4: enterprise.gloo.solo.io.ExtAuthExtension.config_ref:type_name -> core.solo.io.ResourceRef
-	12,  // 5: enterprise.gloo.solo.io.ExtAuthExtension.custom_auth:type_name -> enterprise.gloo.solo.io.CustomAuth
-	111, // 6: enterprise.gloo.solo.io.Settings.extauthz_server_ref:type_name -> core.solo.io.ResourceRef
-	10,  // 7: enterprise.gloo.solo.io.Settings.http_service:type_name -> enterprise.gloo.solo.io.HttpService
-	9,   // 8: enterprise.gloo.solo.io.Settings.grpc_service:type_name -> enterprise.gloo.solo.io.GrpcService
-	112, // 9: enterprise.gloo.solo.io.Settings.request_timeout:type_name -> google.protobuf.Duration
-	11,  // 10: enterprise.gloo.solo.io.Settings.request_body:type_name -> enterprise.gloo.solo.io.BufferSettings
+	112, // 0: enterprise.gloo.solo.io.AuthConfig.namespaced_statuses:type_name -> core.solo.io.NamespacedStatuses
+	113, // 1: enterprise.gloo.solo.io.AuthConfig.metadata:type_name -> core.solo.io.Metadata
+	60,  // 2: enterprise.gloo.solo.io.AuthConfig.configs:type_name -> enterprise.gloo.solo.io.AuthConfig.Config
+	114, // 3: enterprise.gloo.solo.io.AuthConfig.boolean_expr:type_name -> google.protobuf.StringValue
+	115, // 4: enterprise.gloo.solo.io.ExtAuthExtension.config_ref:type_name -> core.solo.io.ResourceRef
+	13,  // 5: enterprise.gloo.solo.io.ExtAuthExtension.custom_auth:type_name -> enterprise.gloo.solo.io.CustomAuth
+	115, // 6: enterprise.gloo.solo.io.Settings.extauthz_server_ref:type_name -> core.solo.io.ResourceRef
+	11,  // 7: enterprise.gloo.solo.io.Settings.http_service:type_name -> enterprise.gloo.solo.io.HttpService
+	10,  // 8: enterprise.gloo.solo.io.Settings.grpc_service:type_name -> enterprise.gloo.solo.io.GrpcService
+	116, // 9: enterprise.gloo.solo.io.Settings.request_timeout:type_name -> google.protobuf.Duration
+	12,  // 10: enterprise.gloo.solo.io.Settings.request_body:type_name -> enterprise.gloo.solo.io.BufferSettings
 	0,   // 11: enterprise.gloo.solo.io.Settings.transport_api_version:type_name -> enterprise.gloo.solo.io.Settings.ApiVersion
-	57,  // 12: enterprise.gloo.solo.io.HttpService.request:type_name -> enterprise.gloo.solo.io.HttpService.Request
-	58,  // 13: enterprise.gloo.solo.io.HttpService.response:type_name -> enterprise.gloo.solo.io.HttpService.Response
-	60,  // 14: enterprise.gloo.solo.io.CustomAuth.context_extensions:type_name -> enterprise.gloo.solo.io.CustomAuth.ContextExtensionsEntry
-	113, // 15: enterprise.gloo.solo.io.AuthPlugin.config:type_name -> google.protobuf.Struct
-	61,  // 16: enterprise.gloo.solo.io.BasicAuth.apr:type_name -> enterprise.gloo.solo.io.BasicAuth.Apr
-	62,  // 17: enterprise.gloo.solo.io.BasicAuth.encryption:type_name -> enterprise.gloo.solo.io.BasicAuth.EncryptionType
-	64,  // 18: enterprise.gloo.solo.io.BasicAuth.user_list:type_name -> enterprise.gloo.solo.io.BasicAuth.UserList
-	16,  // 19: enterprise.gloo.solo.io.HmacAuth.secret_refs:type_name -> enterprise.gloo.solo.io.SecretRefList
-	17,  // 20: enterprise.gloo.solo.io.HmacAuth.parameters_in_headers:type_name -> enterprise.gloo.solo.io.HmacParametersInHeaders
-	111, // 21: enterprise.gloo.solo.io.SecretRefList.secret_refs:type_name -> core.solo.io.ResourceRef
-	111, // 22: enterprise.gloo.solo.io.OAuth.client_secret_ref:type_name -> core.solo.io.ResourceRef
-	70,  // 23: enterprise.gloo.solo.io.OAuth.auth_endpoint_query_params:type_name -> enterprise.gloo.solo.io.OAuth.AuthEndpointQueryParamsEntry
-	29,  // 24: enterprise.gloo.solo.io.OAuth2.oidc_authorization_code:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode
-	33,  // 25: enterprise.gloo.solo.io.OAuth2.access_token_validation:type_name -> enterprise.gloo.solo.io.AccessTokenValidation
-	30,  // 26: enterprise.gloo.solo.io.OAuth2.oauth2:type_name -> enterprise.gloo.solo.io.PlainOAuth2
+	61,  // 12: enterprise.gloo.solo.io.HttpService.request:type_name -> enterprise.gloo.solo.io.HttpService.Request
+	62,  // 13: enterprise.gloo.solo.io.HttpService.response:type_name -> enterprise.gloo.solo.io.HttpService.Response
+	64,  // 14: enterprise.gloo.solo.io.CustomAuth.context_extensions:type_name -> enterprise.gloo.solo.io.CustomAuth.ContextExtensionsEntry
+	117, // 15: enterprise.gloo.solo.io.AuthPlugin.config:type_name -> google.protobuf.Struct
+	65,  // 16: enterprise.gloo.solo.io.BasicAuth.apr:type_name -> enterprise.gloo.solo.io.BasicAuth.Apr
+	66,  // 17: enterprise.gloo.solo.io.BasicAuth.encryption:type_name -> enterprise.gloo.solo.io.BasicAuth.EncryptionType
+	68,  // 18: enterprise.gloo.solo.io.BasicAuth.user_list:type_name -> enterprise.gloo.solo.io.BasicAuth.UserList
+	17,  // 19: enterprise.gloo.solo.io.HmacAuth.secret_refs:type_name -> enterprise.gloo.solo.io.SecretRefList
+	18,  // 20: enterprise.gloo.solo.io.HmacAuth.parameters_in_headers:type_name -> enterprise.gloo.solo.io.HmacParametersInHeaders
+	115, // 21: enterprise.gloo.solo.io.SecretRefList.secret_refs:type_name -> core.solo.io.ResourceRef
+	115, // 22: enterprise.gloo.solo.io.OAuth.client_secret_ref:type_name -> core.solo.io.ResourceRef
+	74,  // 23: enterprise.gloo.solo.io.OAuth.auth_endpoint_query_params:type_name -> enterprise.gloo.solo.io.OAuth.AuthEndpointQueryParamsEntry
+	30,  // 24: enterprise.gloo.solo.io.OAuth2.oidc_authorization_code:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode
+	34,  // 25: enterprise.gloo.solo.io.OAuth2.access_token_validation:type_name -> enterprise.gloo.solo.io.AccessTokenValidation
+	31,  // 26: enterprise.gloo.solo.io.OAuth2.oauth2:type_name -> enterprise.gloo.solo.io.PlainOAuth2
 	1,   // 27: enterprise.gloo.solo.io.RedisOptions.socket_type:type_name -> enterprise.gloo.solo.io.RedisOptions.SocketType
-	73,  // 28: enterprise.gloo.solo.io.UserSession.cookie_options:type_name -> enterprise.gloo.solo.io.UserSession.CookieOptions
-	71,  // 29: enterprise.gloo.solo.io.UserSession.cookie:type_name -> enterprise.gloo.solo.io.UserSession.InternalSession
-	72,  // 30: enterprise.gloo.solo.io.UserSession.redis:type_name -> enterprise.gloo.solo.io.UserSession.RedisSession
-	74,  // 31: enterprise.gloo.solo.io.UserSession.cipher_config:type_name -> enterprise.gloo.solo.io.UserSession.CipherConfig
-	114, // 32: enterprise.gloo.solo.io.HeaderConfiguration.use_bearer_schema_for_authorization:type_name -> google.protobuf.BoolValue
-	115, // 33: enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy.never:type_name -> google.protobuf.Empty
-	115, // 34: enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy.always:type_name -> google.protobuf.Empty
+	77,  // 28: enterprise.gloo.solo.io.UserSession.cookie_options:type_name -> enterprise.gloo.solo.io.UserSession.CookieOptions
+	75,  // 29: enterprise.gloo.solo.io.UserSession.cookie:type_name -> enterprise.gloo.solo.io.UserSession.InternalSession
+	76,  // 30: enterprise.gloo.solo.io.UserSession.redis:type_name -> enterprise.gloo.solo.io.UserSession.RedisSession
+	78,  // 31: enterprise.gloo.solo.io.UserSession.cipher_config:type_name -> enterprise.gloo.solo.io.UserSession.CipherConfig
+	118, // 32: enterprise.gloo.solo.io.HeaderConfiguration.use_bearer_schema_for_authorization:type_name -> google.protobuf.BoolValue
+	119, // 33: enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy.never:type_name -> google.protobuf.Empty
+	119, // 34: enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy.always:type_name -> google.protobuf.Empty
 	3,   // 35: enterprise.gloo.solo.io.EndSessionProperties.methodType:type_name -> enterprise.gloo.solo.io.EndSessionProperties.MethodType
-	111, // 36: enterprise.gloo.solo.io.Azure.client_secret:type_name -> core.solo.io.ResourceRef
-	20,  // 37: enterprise.gloo.solo.io.Azure.claims_caching_options:type_name -> enterprise.gloo.solo.io.RedisOptions
-	111, // 38: enterprise.gloo.solo.io.OidcAuthorizationCode.client_secret_ref:type_name -> core.solo.io.ResourceRef
-	75,  // 39: enterprise.gloo.solo.io.OidcAuthorizationCode.auth_endpoint_query_params:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.AuthEndpointQueryParamsEntry
-	76,  // 40: enterprise.gloo.solo.io.OidcAuthorizationCode.token_endpoint_query_params:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.TokenEndpointQueryParamsEntry
-	21,  // 41: enterprise.gloo.solo.io.OidcAuthorizationCode.session:type_name -> enterprise.gloo.solo.io.UserSession
-	22,  // 42: enterprise.gloo.solo.io.OidcAuthorizationCode.headers:type_name -> enterprise.gloo.solo.io.HeaderConfiguration
-	23,  // 43: enterprise.gloo.solo.io.OidcAuthorizationCode.discovery_override:type_name -> enterprise.gloo.solo.io.DiscoveryOverride
-	112, // 44: enterprise.gloo.solo.io.OidcAuthorizationCode.discovery_poll_interval:type_name -> google.protobuf.Duration
-	24,  // 45: enterprise.gloo.solo.io.OidcAuthorizationCode.jwks_cache_refresh_policy:type_name -> enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy
-	25,  // 46: enterprise.gloo.solo.io.OidcAuthorizationCode.auto_map_from_metadata:type_name -> enterprise.gloo.solo.io.AutoMapFromMetadata
-	26,  // 47: enterprise.gloo.solo.io.OidcAuthorizationCode.end_session_properties:type_name -> enterprise.gloo.solo.io.EndSessionProperties
-	77,  // 48: enterprise.gloo.solo.io.OidcAuthorizationCode.dynamic_metadata_from_claims:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.DynamicMetadataFromClaimsEntry
-	114, // 49: enterprise.gloo.solo.io.OidcAuthorizationCode.disable_client_secret:type_name -> google.protobuf.BoolValue
-	78,  // 50: enterprise.gloo.solo.io.OidcAuthorizationCode.access_token:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.AccessToken
-	79,  // 51: enterprise.gloo.solo.io.OidcAuthorizationCode.identity_token:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.IdentityToken
-	80,  // 52: enterprise.gloo.solo.io.OidcAuthorizationCode.client_authentication:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication
-	81,  // 53: enterprise.gloo.solo.io.OidcAuthorizationCode.default:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.Default
-	28,  // 54: enterprise.gloo.solo.io.OidcAuthorizationCode.azure:type_name -> enterprise.gloo.solo.io.Azure
-	82,  // 55: enterprise.gloo.solo.io.OidcAuthorizationCode.front_channel_logout:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.FrontChannelLogout
-	111, // 56: enterprise.gloo.solo.io.PlainOAuth2.client_secret_ref:type_name -> core.solo.io.ResourceRef
-	85,  // 57: enterprise.gloo.solo.io.PlainOAuth2.auth_endpoint_query_params:type_name -> enterprise.gloo.solo.io.PlainOAuth2.AuthEndpointQueryParamsEntry
-	21,  // 58: enterprise.gloo.solo.io.PlainOAuth2.session:type_name -> enterprise.gloo.solo.io.UserSession
-	86,  // 59: enterprise.gloo.solo.io.PlainOAuth2.token_endpoint_query_params:type_name -> enterprise.gloo.solo.io.PlainOAuth2.TokenEndpointQueryParamsEntry
-	114, // 60: enterprise.gloo.solo.io.PlainOAuth2.disable_client_secret:type_name -> google.protobuf.BoolValue
-	87,  // 61: enterprise.gloo.solo.io.JwtValidation.remote_jwks:type_name -> enterprise.gloo.solo.io.JwtValidation.RemoteJwks
-	88,  // 62: enterprise.gloo.solo.io.JwtValidation.local_jwks:type_name -> enterprise.gloo.solo.io.JwtValidation.LocalJwks
-	111, // 63: enterprise.gloo.solo.io.IntrospectionValidation.client_secret_ref:type_name -> core.solo.io.ResourceRef
-	114, // 64: enterprise.gloo.solo.io.IntrospectionValidation.disable_client_secret:type_name -> google.protobuf.BoolValue
-	31,  // 65: enterprise.gloo.solo.io.AccessTokenValidation.jwt:type_name -> enterprise.gloo.solo.io.JwtValidation
-	32,  // 66: enterprise.gloo.solo.io.AccessTokenValidation.introspection:type_name -> enterprise.gloo.solo.io.IntrospectionValidation
-	112, // 67: enterprise.gloo.solo.io.AccessTokenValidation.cache_timeout:type_name -> google.protobuf.Duration
-	91,  // 68: enterprise.gloo.solo.io.AccessTokenValidation.required_scopes:type_name -> enterprise.gloo.solo.io.AccessTokenValidation.ScopeList
-	89,  // 69: enterprise.gloo.solo.io.AccessTokenValidation.dynamic_metadata_from_claims:type_name -> enterprise.gloo.solo.io.AccessTokenValidation.DynamicMetadataFromClaimsEntry
-	27,  // 70: enterprise.gloo.solo.io.AccessTokenValidation.claims_to_headers:type_name -> enterprise.gloo.solo.io.ClaimToHeader
-	90,  // 71: enterprise.gloo.solo.io.AccessTokenValidation.default:type_name -> enterprise.gloo.solo.io.AccessTokenValidation.Default
-	28,  // 72: enterprise.gloo.solo.io.AccessTokenValidation.azure:type_name -> enterprise.gloo.solo.io.Azure
-	92,  // 73: enterprise.gloo.solo.io.ApiKeyAuth.label_selector:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.LabelSelectorEntry
-	111, // 74: enterprise.gloo.solo.io.ApiKeyAuth.api_key_secret_refs:type_name -> core.solo.io.ResourceRef
-	93,  // 75: enterprise.gloo.solo.io.ApiKeyAuth.headers_from_metadata:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntry
-	94,  // 76: enterprise.gloo.solo.io.ApiKeyAuth.headers_from_metadata_entry:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntryEntry
-	37,  // 77: enterprise.gloo.solo.io.ApiKeyAuth.k8s_secret_apikey_storage:type_name -> enterprise.gloo.solo.io.K8sSecretApiKeyStorage
-	38,  // 78: enterprise.gloo.solo.io.ApiKeyAuth.aerospike_apikey_storage:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage
-	36,  // 79: enterprise.gloo.solo.io.ApiKeyAuth.hmac:type_name -> enterprise.gloo.solo.io.ApiKeyHmac
-	4,   // 80: enterprise.gloo.solo.io.ApiKeyHmac.algorithm:type_name -> enterprise.gloo.solo.io.ApiKeyHmac.Algorithm
-	111, // 81: enterprise.gloo.solo.io.ApiKeyHmac.shared_secret_ref:type_name -> core.solo.io.ResourceRef
-	97,  // 82: enterprise.gloo.solo.io.K8sSecretApiKeyStorage.label_selector:type_name -> enterprise.gloo.solo.io.K8sSecretApiKeyStorage.LabelSelectorEntry
-	111, // 83: enterprise.gloo.solo.io.K8sSecretApiKeyStorage.api_key_secret_refs:type_name -> core.solo.io.ResourceRef
-	98,  // 84: enterprise.gloo.solo.io.AerospikeApiKeyStorage.read_mode_sc:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeSc
-	99,  // 85: enterprise.gloo.solo.io.AerospikeApiKeyStorage.read_mode_ap:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeAp
-	100, // 86: enterprise.gloo.solo.io.AerospikeApiKeyStorage.tls_curve_groups:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.tlsCurveID
-	101, // 87: enterprise.gloo.solo.io.AerospikeApiKeyStorage.label_selector:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.LabelSelectorEntry
-	102, // 88: enterprise.gloo.solo.io.ApiKey.metadata:type_name -> enterprise.gloo.solo.io.ApiKey.MetadataEntry
-	103, // 89: enterprise.gloo.solo.io.ApiKeySecret.metadata:type_name -> enterprise.gloo.solo.io.ApiKeySecret.MetadataEntry
-	111, // 90: enterprise.gloo.solo.io.OpaAuth.modules:type_name -> core.solo.io.ResourceRef
-	43,  // 91: enterprise.gloo.solo.io.OpaAuth.options:type_name -> enterprise.gloo.solo.io.OpaAuthOptions
-	43,  // 92: enterprise.gloo.solo.io.OpaServerAuth.options:type_name -> enterprise.gloo.solo.io.OpaAuthOptions
-	104, // 93: enterprise.gloo.solo.io.Ldap.pool:type_name -> enterprise.gloo.solo.io.Ldap.ConnectionPool
-	46,  // 94: enterprise.gloo.solo.io.Ldap.group_lookup_settings:type_name -> enterprise.gloo.solo.io.LdapServiceAccount
-	111, // 95: enterprise.gloo.solo.io.LdapServiceAccount.credentials_secret_ref:type_name -> core.solo.io.ResourceRef
-	50,  // 96: enterprise.gloo.solo.io.PassThroughAuth.grpc:type_name -> enterprise.gloo.solo.io.PassThroughGrpc
-	51,  // 97: enterprise.gloo.solo.io.PassThroughAuth.http:type_name -> enterprise.gloo.solo.io.PassThroughHttp
-	113, // 98: enterprise.gloo.solo.io.PassThroughAuth.config:type_name -> google.protobuf.Struct
-	112, // 99: enterprise.gloo.solo.io.BackoffStrategy.base_interval:type_name -> google.protobuf.Duration
-	112, // 100: enterprise.gloo.solo.io.BackoffStrategy.max_interval:type_name -> google.protobuf.Duration
-	116, // 101: enterprise.gloo.solo.io.RetryPolicy.num_retries:type_name -> google.protobuf.UInt32Value
-	48,  // 102: enterprise.gloo.solo.io.RetryPolicy.retry_back_off:type_name -> enterprise.gloo.solo.io.BackoffStrategy
-	112, // 103: enterprise.gloo.solo.io.PassThroughGrpc.connection_timeout:type_name -> google.protobuf.Duration
-	52,  // 104: enterprise.gloo.solo.io.PassThroughGrpc.tls_config:type_name -> enterprise.gloo.solo.io.PassThroughGrpcTLSConfig
-	49,  // 105: enterprise.gloo.solo.io.PassThroughGrpc.retry_policy:type_name -> enterprise.gloo.solo.io.RetryPolicy
-	105, // 106: enterprise.gloo.solo.io.PassThroughHttp.request:type_name -> enterprise.gloo.solo.io.PassThroughHttp.Request
-	106, // 107: enterprise.gloo.solo.io.PassThroughHttp.response:type_name -> enterprise.gloo.solo.io.PassThroughHttp.Response
-	112, // 108: enterprise.gloo.solo.io.PassThroughHttp.connection_timeout:type_name -> google.protobuf.Duration
-	53,  // 109: enterprise.gloo.solo.io.PassThroughHttp.tls_config:type_name -> enterprise.gloo.solo.io.PassThroughHttpTLSConfig
-	111, // 110: enterprise.gloo.solo.io.PassThroughGrpcTLSConfig.secret_ref:type_name -> core.solo.io.ResourceRef
-	54,  // 111: enterprise.gloo.solo.io.PassThroughGrpcTLSConfig.ssl_params:type_name -> enterprise.gloo.solo.io.SslParameters
-	111, // 112: enterprise.gloo.solo.io.PassThroughHttpTLSConfig.secret_ref:type_name -> core.solo.io.ResourceRef
-	54,  // 113: enterprise.gloo.solo.io.PassThroughHttpTLSConfig.ssl_params:type_name -> enterprise.gloo.solo.io.SslParameters
-	5,   // 114: enterprise.gloo.solo.io.SslParameters.minimum_protocol_version:type_name -> enterprise.gloo.solo.io.SslParameters.ProtocolVersion
-	5,   // 115: enterprise.gloo.solo.io.SslParameters.maximum_protocol_version:type_name -> enterprise.gloo.solo.io.SslParameters.ProtocolVersion
-	20,  // 116: enterprise.gloo.solo.io.PortalAuth.redis_options:type_name -> enterprise.gloo.solo.io.RedisOptions
-	112, // 117: enterprise.gloo.solo.io.PortalAuth.cache_duration:type_name -> google.protobuf.Duration
-	112, // 118: enterprise.gloo.solo.io.PortalAuth.request_timeout:type_name -> google.protobuf.Duration
-	110, // 119: enterprise.gloo.solo.io.AuthConfig.Config.name:type_name -> google.protobuf.StringValue
-	14,  // 120: enterprise.gloo.solo.io.AuthConfig.Config.basic_auth:type_name -> enterprise.gloo.solo.io.BasicAuth
-	18,  // 121: enterprise.gloo.solo.io.AuthConfig.Config.oauth:type_name -> enterprise.gloo.solo.io.OAuth
-	19,  // 122: enterprise.gloo.solo.io.AuthConfig.Config.oauth2:type_name -> enterprise.gloo.solo.io.OAuth2
-	35,  // 123: enterprise.gloo.solo.io.AuthConfig.Config.api_key_auth:type_name -> enterprise.gloo.solo.io.ApiKeyAuth
-	13,  // 124: enterprise.gloo.solo.io.AuthConfig.Config.plugin_auth:type_name -> enterprise.gloo.solo.io.AuthPlugin
-	42,  // 125: enterprise.gloo.solo.io.AuthConfig.Config.opa_auth:type_name -> enterprise.gloo.solo.io.OpaAuth
-	45,  // 126: enterprise.gloo.solo.io.AuthConfig.Config.ldap:type_name -> enterprise.gloo.solo.io.Ldap
-	115, // 127: enterprise.gloo.solo.io.AuthConfig.Config.jwt:type_name -> google.protobuf.Empty
-	47,  // 128: enterprise.gloo.solo.io.AuthConfig.Config.pass_through_auth:type_name -> enterprise.gloo.solo.io.PassThroughAuth
-	15,  // 129: enterprise.gloo.solo.io.AuthConfig.Config.hmac_auth:type_name -> enterprise.gloo.solo.io.HmacAuth
-	44,  // 130: enterprise.gloo.solo.io.AuthConfig.Config.opa_server_auth:type_name -> enterprise.gloo.solo.io.OpaServerAuth
-	55,  // 131: enterprise.gloo.solo.io.AuthConfig.Config.portal_auth:type_name -> enterprise.gloo.solo.io.PortalAuth
-	59,  // 132: enterprise.gloo.solo.io.HttpService.Request.headers_to_add:type_name -> enterprise.gloo.solo.io.HttpService.Request.HeadersToAddEntry
-	66,  // 133: enterprise.gloo.solo.io.BasicAuth.Apr.users:type_name -> enterprise.gloo.solo.io.BasicAuth.Apr.UsersEntry
-	68,  // 134: enterprise.gloo.solo.io.BasicAuth.EncryptionType.apr:type_name -> enterprise.gloo.solo.io.BasicAuth.EncryptionType.Apr
-	67,  // 135: enterprise.gloo.solo.io.BasicAuth.EncryptionType.sha1:type_name -> enterprise.gloo.solo.io.BasicAuth.EncryptionType.Sha1
-	69,  // 136: enterprise.gloo.solo.io.BasicAuth.UserList.users:type_name -> enterprise.gloo.solo.io.BasicAuth.UserList.UsersEntry
-	65,  // 137: enterprise.gloo.solo.io.BasicAuth.Apr.UsersEntry.value:type_name -> enterprise.gloo.solo.io.BasicAuth.Apr.SaltedHashedPassword
-	63,  // 138: enterprise.gloo.solo.io.BasicAuth.UserList.UsersEntry.value:type_name -> enterprise.gloo.solo.io.BasicAuth.User
-	114, // 139: enterprise.gloo.solo.io.UserSession.InternalSession.allow_refreshing:type_name -> google.protobuf.BoolValue
-	20,  // 140: enterprise.gloo.solo.io.UserSession.RedisSession.options:type_name -> enterprise.gloo.solo.io.RedisOptions
-	114, // 141: enterprise.gloo.solo.io.UserSession.RedisSession.allow_refreshing:type_name -> google.protobuf.BoolValue
-	112, // 142: enterprise.gloo.solo.io.UserSession.RedisSession.pre_expiry_buffer:type_name -> google.protobuf.Duration
-	116, // 143: enterprise.gloo.solo.io.UserSession.CookieOptions.max_age:type_name -> google.protobuf.UInt32Value
-	114, // 144: enterprise.gloo.solo.io.UserSession.CookieOptions.http_only:type_name -> google.protobuf.BoolValue
-	110, // 145: enterprise.gloo.solo.io.UserSession.CookieOptions.path:type_name -> google.protobuf.StringValue
-	2,   // 146: enterprise.gloo.solo.io.UserSession.CookieOptions.same_site:type_name -> enterprise.gloo.solo.io.UserSession.CookieOptions.SameSite
-	111, // 147: enterprise.gloo.solo.io.UserSession.CipherConfig.key_ref:type_name -> core.solo.io.ResourceRef
-	27,  // 148: enterprise.gloo.solo.io.OidcAuthorizationCode.AccessToken.claims_to_headers:type_name -> enterprise.gloo.solo.io.ClaimToHeader
-	27,  // 149: enterprise.gloo.solo.io.OidcAuthorizationCode.IdentityToken.claims_to_headers:type_name -> enterprise.gloo.solo.io.ClaimToHeader
-	83,  // 150: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.client_secret:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret
-	84,  // 151: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.private_key_jwt:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt
-	111, // 152: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret.client_secret_ref:type_name -> core.solo.io.ResourceRef
-	114, // 153: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret.disable_client_secret:type_name -> google.protobuf.BoolValue
-	111, // 154: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt.signing_key_ref:type_name -> core.solo.io.ResourceRef
-	112, // 155: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt.valid_for:type_name -> google.protobuf.Duration
-	112, // 156: enterprise.gloo.solo.io.JwtValidation.RemoteJwks.refresh_interval:type_name -> google.protobuf.Duration
-	95,  // 157: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntry.value:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.SecretKey
-	96,  // 158: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntryEntry.value:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.MetadataEntry
-	116, // 159: enterprise.gloo.solo.io.Ldap.ConnectionPool.maxSize:type_name -> google.protobuf.UInt32Value
-	116, // 160: enterprise.gloo.solo.io.Ldap.ConnectionPool.initialSize:type_name -> google.protobuf.UInt32Value
-	107, // 161: enterprise.gloo.solo.io.PassThroughHttp.Request.headers_to_add:type_name -> enterprise.gloo.solo.io.PassThroughHttp.Request.HeadersToAddEntry
-	162, // [162:162] is the sub-list for method output_type
-	162, // [162:162] is the sub-list for method input_type
-	162, // [162:162] is the sub-list for extension type_name
-	162, // [162:162] is the sub-list for extension extendee
-	0,   // [0:162] is the sub-list for field type_name
+	115, // 36: enterprise.gloo.solo.io.Azure.client_secret:type_name -> core.solo.io.ResourceRef
+	21,  // 37: enterprise.gloo.solo.io.Azure.claims_caching_options:type_name -> enterprise.gloo.solo.io.RedisOptions
+	115, // 38: enterprise.gloo.solo.io.OidcAuthorizationCode.client_secret_ref:type_name -> core.solo.io.ResourceRef
+	79,  // 39: enterprise.gloo.solo.io.OidcAuthorizationCode.auth_endpoint_query_params:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.AuthEndpointQueryParamsEntry
+	80,  // 40: enterprise.gloo.solo.io.OidcAuthorizationCode.token_endpoint_query_params:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.TokenEndpointQueryParamsEntry
+	22,  // 41: enterprise.gloo.solo.io.OidcAuthorizationCode.session:type_name -> enterprise.gloo.solo.io.UserSession
+	23,  // 42: enterprise.gloo.solo.io.OidcAuthorizationCode.headers:type_name -> enterprise.gloo.solo.io.HeaderConfiguration
+	24,  // 43: enterprise.gloo.solo.io.OidcAuthorizationCode.discovery_override:type_name -> enterprise.gloo.solo.io.DiscoveryOverride
+	116, // 44: enterprise.gloo.solo.io.OidcAuthorizationCode.discovery_poll_interval:type_name -> google.protobuf.Duration
+	25,  // 45: enterprise.gloo.solo.io.OidcAuthorizationCode.jwks_cache_refresh_policy:type_name -> enterprise.gloo.solo.io.JwksOnDemandCacheRefreshPolicy
+	26,  // 46: enterprise.gloo.solo.io.OidcAuthorizationCode.auto_map_from_metadata:type_name -> enterprise.gloo.solo.io.AutoMapFromMetadata
+	27,  // 47: enterprise.gloo.solo.io.OidcAuthorizationCode.end_session_properties:type_name -> enterprise.gloo.solo.io.EndSessionProperties
+	81,  // 48: enterprise.gloo.solo.io.OidcAuthorizationCode.dynamic_metadata_from_claims:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.DynamicMetadataFromClaimsEntry
+	118, // 49: enterprise.gloo.solo.io.OidcAuthorizationCode.disable_client_secret:type_name -> google.protobuf.BoolValue
+	82,  // 50: enterprise.gloo.solo.io.OidcAuthorizationCode.access_token:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.AccessToken
+	83,  // 51: enterprise.gloo.solo.io.OidcAuthorizationCode.identity_token:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.IdentityToken
+	84,  // 52: enterprise.gloo.solo.io.OidcAuthorizationCode.client_authentication:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication
+	85,  // 53: enterprise.gloo.solo.io.OidcAuthorizationCode.default:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.Default
+	29,  // 54: enterprise.gloo.solo.io.OidcAuthorizationCode.azure:type_name -> enterprise.gloo.solo.io.Azure
+	86,  // 55: enterprise.gloo.solo.io.OidcAuthorizationCode.front_channel_logout:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.FrontChannelLogout
+	115, // 56: enterprise.gloo.solo.io.PlainOAuth2.client_secret_ref:type_name -> core.solo.io.ResourceRef
+	89,  // 57: enterprise.gloo.solo.io.PlainOAuth2.auth_endpoint_query_params:type_name -> enterprise.gloo.solo.io.PlainOAuth2.AuthEndpointQueryParamsEntry
+	22,  // 58: enterprise.gloo.solo.io.PlainOAuth2.session:type_name -> enterprise.gloo.solo.io.UserSession
+	90,  // 59: enterprise.gloo.solo.io.PlainOAuth2.token_endpoint_query_params:type_name -> enterprise.gloo.solo.io.PlainOAuth2.TokenEndpointQueryParamsEntry
+	118, // 60: enterprise.gloo.solo.io.PlainOAuth2.disable_client_secret:type_name -> google.protobuf.BoolValue
+	91,  // 61: enterprise.gloo.solo.io.JwtValidation.remote_jwks:type_name -> enterprise.gloo.solo.io.JwtValidation.RemoteJwks
+	92,  // 62: enterprise.gloo.solo.io.JwtValidation.local_jwks:type_name -> enterprise.gloo.solo.io.JwtValidation.LocalJwks
+	115, // 63: enterprise.gloo.solo.io.IntrospectionValidation.client_secret_ref:type_name -> core.solo.io.ResourceRef
+	118, // 64: enterprise.gloo.solo.io.IntrospectionValidation.disable_client_secret:type_name -> google.protobuf.BoolValue
+	32,  // 65: enterprise.gloo.solo.io.AccessTokenValidation.jwt:type_name -> enterprise.gloo.solo.io.JwtValidation
+	33,  // 66: enterprise.gloo.solo.io.AccessTokenValidation.introspection:type_name -> enterprise.gloo.solo.io.IntrospectionValidation
+	116, // 67: enterprise.gloo.solo.io.AccessTokenValidation.cache_timeout:type_name -> google.protobuf.Duration
+	95,  // 68: enterprise.gloo.solo.io.AccessTokenValidation.required_scopes:type_name -> enterprise.gloo.solo.io.AccessTokenValidation.ScopeList
+	93,  // 69: enterprise.gloo.solo.io.AccessTokenValidation.dynamic_metadata_from_claims:type_name -> enterprise.gloo.solo.io.AccessTokenValidation.DynamicMetadataFromClaimsEntry
+	28,  // 70: enterprise.gloo.solo.io.AccessTokenValidation.claims_to_headers:type_name -> enterprise.gloo.solo.io.ClaimToHeader
+	94,  // 71: enterprise.gloo.solo.io.AccessTokenValidation.default:type_name -> enterprise.gloo.solo.io.AccessTokenValidation.Default
+	29,  // 72: enterprise.gloo.solo.io.AccessTokenValidation.azure:type_name -> enterprise.gloo.solo.io.Azure
+	96,  // 73: enterprise.gloo.solo.io.ApiKeyAuth.label_selector:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.LabelSelectorEntry
+	115, // 74: enterprise.gloo.solo.io.ApiKeyAuth.api_key_secret_refs:type_name -> core.solo.io.ResourceRef
+	97,  // 75: enterprise.gloo.solo.io.ApiKeyAuth.headers_from_metadata:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntry
+	98,  // 76: enterprise.gloo.solo.io.ApiKeyAuth.headers_from_metadata_entry:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntryEntry
+	41,  // 77: enterprise.gloo.solo.io.ApiKeyAuth.k8s_secret_apikey_storage:type_name -> enterprise.gloo.solo.io.K8sSecretApiKeyStorage
+	42,  // 78: enterprise.gloo.solo.io.ApiKeyAuth.aerospike_apikey_storage:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage
+	37,  // 79: enterprise.gloo.solo.io.ApiKeyAuth.hmac:type_name -> enterprise.gloo.solo.io.ApiKeyHmac
+	38,  // 80: enterprise.gloo.solo.io.ApiKeyAuth.digest:type_name -> enterprise.gloo.solo.io.ApiKeyDigest
+	39,  // 81: enterprise.gloo.solo.io.ApiKeyAuth.match:type_name -> enterprise.gloo.solo.io.ApiKeyMatch
+	4,   // 82: enterprise.gloo.solo.io.ApiKeyHmac.algorithm:type_name -> enterprise.gloo.solo.io.ApiKeyHmac.Algorithm
+	115, // 83: enterprise.gloo.solo.io.ApiKeyHmac.shared_secret_ref:type_name -> core.solo.io.ResourceRef
+	5,   // 84: enterprise.gloo.solo.io.ApiKeyDigest.algorithm:type_name -> enterprise.gloo.solo.io.ApiKeyDigest.Algorithm
+	40,  // 85: enterprise.gloo.solo.io.ApiKeyMatch.headers:type_name -> enterprise.gloo.solo.io.HeaderMatch
+	101, // 86: enterprise.gloo.solo.io.K8sSecretApiKeyStorage.label_selector:type_name -> enterprise.gloo.solo.io.K8sSecretApiKeyStorage.LabelSelectorEntry
+	115, // 87: enterprise.gloo.solo.io.K8sSecretApiKeyStorage.api_key_secret_refs:type_name -> core.solo.io.ResourceRef
+	102, // 88: enterprise.gloo.solo.io.AerospikeApiKeyStorage.read_mode_sc:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeSc
+	103, // 89: enterprise.gloo.solo.io.AerospikeApiKeyStorage.read_mode_ap:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.readModeAp
+	104, // 90: enterprise.gloo.solo.io.AerospikeApiKeyStorage.tls_curve_groups:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.tlsCurveID
+	105, // 91: enterprise.gloo.solo.io.AerospikeApiKeyStorage.label_selector:type_name -> enterprise.gloo.solo.io.AerospikeApiKeyStorage.LabelSelectorEntry
+	106, // 92: enterprise.gloo.solo.io.ApiKey.metadata:type_name -> enterprise.gloo.solo.io.ApiKey.MetadataEntry
+	107, // 93: enterprise.gloo.solo.io.ApiKeySecret.metadata:type_name -> enterprise.gloo.solo.io.ApiKeySecret.MetadataEntry
+	115, // 94: enterprise.gloo.solo.io.OpaAuth.modules:type_name -> core.solo.io.ResourceRef
+	47,  // 95: enterprise.gloo.solo.io.OpaAuth.options:type_name -> enterprise.gloo.solo.io.OpaAuthOptions
+	47,  // 96: enterprise.gloo.solo.io.OpaServerAuth.options:type_name -> enterprise.gloo.solo.io.OpaAuthOptions
+	108, // 97: enterprise.gloo.solo.io.Ldap.pool:type_name -> enterprise.gloo.solo.io.Ldap.ConnectionPool
+	50,  // 98: enterprise.gloo.solo.io.Ldap.group_lookup_settings:type_name -> enterprise.gloo.solo.io.LdapServiceAccount
+	115, // 99: enterprise.gloo.solo.io.LdapServiceAccount.credentials_secret_ref:type_name -> core.solo.io.ResourceRef
+	54,  // 100: enterprise.gloo.solo.io.PassThroughAuth.grpc:type_name -> enterprise.gloo.solo.io.PassThroughGrpc
+	55,  // 101: enterprise.gloo.solo.io.PassThroughAuth.http:type_name -> enterprise.gloo.solo.io.PassThroughHttp
+	117, // 102: enterprise.gloo.solo.io.PassThroughAuth.config:type_name -> google.protobuf.Struct
+	116, // 103: enterprise.gloo.solo.io.BackoffStrategy.base_interval:type_name -> google.protobuf.Duration
+	116, // 104: enterprise.gloo.solo.io.BackoffStrategy.max_interval:type_name -> google.protobuf.Duration
+	120, // 105: enterprise.gloo.solo.io.RetryPolicy.num_retries:type_name -> google.protobuf.UInt32Value
+	52,  // 106: enterprise.gloo.solo.io.RetryPolicy.retry_back_off:type_name -> enterprise.gloo.solo.io.BackoffStrategy
+	116, // 107: enterprise.gloo.solo.io.PassThroughGrpc.connection_timeout:type_name -> google.protobuf.Duration
+	56,  // 108: enterprise.gloo.solo.io.PassThroughGrpc.tls_config:type_name -> enterprise.gloo.solo.io.PassThroughGrpcTLSConfig
+	53,  // 109: enterprise.gloo.solo.io.PassThroughGrpc.retry_policy:type_name -> enterprise.gloo.solo.io.RetryPolicy
+	109, // 110: enterprise.gloo.solo.io.PassThroughHttp.request:type_name -> enterprise.gloo.solo.io.PassThroughHttp.Request
+	110, // 111: enterprise.gloo.solo.io.PassThroughHttp.response:type_name -> enterprise.gloo.solo.io.PassThroughHttp.Response
+	116, // 112: enterprise.gloo.solo.io.PassThroughHttp.connection_timeout:type_name -> google.protobuf.Duration
+	57,  // 113: enterprise.gloo.solo.io.PassThroughHttp.tls_config:type_name -> enterprise.gloo.solo.io.PassThroughHttpTLSConfig
+	115, // 114: enterprise.gloo.solo.io.PassThroughGrpcTLSConfig.secret_ref:type_name -> core.solo.io.ResourceRef
+	58,  // 115: enterprise.gloo.solo.io.PassThroughGrpcTLSConfig.ssl_params:type_name -> enterprise.gloo.solo.io.SslParameters
+	115, // 116: enterprise.gloo.solo.io.PassThroughHttpTLSConfig.secret_ref:type_name -> core.solo.io.ResourceRef
+	58,  // 117: enterprise.gloo.solo.io.PassThroughHttpTLSConfig.ssl_params:type_name -> enterprise.gloo.solo.io.SslParameters
+	6,   // 118: enterprise.gloo.solo.io.SslParameters.minimum_protocol_version:type_name -> enterprise.gloo.solo.io.SslParameters.ProtocolVersion
+	6,   // 119: enterprise.gloo.solo.io.SslParameters.maximum_protocol_version:type_name -> enterprise.gloo.solo.io.SslParameters.ProtocolVersion
+	21,  // 120: enterprise.gloo.solo.io.PortalAuth.redis_options:type_name -> enterprise.gloo.solo.io.RedisOptions
+	116, // 121: enterprise.gloo.solo.io.PortalAuth.cache_duration:type_name -> google.protobuf.Duration
+	116, // 122: enterprise.gloo.solo.io.PortalAuth.request_timeout:type_name -> google.protobuf.Duration
+	114, // 123: enterprise.gloo.solo.io.AuthConfig.Config.name:type_name -> google.protobuf.StringValue
+	15,  // 124: enterprise.gloo.solo.io.AuthConfig.Config.basic_auth:type_name -> enterprise.gloo.solo.io.BasicAuth
+	19,  // 125: enterprise.gloo.solo.io.AuthConfig.Config.oauth:type_name -> enterprise.gloo.solo.io.OAuth
+	20,  // 126: enterprise.gloo.solo.io.AuthConfig.Config.oauth2:type_name -> enterprise.gloo.solo.io.OAuth2
+	36,  // 127: enterprise.gloo.solo.io.AuthConfig.Config.api_key_auth:type_name -> enterprise.gloo.solo.io.ApiKeyAuth
+	14,  // 128: enterprise.gloo.solo.io.AuthConfig.Config.plugin_auth:type_name -> enterprise.gloo.solo.io.AuthPlugin
+	46,  // 129: enterprise.gloo.solo.io.AuthConfig.Config.opa_auth:type_name -> enterprise.gloo.solo.io.OpaAuth
+	49,  // 130: enterprise.gloo.solo.io.AuthConfig.Config.ldap:type_name -> enterprise.gloo.solo.io.Ldap
+	119, // 131: enterprise.gloo.solo.io.AuthConfig.Config.jwt:type_name -> google.protobuf.Empty
+	51,  // 132: enterprise.gloo.solo.io.AuthConfig.Config.pass_through_auth:type_name -> enterprise.gloo.solo.io.PassThroughAuth
+	16,  // 133: enterprise.gloo.solo.io.AuthConfig.Config.hmac_auth:type_name -> enterprise.gloo.solo.io.HmacAuth
+	48,  // 134: enterprise.gloo.solo.io.AuthConfig.Config.opa_server_auth:type_name -> enterprise.gloo.solo.io.OpaServerAuth
+	59,  // 135: enterprise.gloo.solo.io.AuthConfig.Config.portal_auth:type_name -> enterprise.gloo.solo.io.PortalAuth
+	63,  // 136: enterprise.gloo.solo.io.HttpService.Request.headers_to_add:type_name -> enterprise.gloo.solo.io.HttpService.Request.HeadersToAddEntry
+	70,  // 137: enterprise.gloo.solo.io.BasicAuth.Apr.users:type_name -> enterprise.gloo.solo.io.BasicAuth.Apr.UsersEntry
+	72,  // 138: enterprise.gloo.solo.io.BasicAuth.EncryptionType.apr:type_name -> enterprise.gloo.solo.io.BasicAuth.EncryptionType.Apr
+	71,  // 139: enterprise.gloo.solo.io.BasicAuth.EncryptionType.sha1:type_name -> enterprise.gloo.solo.io.BasicAuth.EncryptionType.Sha1
+	73,  // 140: enterprise.gloo.solo.io.BasicAuth.UserList.users:type_name -> enterprise.gloo.solo.io.BasicAuth.UserList.UsersEntry
+	69,  // 141: enterprise.gloo.solo.io.BasicAuth.Apr.UsersEntry.value:type_name -> enterprise.gloo.solo.io.BasicAuth.Apr.SaltedHashedPassword
+	67,  // 142: enterprise.gloo.solo.io.BasicAuth.UserList.UsersEntry.value:type_name -> enterprise.gloo.solo.io.BasicAuth.User
+	118, // 143: enterprise.gloo.solo.io.UserSession.InternalSession.allow_refreshing:type_name -> google.protobuf.BoolValue
+	21,  // 144: enterprise.gloo.solo.io.UserSession.RedisSession.options:type_name -> enterprise.gloo.solo.io.RedisOptions
+	118, // 145: enterprise.gloo.solo.io.UserSession.RedisSession.allow_refreshing:type_name -> google.protobuf.BoolValue
+	116, // 146: enterprise.gloo.solo.io.UserSession.RedisSession.pre_expiry_buffer:type_name -> google.protobuf.Duration
+	120, // 147: enterprise.gloo.solo.io.UserSession.CookieOptions.max_age:type_name -> google.protobuf.UInt32Value
+	118, // 148: enterprise.gloo.solo.io.UserSession.CookieOptions.http_only:type_name -> google.protobuf.BoolValue
+	114, // 149: enterprise.gloo.solo.io.UserSession.CookieOptions.path:type_name -> google.protobuf.StringValue
+	2,   // 150: enterprise.gloo.solo.io.UserSession.CookieOptions.same_site:type_name -> enterprise.gloo.solo.io.UserSession.CookieOptions.SameSite
+	115, // 151: enterprise.gloo.solo.io.UserSession.CipherConfig.key_ref:type_name -> core.solo.io.ResourceRef
+	28,  // 152: enterprise.gloo.solo.io.OidcAuthorizationCode.AccessToken.claims_to_headers:type_name -> enterprise.gloo.solo.io.ClaimToHeader
+	28,  // 153: enterprise.gloo.solo.io.OidcAuthorizationCode.IdentityToken.claims_to_headers:type_name -> enterprise.gloo.solo.io.ClaimToHeader
+	87,  // 154: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.client_secret:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret
+	88,  // 155: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.private_key_jwt:type_name -> enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt
+	115, // 156: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret.client_secret_ref:type_name -> core.solo.io.ResourceRef
+	118, // 157: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.ClientSecret.disable_client_secret:type_name -> google.protobuf.BoolValue
+	115, // 158: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt.signing_key_ref:type_name -> core.solo.io.ResourceRef
+	116, // 159: enterprise.gloo.solo.io.OidcAuthorizationCode.ClientAuthentication.PrivateKeyJwt.valid_for:type_name -> google.protobuf.Duration
+	116, // 160: enterprise.gloo.solo.io.JwtValidation.RemoteJwks.refresh_interval:type_name -> google.protobuf.Duration
+	99,  // 161: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntry.value:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.SecretKey
+	100, // 162: enterprise.gloo.solo.io.ApiKeyAuth.HeadersFromMetadataEntryEntry.value:type_name -> enterprise.gloo.solo.io.ApiKeyAuth.MetadataEntry
+	120, // 163: enterprise.gloo.solo.io.Ldap.ConnectionPool.maxSize:type_name -> google.protobuf.UInt32Value
+	120, // 164: enterprise.gloo.solo.io.Ldap.ConnectionPool.initialSize:type_name -> google.protobuf.UInt32Value
+	111, // 165: enterprise.gloo.solo.io.PassThroughHttp.Request.headers_to_add:type_name -> enterprise.gloo.solo.io.PassThroughHttp.Request.HeadersToAddEntry
+	166, // [166:166] is the sub-list for method output_type
+	166, // [166:166] is the sub-list for method input_type
+	166, // [166:166] is the sub-list for extension type_name
+	166, // [166:166] is the sub-list for extension extendee
+	0,   // [0:166] is the sub-list for field type_name
 }
 
 func init() {
@@ -8502,18 +8728,18 @@ func file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extaut
 		(*ApiKeyAuth_K8SSecretApikeyStorage)(nil),
 		(*ApiKeyAuth_AerospikeApikeyStorage)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[32].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[35].OneofWrappers = []any{
 		(*AerospikeApiKeyStorage_CommitAll)(nil),
 		(*AerospikeApiKeyStorage_CommitMaster)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[41].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[44].OneofWrappers = []any{
 		(*PassThroughAuth_Grpc)(nil),
 		(*PassThroughAuth_Http)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[43].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[46].OneofWrappers = []any{
 		(*RetryPolicy_RetryBackOff)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[50].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[53].OneofWrappers = []any{
 		(*AuthConfig_Config_BasicAuth)(nil),
 		(*AuthConfig_Config_Oauth)(nil),
 		(*AuthConfig_Config_Oauth2)(nil),
@@ -8527,28 +8753,28 @@ func file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extaut
 		(*AuthConfig_Config_OpaServerAuth)(nil),
 		(*AuthConfig_Config_PortalAuth)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[56].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[59].OneofWrappers = []any{
 		(*BasicAuth_EncryptionType_Apr_)(nil),
 		(*BasicAuth_EncryptionType_Sha1_)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[68].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[71].OneofWrappers = []any{
 		(*UserSession_CipherConfig_KeyRef)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[74].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[77].OneofWrappers = []any{
 		(*OidcAuthorizationCode_ClientAuthentication_ClientSecret_)(nil),
 		(*OidcAuthorizationCode_ClientAuthentication_PrivateKeyJwt_)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[92].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[95].OneofWrappers = []any{
 		(*AerospikeApiKeyStorageReadModeSc_ReadModeScSession)(nil),
 		(*AerospikeApiKeyStorageReadModeSc_ReadModeScLinearize)(nil),
 		(*AerospikeApiKeyStorageReadModeSc_ReadModeScReplica)(nil),
 		(*AerospikeApiKeyStorageReadModeSc_ReadModeScAllowUnavailable)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[93].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[96].OneofWrappers = []any{
 		(*AerospikeApiKeyStorageReadModeAp_ReadModeApOne)(nil),
 		(*AerospikeApiKeyStorageReadModeAp_ReadModeApAll)(nil),
 	}
-	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[94].OneofWrappers = []any{
+	file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_msgTypes[97].OneofWrappers = []any{
 		(*AerospikeApiKeyStorageTlsCurveID_CurveP256)(nil),
 		(*AerospikeApiKeyStorageTlsCurveID_CurveP384)(nil),
 		(*AerospikeApiKeyStorageTlsCurveID_CurveP521)(nil),
@@ -8559,8 +8785,8 @@ func file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extaut
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDesc), len(file_github_com_solo_io_gloo_projects_gloo_api_v1_enterprise_options_extauth_v1_extauth_proto_rawDesc)),
-			NumEnums:      6,
-			NumMessages:   102,
+			NumEnums:      7,
+			NumMessages:   105,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.hash.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.hash.go
@@ -2649,6 +2649,46 @@ func (m *ApiKeyAuth) Hash(hasher hash.Hash64) (uint64, error) {
 		}
 	}
 
+	if h, ok := interface{}(m.GetDigest()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("Digest")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetDigest(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("Digest")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	if h, ok := interface{}(m.GetMatch()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("Match")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetMatch(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("Match")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
 	switch m.StorageBackend.(type) {
 
 	case *ApiKeyAuth_K8SSecretApikeyStorage:
@@ -2740,6 +2780,99 @@ func (m *ApiKeyHmac) Hash(hasher hash.Hash64) (uint64, error) {
 				return 0, err
 			}
 		}
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// Hash function
+//
+// Deprecated: due to hashing implemention only using field values. The omission
+// of the field name in the hash calculation can lead to hash collisions.
+// Prefer the HashUnique function instead.
+func (m *ApiKeyDigest) Hash(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("enterprise.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1.ApiKeyDigest")); err != nil {
+		return 0, err
+	}
+
+	err = binary.Write(hasher, binary.LittleEndian, m.GetAlgorithm())
+	if err != nil {
+		return 0, err
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// Hash function
+//
+// Deprecated: due to hashing implemention only using field values. The omission
+// of the field name in the hash calculation can lead to hash collisions.
+// Prefer the HashUnique function instead.
+func (m *ApiKeyMatch) Hash(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("enterprise.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1.ApiKeyMatch")); err != nil {
+		return 0, err
+	}
+
+	for _, v := range m.GetHeaders() {
+
+		if h, ok := interface{}(v).(safe_hasher.SafeHasher); ok {
+			if _, err = hasher.Write([]byte("")); err != nil {
+				return 0, err
+			}
+			if _, err = h.Hash(hasher); err != nil {
+				return 0, err
+			}
+		} else {
+			if fieldValue, err := hashstructure.Hash(v, nil); err != nil {
+				return 0, err
+			} else {
+				if _, err = hasher.Write([]byte("")); err != nil {
+					return 0, err
+				}
+				if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+					return 0, err
+				}
+			}
+		}
+
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// Hash function
+//
+// Deprecated: due to hashing implemention only using field values. The omission
+// of the field name in the hash calculation can lead to hash collisions.
+// Prefer the HashUnique function instead.
+func (m *HeaderMatch) Hash(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("enterprise.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1.HeaderMatch")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte(m.GetName())); err != nil {
+		return 0, err
 	}
 
 	return hasher.Sum64(), nil

--- a/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.uniquehash.go
+++ b/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1/extauth.pb.uniquehash.go
@@ -2990,6 +2990,46 @@ func (m *ApiKeyAuth) HashUnique(hasher hash.Hash64) (uint64, error) {
 		}
 	}
 
+	if h, ok := interface{}(m.GetDigest()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("Digest")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetDigest(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("Digest")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	if h, ok := interface{}(m.GetMatch()).(safe_hasher.SafeHasher); ok {
+		if _, err = hasher.Write([]byte("Match")); err != nil {
+			return 0, err
+		}
+		if _, err = h.Hash(hasher); err != nil {
+			return 0, err
+		}
+	} else {
+		if fieldValue, err := hashstructure.Hash(m.GetMatch(), nil); err != nil {
+			return 0, err
+		} else {
+			if _, err = hasher.Write([]byte("Match")); err != nil {
+				return 0, err
+			}
+			if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+				return 0, err
+			}
+		}
+	}
+
 	switch m.StorageBackend.(type) {
 
 	case *ApiKeyAuth_K8SSecretApikeyStorage:
@@ -3083,6 +3123,108 @@ func (m *ApiKeyHmac) HashUnique(hasher hash.Hash64) (uint64, error) {
 				return 0, err
 			}
 		}
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// HashUnique function generates a hash of the object that is unique to the object by
+// hashing field name and value pairs.
+// Replaces Hash due to original hashing implemention only using field values. The omission
+// of the field name in the hash calculation can lead to hash collisions.
+func (m *ApiKeyDigest) HashUnique(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("enterprise.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1.ApiKeyDigest")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte("Algorithm")); err != nil {
+		return 0, err
+	}
+	err = binary.Write(hasher, binary.LittleEndian, m.GetAlgorithm())
+	if err != nil {
+		return 0, err
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// HashUnique function generates a hash of the object that is unique to the object by
+// hashing field name and value pairs.
+// Replaces Hash due to original hashing implemention only using field values. The omission
+// of the field name in the hash calculation can lead to hash collisions.
+func (m *ApiKeyMatch) HashUnique(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("enterprise.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1.ApiKeyMatch")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte("Headers")); err != nil {
+		return 0, err
+	}
+	for i, v := range m.GetHeaders() {
+		if _, err = hasher.Write([]byte(strconv.Itoa(i))); err != nil {
+			return 0, err
+		}
+
+		if h, ok := interface{}(v).(safe_hasher.SafeHasher); ok {
+			if _, err = hasher.Write([]byte("v")); err != nil {
+				return 0, err
+			}
+			if _, err = h.Hash(hasher); err != nil {
+				return 0, err
+			}
+		} else {
+			if fieldValue, err := hashstructure.Hash(v, nil); err != nil {
+				return 0, err
+			} else {
+				if _, err = hasher.Write([]byte("v")); err != nil {
+					return 0, err
+				}
+				if err := binary.Write(hasher, binary.LittleEndian, fieldValue); err != nil {
+					return 0, err
+				}
+			}
+		}
+
+	}
+
+	return hasher.Sum64(), nil
+}
+
+// HashUnique function generates a hash of the object that is unique to the object by
+// hashing field name and value pairs.
+// Replaces Hash due to original hashing implemention only using field values. The omission
+// of the field name in the hash calculation can lead to hash collisions.
+func (m *HeaderMatch) HashUnique(hasher hash.Hash64) (uint64, error) {
+	if m == nil {
+		return 0, nil
+	}
+	if hasher == nil {
+		hasher = fnv.New64()
+	}
+	var err error
+	if _, err = hasher.Write([]byte("enterprise.gloo.solo.io.github.com/solo-io/gloo/projects/gloo/pkg/api/v1/enterprise/options/extauth/v1.HeaderMatch")); err != nil {
+		return 0, err
+	}
+
+	if _, err = hasher.Write([]byte("Name")); err != nil {
+		return 0, err
+	}
+	if _, err = hasher.Write([]byte(m.GetName())); err != nil {
+		return 0, err
 	}
 
 	return hasher.Sum64(), nil


### PR DESCRIPTION
# Description

Part of EP-1581 (solo-io/gloo-gateway#1581) and based on https://github.com/solo-io/gloo-gateway/pull/1950 design doc.

This PR adds the enterprise ExtAuth API surface for API-key SHA256 digest configuration and same-name header matching in AuthConfig.

- Adds `ApiKeyAuth.digest` and `ApiKeyAuth.match`
- Adds `ApiKeyDigest`, `ApiKeyMatch`, and `HeaderMatch`
- Regenerates enterprise protobuf Go types, CRD schema, and API docs
- Updates the extauth docs post-processing helper in `generate.go` for generated duplicate anchors

No runtime auth behavior change in this PR; runtime translation and validation support will be implemented downstream in `ext-auth-service`.

## Testing

- `SKIP_VERSION_CHECKS=1 make -B install-go-tools generate-all`
- `go test ./projects/gloo/pkg/api/v1/enterprise/options/extauth/v1`
- `go test .`
