### PR TITLE
fix: users can explicitly set the gateway-proxy workoad type, resolving a bug with deployment / daemonSet behavior

### DIFF
--- a/changelog/v1.22.0-beta11/add-gateway-proxy-workload-type.yaml
+++ b/changelog/v1.22.0-beta11/add-gateway-proxy-workload-type.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: HELM
+    issueLink: https://github.com/solo-io/solo-projects/issues/8948
+    resolvesIssue: true
+    description: >-
+      Add gatewayProxies.NAME.kind.workloadType to explicitly select the gateway proxy workload type
+      ("Deployment" or "DaemonSet"). When set, it takes precedence over the kind.deployment and
+      kind.daemonSet fields, avoiding the ambiguity of an empty kind.deployment object that some GitOps
+      tools normalize inconsistently; any other value fails at render time. When unset, behavior is unchanged.

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -873,6 +873,7 @@
 |gateway.persistProxySpec|bool||Enable writing Proxy CRD to etcd. Disabled by default for performance.|
 |gateway.translateEmptyGateways|bool|false|If true, the gateways will be translated into Envoy listeners even if no VirtualServices exist.|
 |gateway.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
+|gatewayProxies.NAME.kind.workloadType|string||set to 'Deployment' or 'DaemonSet' to explicitly select the workload type, taking precedence over the deployment and daemonSet fields, otherwise inferred from those fields|
 |gatewayProxies.NAME.kind.deployment.replicas|int||number of instances to deploy|
 |gatewayProxies.NAME.kind.deployment.customEnv[].name|string|||
 |gatewayProxies.NAME.kind.deployment.customEnv[].value|string|||
@@ -1132,6 +1133,7 @@
 |gatewayProxies.NAME.disableCoreDumps|bool||If set to true, Envoy will not generate core dumps in the event of a crash. Defaults to false|
 |gatewayProxies.NAME.disableExtauthSidecar|bool||If set to true, this gateway proxy will not come up with an extauth sidecar container when global.extAuth.envoySidecar is enabled. This setting has no effect otherwise. Defaults to false|
 |gatewayProxies.NAME.kubeResourceOverride.NAME|interface||override fields in the generated resource by specifying the yaml structure to override under the top-level key.|
+|gatewayProxies.gatewayProxy.kind.workloadType|string||set to 'Deployment' or 'DaemonSet' to explicitly select the workload type, taking precedence over the deployment and daemonSet fields, otherwise inferred from those fields|
 |gatewayProxies.gatewayProxy.kind.deployment.replicas|int|1|number of instances to deploy|
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].name|string|||
 |gatewayProxies.gatewayProxy.kind.deployment.customEnv[].value|string|||

--- a/install/helm/gloo/generate/values.go
+++ b/install/helm/gloo/generate/values.go
@@ -642,8 +642,9 @@ type GatewayProxyGatewaySettings struct {
 }
 
 type GatewayProxyKind struct {
-	Deployment *GatewayProxyDeployment `json:"deployment,omitempty" desc:"set to deploy as a kubernetes deployment, otherwise nil"`
-	DaemonSet  *DaemonSetSpec          `json:"daemonSet,omitempty" desc:"set to deploy as a kubernetes daemonset, otherwise nil"`
+	WorkloadType *string                 `json:"workloadType,omitempty" desc:"set to 'Deployment' or 'DaemonSet' to explicitly select the workload type, taking precedence over the deployment and daemonSet fields, otherwise inferred from those fields"`
+	Deployment   *GatewayProxyDeployment `json:"deployment,omitempty" desc:"set to deploy as a kubernetes deployment, otherwise nil"`
+	DaemonSet    *DaemonSetSpec          `json:"daemonSet,omitempty" desc:"set to deploy as a kubernetes daemonset, otherwise nil"`
 }
 type GatewayProxyDeployment struct {
 	*DeploymentSpecSansResources

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -24,6 +24,7 @@
 {{- $image = merge $spec.podTemplate.image $global.image }}
 {{- end }}
 {{- $statsConfig := coalesce $spec.stats $global.glooStats }}
+{{- include "gloo.gatewayProxyKindOverride" $spec.kind }}
 {{- if not $spec.disabled }}
 apiVersion: apps/v1
 {{- if (kindIs "map" $spec.kind.deployment)}}

--- a/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-horizontal-pod-autoscaler.yaml
@@ -4,6 +4,7 @@
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
+{{- include "gloo.gatewayProxyKindOverride" $spec.kind }}
 {{- if not $spec.disabled }}
 {{- if (kindIs "map" $spec.kind.deployment) }}
 {{- if $spec.horizontalPodAutoscaler }}

--- a/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
+++ b/install/helm/gloo/templates/8-gateway-proxy-pod-disruption-budget.yaml
@@ -4,6 +4,7 @@
 {{- with (first .) }}
 {{- $gatewayProxy := .Values.gatewayProxies.gatewayProxy -}}
 {{- $spec := include "gloo.util.mergeOverwriteWithOmit" (list $gatewaySpec $gatewayProxy) | fromJson }}
+{{- include "gloo.gatewayProxyKindOverride" $spec.kind }}
 {{- if (kindIs "map" $spec.kind.deployment)}}
 {{- if $spec.podDisruptionBudget }}
 apiVersion: policy/v1

--- a/install/helm/gloo/templates/_helpers.tpl
+++ b/install/helm/gloo/templates/_helpers.tpl
@@ -397,6 +397,26 @@ Otherwise it will generate ["Create", "Update", "Delete"]
 {{ toJson $result }}
 {{- end -}}
 
+{{/*
+gloo.gatewayProxyKindOverride: normalize a gateway proxy `kind` map when kind.workloadType is set.
+Call once with the kind map after $spec is built and before reading .kind, so the rest of the
+templates resolve to a single workload type. workloadType takes precedence over the deployment and
+daemonSet fields: it ensures the matching field is present and removes the other one.
+*/}}
+{{- define "gloo.gatewayProxyKindOverride" -}}
+{{- $kind := . -}}
+{{- if and (kindIs "map" $kind) $kind.workloadType -}}
+{{- if eq $kind.workloadType "Deployment" -}}
+{{- if not (kindIs "map" $kind.deployment) }}{{- $_ := set $kind "deployment" dict -}}{{- end -}}
+{{- $_ := unset $kind "daemonSet" -}}
+{{- else if eq $kind.workloadType "DaemonSet" -}}
+{{- $_ := unset $kind "deployment" -}}
+{{- else -}}
+{{- fail (printf "gatewayProxies kind.workloadType must be \"Deployment\" or \"DaemonSet\", got %q" $kind.workloadType) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/* Additional labels added to every resource */}}
 {{- define "gloo.labels" -}}
 app: gloo

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3082,6 +3082,27 @@ spec:
 							})
 							testManifest.Expect("DaemonSet", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).To(BeEquivalentTo(daemonSet))
 						})
