### PR TITLE
backport: disable shadow host suffix append v1.20.x

### DIFF
--- a/changelog/v1.20.18/disable-shadow-host-suffix-append.yaml
+++ b/changelog/v1.20.18/disable-shadow-host-suffix-append.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/8699
+    resolvesIssue: false
+    description: >-
+      Add support for disableShadowHostSuffixAppend in the shadowing plugin, allowing users to prevent
+      the -shadow suffix from being appended to the Host header of mirrored requests.

--- a/changelog/v1.20.18/disable-shadow-host-suffix-append.yaml
+++ b/changelog/v1.20.18/disable-shadow-host-suffix-append.yaml
@@ -1,5 +1,5 @@
 changelog:
-  - type: NEW_FEATURE
+  - type: NON_USER_FACING
     issueLink: https://github.com/solo-io/solo-projects/issues/8699
     resolvesIssue: false
     description: >-

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto.sk.md
@@ -35,6 +35,7 @@ See here for additional information on Envoy's shadowing capabilities: https://w
 ```yaml
 "upstream": .core.solo.io.ResourceRef
 "percentage": float
+"disableShadowHostSuffixAppend": bool
 
 ```
 
@@ -42,6 +43,7 @@ See here for additional information on Envoy's shadowing capabilities: https://w
 | ----- | ---- | ----------- | 
 | `upstream` | [.core.solo.io.ResourceRef](../../../../../../../../solo-kit/api/v1/ref.proto.sk/#resourceref) | The upstream to which the shadowed traffic should be sent. |
 | `percentage` | `float` | This should be a value between 0.0 and 100.0, with up to 6 significant digits. |
+| `disableShadowHostSuffixAppend` | `bool` | If true, the host/authority header of the shadow request will not have `-shadow` appended. Useful when the shadow destination has strict host-based routing rules that would reject the modified header. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-disable-shadow-host-suffix-append. |
 
 
 

--- a/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
@@ -1891,6 +1891,8 @@ spec:
                     type: object
                   shadowing:
                     properties:
+                      disableShadowHostSuffixAppend:
+                        type: boolean
                       percentage:
                         type: number
                       upstream:

--- a/install/helm/gloo/crds/gateway.solo.io_v1_RouteTable.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_RouteTable.yaml
@@ -1994,6 +1994,8 @@ spec:
                           type: object
                         shadowing:
                           properties:
+                            disableShadowHostSuffixAppend:
+                              type: boolean
                             percentage:
                               type: number
                             upstream:

--- a/install/helm/gloo/crds/gateway.solo.io_v1_VirtualService.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_VirtualService.yaml
@@ -5298,6 +5298,8 @@ spec:
                               type: object
                             shadowing:
                               properties:
+                                disableShadowHostSuffixAppend:
+                                  type: boolean
                                 percentage:
                                   type: number
                                 upstream:

--- a/projects/gloo/api/v1/options/shadowing/shadowing.proto
+++ b/projects/gloo/api/v1/options/shadowing/shadowing.proto
@@ -21,4 +21,9 @@ message RouteShadowing {
 
     // This should be a value between 0.0 and 100.0, with up to 6 significant digits.
     float percentage = 2;
+
+    // If true, the host/authority header of the shadow request will not have `-shadow` appended.
+    // Useful when the shadow destination has strict host-based routing rules that would reject the modified header.
+    // See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-disable-shadow-host-suffix-append
+    bool disable_shadow_host_suffix_append = 3;
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.clone.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.clone.go
@@ -43,5 +43,7 @@ func (m *RouteShadowing) Clone() proto.Message {
 
 	target.Percentage = m.GetPercentage()
 
+	target.DisableShadowHostSuffixAppend = m.GetDisableShadowHostSuffixAppend()
+
 	return target
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.equal.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.equal.go
@@ -60,5 +60,9 @@ func (m *RouteShadowing) Equal(that interface{}) bool {
 		return false
 	}
 
+	if m.GetDisableShadowHostSuffixAppend() != target.GetDisableShadowHostSuffixAppend() {
+		return false
+	}
+
 	return true
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.go
@@ -34,9 +34,13 @@ type RouteShadowing struct {
 	// The upstream to which the shadowed traffic should be sent.
 	Upstream *core.ResourceRef `protobuf:"bytes,1,opt,name=upstream,proto3" json:"upstream,omitempty"`
 	// This should be a value between 0.0 and 100.0, with up to 6 significant digits.
-	Percentage    float32 `protobuf:"fixed32,2,opt,name=percentage,proto3" json:"percentage,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Percentage float32 `protobuf:"fixed32,2,opt,name=percentage,proto3" json:"percentage,omitempty"`
+	// If true, the host/authority header of the shadow request will not have `-shadow` appended.
+	// Useful when the shadow destination has strict host-based routing rules that would reject the modified header.
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-disable-shadow-host-suffix-append
+	DisableShadowHostSuffixAppend bool `protobuf:"varint,3,opt,name=disable_shadow_host_suffix_append,json=disableShadowHostSuffixAppend,proto3" json:"disable_shadow_host_suffix_append,omitempty"`
+	unknownFields                 protoimpl.UnknownFields
+	sizeCache                     protoimpl.SizeCache
 }
 
 func (x *RouteShadowing) Reset() {
@@ -83,16 +87,24 @@ func (x *RouteShadowing) GetPercentage() float32 {
 	return 0
 }
 
+func (x *RouteShadowing) GetDisableShadowHostSuffixAppend() bool {
+	if x != nil {
+		return x.DisableShadowHostSuffixAppend
+	}
+	return false
+}
+
 var File_github_com_solo_io_gloo_projects_gloo_api_v1_options_shadowing_shadowing_proto protoreflect.FileDescriptor
 
 const file_github_com_solo_io_gloo_projects_gloo_api_v1_options_shadowing_shadowing_proto_rawDesc = "" +
 	"\n" +
-	"Ngithub.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto\x12\x1eshadowing.options.gloo.solo.io\x1a,github.com/solo-io/solo-kit/api/v1/ref.proto\x1a\x12extproto/ext.proto\"g\n" +
+	"Ngithub.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto\x12\x1eshadowing.options.gloo.solo.io\x1a,github.com/solo-io/solo-kit/api/v1/ref.proto\x1a\x12extproto/ext.proto\"\xb1\x01\n" +
 	"\x0eRouteShadowing\x125\n" +
 	"\bupstream\x18\x01 \x01(\v2\x19.core.solo.io.ResourceRefR\bupstream\x12\x1e\n" +
 	"\n" +
 	"percentage\x18\x02 \x01(\x02R\n" +
-	"percentageBP\xb8\xf5\x04\x01\xc0\xf5\x04\x01\xd0\xf5\x04\x01ZBgithub.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/shadowingb\x06proto3"
+	"percentage\x12H\n" +
+	"!disable_shadow_host_suffix_append\x18\x03 \x01(\bR\x1ddisableShadowHostSuffixAppendBP\xb8\xf5\x04\x01\xc0\xf5\x04\x01\xd0\xf5\x04\x01ZBgithub.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/shadowingb\x06proto3"
 
 var (
 	file_github_com_solo_io_gloo_projects_gloo_api_v1_options_shadowing_shadowing_proto_rawDescOnce sync.Once

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.hash.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.hash.go
@@ -67,5 +67,10 @@ func (m *RouteShadowing) Hash(hasher hash.Hash64) (uint64, error) {
 		return 0, err
 	}
 
+	err = binary.Write(hasher, binary.LittleEndian, m.GetDisableShadowHostSuffixAppend())
+	if err != nil {
+		return 0, err
+	}
+
 	return hasher.Sum64(), nil
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.uniquehash.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.uniquehash.go
@@ -71,5 +71,13 @@ func (m *RouteShadowing) HashUnique(hasher hash.Hash64) (uint64, error) {
 		return 0, err
 	}
 
+	if _, err = hasher.Write([]byte("DisableShadowHostSuffixAppend")); err != nil {
+		return 0, err
+	}
+	err = binary.Write(hasher, binary.LittleEndian, m.GetDisableShadowHostSuffixAppend())
+	if err != nil {
+		return 0, err
+	}
+
 	return hasher.Sum64(), nil
 }

--- a/projects/gloo/pkg/plugins/shadowing/plugin.go
+++ b/projects/gloo/pkg/plugins/shadowing/plugin.go
@@ -72,8 +72,9 @@ func applyShadowSpec(out *envoy_config_route_v3.RouteAction, spec *shadowing.Rou
 	}
 	out.RequestMirrorPolicies = []*envoy_config_route_v3.RouteAction_RequestMirrorPolicy{
 		{
-			Cluster:         translator.UpstreamToClusterName(spec.GetUpstream()),
-			RuntimeFraction: getFractionalPercent(spec.GetPercentage()),
+			Cluster:                       translator.UpstreamToClusterName(spec.GetUpstream()),
+			RuntimeFraction:               getFractionalPercent(spec.GetPercentage()),
+			DisableShadowHostSuffixAppend: spec.GetDisableShadowHostSuffixAppend(),
 		},
 	}
 	return nil

--- a/projects/gloo/pkg/plugins/shadowing/plugin_test.go
+++ b/projects/gloo/pkg/plugins/shadowing/plugin_test.go
@@ -109,6 +109,28 @@ var _ = Describe("Plugin", func() {
 		Expect(err).To(HaveInErrorChain(InvalidRouteActionError))
 	})
 
+	It("should set DisableShadowHostSuffixAppend when specified", func() {
+		p := NewPlugin()
+
+		upRef := &core.ResourceRef{
+			Name:      "some-upstream",
+			Namespace: "default",
+		}
+		in := &v1.Route{
+			Options: &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:                      upRef,
+					Percentage:                    100,
+					DisableShadowHostSuffixAppend: true,
+				},
+			},
+		}
+		out := &envoy_config_route_v3.Route{}
+		err := p.ProcessRoute(plugins.RouteParams{}, in, out)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out.GetRoute().GetRequestMirrorPolicies()[0].GetDisableShadowHostSuffixAppend()).To(BeTrue())
+	})
+
 	It("should error when given invalid specs", func() {
 		p := NewPlugin()
 

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -70,6 +70,7 @@ import (
 	v1kubernetes "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/kubernetes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/protocol_upgrade"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/retries"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/shadowing"
 	v1static "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/tracing"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/transformation"
@@ -4058,6 +4059,39 @@ var _ = Describe("Translator", func() {
 					},
 				},
 			})))
+		})
+	})
+
+	Context("shadowing", func() {
+		It("should translate shadowing with DisableShadowHostSuffixAppend", func() {
+			routes[0].Options = &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:                      upstream.Metadata.Ref(),
+					Percentage:                    100,
+					DisableShadowHostSuffixAppend: true,
+				},
+			}
+
+			translate()
+
+			mirrorPolicies := routeConfiguration.VirtualHosts[0].Routes[0].GetRoute().GetRequestMirrorPolicies()
+			Expect(mirrorPolicies).To(HaveLen(1))
+			Expect(mirrorPolicies[0].GetDisableShadowHostSuffixAppend()).To(BeTrue())
+		})
+
+		It("should translate shadowing without DisableShadowHostSuffixAppend by default", func() {
+			routes[0].Options = &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:   upstream.Metadata.Ref(),
+					Percentage: 100,
+				},
+			}
+
+			translate()
+
+			mirrorPolicies := routeConfiguration.VirtualHosts[0].Routes[0].GetRoute().GetRequestMirrorPolicies()
+			Expect(mirrorPolicies).To(HaveLen(1))
+			Expect(mirrorPolicies[0].GetDisableShadowHostSuffixAppend()).To(BeFalse())
 		})
 	})
 


### PR DESCRIPTION
# Description

Backporting #11252 to v1.20.x to support adding the `disable_shadow_host_suffix_append` field to the `RouteShadowing` proto, which will allow users to prevent Envoy from appending `shadow` to the `Host/:authority` header when mirroring requests.

## Testing steps

Covered by unit and translator tests, included in the cherry-pick from main.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works