### PR TITLE
fixed helm template for proxy deployment kind check

### DIFF
--- a/changelog/v1.22.0-beta5/fix-helm-proxy-deployment-template.yaml
+++ b/changelog/v1.22.0-beta5/fix-helm-proxy-deployment-template.yaml
@@ -1,6 +1,8 @@
 changelog:
-  - type: FIX
+  - type: BREAKING_CHANGE
     issueLink: https://github.com/solo-io/solo-projects/issues/8948
     resolvesIssue: false
     description: >-
-      "fixed helm template for proxy deployment kind check"
+      Fixed helm template for proxy deployment kind check to correctly detect empty map/object.
+      While this is technically a fix but if any user relies on the existing behavior that has deployed the proxy
+      as daemonset, this can be a breaking change.

--- a/changelog/v1.22.0-beta5/fix-helm-proxy-deployment-template.yaml
+++ b/changelog/v1.22.0-beta5/fix-helm-proxy-deployment-template.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8948
+    resolvesIssue: false
+    description: >-
+      "fixed helm template for proxy deployment kind check"

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -26,7 +26,7 @@
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
 {{- if not $spec.disabled }}
 apiVersion: apps/v1
-{{- if $spec.kind.deployment}}
+{{- if (hasKey $spec.kind "deployment")}}
 kind: Deployment
 {{- else }}
 kind: DaemonSet
@@ -39,7 +39,7 @@ metadata:
   name: {{ $name | kebabcase }}
   namespace: {{ $spec.namespace | default .Release.Namespace }}
 spec:
-  {{- if $spec.kind.deployment}}
+  {{- if (hasKey $spec.kind "deployment")}}
   {{- if $spec.kind.deployment.replicas}}
   replicas: {{ $spec.kind.deployment.replicas }}
   {{- end}}
@@ -109,7 +109,7 @@ spec:
 {{ include "gloo.securityContext" (dict "values" $spec.podTemplate.podSecurityContext "defaults" $securityDefaults "indent" 6 "globalSec" $global.securitySettings) -}}
 {{- end -}}
 
-{{- if $spec.kind.deployment }}
+{{- if (hasKey $spec.kind "deployment") }}
 {{ if or ($spec.antiAffinity) ($spec.affinity) }}
       affinity:
 {{- end }}
@@ -142,7 +142,7 @@ spec:
       {{- if $spec.podTemplate.nodeName }}
       nodeName: {{$spec.podTemplate.nodeName}}
       {{- end }}
-      {{- if $spec.kind.deployment}}
+      {{- if (hasKey $spec.kind "deployment")}}
       {{- if $spec.kind.deployment.priorityClassName }}
       priorityClassName: {{ $spec.kind.deployment.priorityClassName }}
       {{- end }}
@@ -184,7 +184,7 @@ spec:
             {{- end }}
           {{- end}}
         env:
