### PR TITLE
Update push-docs workflow paths for docs repo migration

### DIFF
--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -203,10 +203,10 @@ jobs:
     - name: Copy API
       run: |
         pushd docs || exit 1
-        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/direct_responses.md assets/conrefs/pages/gateway/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
-        sed -i '1,2d' assets/conrefs/pages/gateway/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
-        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/gateway_parameters.md assets/conrefs/pages/gateway/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
-        sed -i '1,2d' assets/conrefs/pages/gateway/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/direct_responses.md assets/gateway-docs/pages/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
+        sed -i '1,2d' assets/gateway-docs/pages/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/gateway_parameters.md assets/gateway-docs/pages/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
+        sed -i '1,2d' assets/gateway-docs/pages/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
         popd || exit 1
     - name: Push and create PR
       uses: peter-evans/create-pull-request@v7

--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -178,8 +178,8 @@ jobs:
     - name: Copy OSA
       run: |
         pushd docs || exit 1
-        cp ../gloo/docs/content/static/content/osa_included.md assets/conrefs/pages/gateway/reference/osa_included_${{ steps.version-variables.outputs.minor }}.md
-        cp ../gloo/docs/content/static/content/osa_provided.md assets/conrefs/pages/gateway/reference/osa_provided_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/static/content/osa_included.md assets/gateway-docs/pages/reference/osa_included_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/static/content/osa_provided.md assets/gateway-docs/pages/reference/osa_provided_${{ steps.version-variables.outputs.minor }}.md
         popd || exit 1
     - name: Copy Helm
       run: |

--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -185,9 +185,9 @@ jobs:
       run: |
         pushd docs || exit 1
         # OSS
-        cp ../gloo/docs/content/reference/values.txt assets/conrefs/pages/gloo-platform/reference/helm/values_${{ steps.version-variables.outputs.minor }}.txt
+        cp ../gloo/docs/content/reference/values.txt assets/gateway-docs/pages/reference/helm/values_${{ steps.version-variables.outputs.minor }}.txt
         # Enterprise
-        cp ../gloo/docs/content/static/content/glooe-values.docgen assets/conrefs/pages/gloo-platform/reference/helm/glooe-values_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/static/content/glooe-values.docgen assets/gateway-docs/pages/reference/helm/glooe-values_${{ steps.version-variables.outputs.minor }}.md
     - name: Copy CLI
       run: |
         pushd docs || exit 1

--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -185,9 +185,9 @@ jobs:
       run: |
         pushd docs || exit 1
         # OSS
-        cp ../gloo/docs/content/reference/values.txt assets/conrefs/pages/reference/helm/values_${{ steps.version-variables.outputs.minor }}.txt
+        cp ../gloo/docs/content/reference/values.txt assets/conrefs/pages/gloo-platform/reference/helm/values_${{ steps.version-variables.outputs.minor }}.txt
         # Enterprise
-        cp ../gloo/docs/content/static/content/glooe-values.docgen assets/conrefs/pages/reference/helm/glooe-values_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/static/content/glooe-values.docgen assets/conrefs/pages/gloo-platform/reference/helm/glooe-values_${{ steps.version-variables.outputs.minor }}.md
     - name: Copy CLI
       run: |
         pushd docs || exit 1

--- a/changelog/v1.22.0-beta11/update-push-docs-paths.yaml
+++ b/changelog/v1.22.0-beta11/update-push-docs-paths.yaml
@@ -1,0 +1,5 @@
+changelog:
+- type: NON_USER_FACING
+  issueLink: https://github.com/solo-io/gloo/pull/11306
+  resolvesIssue: false
+  description: Update push-docs workflow output paths to match the current docs repo directory structure.


### PR DESCRIPTION
- Updates output paths in `.github/workflows/push-docs.yaml` to match the current directory structure in the `solo-io/docs` repo after a large content migration
- The former `assets/conrefs/pages/reference/` tree no longer exists; Helm values docs now land under `conrefs/pages/gloo-platform/reference/helm/`
- Changes:
  - OSS Helm values: `assets/conrefs/pages/reference/helm/values_*.txt` → `assets/conrefs/pages/gloo-platform/reference/helm/values_*.txt`
  - Enterprise Helm values: `assets/conrefs/pages/reference/helm/glooe-values_*.md` → `assets/conrefs/pages/gloo-platform/reference/helm/glooe-values_*.md`