+
+						It("renders a DaemonSet when kind.workloadType is DaemonSet even though kind.deployment is set", func() {
+							prepareMakefile(namespace, glootestutils.HelmValues{
+								ValuesArgs: []string{
+									"gatewayProxies.gatewayProxy.kind.workloadType=DaemonSet",
+									"gatewayProxies.gatewayProxy.kind.daemonSet.hostPort=true",
+								},
+							})
+							testManifest.Expect("DaemonSet", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).To(BeEquivalentTo(daemonSet))
+							testManifest.Expect("Deployment", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).To(BeNil())
+
+							// Assert on the raw manifest: spec.replicas is invalid on a DaemonSet, and a
+							// typed comparison silently drops it, so check the unstructured field directly.
+							testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
+								return resource.GetKind() == "DaemonSet" && resource.GetName() == "gateway-proxy"
+							}).ExpectAll(func(ds *unstructured.Unstructured) {
+								_, found, err := unstructured.NestedFieldNoCopy(ds.Object, "spec", "replicas")
+								ExpectWithOffset(1, err).NotTo(HaveOccurred())
+								ExpectWithOffset(1, found).To(BeFalse(), "DaemonSet must not have spec.replicas")
+							})
+						})
 					})
 
 					It("creates a deployment", func() {
@@ -3107,6 +3128,55 @@ spec:
 						deploy := getStructuredDeployment(testManifest, "gateway-proxy")
 						Expect(deploy.Spec.Replicas).NotTo(BeNil())
 						Expect(*deploy.Spec.Replicas).To(Equal(int32(1)))
+					})
+
+					It("renders a Deployment when kind.workloadType is Deployment even if kind.deployment is an empty object", func() {
+						prepareMakefileFromValuesFile("values/val_gwp_workload_type_deployment_empty.yaml")
+						deploy := getStructuredDeployment(testManifest, "gateway-proxy")
+						Expect(deploy).NotTo(BeNil())
+						Expect(deploy.Spec.Replicas).NotTo(BeNil())
+						Expect(*deploy.Spec.Replicas).To(Equal(int32(1)))
+						testManifest.Expect("DaemonSet", namespace, "gateway-proxy").To(BeNil())
+					})
+
+					It("renders a Deployment with no replicas and an HPA when kind.workloadType is Deployment and kind.deployment.replicas is null", func() {
+						prepareMakefile(namespace, glootestutils.HelmValues{
+							ValuesArgs: []string{
+								"gatewayProxies.gatewayProxy.kind.workloadType=Deployment",
+								"gatewayProxies.gatewayProxy.kind.deployment.replicas=null",
+								"gatewayProxies.gatewayProxy.horizontalPodAutoscaler.apiVersion=autoscaling/v2",
+								"gatewayProxies.gatewayProxy.horizontalPodAutoscaler.minReplicas=1",
+								"gatewayProxies.gatewayProxy.horizontalPodAutoscaler.maxReplicas=5",
+							},
+						})
+						deploy := getStructuredDeployment(testManifest, "gateway-proxy")
+						Expect(deploy).NotTo(BeNil())
+						Expect(deploy.Spec.Replicas).To(BeNil())
+						testManifest.Expect("DaemonSet", namespace, "gateway-proxy").To(BeNil())
+						testManifest.ExpectUnstructured("HorizontalPodAutoscaler", namespace, defaults.GatewayProxyName+"-hpa").NotTo(BeNil())
+					})
+
+					It("does not apply daemonSet pod settings when kind.workloadType is Deployment", func() {
+						prepareMakefile(namespace, glootestutils.HelmValues{
+							ValuesArgs: []string{
+								"gatewayProxies.gatewayProxy.kind.workloadType=Deployment",
+								"gatewayProxies.gatewayProxy.kind.daemonSet.hostPort=true",
+							},
+						})
+						deploy := getStructuredDeployment(testManifest, "gateway-proxy")
+						Expect(deploy).NotTo(BeNil())
+						Expect(deploy.Spec.Template.Spec.HostNetwork).To(BeFalse())
+						testManifest.Expect("DaemonSet", namespace, "gateway-proxy").To(BeNil())
+					})
+
+					It("errors when kind.workloadType is not Deployment or DaemonSet", func() {
+						expectRenderError(namespace, glootestutils.HelmValues{
+							ValuesArgs: []string{
+								"gatewayProxies.gatewayProxy.kind.workloadType=Nonsense",
+							},
+						})
+						Expect(renderErr).To(HaveOccurred())
+						Expect(renderErr.Error()).To(ContainSubstring("kind.workloadType must be"))
 					})
 
 					It("supports multiple deployments", func() {

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3095,14 +3095,25 @@ spec:
 							testManifest.Expect("DaemonSet", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).NotTo(BeNil())
 							testManifest.Expect("Deployment", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).To(BeNil())
 
-							// Assert on the raw manifest: spec.replicas is invalid on a DaemonSet, and a
-							// typed comparison silently drops it, so check the unstructured field directly.
 							testManifest.SelectResources(func(resource *unstructured.Unstructured) bool {
 								return resource.GetKind() == "DaemonSet" && resource.GetName() == "gateway-proxy"
-							}).ExpectAll(func(ds *unstructured.Unstructured) {
-								_, found, err := unstructured.NestedFieldNoCopy(ds.Object, "spec", "replicas")
+							}).ExpectAll(func(resource *unstructured.Unstructured) {
+								// spec.replicas is invalid on a DaemonSet, and a typed comparison silently
+								// drops it, so check the unstructured field directly.
+								_, found, err := unstructured.NestedFieldNoCopy(resource.Object, "spec", "replicas")
 								ExpectWithOffset(1, err).NotTo(HaveOccurred())
 								ExpectWithOffset(1, found).To(BeFalse(), "DaemonSet must not have spec.replicas")
+
+								obj, err := kuberesource.ConvertUnstructured(resource)
+								ExpectWithOffset(1, err).NotTo(HaveOccurred())
+								ds, ok := obj.(*appsv1.DaemonSet)
+								ExpectWithOffset(1, ok).To(BeTrue())
+								// A real gateway-proxy DaemonSet: it targets the gateway-proxy pods and renders
+								// the pod template, and no daemonSet-only host networking leaks in since
+								// kind.daemonSet is unset.
+								ExpectWithOffset(1, ds.Spec.Selector).To(Equal(gatewayProxyDeployment.Spec.Selector))
+								ExpectWithOffset(1, ds.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+								ExpectWithOffset(1, ds.Spec.Template.Spec.HostNetwork).To(BeFalse())
 							})
 						})
 					})

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3084,9 +3084,13 @@ spec:
 						})
 
 						It("renders a DaemonSet when kind.workloadType is DaemonSet even though kind.deployment is set", func() {
+							// workloadType takes precedence over the kind.deployment/kind.daemonSet fields:
+							// kind.deployment is set here, but workloadType=DaemonSet still selects a DaemonSet.
+							// daemonSet.hostPort is set so the rendered manifest matches the expected daemonSet.
 							prepareMakefile(namespace, glootestutils.HelmValues{
 								ValuesArgs: []string{
 									"gatewayProxies.gatewayProxy.kind.workloadType=DaemonSet",
+									"gatewayProxies.gatewayProxy.kind.deployment.replicas=1",
 									"gatewayProxies.gatewayProxy.kind.daemonSet.hostPort=true",
 								},
 							})

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3159,11 +3159,13 @@ spec:
 					})
 
 					It("renders a Deployment when kind.workloadType is Deployment even though kind.daemonSet is set", func() {
-						// workloadType takes precedence: kind.daemonSet is set, yet workloadType=Deployment
+						// workloadType takes precedence: only kind.daemonSet is set (kind.deployment is
+						// nulled, so this config alone renders a DaemonSet), yet workloadType=Deployment
 						// still selects a Deployment and the daemonSet-only pod settings do not leak in.
 						prepareMakefile(namespace, glootestutils.HelmValues{
 							ValuesArgs: []string{
 								"gatewayProxies.gatewayProxy.kind.workloadType=Deployment",
+								"gatewayProxies.gatewayProxy.kind.deployment=null",
 								"gatewayProxies.gatewayProxy.kind.daemonSet.hostPort=true",
 							},
 						})

--- a/install/test/helm_test.go
+++ b/install/test/helm_test.go
@@ -3084,17 +3084,15 @@ spec:
 						})
 
 						It("renders a DaemonSet when kind.workloadType is DaemonSet even though kind.deployment is set", func() {
-							// workloadType takes precedence over the kind.deployment/kind.daemonSet fields:
-							// kind.deployment is set here, but workloadType=DaemonSet still selects a DaemonSet.
-							// daemonSet.hostPort is set so the rendered manifest matches the expected daemonSet.
+							// workloadType takes precedence: kind.deployment is set and kind.daemonSet is not,
+							// yet workloadType=DaemonSet still selects a DaemonSet.
 							prepareMakefile(namespace, glootestutils.HelmValues{
 								ValuesArgs: []string{
 									"gatewayProxies.gatewayProxy.kind.workloadType=DaemonSet",
 									"gatewayProxies.gatewayProxy.kind.deployment.replicas=1",
-									"gatewayProxies.gatewayProxy.kind.daemonSet.hostPort=true",
 								},
 							})
-							testManifest.Expect("DaemonSet", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).To(BeEquivalentTo(daemonSet))
+							testManifest.Expect("DaemonSet", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).NotTo(BeNil())
 							testManifest.Expect("Deployment", gatewayProxyDeployment.Namespace, gatewayProxyDeployment.Name).To(BeNil())
 
 							// Assert on the raw manifest: spec.replicas is invalid on a DaemonSet, and a
@@ -3160,7 +3158,9 @@ spec:
 						testManifest.ExpectUnstructured("HorizontalPodAutoscaler", namespace, defaults.GatewayProxyName+"-hpa").NotTo(BeNil())
 					})
 
