### PR TITLE
chore: bump alpine to 3.23.4 in Dockerfiles and docs

### DIFF
--- a/changelog/v1.22.0-beta8/bump-alpine.yaml
+++ b/changelog/v1.22.0-beta8/bump-alpine.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    description: Bumped alpine base image to 3.23.4 in Dockerfiles and docs.
+    dependencyOwner: alpinelinux
+    dependencyRepo: aports
+    dependencyTag: v3.23.4
+    issueLink: https://github.com/solo-io/gloo/issues/11237

--- a/docs/content/guides/security/tls/Dockerfile
+++ b/docs/content/guides/security/tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.23.4
 
 COPY cert.pem /cert.pem
 COPY key.pem /key.pem

--- a/docs/content/installation/advanced_configuration/wasm.md
+++ b/docs/content/installation/advanced_configuration/wasm.md
@@ -87,7 +87,7 @@ Build a Docker image that has the Wasm filter image you previously created and u
 
 1. Create a Dockerfile in the same location as your Wasm filter. The Dockerfile makes an image that has your Wasm filter, and copies the filter to the `/wasm-filters/` directory when the image runs. Later, you mount this directory in a shared volume. _Note: In the previous section, your Wasm file is called `filter.wasm` and is located at `.wasmstore/<uniqueId>/filter.wasm`. If built your filter with a different tool than `wasme` (such as `bazel`), your filter location might differ._
    ```
-   FROM alpine
+   FROM alpine:3.23.4
 
    COPY filter.wasm filter.wasm
    

--- a/docs/examples/grpc-json-transcoding/bookstore/Dockerfile
+++ b/docs/examples/grpc-json-transcoding/bookstore/Dockerfile
@@ -1,3 +1,3 @@
-FROM alpine
+FROM alpine:3.23.4
 COPY bookstore /
 ENTRYPOINT ["/bookstore"]

--- a/docs/examples/session-affinity/Dockerfile
+++ b/docs/examples/session-affinity/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.23.4
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \

--- a/docs/examples/xslt-guide/Dockerfile
+++ b/docs/examples/xslt-guide/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.23.4
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates curl \

--- a/example/proxycontroller/Dockerfile
+++ b/example/proxycontroller/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.23.4
 
 COPY proxycontroller-linux-amd64 /usr/local/bin/proxycontroller
 

--- a/projects/examples/services/sleeper/Dockerfile
+++ b/projects/examples/services/sleeper/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine
+FROM alpine:3.23.4
 
 RUN apk upgrade --update-cache \
     && apk add ca-certificates \


### PR DESCRIPTION
Fixes #11237

pinned all bare  **FROM alpine**  references to  **alpine:3.23.4**  in 
Dockerfiles and documentation examples consistent with the version 
already set in the Makefile **( ALPINE_BASE_IMAGE = alpine:3.23.4 )**
BOT NOTES: 
resolves https://github.com/solo-io/gloo/issues/11237