### PR TITLE
backport: add validation for protoDescriptorBin in grpcjson plugin v1.21.x

### DIFF
--- a/changelog/v1.21.9/fix-grpcjson-validate-proto-descriptor-bin.yaml
+++ b/changelog/v1.21.9/fix-grpcjson-validate-proto-descriptor-bin.yaml
@@ -1,0 +1,8 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8979
+    resolvesIssue: true
+    description: >-
+      Fix grpcjson plugin to validate protoDescriptorBin bytes form a valid FileDescriptorSet before
+      passing them to Envoy. Before this, invalid bytes would cause Envoy to NACK the RouteConfiguration
+      while the Upstream falsely reported state: Accepted.

--- a/projects/gloo/pkg/plugins/grpcjson/plugin.go
+++ b/projects/gloo/pkg/plugins/grpcjson/plugin.go
@@ -9,6 +9,8 @@ import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_extensions_filters_http_grpc_json_transcoder_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_json_transcoder/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/rotisserie/eris"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -44,6 +46,9 @@ var (
 	DecodingError = func(configRef *grpc_json.GrpcJsonTranscoder_DescriptorConfigMap, key string) error {
 		return eris.Errorf("config map %s:%s contains a value for key %s but is not base64-encoded",
 			configRef.GetConfigMapRef().GetNamespace(), configRef.GetConfigMapRef().GetName(), key)
+	}
+	InvalidProtoDescriptorError = func(err error) error {
+		return eris.Wrapf(err, "protoDescriptorBin is not a valid FileDescriptorSet")
 	}
 )
 
@@ -188,10 +193,16 @@ func translateGlooToEnvoyGrpcJson(params plugins.Params, grpcJsonConf *grpc_json
 		if err != nil {
 			return nil, err
 		}
+		if err := validateFileDescriptorSet(protoDesc); err != nil {
+			return nil, err
+		}
 		envoyGrpcJsonConf.DescriptorSet = &envoy_extensions_filters_http_grpc_json_transcoder_v3.GrpcJsonTranscoder_ProtoDescriptorBin{ProtoDescriptorBin: protoDesc}
 	case *grpc_json.GrpcJsonTranscoder_ProtoDescriptor:
 		envoyGrpcJsonConf.DescriptorSet = &envoy_extensions_filters_http_grpc_json_transcoder_v3.GrpcJsonTranscoder_ProtoDescriptor{ProtoDescriptor: typedDescriptorSet.ProtoDescriptor}
 	case *grpc_json.GrpcJsonTranscoder_ProtoDescriptorBin:
+		if err := validateFileDescriptorSet(typedDescriptorSet.ProtoDescriptorBin); err != nil {
+			return nil, err
+		}
 		envoyGrpcJsonConf.DescriptorSet = &envoy_extensions_filters_http_grpc_json_transcoder_v3.GrpcJsonTranscoder_ProtoDescriptorBin{ProtoDescriptorBin: typedDescriptorSet.ProtoDescriptorBin}
 	}
 
@@ -259,4 +270,11 @@ func translateConfigMapToProtoBin(_ context.Context, snap *gloosnapshot.ApiSnaps
 	}
 
 	return decodedBytes, nil
+}
+
+func validateFileDescriptorSet(b []byte) error {
+	if err := proto.Unmarshal(b, &descriptor.FileDescriptorSet{}); err != nil {
+		return InvalidProtoDescriptorError(err)
+	}
+	return nil
 }

--- a/projects/gloo/pkg/plugins/grpcjson/plugin_test.go
+++ b/projects/gloo/pkg/plugins/grpcjson/plugin_test.go
@@ -1,11 +1,15 @@
 package grpcjson_test
 
 import (
+	"encoding/base64"
+
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_extensions_filters_http_grpc_json_transcoder_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_json_transcoder/v3"
 	envoyhttp "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"github.com/golang/protobuf/proto"
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
@@ -179,14 +183,52 @@ var _ = Describe("GrpcJson", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(f).To(BeEmpty())
 	})
