### PR TITLE
Bump Go to 1.26.4

### DIFF
--- a/changelog/v1.21.8/bump-go-stdlib.yaml
+++ b/changelog/v1.21.8/bump-go-stdlib.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.26.4
+    description: >-
+      Bump Go to 1.26.4 for security fixes.

--- a/docs/examples/grpc-json-transcoding/bookstore/go.mod
+++ b/docs/examples/grpc-json-transcoding/bookstore/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo/examples/bookstore
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/golang/protobuf v1.5.4

--- a/example/proxycontroller/go.mod
+++ b/example/proxycontroller/go.mod
@@ -1,6 +1,6 @@
 module proxycontroller
 
-go 1.25.7
+go 1.25.11
 
 require (
 	github.com/solo-io/gloo v1.18.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo
 
-go 1.26.2
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Bump Go stdlib version to 1.26.4 for CVE fixes.