### PR TITLE
[1.19] added missing certgen-fips in helm helpers template

### DIFF
--- a/changelog/v1.19.18/add-missing-helm-certgen-fips.yaml
+++ b/changelog/v1.19.18/add-missing-helm-certgen-fips.yaml
@@ -1,0 +1,6 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8887
+    resolvesIssue: false
+    description: >-
+      "added missing certgen-fips in helm helpers template"

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -32,7 +32,7 @@ for fips or fips-distroless variants: add -fips to the image repo (name)
 {{- if .repository -}}
 {{- $repository := .repository -}}
 {{- if or .fips (has .variant (list "fips" "fips-distroless")) -}}
-{{- $fipsSupportedImages := list "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" -}}
+{{- $fipsSupportedImages := list "gloo-ee" "extauth-ee" "gloo-ee-envoy-wrapper" "rate-limit-ee" "discovery-ee" "sds-ee" "certgen" -}}
 {{- if (has .repository $fipsSupportedImages) -}}
 {{- $repository = printf "%s-fips" $repository -}}
 {{- end -}}{{- /* if (has .repository $fipsSupportedImages) */ -}}


### PR DESCRIPTION
# Description

backport of #11281 

# Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