+	It("should return error from ProcessUpstream if inline protoDescriptorBin is not a valid FileDescriptorSet", func() {
+		us := &v1.Upstream{
+			Metadata: &core.Metadata{
+				Name:      "testUs",
+				Namespace: "gloo-system",
+			},
+			UpstreamType: &v1.Upstream_Kube{
+				Kube: &kubernetes.UpstreamSpec{
+					ServiceSpec: &options.ServiceSpec{
+						PluginType: &options.ServiceSpec_GrpcJsonTranscoder{
+							GrpcJsonTranscoder: &grpc_json.GrpcJsonTranscoder{
+								DescriptorSet: &grpc_json.GrpcJsonTranscoder_ProtoDescriptorBin{
+									ProtoDescriptorBin: []byte("this is not a valid proto descriptor"),
+								},
+								Services: []string{"main.Bookstore"},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		p := grpcjson.NewPlugin()
+		p.Init(initParams)
+		err := p.ProcessUpstream(plugins.Params{}, us, &envoy_config_cluster_v3.Cluster{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("protoDescriptorBin is not a valid FileDescriptorSet"))
+	})
+
 	Context("proto descriptor configmap", func() {
 		var (
 			snap           *gloosnapshot.ApiSnapshot
 			hl             *v1.HttpListener
 			expectedFilter []plugins.StagedHttpFilter
+			validDescBytes []byte
 		)
 
 		BeforeEach(func() {
+			var err error
+			validDescBytes, err = proto.Marshal(&descriptor.FileDescriptorSet{
+				File: []*descriptor.FileDescriptorProto{
+					{Name: proto.String("test.proto")},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
 			// add an artifact (configmap) containing the proto descriptor data to the snapshot
 			snap = &gloosnapshot.ApiSnapshot{
 				Artifacts: v1.ArtifactList{
@@ -196,7 +238,7 @@ var _ = Describe("GrpcJson", func() {
 							Namespace: "gloo-system",
 						},
 						Data: map[string]string{
-							"protoDesc": "aGVsbG8K",
+							"protoDesc": base64.StdEncoding.EncodeToString(validDescBytes),
 						},
 					},
 				},
@@ -216,7 +258,7 @@ var _ = Describe("GrpcJson", func() {
 
 			envoyGrpcJsonConf := &envoy_extensions_filters_http_grpc_json_transcoder_v3.GrpcJsonTranscoder{
 				DescriptorSet: &envoy_extensions_filters_http_grpc_json_transcoder_v3.GrpcJsonTranscoder_ProtoDescriptorBin{
-					ProtoDescriptorBin: []byte("hello\n"),
+					ProtoDescriptorBin: validDescBytes,
 				},
 				Services: []string{"main.Bookstore"},
 			}
@@ -334,6 +376,18 @@ var _ = Describe("GrpcJson", func() {
 			}, hl)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal(grpcjson.DecodingError(hl.GetOptions().GetGrpcJsonTranscoder().GetProtoDescriptorConfigMap(), "protoDesc").Error()))
+		})
+
+		It("should return error if proto descriptor bytes are not a valid FileDescriptorSet", func() {
+			snap.Artifacts[0].Data["protoDesc"] = base64.StdEncoding.EncodeToString([]byte("this is not a valid proto descriptor"))
+
+			p := grpcjson.NewPlugin()
+			p.Init(initParams)
+			_, err := p.HttpFilters(plugins.Params{
+				Snapshot: snap,
+			}, hl)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("protoDescriptorBin is not a valid FileDescriptorSet"))
 		})
 
 		It("should have no effect if the action is not a routeAction", func() {


### PR DESCRIPTION
# Description

Backporting #11263 to v1.21.x to add validation in the `grpcjson` plugin to make sure that `protoDescriptorBin` bytes form a valid `FileDescriptorSet` before passing them to Envoy. See original PR linked above for full justification for this addition in PR description.

## Testing steps

Covered by unit tests, included in the cherry-pick from main.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/8979