### PR TITLE
[1.21] feat: Add ipV4Only Setting for Gateway API Mode

### DIFF
--- a/changelog/v1.21.4/add-ipv4only.yaml
+++ b/changelog/v1.21.4/add-ipv4only.yaml
@@ -1,6 +1,5 @@
 changelog:
-changelog:
-- type: NEW_FEATURE
+- type: FIX
   description: Add ipV4Only Setting for Gateway API Mode which sets the bind address to `0.0.0.0` instead of `::`. Defaults to false
   issueLink: https://github.com/solo-io/solo-projects/issues/8916
   resolvesIssue: false

--- a/changelog/v1.22.0-beta3/add-ipv4only.yaml
+++ b/changelog/v1.22.0-beta3/add-ipv4only.yaml
@@ -1,0 +1,7 @@
+changelog:
+changelog:
+- type: NEW_FEATURE
+  description: Add ipV4Only Setting for Gateway API Mode which sets the bind address to `0.0.0.0` instead of `::`. Defaults to false
+  issueLink: https://github.com/solo-io/solo-projects/issues/8916
+  resolvesIssue: false
+

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/settings.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/settings.proto.sk.md
@@ -103,6 +103,7 @@ Represents global settings for all the Gloo components.
 "extProc": .extproc.options.gloo.solo.io.Settings
 "extProcLate": .extproc.options.gloo.solo.io.Settings
 "watchNamespaceSelectors": []gloo.solo.io.LabelSelector