-					It("does not apply daemonSet pod settings when kind.workloadType is Deployment", func() {
+					It("renders a Deployment when kind.workloadType is Deployment even though kind.daemonSet is set", func() {
+						// workloadType takes precedence: kind.daemonSet is set, yet workloadType=Deployment
+						// still selects a Deployment and the daemonSet-only pod settings do not leak in.
 						prepareMakefile(namespace, glootestutils.HelmValues{
 							ValuesArgs: []string{
 								"gatewayProxies.gatewayProxy.kind.workloadType=Deployment",

--- a/install/test/values/val_gwp_workload_type_deployment_empty.yaml
+++ b/install/test/values/val_gwp_workload_type_deployment_empty.yaml
@@ -1,0 +1,7 @@
+# workloadType must select a Deployment even when kind.deployment is an empty
+# object, which some GitOps tools (e.g. FluxCD) normalize inconsistently.
+gatewayProxies:
+  gatewayProxy:
+    kind:
+      workloadType: Deployment
+      deployment: {}


### PR DESCRIPTION
## Description

Added a `WorkloadType *string` field to the `GatewayProxyKind` struct to allow users to explicitly select the gateway-proxy workload type. This will resolve a bug where the workload type was inferred from whether the `kind.deployment` object was present, which for example FluxCD would normalize inconsistently - an empty `kind.deployment: {}` would sometimes be dropped and sometimes defaulted, flipping the proxy between a `Deployment` and a `DaemonSet` across environments that shared the same config.

`workloadType` takes precedence over the `deployment/daemonSet` fields, so that an invalid value in that field will lead to a render-time failure rather than a silent fallback to a default.

## API changes

Added `kind.workloadType` field to the gateway proxy Helm values (`GatewayProxyKind`), with possible values "Deployment" or "DaemonSet".

## Interesting decisions

Made the decision to handle `workloadType` by normalizing it once with a helper at the start of the template into the existing `kind.deployment/kind.daemonSet` inputs. This way, the whole chart keeps running largely through the same code path as before without unneeded modification.

## Testing steps

Added helm render tests covering: DaemonSet selection, the empty-deployment FluxCD case, the HPA case (replicas: null), no daemonSet-field leakage into a Deployment, and an invalid-value failure case.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

BOT NOTES: 
resolves https://github.com/solo-io/solo-projects/issues/8948