### PR TITLE
[1.21] fix: stop no-op Gateway report churn

### DIFF
--- a/changelog/v1.21.12/fix-reportmap-equality-hot-loop.yaml
+++ b/changelog/v1.21.12/fix-reportmap-equality-hot-loop.yaml
@@ -1,0 +1,15 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8013
+    resolvesIssue: true
+    description: >-
+      Fix no-op Kubernetes Gateway report churn by comparing report maps by
+      content and keeping status rendering read-only. The report-map equality
+      checks used in change detection (glooProxy.Equals and report.Equals)
+      compared maps of pointer values, so identical translation output could be
+      reported as "changed" on every recompute; condition LastTransitionTime
+      could also prevent convergence. Status rendering also wrote default
+      conditions back into the report objects used for equality. Reports now
+      compare semantically, ignore LastTransitionTime for change detection, and
+      status rendering leaves ReportMap unchanged, allowing stable output to
+      converge without redundant report/status processing.

--- a/projects/gateway2/proxy_syncer/proxy_syncer.go
+++ b/projects/gateway2/proxy_syncer/proxy_syncer.go
@@ -242,22 +242,10 @@ func (p glooProxy) Equals(in glooProxy) bool {
 	if !proto.Equal(p.Proxy, in.Proxy) {
 		return false
 	}
-	if !maps.Equal(p.reportMap.Gateways, in.reportMap.Gateways) {
-		return false
-	}
-	if !maps.Equal(p.reportMap.ListenerSets, in.reportMap.ListenerSets) {
-		return false
-	}
-	if !maps.Equal(p.reportMap.HTTPRoutes, in.reportMap.HTTPRoutes) {
-		return false
-	}
-	if !maps.Equal(p.reportMap.TCPRoutes, in.reportMap.TCPRoutes) {
-		return false
-	}
-	if !maps.Equal(p.reportMap.TLSRoutes, in.reportMap.TLSRoutes) {
-		return false
-	}
-	return true
+	// NOTE: reportMap holds pointer-valued maps; compare by content, not pointer
+	// identity, otherwise this always reports "changed" and krt re-translates
+	// every cycle (constant CPU + memory churn). See reports.ReportMap.Equals.
+	return p.reportMap.Equals(in.reportMap)
 }
 
 func (p glooProxy) ResourceName() string {
@@ -272,24 +260,13 @@ func (r report) ResourceName() string {
 	return "report"
 }
 
-// do we really need this for a singleton?
+// Equals is required even though report is a Singleton: krt uses it as the
+// change-detection predicate, and emitting on every recompute drives a
+// status-write -> watch-event -> recompute hot loop. It must compare report
+// content (the maps hold pointers) and ignore LastTransitionTime; see
+// reports.ReportMap.Equals.
 func (r report) Equals(in report) bool {
-	if !maps.Equal(r.ReportMap.Gateways, in.ReportMap.Gateways) {
-		return false
-	}
-	if !maps.Equal(r.ReportMap.ListenerSets, in.ReportMap.ListenerSets) {
-		return false
-	}
-	if !maps.Equal(r.ReportMap.HTTPRoutes, in.ReportMap.HTTPRoutes) {
-		return false
-	}
-	if !maps.Equal(r.ReportMap.TCPRoutes, in.ReportMap.TCPRoutes) {
-		return false
-	}
-	if !maps.Equal(r.ReportMap.TLSRoutes, in.ReportMap.TLSRoutes) {
-		return false
-	}
-	return true
+	return r.ReportMap.Equals(in.ReportMap)
 }
 
 type proxyList struct {

--- a/projects/gateway2/reports/reporter_equals.go
+++ b/projects/gateway2/reports/reporter_equals.go
@@ -1,0 +1,160 @@
+package reports
+
+import (
+	"maps"
+	"strconv"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	gwv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// Equals reports whether two ReportMaps are semantically equal.
+//
+// This is used as the change-detection predicate for the krt collections that
+// carry reports (glooProxy, the status report singleton). It must compare the
+// pointed-to CONTENT of the report maps, not pointer identity: every
+// translation pass allocates a fresh ReportMap with fresh report pointers, so a
+// pointer-based compare (maps.Equal / ==) always reports "changed" and pegs the
+// control plane re-translating + re-writing status in a hot loop.
+//
+// It also ignores condition LastTransitionTime: SetCondition stamps that field
+// with time.Now() when a condition is first added to a fresh report, so it
+// differs on every pass even when nothing semantically changed. The persisted
+// status (see status.go) preserves the prior LastTransitionTime separately, so
+// ignoring it here does not cause status flapping.
+//
+// NOTE: the per-type equals helpers below compare each field that influences
+// rendered status by hand (there is no reflection fallback). When a field is
+// added to any report type, add it to the corresponding equals helper too, or
+// a real change will be reported as "equal" and status will stop converging.
+func (r ReportMap) Equals(in ReportMap) bool {
+	return maps.EqualFunc(r.Gateways, in.Gateways, (*GatewayReport).equals) &&
+		maps.EqualFunc(r.ListenerSets, in.ListenerSets, (*ListenerSetReport).equals) &&
+		maps.EqualFunc(r.HTTPRoutes, in.HTTPRoutes, (*RouteReport).equals) &&
+		maps.EqualFunc(r.TCPRoutes, in.TCPRoutes, (*RouteReport).equals) &&
+		maps.EqualFunc(r.TLSRoutes, in.TLSRoutes, (*RouteReport).equals)
+}
+
+func (g *GatewayReport) equals(in *GatewayReport) bool {
+	if g == nil || in == nil {
+		return g == in
+	}
+	return g.observedGeneration == in.observedGeneration &&
+		conditionsSemanticEqual(g.conditions, in.conditions) &&
+		maps.EqualFunc(g.listeners, in.listeners, (*ListenerReport).equals)
+}
+
+func (g *ListenerSetReport) equals(in *ListenerSetReport) bool {
+	if g == nil || in == nil {
+		return g == in
+	}
+	return g.observedGeneration == in.observedGeneration &&
+		conditionsSemanticEqual(g.conditions, in.conditions) &&
+		maps.EqualFunc(g.listeners, in.listeners, (*ListenerReport).equals)
+}
+
+func (l *ListenerReport) equals(in *ListenerReport) bool {
+	if l == nil || in == nil {
+		return l == in
+	}
+	if l.Status.Name != in.Status.Name ||
+		l.Status.AttachedRoutes != in.Status.AttachedRoutes {
+		return false
+	}
+	if !routeGroupKindsEqual(l.Status.SupportedKinds, in.Status.SupportedKinds) {
+		return false
+	}
+	return conditionsSemanticEqual(l.Status.Conditions, in.Status.Conditions)
+}
+
+// routeGroupKindsEqual compares two SupportedKinds slices by value, order-
+// insensitively. RouteGroupKind.Group is a *Group, and translation mints fresh
+// Group pointers each pass (see buildDefaultRouteKindsForProtocol), so a struct
+// == / pointer compare would treat semantically identical kinds as different and
+// keep the control plane churning. The builder also ranges a map, so the slice
+// order is not stable across passes.
+func routeGroupKindsEqual(a, b []gwv1.RouteGroupKind) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, gk := range a {
+		counts[routeGroupKindKey(gk)]++
+	}
+	for _, gk := range b {
+		counts[routeGroupKindKey(gk)]--
+	}
+	for _, c := range counts {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func routeGroupKindKey(gk gwv1.RouteGroupKind) string {
+	group := ""
+	if gk.Group != nil {
+		group = string(*gk.Group)
+	}
+	return group + "/" + string(gk.Kind)
+}
+
+func (r *RouteReport) equals(in *RouteReport) bool {
+	if r == nil || in == nil {
+		return r == in
+	}
+	if r.observedGeneration != in.observedGeneration {
+		return false
+	}
+	return maps.EqualFunc(r.Parents, in.Parents, (*ParentRefReport).equals)
+}
+
+func (p *ParentRefReport) equals(in *ParentRefReport) bool {
+	if p == nil || in == nil {
+		return p == in
+	}
+	return conditionsSemanticEqual(p.Conditions, in.Conditions)
+}
+
+// conditionsSemanticEqual reports whether two condition slices are semantically
+// equal, ignoring LastTransitionTime (set to time.Now() per pass) and order. It
+// compares as a multiset so it stays correct even if a slice carries duplicate
+// condition Types: GatewayReport/ListenerReport/ParentRefReport de-dup by type
+// via meta.SetStatusCondition, but ListenerSetReport.SetCondition appends
+// without de-duping, so a by-type lookup could otherwise mask a real change.
+func conditionsSemanticEqual(a, b []metav1.Condition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := make(map[string]int, len(a))
+	for _, c := range a {
+		counts[conditionSemanticKey(c)]++
+	}
+	for _, c := range b {
+		counts[conditionSemanticKey(c)]--
+	}
+	for _, n := range counts {
+		if n != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// conditionSemanticKey is the comparison key for conditionsSemanticEqual: every
+// field that affects rendered status EXCEPT LastTransitionTime. ObservedGeneration
+// is included for completeness, though report-stored conditions never set it (it
+// is stamped onto rendered copies in status.go, not back into the report). The
+// NUL separator cannot appear in a condition's Type/Reason/Message, so distinct
+// conditions never collide on the same key.
+func conditionSemanticKey(c metav1.Condition) string {
+	return strings.Join([]string{
+		c.Type,
+		string(c.Status),
+		strconv.FormatInt(c.ObservedGeneration, 10),
+		c.Reason,
+		c.Message,
+	}, "\x00")
+}

--- a/projects/gateway2/reports/reporter_test.go
+++ b/projects/gateway2/reports/reporter_test.go
@@ -635,6 +635,184 @@ func parentRouteRef() *gwv1.ParentReference {
 	}
 }
 
+var _ = Describe("ReportMap.Equals", func() {
+	// buildReportMap mimics one translation pass: it allocates a fresh
+	// ReportMap (with fresh report pointers) and populates a Gateway and an
+	// HTTPRoute parentRef condition.
+	buildReportMap := func() reports.ReportMap {
+		gw := gw()
+		route := &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		}
+		rm := reports.NewReportMap()
+		reporter := reports.NewReporter(&rm)
+		reporter.Gateway(gw).SetCondition(reports.GatewayCondition{
+			Type:   gwv1.GatewayConditionProgrammed,
+			Status: metav1.ConditionTrue,
+			Reason: gwv1.GatewayReasonProgrammed,
+		})
+		reporter.Route(route).ParentRef(&gwv1.ParentReference{
+			Name: "test",
+		}).SetCondition(reports.RouteCondition{
+			Type:   gwv1.RouteConditionAccepted,
+			Status: metav1.ConditionTrue,
+			Reason: gwv1.RouteReasonAccepted,
+		})
+		return rm
+	}
+
+	It("returns true for two independently-built, identical report maps", func() {
+		// Regression: Equals must compare report content, not pointer identity.
+		// The maps hold *RouteReport/*GatewayReport, so a pointer-based compare
+		// always reports "changed" and pegs the control plane re-translating.
+		a := buildReportMap()
+		b := buildReportMap()
+		Expect(a.Equals(b)).To(BeTrue(), "identical report content must compare equal")
+	})
+
+	It("returns false when a condition differs", func() {
+		a := buildReportMap()
+		b := buildReportMap()
+
+		route := &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		}
+		reports.NewReporter(&b).Route(route).ParentRef(&gwv1.ParentReference{
+			Name: "test",
+		}).SetCondition(reports.RouteCondition{
+			Type:   gwv1.RouteConditionAccepted,
+			Status: metav1.ConditionFalse,
+			Reason: gwv1.RouteReasonBackendNotFound,
+		})
+
+		Expect(a.Equals(b)).To(BeFalse(), "differing condition must compare not-equal")
+	})
+
+	It("returns false when route sets differ", func() {
+		a := buildReportMap()
+		b := buildReportMap()
+		extra := &gwv1.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route2"},
+		}
+		reports.NewReporter(&b).Route(extra)
+		Expect(a.Equals(b)).To(BeFalse(), "different route key set must compare not-equal")
+	})
+
+	It("returns false when route observedGeneration differs", func() {
+		buildWithGeneration := func(gen int64) reports.ReportMap {
+			route := &gwv1.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route", Generation: gen},
+			}
+			rm := reports.NewReportMap()
+			reports.NewReporter(&rm).Route(route).ParentRef(&gwv1.ParentReference{
+				Name: "test",
+			}).SetCondition(reports.RouteCondition{
+				Type:   gwv1.RouteConditionAccepted,
+				Status: metav1.ConditionTrue,
+				Reason: gwv1.RouteReasonAccepted,
+			})
+			return rm
+		}
+		a := buildWithGeneration(1)
+		b := buildWithGeneration(2)
+		Expect(a.Equals(b)).To(BeFalse(), "differing route observedGeneration must compare not-equal")
+	})
+
+	// supportedKinds mimics translation building RouteGroupKinds with FRESH Group
+	// pointers each pass (see buildDefaultRouteKindsForProtocol). Each call returns
+	// equal-by-value kinds backed by distinct *Group pointers.
+	supportedKinds := func() []gwv1.RouteGroupKind {
+		http := gwv1.Group(gwv1.GroupName)
+		grpc := gwv1.Group(gwv1.GroupName)
+		return []gwv1.RouteGroupKind{
+			{Group: &http, Kind: gwv1.Kind("HTTPRoute")},
+			{Group: &grpc, Kind: gwv1.Kind("GRPCRoute")},
+		}
+	}
+
+	buildWithSupportedKinds := func(kinds []gwv1.RouteGroupKind) reports.ReportMap {
+		gw := gw()
+		rm := reports.NewReportMap()
+		reports.NewReporter(&rm).Gateway(gw).Listener(listener()).SetSupportedKinds(kinds)
+		return rm
+	}
+
+	It("returns true when SupportedKinds are equal by value but use fresh Group pointers", func() {
+		// Regression: RouteGroupKind.Group is a *Group; comparing the struct with
+		// == compares the pointer, so identical kinds with fresh pointers (as
+		// translation produces every pass) would otherwise look "changed" and keep
+		// the hot loop alive for normal valid listeners.
+		a := buildWithSupportedKinds(supportedKinds())
+		b := buildWithSupportedKinds(supportedKinds())
+		Expect(a.Equals(b)).To(BeTrue(), "value-equal SupportedKinds with fresh Group pointers must compare equal")
+	})
+
+	It("returns true when SupportedKinds match but are in a different order", func() {
+		// The kinds builder ranges a map, so slice order is not stable across passes.
+		// Build the reversed slice from a fresh supportedKinds() call so it also uses
+		// distinct *Group pointers; equality must hold across BOTH order and pointer
+		// differences, as translation produces every pass.
+		fresh := supportedKinds()
+		reversed := []gwv1.RouteGroupKind{fresh[1], fresh[0]}
+		a := buildWithSupportedKinds(supportedKinds())
+		b := buildWithSupportedKinds(reversed)
+		Expect(a.Equals(b)).To(BeTrue(), "SupportedKinds must compare order-insensitively")
+	})
+
+	It("returns false when SupportedKinds differ in value", func() {
+		http := gwv1.Group(gwv1.GroupName)
+		a := buildWithSupportedKinds([]gwv1.RouteGroupKind{{Group: &http, Kind: gwv1.Kind("HTTPRoute")}})
+		tcp := gwv1.Group(gwv1.GroupName)
+		b := buildWithSupportedKinds([]gwv1.RouteGroupKind{{Group: &tcp, Kind: gwv1.Kind("TCPRoute")}})
+		Expect(a.Equals(b)).To(BeFalse(), "different SupportedKinds must compare not-equal")
+	})
+
+	It("remains equal to fresh translation output after gateway status rendering", func() {
+		gateway := gw()
+		build := func() reports.ReportMap {
+			rm := reports.NewReportMap()
+			reports.NewReporter(&rm).Gateway(gateway)
+			return rm
+		}
+
+		rm := build()
+		expected := build()
+
+		Expect(rm.BuildGWStatus(context.Background(), *gateway)).NotTo(BeNil())
+		Expect(rm.Equals(expected)).To(BeTrue(), "status rendering must not add default conditions to the report")
+	})
+
+	It("remains equal to fresh translation output after listener set status rendering", func() {
+		listenerSet := ls()
+		build := func() reports.ReportMap {
+			rm := reports.NewReportMap()
+			reports.NewReporter(&rm).ListenerSet(listenerSet)
+			return rm
+		}
+
+		rm := build()
+		expected := build()
+
+		Expect(rm.BuildListenerSetStatus(context.Background(), *listenerSet)).NotTo(BeNil())
+		Expect(rm.Equals(expected)).To(BeTrue(), "status rendering must not add listener set defaults to the report")
+	})
+
+	It("remains equal to fresh translation output after route status rendering", func() {
+		route := httpRoute()
+		build := func() reports.ReportMap {
+			rm := reports.NewReportMap()
+			reports.NewReporter(&rm).Route(route)
+			return rm
+		}
+
+		rm := build()
+		expected := build()
+
+		Expect(rm.BuildRouteStatus(context.Background(), route, "gloo-gateway")).NotTo(BeNil())
+		Expect(rm.Equals(expected)).To(BeTrue(), "status rendering must not add parent defaults to the report")
+	})
+})
+
 func gw() *gwv1.Gateway {
 	gw := &gwv1.Gateway{
 		ObjectMeta: metav1.ObjectMeta{

--- a/projects/gateway2/reports/status.go
+++ b/projects/gateway2/reports/status.go
@@ -26,14 +26,13 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 
 	finalListeners := make([]gwv1.ListenerStatus, 0, len(gw.Spec.Listeners))
 	for _, lis := range gw.Spec.Listeners {
-		lisReport := gwReport.listener(&lis)
-		addMissingListenerConditions(lisReport)
+		listenerStatus := listenerStatusWithDefaults(listenerReport(gwReport.listeners, lis.Name), lis.Name)
 
-		finalConditions := make([]metav1.Condition, 0, len(lisReport.Status.Conditions))
+		finalConditions := make([]metav1.Condition, 0, len(listenerStatus.Conditions))
 		oldLisStatusIndex := slices.IndexFunc(gw.Status.Listeners, func(l gwv1.ListenerStatus) bool {
 			return l.Name == lis.Name
 		})
-		for _, lisCondition := range lisReport.Status.Conditions {
+		for _, lisCondition := range listenerStatus.Conditions {
 			lisCondition.ObservedGeneration = gwReport.observedGeneration
 
 			// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -44,14 +43,12 @@ func (r *ReportMap) BuildGWStatus(ctx context.Context, gw gwv1.Gateway) *gwv1.Ga
 			}
 			meta.SetStatusCondition(&finalConditions, lisCondition)
 		}
-		lisReport.Status.Conditions = finalConditions
-		finalListeners = append(finalListeners, lisReport.Status)
+		listenerStatus.Conditions = finalConditions
+		finalListeners = append(finalListeners, listenerStatus)
 	}
 
-	addMissingGatewayConditions(r.Gateway(&gw))
-
 	finalConditions := make([]metav1.Condition, 0)
-	for _, gwCondition := range gwReport.GetConditions() {
+	for _, gwCondition := range gatewayConditionsWithDefaults(gwReport.GetConditions()) {
 		gwCondition.ObservedGeneration = gwReport.observedGeneration
 
 		// copy old condition from gw so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -93,14 +90,13 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwxv1a1.XList
 	if !listenerSetRejected(lsReport) {
 		for _, l := range ls.Spec.Listeners {
 			lis := utils.ToListener(l)
-			lisReport := lsReport.listener(&lis)
-			addMissingListenerConditions(lisReport)
+			listenerStatus := listenerStatusWithDefaults(listenerReport(lsReport.listeners, lis.Name), lis.Name)
 
-			finalConditions := make([]metav1.Condition, 0, len(lisReport.Status.Conditions))
+			finalConditions := make([]metav1.Condition, 0, len(listenerStatus.Conditions))
 			oldLisStatusIndex := slices.IndexFunc(ls.Status.Listeners, func(l gwxv1a1.ListenerEntryStatus) bool {
 				return l.Name == lis.Name
 			})
-			for _, lisCondition := range lisReport.Status.Conditions {
+			for _, lisCondition := range listenerStatus.Conditions {
 				lisCondition.ObservedGeneration = lsReport.observedGeneration
 
 				// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -111,15 +107,13 @@ func (r *ReportMap) BuildListenerSetStatus(ctx context.Context, ls gwxv1a1.XList
 				}
 				meta.SetStatusCondition(&finalConditions, lisCondition)
 			}
-			lisReport.Status.Conditions = finalConditions
-			finalListeners = append(finalListeners, lisReport.Status)
+			listenerStatus.Conditions = finalConditions
+			finalListeners = append(finalListeners, listenerStatus)
 		}
 	}
 
-	addMissingListenerSetConditions(r.ListenerSet(&ls))
-
 	finalConditions := make([]metav1.Condition, 0)
-	for _, lsCondition := range lsReport.GetConditions() {
+	for _, lsCondition := range gatewayConditionsWithDefaults(lsReport.GetConditions()) {
 		lsCondition.ObservedGeneration = lsReport.observedGeneration
 
 		// copy old condition from ls so LastTransitionTime is set correctly below by SetStatusCondition()
@@ -203,8 +197,7 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 	// Process the parent references to build the RouteParentStatus
 	routeStatus := gwv1.RouteStatus{}
 	for _, parentRef := range parentRefs {
-		parentStatusReport := routeReport.parentRef(&parentRef)
-		addMissingParentRefConditions(parentStatusReport)
+		parentConditions := parentRefConditionsWithDefaults(parentRefReport(routeReport, &parentRef))
 
 		// Get the status of the current parentRef conditions if they exist
 		var currentParentRefConditions []metav1.Condition
@@ -215,8 +208,8 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 			currentParentRefConditions = existingStatus.Parents[currentParentRefIdx].Conditions
 		}
 
-		finalConditions := make([]metav1.Condition, 0, len(parentStatusReport.Conditions))
-		for _, pCondition := range parentStatusReport.Conditions {
+		finalConditions := make([]metav1.Condition, 0, len(parentConditions))
+		for _, pCondition := range parentConditions {
 			pCondition.ObservedGeneration = routeReport.observedGeneration
 
 			// Copy old condition to preserve LastTransitionTime, if it exists
@@ -245,96 +238,108 @@ func (r *ReportMap) BuildRouteStatus(ctx context.Context, obj client.Object, cNa
 }
 
 // Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingGatewayConditions(gwReport *GatewayReport) {
-	if cond := meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionAccepted)); cond == nil {
-		gwReport.SetCondition(GatewayCondition{
-			Type:   gwv1.GatewayConditionAccepted,
+// so all missing conditions are assumed to be positive. The helpers below add
+// those defaults to clones so status rendering does not mutate the ReportMap
+// used by krt equality.
+//
+// gatewayConditionsWithDefaults adds the default-positive Accepted and Programmed
+// conditions when absent. Gateways and ListenerSets share the same defaults, so
+// both BuildGWStatus and BuildListenerSetStatus call this with the report's
+// conditions.
+func gatewayConditionsWithDefaults(reportConditions []metav1.Condition) []metav1.Condition {
+	conditions := slices.Clone(reportConditions)
+	if cond := meta.FindStatusCondition(conditions, string(gwv1.GatewayConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&conditions, metav1.Condition{
+			Type:   string(gwv1.GatewayConditionAccepted),
 			Status: metav1.ConditionTrue,
-			Reason: gwv1.GatewayReasonAccepted,
+			Reason: string(gwv1.GatewayReasonAccepted),
 		})
 	}
-	if cond := meta.FindStatusCondition(gwReport.GetConditions(), string(gwv1.GatewayConditionProgrammed)); cond == nil {
-		gwReport.SetCondition(GatewayCondition{
-			Type:   gwv1.GatewayConditionProgrammed,
+	if cond := meta.FindStatusCondition(conditions, string(gwv1.GatewayConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&conditions, metav1.Condition{
+			Type:   string(gwv1.GatewayConditionProgrammed),
 			Status: metav1.ConditionTrue,
-			Reason: gwv1.GatewayReasonProgrammed,
+			Reason: string(gwv1.GatewayReasonProgrammed),
 		})
 	}
+	return conditions
 }
 
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingListenerSetConditions(lsReport *ListenerSetReport) {
-	if cond := meta.FindStatusCondition(lsReport.GetConditions(), string(gwv1.GatewayConditionAccepted)); cond == nil {
-		lsReport.SetCondition(GatewayCondition{
-			Type:   gwv1.GatewayConditionAccepted,
-			Status: metav1.ConditionTrue,
-			Reason: gwv1.GatewayReasonAccepted,
-		})
+func listenerStatusWithDefaults(lisReport *ListenerReport, name gwv1.SectionName) gwv1.ListenerStatus {
+	status := gwv1.ListenerStatus{Name: name}
+	if lisReport != nil {
+		status = lisReport.Status
+		// The rendered status name is the spec listener name the caller asked for,
+		// independent of how the report happens to be keyed.
+		status.Name = name
+		status.Conditions = slices.Clone(lisReport.Status.Conditions)
+		status.SupportedKinds = slices.Clone(lisReport.Status.SupportedKinds)
 	}
-	if cond := meta.FindStatusCondition(lsReport.GetConditions(), string(gwv1.GatewayConditionProgrammed)); cond == nil {
-		lsReport.SetCondition(GatewayCondition{
-			Type:   gwv1.GatewayConditionProgrammed,
-			Status: metav1.ConditionTrue,
-			Reason: gwv1.GatewayReasonProgrammed,
-		})
-	}
-}
 
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingListenerConditions(lisReport *ListenerReport) {
 	// set healthy conditions for Condition Types not set yet (i.e. no negative status yet, we can assume positive)
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionAccepted)); cond == nil {
-		lisReport.SetCondition(ListenerCondition{
-			Type:   gwv1.ListenerConditionAccepted,
+	if cond := meta.FindStatusCondition(status.Conditions, string(gwv1.ListenerConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:   string(gwv1.ListenerConditionAccepted),
 			Status: metav1.ConditionTrue,
-			Reason: gwv1.ListenerReasonAccepted,
+			Reason: string(gwv1.ListenerReasonAccepted),
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionConflicted)); cond == nil {
-		lisReport.SetCondition(ListenerCondition{
-			Type:   gwv1.ListenerConditionConflicted,
+	if cond := meta.FindStatusCondition(status.Conditions, string(gwv1.ListenerConditionConflicted)); cond == nil {
+		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:   string(gwv1.ListenerConditionConflicted),
 			Status: metav1.ConditionFalse,
-			Reason: gwv1.ListenerReasonNoConflicts,
+			Reason: string(gwv1.ListenerReasonNoConflicts),
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionResolvedRefs)); cond == nil {
-		lisReport.SetCondition(ListenerCondition{
-			Type:   gwv1.ListenerConditionResolvedRefs,
+	if cond := meta.FindStatusCondition(status.Conditions, string(gwv1.ListenerConditionResolvedRefs)); cond == nil {
+		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:   string(gwv1.ListenerConditionResolvedRefs),
 			Status: metav1.ConditionTrue,
-			Reason: gwv1.ListenerReasonResolvedRefs,
+			Reason: string(gwv1.ListenerReasonResolvedRefs),
 		})
 	}
-	if cond := meta.FindStatusCondition(lisReport.Status.Conditions, string(gwv1.ListenerConditionProgrammed)); cond == nil {
-		lisReport.SetCondition(ListenerCondition{
-			Type:   gwv1.ListenerConditionProgrammed,
+	if cond := meta.FindStatusCondition(status.Conditions, string(gwv1.ListenerConditionProgrammed)); cond == nil {
+		meta.SetStatusCondition(&status.Conditions, metav1.Condition{
+			Type:   string(gwv1.ListenerConditionProgrammed),
 			Status: metav1.ConditionTrue,
-			Reason: gwv1.ListenerReasonProgrammed,
+			Reason: string(gwv1.ListenerReasonProgrammed),
 		})
 	}
+	return status
 }
 
-// Reports will initially only contain negative conditions found during translation,
-// so all missing conditions are assumed to be positive. Here we will add all missing conditions
-// to a given report, i.e. set healthy conditions
-func addMissingParentRefConditions(report *ParentRefReport) {
-	if cond := meta.FindStatusCondition(report.Conditions, string(gwv1.RouteConditionAccepted)); cond == nil {
-		report.SetCondition(RouteCondition{
-			Type:   gwv1.RouteConditionAccepted,
+func parentRefConditionsWithDefaults(report *ParentRefReport) []metav1.Condition {
+	var conditions []metav1.Condition
+	if report != nil {
+		conditions = slices.Clone(report.Conditions)
+	}
+	if cond := meta.FindStatusCondition(conditions, string(gwv1.RouteConditionAccepted)); cond == nil {
+		meta.SetStatusCondition(&conditions, metav1.Condition{
+			Type:   string(gwv1.RouteConditionAccepted),
 			Status: metav1.ConditionTrue,
-			Reason: gwv1.RouteReasonAccepted,
+			Reason: string(gwv1.RouteReasonAccepted),
 		})
 	}
-	if cond := meta.FindStatusCondition(report.Conditions, string(gwv1.RouteConditionResolvedRefs)); cond == nil {
-		report.SetCondition(RouteCondition{
-			Type:   gwv1.RouteConditionResolvedRefs,
+	if cond := meta.FindStatusCondition(conditions, string(gwv1.RouteConditionResolvedRefs)); cond == nil {
+		meta.SetStatusCondition(&conditions, metav1.Condition{
+			Type:   string(gwv1.RouteConditionResolvedRefs),
 			Status: metav1.ConditionTrue,
-			Reason: gwv1.RouteReasonResolvedRefs,
+			Reason: string(gwv1.RouteReasonResolvedRefs),
 		})
 	}
+	return conditions
+}
+
+// listenerReport returns the ListenerReport for the named listener, or nil if
+// none was recorded during translation. Indexing a nil map is safe, so callers
+// may pass a nil listeners map.
+func listenerReport(listeners map[string]*ListenerReport, name gwv1.SectionName) *ListenerReport {
+	return listeners[string(name)]
+}
+
+func parentRefReport(routeReport *RouteReport, parentRef *gwv1.ParentReference) *ParentRefReport {
+	if routeReport == nil || routeReport.Parents == nil {
+		return nil
+	}
+	return routeReport.Parents[getParentRefKey(parentRef)]
 }


### PR DESCRIPTION
# Description
https://github.com/solo-io/gloo/pull/11308 port
<!--
Please include a high level summary of the changes.

This bug fixes ... \ This new feature can be used to ...

_Fill out any of the following sections that are relevant and remove the others_
-->

## API changes

<!--
- Added x field to y resource
- ...
-->

## Code changes

<!--
- Fix error in `Foo()` function
- Add `Bar()` function
- ...
-->

## CI changes

<!--
- Adjusted schedule for x job
- ...
-->

## Docs changes

<!--
- Added guide about feature x to public docs
- Updated README to account for y behavior
- ...
-->

# Context

<!-- Users ran into this bug doing ... \ Users needed this feature to ...

See slack conversation [here](https://solo-io-corp.slack.com/archives/some/post)
-->

## Interesting decisions

<!-- We chose to do things this way because ... -->

## Testing steps

<!-- I manually verified behavior by ... -->

## Notes for reviewers

<!-- Be sure to verify intended behavior by ...

Please proofread comments on ...

This is a complex PR and may require a huddle to discuss ...
-->

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!---
# Author reminders (delete before opening)
- Include a concise, user-facing changelog (for details, see https://github.com/solo-io/go-utils/tree/main/changelogutils) referencing the issue that is resolved
  - Include `resolvesIssue: false` unless the issue does not require a release to be resolved; only a subset of non-user-facing issues can be considered resolved without release
- Run codegen via `make -B install-go-tools generated-code`
- Follow guidelines laid out in the Gloo Edge [contribution guide](https://docs.solo.io/gloo-edge/latest/contributing/)
- If not ready for review, open a draft PR or apply the `work in progress` label
-->

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/8013