+"ipV4Only": bool
 
 ```
 
@@ -146,6 +147,7 @@ Represents global settings for all the Gloo components.
 | `extProc` | [.extproc.options.gloo.solo.io.Settings](../enterprise/options/extproc/extproc.proto.sk/#settings) | Enterprise-only: External Processing filter settings. These settings are used as defaults globally, and can be overridden by HttpListenerOptions, VirtualHostOptions, or RouteOptions. |
 | `extProcLate` | [.extproc.options.gloo.solo.io.Settings](../enterprise/options/extproc/extproc.proto.sk/#settings) | Enterprise-only: Late External Processing filter settings that happens at the end of the filter chain as an UpstreamHttpFilter. These settings are used as defaults globally, and can be overridden by HttpListenerOptions, VirtualHostOptions, or RouteOptions. |
 | `watchNamespaceSelectors` | [[]gloo.solo.io.LabelSelector](../settings.proto.sk/#labelselector) | A list of Kubernetes selectors that specify the set of namespaces to restrict the namespaces that Gloo controllers take into consideration when watching for resources. Elements in the list are disjunctive (OR semantics), i.e. a namespace will be included if it matches any selector. The following example selects any namespace that matches either below: 1. The namespace has both of these labels: `env: prod` and `region: us-east1` 2. The namespace has label `app` equal to `cassandra` or `spark`. ```yaml watchNamespaceSelectors: - matchLabels: env: prod region: us-east1 - matchExpressions: - key: app operator: In values: - cassandra - spark ``` However, if the match conditions are part of the same same list item, the namespace must match all conditions. ```yaml watchNamespaceSelectors: - matchLabels: env: prod region: us-east1 matchExpressions: - key: app operator: In values: - cassandra - spark ``` Refer to the [Kubernetes selector docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors) for additional detail on selector semantics. |
+| `ipV4Only` | `bool` | Set to true to only use ipv4 when creating gateways when running in gateway api mode. Defaults to false. |
 
 
 

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -419,6 +419,7 @@
 |settings.secretOptions.sources[].vault.aws.sessionToken|string||The Session Token as provided by the security credentials on the AWS IAM resource.|
 |settings.secretOptions.sources[].vault.aws.leaseIncrement|uint32||The time increment, in seconds, used in renewing the lease of the Vault token. See: https://developer.hashicorp.com/vault/docs/concepts/lease#lease-durations-and-renewal. Defaults to 0, which causes the default TTL to be used.|
 |settings.secretOptions.sources[].directory.directory|string||Directory to read secrets from.|
+|settings.ipV4Only|bool|false|Set to true to only use IPv4 when creating gateways in Gateway API mode. Sets listener bind addresses to 0.0.0.0 instead of ::.|
 |settings.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
 |gloo.deployment.xdsPort|int|9977|port where gloo serves xDS API to Envoy.|
 |gloo.deployment.restXdsPort|uint32|9976|port where gloo serves REST xDS API to Envoy.|

--- a/install/helm/gloo/crds/gloo.solo.io_v1_Settings.yaml
+++ b/install/helm/gloo/crds/gloo.solo.io_v1_Settings.yaml
@@ -1100,6 +1100,8 @@ spec:
                   xdsBindAddr:
                     type: string
                 type: object
+              ipV4Only:
+                type: boolean
               knative:
                 properties:
                   clusterIngressProxyAddress:

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -235,6 +235,7 @@ type Settings struct {
 	// NOTE: DevMode is deprecated. See https://docs.solo.io/gloo-edge/latest/operations/debugging_gloo/#debugging-the-control-plane for more details.
 	DevMode       *bool         `json:"devMode,omitempty" desc:"Whether or not to enable dev mode. Defaults to false. Setting to true at install time will expose the gloo dev admin endpoint on port 10010. Not recommended for production. Warning: this value is deprecated as of 1.17 and will be removed in a future release."`
 	SecretOptions SecretOptions `json:"secretOptions,omitempty" desc:"Options for how Gloo Edge should handle secrets."`
+	IPv4Only      *bool         `json:"ipV4Only,omitempty" desc:"Set to true to only use IPv4 when creating gateways in Gateway API mode. Sets listener bind addresses to 0.0.0.0 instead of ::."`
 	*KubeResourceOverride
 }
 

--- a/install/helm/gloo/templates/18-settings.yaml
+++ b/install/helm/gloo/templates/18-settings.yaml
@@ -105,6 +105,9 @@ spec:
 {{- if .Values.settings.linkerd }}
   linkerd: true
 {{- end }}
+{{- if .Values.settings.ipV4Only }}
+  ipV4Only: {{ .Values.settings.ipV4Only }}
+{{- end }}
 {{- if .Values.settings.integrations.knative.enabled }}
   knative:
 {{- if (semverCompare "< 0.8.0" .Values.settings.integrations.knative.version ) }}

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -105,6 +105,7 @@ settings:
   # Envoy default max program size is 100 which is too often not enough for users. We will set all users to base value of 1024
   # This can be overriden if users wish to be more stringent
   regexMaxProgramSize: 1024
+  ipV4Only: false
 gloo:
   deployment:
     image:

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -4294,6 +4294,20 @@ spec:
 						testManifest.ExpectUnstructured(settings.GetKind(), settings.GetNamespace(), settings.GetName()).To(BeEquivalentTo(settings))
 					})
 
+					It("correctly sets the `ipV4Only` field in the settings", func() {
+						prepareMakefile(namespace, glootestutils.HelmValues{
+							ValuesArgs: []string{
+								"settings.ipV4Only=true",
+							},
+						})
+						testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+							return resource.GetKind() == "Settings"
+						}).ExpectAll(func(settings *unstructured.Unstructured) {
+							field := getFieldFromUnstructured(settings, "spec", "ipV4Only")
+							Expect(field).To(BeTrue())
+						})
+					})
+
 					It("correctly sets the gateway validation fields in the settings", func() {
 						settings := makeUnstructureFromTemplateFile("fixtures/settings/gateway_validation.yaml", namespace)
 

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -37,11 +37,13 @@ import (
 	"istio.io/istio/pkg/kube/kclient"
 	"istio.io/istio/pkg/kube/krt"
 	"istio.io/istio/pkg/kube/kubetypes"
+	"istio.io/istio/pkg/ptr"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/avast/retry-go/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/solo-io/gloo/pkg/utils/settingsutil"
 	"github.com/solo-io/gloo/pkg/utils/statsutils"
 	"github.com/solo-io/gloo/projects/gateway2/extensions"
 	"github.com/solo-io/gloo/projects/gateway2/krtcollections"
@@ -432,6 +434,10 @@ func (s *ProxySyncer) Init(ctx context.Context, dbg *krt.DebugHandler) error {
 		}
 		logger.Debugf("building proxy for kube gw %s version %s", client.ObjectKeyFromObject(gw), gw.GetResourceVersion())
 		s.proxyTrigger.MarkDependant(kctx)
+
+		ksettings := ptr.Flatten(krt.FetchOne(kctx, s.proxyTranslator.settings.AsCollection()))
+		ctx = settingsutil.WithSettings(ctx, &ksettings.Spec)
+
 		proxy := s.buildProxy(ctx, gw)
 		return proxy
 	}, withDebug, krt.WithName("GlooProxies"))

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -436,9 +436,9 @@ func (s *ProxySyncer) Init(ctx context.Context, dbg *krt.DebugHandler) error {
 		s.proxyTrigger.MarkDependant(kctx)
 
 		ksettings := ptr.Flatten(krt.FetchOne(kctx, s.proxyTranslator.settings.AsCollection()))
-		ctx = settingsutil.WithSettings(ctx, &ksettings.Spec)
+		proxyCtx := settingsutil.WithSettings(ctx, &ksettings.Spec)
 
-		proxy := s.buildProxy(ctx, gw)
+		proxy := s.buildProxy(proxyCtx, gw)
 		return proxy
 	}, withDebug, krt.WithName("GlooProxies"))
 	s.mostXdsSnapshots = krt.NewCollection(glooProxies, func(kctx krt.HandlerContext, proxy glooProxy) *XdsSnapWrapper {

--- a/projects/gateway2/setup/ggv2setup_test.go
+++ b/projects/gateway2/setup/ggv2setup_test.go
@@ -201,7 +201,7 @@ func testScenariosWithCRDs(
 		Port: int(0),
 	}
 	controlPlane := gloosetup.NewControlPlane(ctx, setupOpts.Cache, grpc.NewServer(), addr, bootstrap.KubernetesControlPlaneConfig{}, uniqueClientCallbacks, true)
-	xds.SetupEnvoyXds(controlPlane.GrpcServer, controlPlane.XDSServer, controlPlane.SnapshotCache)
+	xds.SetupEnvoyXds(controlPlane.GrpcServer, controlPlane.XDSServer, controlPlane.SnapshotCache, false)
 
 	lis, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {

--- a/projects/gateway2/translator/gateway_translator_test.go
+++ b/projects/gateway2/translator/gateway_translator_test.go
@@ -14,6 +14,7 @@ import (
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
 	"github.com/solo-io/gloo/projects/gateway2/reports"
+	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
 )
 
 type translatorTestCase struct {
@@ -21,6 +22,7 @@ type translatorTestCase struct {
 	outputFile    string
 	gwNN          types.NamespacedName
 	assertReports func(gwNN types.NamespacedName, reportsMap reports.ReportMap)
+	settings      *v1.Settings
 }
 
 var _ = DescribeTable("Basic GatewayTranslator Tests",
@@ -30,6 +32,7 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 
 		results, err := TestCase{
 			InputFiles: []string{filepath.Join(dir, "testutils/inputs/", in.inputFile)},
+			Settings:   in.settings,
 		}.Run(ctx)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -375,6 +378,19 @@ var _ = DescribeTable("Basic GatewayTranslator Tests",
 			gwNN: types.NamespacedName{
 				Namespace: "default",
 				Name:      "example-gateway",
+			},
+		}),
+	Entry(
+		"With ipV4Only=true",
+		translatorTestCase{
+			inputFile:  "ipv4only",
+			outputFile: "ipv4only-proxy.yaml",
+			gwNN: types.NamespacedName{
+				Namespace: "default",
+				Name:      "example-gateway",
+			},
+			settings: &v1.Settings{
+				IpV4Only: true,
 			},
 		}),
 )

--- a/projects/gateway2/translator/listener/gateway_listener_translator.go
+++ b/projects/gateway2/translator/listener/gateway_listener_translator.go
@@ -16,6 +16,7 @@ import (
 	gwv1a2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gwxv1a1 "sigs.k8s.io/gateway-api/apisx/v1alpha1"
 
+	"github.com/solo-io/gloo/pkg/utils/settingsutil"
 	"github.com/solo-io/gloo/projects/gateway2/ports"
 	"github.com/solo-io/gloo/projects/gateway2/query"
 	"github.com/solo-io/gloo/projects/gateway2/reports"
@@ -530,10 +531,15 @@ func (ml *MergedListener) TranslateListener(
 		}
 	}
 
+	bindAddress := "::"
+	if settingsutil.MaybeFromContext(ctx).GetIpV4Only() {
+		bindAddress = "0.0.0.0"
+	}
+
 	// Create and return the listener with all filter chains and TCP listeners
 	return &v1.Listener{
 		Name:        ml.name,
-		BindAddress: "::",
+		BindAddress: bindAddress,
 		BindPort:    uint32(ml.port),
 		ListenerType: &v1.Listener_AggregateListener{
 			AggregateListener: &v1.AggregateListener{

--- a/projects/gateway2/translator/testutils/inputs/ipv4only/manifests.yaml
+++ b/projects/gateway2/translator/testutils/inputs/ipv4only/manifests.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: example-gateway
+spec:
+  gatewayClassName: example-gateway-class
+  listeners:
+  - name: https
+    protocol: HTTP
+    port: 8080
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: example-route
+spec:
+  parentRefs:
+  - name: example-gateway
+  hostnames:
+  - "example.com"
+  rules:
+  - backendRefs:
+    - name: example-svc
+      port: 80

--- a/projects/gateway2/translator/testutils/outputs/ipv4only-proxy.yaml
+++ b/projects/gateway2/translator/testutils/outputs/ipv4only-proxy.yaml
@@ -1,0 +1,39 @@
+listeners:
+- aggregateListener:
+    httpFilterChains:
+    - matcher: {}
+      virtualHostRefs:
+      - listener~8080~example_com
+    httpResources:
+      virtualHosts:
+        listener~8080~example_com:
+          domains:
+          - example.com
+          name: listener~8080~example_com
+          routes:
+          - matchers:
+            - prefix: /
+            name: httproute-example-route-default-0-0
+            options: {}
+            routeAction:
+              single:
+                kube:
+                  port: 80
+                  ref:
+                    name: blackhole_cluster
+                    namespace: blackhole_ns
+  bindAddress: 0.0.0.0
+  bindPort: 8080
+  metadataStatic:
+    sources:
+    - resourceKind: gateway.networking.k8s.io/Gateway
+      resourceRef:
+        name: listener~8080
+        namespace: default
+  name: listener~8080
+metadata:
+  labels:
+    created_by: gloo-kube-gateway-api
+    gateway_namespace: default
+  name: default-example-gateway
+  namespace: gloo-system

--- a/projects/gateway2/translator/translator_case_test.go
+++ b/projects/gateway2/translator/translator_case_test.go
@@ -21,6 +21,7 @@ import (
 	core "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/solo-io/solo-kit/pkg/api/v2/reporter"
 
+	"github.com/solo-io/gloo/pkg/utils/settingsutil"
 	"github.com/solo-io/gloo/pkg/utils/statusutils"
 	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	solokubev1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1/kube/apis/gateway.solo.io/v1"
@@ -41,6 +42,7 @@ import (
 
 type TestCase struct {
 	InputFiles []string
+	Settings   *v1.Settings
 }
 
 type ActualTestResult struct {
@@ -159,6 +161,10 @@ func (tc TestCase) Run(ctx context.Context) (map[types.NamespacedName]ActualTest
 	pluginRegistry := registry.NewPluginRegistry(allPlugins)
 
 	results := make(map[types.NamespacedName]ActualTestResult)
+
+	if tc.Settings != nil {
+		ctx = settingsutil.WithSettings(ctx, tc.Settings)
+	}
 
 	for _, gw := range gateways {
 		gwNN := types.NamespacedName{

--- a/projects/gloo/api/v1/settings.proto
+++ b/projects/gloo/api/v1/settings.proto
@@ -615,7 +615,9 @@ message Settings {
     // for additional detail on selector semantics.
     repeated LabelSelector watch_namespace_selectors = 40;
 
-
+    // Set to true to only use ipv4 when creating gateways when running in gateway api mode.
+    // Defaults to false
+    bool ip_v4_only = 43;
 }
 
 // A label selector requirement is a selector that contains values, a key, and an operator that

--- a/projects/gloo/pkg/api/v1/settings.pb.clone.go
+++ b/projects/gloo/pkg/api/v1/settings.pb.clone.go
@@ -236,6 +236,8 @@ func (m *Settings) Clone() proto.Message {
 		}
 	}
 
+	target.IpV4Only = m.GetIpV4Only()
+
 	switch m.ConfigSource.(type) {
 
 	case *Settings_KubernetesConfigSource:

--- a/projects/gloo/pkg/api/v1/settings.pb.equal.go
+++ b/projects/gloo/pkg/api/v1/settings.pb.equal.go
@@ -337,6 +337,10 @@ func (m *Settings) Equal(that interface{}) bool {
 
 	}
 
+	if m.GetIpV4Only() != target.GetIpV4Only() {
+		return false
+	}
+
 	switch m.ConfigSource.(type) {
 
 	case *Settings_KubernetesConfigSource:

--- a/projects/gloo/pkg/api/v1/settings.pb.go
+++ b/projects/gloo/pkg/api/v1/settings.pb.go
@@ -256,8 +256,11 @@ type Settings struct {
 	// Refer to the [Kubernetes selector docs](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors)
 	// for additional detail on selector semantics.
 	WatchNamespaceSelectors []*LabelSelector `protobuf:"bytes,40,rep,name=watch_namespace_selectors,json=watchNamespaceSelectors,proto3" json:"watch_namespace_selectors,omitempty"`
-	unknownFields           protoimpl.UnknownFields
-	sizeCache               protoimpl.SizeCache
+	// Set to true to only use ipv4 when creating gateways when running in gateway api mode.
+	// Defaults to false
+	IpV4Only      bool `protobuf:"varint,43,opt,name=ip_v4_only,json=ipV4Only,proto3" json:"ip_v4_only,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *Settings) Reset() {
@@ -595,6 +598,13 @@ func (x *Settings) GetWatchNamespaceSelectors() []*LabelSelector {
 		return x.WatchNamespaceSelectors
 	}
 	return nil
