### PR TITLE
fix: add mkdir -p before copying CLI docs in push-docs workflow

### DIFF
--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -191,6 +191,7 @@ jobs:
     - name: Copy CLI
       run: |
         pushd docs || exit 1
+        mkdir -p content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli
         cp ../gloo/docs/content/reference/cli/glooctl_check.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_check.md
         cp ../gloo/docs/content/reference/cli/glooctl_debug.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_debug.md
         cp ../gloo/docs/content/reference/cli/glooctl_debug_yaml.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_debug_yaml.md

--- a/changelog/v1.22.0-beta4/push-docs-mkdir-cli.yaml
+++ b/changelog/v1.22.0-beta4/push-docs-mkdir-cli.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/gloo/pull/11225
+  resolvesIssue: false
+  description: Add mkdir -p in push-docs workflow before copying CLI reference docs to ensure destination directory exists for new minor versions.


### PR DESCRIPTION
## Summary

The `Copy CLI` step in the `push-docs` workflow was failing with `cp: cannot create regular file '...': No such file or directory` because the destination directory doesn't exist for new minor versions (e.g., `1.22.x`) until the docs version tree is scaffolded.

- Adds `mkdir -p content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli` before the `cp` commands in the `Copy CLI` step

## Related

Fixes the failure in https://github.com/solo-io/gloo/actions/runs/25114441176/job/73597340277