### PR TITLE
Bump Go to 1.25.11

### DIFF
--- a/changelog/v1.20.18/bump-go-stdlib.yaml
+++ b/changelog/v1.20.18/bump-go-stdlib.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.25.11
+    description: >-
+      Bump Go to 1.25.11 for security fixes.

--- a/changelog/v1.20.18/bump-go-stdlib.yaml
+++ b/changelog/v1.20.18/bump-go-stdlib.yaml
@@ -1,7 +1,0 @@
-changelog:
-  - type: DEPENDENCY_BUMP
-    dependencyOwner: golang
-    dependencyRepo: go
-    dependencyTag: v1.25.11
-    description: >-
-      Bump Go to 1.25.11 for security fixes.

--- a/changelog/v1.20.19/bump-go-stdlib.yaml
+++ b/changelog/v1.20.19/bump-go-stdlib.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: DEPENDENCY_BUMP
+    dependencyOwner: golang
+    dependencyRepo: go
+    dependencyTag: v1.25.11
+    description: >-
+      Bump Go to 1.25.11 for security fixes.

--- a/docs/examples/grpc-json-transcoding/bookstore/go.mod
+++ b/docs/examples/grpc-json-transcoding/bookstore/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo/examples/bookstore
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/golang/protobuf v1.3.5

--- a/docs/examples/grpc-passthrough-auth/go.mod
+++ b/docs/examples/grpc-passthrough-auth/go.mod
@@ -1,6 +1,6 @@
 module github.com/envoyproxy/envoy/examples/ext_authz/auth/grpc-service
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/envoyproxy/go-control-plane/envoy v1.32.3

--- a/docs/examples/http-passthrough-auth/go.mod
+++ b/docs/examples/http-passthrough-auth/go.mod
@@ -1,5 +1,5 @@
 module github.com/solo-io/gloo/examples/http-passthrough-auth
 
-go 1.25.8
+go 1.25.11
 
 require github.com/solo-io/gloo v1.18.10 // indirect

--- a/docs/examples/xslt-guide/go.mod
+++ b/docs/examples/xslt-guide/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo/docs/examples/xslt-guide
 
-go 1.25.8
+go 1.25.11
 
 require (
 	github.com/foomo/soap v0.1.0

--- a/example/proxycontroller/go.mod
+++ b/example/proxycontroller/go.mod
@@ -1,6 +1,6 @@
 module proxycontroller
 
-go 1.25.8
+go 1.25.11
 
 require (
        github.com/solo-io/gloo v1.6.0-beta16

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/solo-io/gloo
 
-go 1.25.9
+go 1.25.11
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0


### PR DESCRIPTION
Bump Go stdlib version to 1.25.11 for CVE fixes.