+}
+
+func (x *Settings) GetIpV4Only() bool {
+	if x != nil {
+		return x.IpV4Only
+	}
+	return false
 }
 
 type isSettings_ConfigSource interface {
@@ -3524,7 +3534,7 @@ var File_github_com_solo_io_gloo_projects_gloo_api_v1_settings_proto protoreflec
 
 const file_github_com_solo_io_gloo_projects_gloo_api_v1_settings_proto_rawDesc = "" +
 	"\n" +
-	";github.com/solo-io/gloo/projects/gloo/api/v1/settings.proto\x12\fgloo.solo.io\x1a\x12extproto/ext.proto\x1a1github.com/solo-io/solo-kit/api/v1/metadata.proto\x1a/github.com/solo-io/solo-kit/api/v1/status.proto\x1a1github.com/solo-io/solo-kit/api/v1/solo-kit.proto\x1a,github.com/solo-io/solo-kit/api/v1/ref.proto\x1a=github.com/solo-io/gloo/projects/gloo/api/v1/extensions.proto\x1aYgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/ratelimit/ratelimit.proto\x1aUgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/caching/caching.proto\x1aXgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto\x1aUgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extproc/extproc.proto\x1aOgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/rbac/rbac.proto\x1aRgithub.com/solo-io/gloo/projects/gloo/api/v1/circuit_breaker/circuit_breaker.proto\x1a:github.com/solo-io/gloo/projects/gloo/api/v1/ssl/ssl.proto\x1aTgithub.com/solo-io/gloo/projects/gloo/api/external/envoy/extensions/aws/filter.proto\x1aOgithub.com/solo-io/gloo/projects/gloo/api/v1/options/consul/query_options.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xaf;\n" +
+	";github.com/solo-io/gloo/projects/gloo/api/v1/settings.proto\x12\fgloo.solo.io\x1a\x12extproto/ext.proto\x1a1github.com/solo-io/solo-kit/api/v1/metadata.proto\x1a/github.com/solo-io/solo-kit/api/v1/status.proto\x1a1github.com/solo-io/solo-kit/api/v1/solo-kit.proto\x1a,github.com/solo-io/solo-kit/api/v1/ref.proto\x1a=github.com/solo-io/gloo/projects/gloo/api/v1/extensions.proto\x1aYgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/ratelimit/ratelimit.proto\x1aUgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/caching/caching.proto\x1aXgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extauth/v1/extauth.proto\x1aUgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/extproc/extproc.proto\x1aOgithub.com/solo-io/gloo/projects/gloo/api/v1/enterprise/options/rbac/rbac.proto\x1aRgithub.com/solo-io/gloo/projects/gloo/api/v1/circuit_breaker/circuit_breaker.proto\x1a:github.com/solo-io/gloo/projects/gloo/api/v1/ssl/ssl.proto\x1aTgithub.com/solo-io/gloo/projects/gloo/api/external/envoy/extensions/aws/filter.proto\x1aOgithub.com/solo-io/gloo/projects/gloo/api/v1/options/consul/query_options.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1egoogle/protobuf/wrappers.proto\"\xcd;\n" +
 	"\bSettings\x12/\n" +
 	"\x13discovery_namespace\x18\x01 \x01(\tR\x12discoveryNamespace\x12)\n" +
 	"\x10watch_namespaces\x18\x02 \x03(\tR\x0fwatchNamespaces\x12a\n" +
@@ -3568,7 +3578,9 @@ const file_github_com_solo_io_gloo_projects_gloo_api_v1_settings_proto_rawDesc =
 	"\x0eext_proc_early\x18* \x01(\v2&.extproc.options.gloo.solo.io.SettingsR\fextProcEarly\x12A\n" +
 	"\bext_proc\x18' \x01(\v2&.extproc.options.gloo.solo.io.SettingsR\aextProc\x12J\n" +
 	"\rext_proc_late\x18) \x01(\v2&.extproc.options.gloo.solo.io.SettingsR\vextProcLate\x12W\n" +
-	"\x19watch_namespace_selectors\x18( \x03(\v2\x1b.gloo.solo.io.LabelSelectorR\x17watchNamespaceSelectors\x1a\xb6\x02\n" +
+	"\x19watch_namespace_selectors\x18( \x03(\v2\x1b.gloo.solo.io.LabelSelectorR\x17watchNamespaceSelectors\x12\x1c\n" +
+	"\n" +
+	"ip_v4_only\x18+ \x01(\bR\bipV4Only\x1a\xb6\x02\n" +
 	"\rSecretOptions\x12E\n" +
 	"\asources\x18\x01 \x03(\v2+.gloo.solo.io.Settings.SecretOptions.SourceR\asources\x1a\xdd\x01\n" +
 	"\x06Source\x12J\n" +

--- a/projects/gloo/pkg/api/v1/settings.pb.hash.go
+++ b/projects/gloo/pkg/api/v1/settings.pb.hash.go
@@ -571,6 +571,11 @@ func (m *Settings) Hash(hasher hash.Hash64) (uint64, error) {
 
 	}
 
+	err = binary.Write(hasher, binary.LittleEndian, m.GetIpV4Only())
+	if err != nil {
+		return 0, err
+	}
+
 	switch m.ConfigSource.(type) {
 
 	case *Settings_KubernetesConfigSource:

--- a/projects/gloo/pkg/api/v1/settings.pb.uniquehash.go
+++ b/projects/gloo/pkg/api/v1/settings.pb.uniquehash.go
@@ -599,6 +599,14 @@ func (m *Settings) HashUnique(hasher hash.Hash64) (uint64, error) {
 
 	}
 
+	if _, err = hasher.Write([]byte("IpV4Only")); err != nil {
+		return 0, err
+	}
+	err = binary.Write(hasher, binary.LittleEndian, m.GetIpV4Only())
+	if err != nil {
+		return 0, err
+	}
+
 	switch m.ConfigSource.(type) {
 
 	case *Settings_KubernetesConfigSource:

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -653,7 +653,7 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 	statusClient := gloostatusutils.GetStatusClientForNamespace(opts.StatusReporterNamespace)
 
 	// Register grpc endpoints to the grpc server
-	xds.SetupEnvoyXds(opts.ControlPlane.GrpcServer, opts.ControlPlane.XDSServer, opts.ControlPlane.SnapshotCache)
+	xds.SetupEnvoyXds(opts.ControlPlane.GrpcServer, opts.ControlPlane.XDSServer, opts.ControlPlane.SnapshotCache, opts.Settings.GetIpV4Only())
 
 	pluginRegistry := extensions.PluginRegistryFactory(watchOpts.Ctx)
 	var discoveryPlugins []discovery.DiscoveryPlugin

--- a/projects/gloo/pkg/xds/envoy.go
+++ b/projects/gloo/pkg/xds/envoy.go
@@ -14,7 +14,7 @@ import (
 )
 
 // register xDS methods with GRPC server
-func SetupEnvoyXds(grpcServer *grpc.Server, xdsServer envoyserver.Server, envoyCache envoycache.SnapshotCache) {
+func SetupEnvoyXds(grpcServer *grpc.Server, xdsServer envoyserver.Server, envoyCache envoycache.SnapshotCache, ipV4Only bool) {
 
 	// check if we need to register
 	if _, ok := grpcServer.GetServiceInfo()["solo.io.xds.SoloDiscoveryService"]; ok {
@@ -35,5 +35,5 @@ func SetupEnvoyXds(grpcServer *grpc.Server, xdsServer envoyserver.Server, envoyC
 	envoy_service_discovery_v3.RegisterAggregatedDiscoveryServiceServer(grpcServer, envoyServer)
 
 	// Seed the cache with a fallback snapshot
-	envoyCache.SetSnapshot(FallbackNodeCacheKey, createFallbackSnapshot())
+	envoyCache.SetSnapshot(FallbackNodeCacheKey, createFallbackSnapshot(ipV4Only))
 }

--- a/projects/gloo/pkg/xds/fallback_snapshot.go
+++ b/projects/gloo/pkg/xds/fallback_snapshot.go
@@ -17,13 +17,18 @@ import (
 var fallbackBindPort = defaults.HttpPort
 
 const (
-	fallbackBindAddr   = "::"
-	fallbackStatusCode = 500
+	fallbackBindAddrIPV6 = "::"
+	fallbackBindAddrIPV4 = "0.0.0.0"
+	fallbackStatusCode   = 500
 )
 
 // createFallbackSnapshot returns a snapshot that is served to proxies which
 // do not contain a node identifier, as a way of signaling that they are invalid
-func createFallbackSnapshot() cache.Snapshot {
+func createFallbackSnapshot(ipV4Only bool) cache.Snapshot {
+	fallbackBindAddr := fallbackBindAddrIPV6
+	if ipV4Only {
+		fallbackBindAddr = fallbackBindAddrIPV4
+	}
 	return fallbackSnapshot(fallbackBindAddr, fallbackBindPort, fallbackStatusCode)
 }
 


### PR DESCRIPTION
<!--
Thanks for opening a PR! Please delete any sections that don’t apply.
-->

# Description
Backport of https://github.com/solo-io/gloo/pull/11217

## Problem                                                                                                                                                                   

Gloo Edge hardcodes :: (IPv6) as the bind address for listeners and the xDS fallback snapshot. In IPv4-only Kubernetes environments, this causes gateways to fail to bind and proxies to receive an invalid fallback configuration.
                                                                                                                                                                            
## Solution                                                                                                                                                                  
   
Introduce a new ipV4Only boolean field on the Settings CRD. When enabled, listener bind addresses switch from :: to 0.0.0.0 across all relevant paths.                    
                  
## Changes                                                                                                                                                                   
                  
Added ip_v4_only to the settings which toggles between setting `::` && `0.0.0.0` as the bind address