-{{- if $spec.kind.deployment }}
+{{- if (hasKey $spec.kind "deployment") }}
 {{- if $spec.kind.deployment.customEnv }}
 {{ toYaml $spec.kind.deployment.customEnv | indent 8 }}
 {{- end }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -26,7 +26,7 @@
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
 {{- if not $spec.disabled }}
 apiVersion: apps/v1
-{{- if (hasKey $spec.kind "deployment")}}
+{{- if (kindIs "map" $spec.kind.deployment)}}
 kind: Deployment
 {{- else }}
 kind: DaemonSet
@@ -39,7 +39,7 @@ metadata:
   name: {{ $name | kebabcase }}
   namespace: {{ $spec.namespace | default .Release.Namespace }}
 spec:
-  {{- if (hasKey $spec.kind "deployment")}}
+  {{- if (kindIs "map" $spec.kind.deployment)}}
   {{- if $spec.kind.deployment.replicas}}
   replicas: {{ $spec.kind.deployment.replicas }}
   {{- end}}
@@ -109,7 +109,7 @@ spec:
 {{ include "gloo.securityContext" (dict "values" $spec.podTemplate.podSecurityContext "defaults" $securityDefaults "indent" 6 "globalSec" $global.securitySettings) -}}
 {{- end -}}
 
-{{- if (hasKey $spec.kind "deployment") }}
+{{- if (kindIs "map" $spec.kind.deployment) }}
 {{ if or ($spec.antiAffinity) ($spec.affinity) }}
       affinity:
 {{- end }}
@@ -142,7 +142,7 @@ spec:
       {{- if $spec.podTemplate.nodeName }}
       nodeName: {{$spec.podTemplate.nodeName}}
       {{- end }}
-      {{- if (hasKey $spec.kind "deployment")}}
+      {{- if (kindIs "map" $spec.kind.deployment)}}
       {{- if $spec.kind.deployment.priorityClassName }}
       priorityClassName: {{ $spec.kind.deployment.priorityClassName }}
       {{- end }}
@@ -184,7 +184,7 @@ spec:
             {{- end }}
           {{- end}}
         env:
-{{- if (hasKey $spec.kind "deployment") }}
+{{- if (kindIs "map" $spec.kind.deployment) }}
 {{- if $spec.kind.deployment.customEnv }}
 {{ toYaml $spec.kind.deployment.customEnv | indent 8 }}
 {{- end }}

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -5,7 +5,7 @@
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
 {{- if not $spec.disabled }}
-{{- if $spec.kind.deployment }}
+{{- if (hasKey $spec.kind "deployment") }}
 {{- if $spec.horizontalPodAutoscaler }}
 apiVersion: {{ $spec.horizontalPodAutoscaler.apiVersion }}
 kind: HorizontalPodAutoscaler

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -5,7 +5,7 @@
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
 {{- if not $spec.disabled }}
-{{- if (hasKey $spec.kind "deployment") }}
+{{- if (kindIs "map" $spec.kind.deployment) }}
 {{- if $spec.horizontalPodAutoscaler }}
 apiVersion: {{ $spec.horizontalPodAutoscaler.apiVersion }}
 kind: HorizontalPodAutoscaler
@@ -35,7 +35,7 @@ spec:
   {{ toYaml $spec.horizontalPodAutoscaler.behavior | nindent 4 }}
   {{- end }}
 {{- end }} {{/* if $spec.horizontalPodAutoscaler */}}
-{{- end }} {{/* if $spec.kind.deployment */}}
+{{- end }} {{/* if (kindIs "map" $spec.kind.deployment) */}}
 {{- end }} {{/* if not $spec.disabled */}}
 {{- end }} {{/* with */}}
 {{- end }} {{/* define gatewayProxy.autoscalerSpec*/}}

--- a/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
@@ -4,7 +4,7 @@
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
-{{- if $spec.kind.deployment}}
+{{- if (hasKey $spec.kind "deployment")}}
 {{- if $spec.podDisruptionBudget }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
@@ -4,7 +4,7 @@
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
-{{- if (hasKey $spec.kind "deployment")}}
+{{- if (kindIs "map" $spec.kind.deployment)}}
 {{- if $spec.podDisruptionBudget }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3089,6 +3089,26 @@ spec:
 						testManifest.ExpectDeploymentAppsV1(gatewayProxyDeployment)
 					})
 
+					It("renders a Deployment (not DaemonSet) when kind.deployment.replicas is null", func() {
+						prepareMakefile(namespace, glootestutils.HelmValues{
+							ValuesArgs: []string{
+								"gatewayProxies.gatewayProxy.kind.deployment.replicas=null",
+							},
+						})
+						deploy := getStructuredDeployment(testManifest, "gateway-proxy")
+						Expect(deploy).NotTo(BeNil())
+						Expect(deploy.Spec.Replicas).To(BeNil())
+					})
+
+					It("renders a Deployment with default replicas when kind.deployment is an empty object: deployment:{} merges to deployment:{replicas:1})", func() {
+						// HelmRelease sets kind.deployment={}; Helm deep-merges
+						// the empty object with chart defaults, applying replicas:1.
+						prepareMakefileFromValuesFile("values/val_gwp_deployment_empty.yaml")
+						deploy := getStructuredDeployment(testManifest, "gateway-proxy")
+						Expect(deploy.Spec.Replicas).NotTo(BeNil())
+						Expect(*deploy.Spec.Replicas).To(Equal(int32(1)))
+					})
+
 					It("supports multiple deployments", func() {
 						prepareMakefile(namespace, glootestutils.HelmValues{
 							ValuesArgs: []string{

--- a/install/test/values/val_gwp_deployment_empty.yaml
+++ b/install/test/values/val_gwp_deployment_empty.yaml
@@ -1,0 +1,12 @@
+# In some env, the follow can become `deployment: {}`
+# with empty map, we should still use `deployment` as kind
+# gloo:
+#   gatewayProxies:
+#     gatewayProxy:
+#       kind:
+#         deployment:
+#           replicas: null
+gatewayProxies:
+  gatewayProxy:
+    kind:
+      deployment: {}


### PR DESCRIPTION
# Description

fixes https://github.com/solo-io/solo-projects/issues/8948

In Go templates, `{{- if $spec.kind.deployment}}` evaluates an **empty map** (`{}`) as **falsy** — just like `nil` or `null`. So:

| Helm value | Go template result | `kind:` rendered |
|---|---|---|
| `deployment: null` | falsy | `DaemonSet` |
| `deployment: {}` | falsy (empty map!) | `DaemonSet` |
| `deployment: {replicas: 1}` | truthy (non-empty map) | `Deployment` |

**The root cause**: FluxCD/Helm normalization is non-deterministic across environments. In Env A, `replicas: null` gets dropped, leaving `deployment: {}` at runtime. In Env B, the empty map is already the desired state but somehow `replicas: 1` gets defaulted in. The real problem is that `deployment: {}` should mean "use a Deployment with defaults" but the template treats it identically to "no deployment key at all."

**The fix** is to check `kindIs "map"` instead of truthiness:

```yaml
{{- if (kindIs "map" $spec.kind.deployment)}}
```

This distinguishes between:
- `kind: {}` or `kind: {daemonSet: ...}` → no `deployment` object → DaemonSet
- `kind: {deployment: {}}` → object present, even if empty → Deployment
- `kind: {deployment: {replicas: null}}` → object present → Deployment

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

