### PR TITLE
[1.18] Fix push-docs workflow paths for docs migration

### DIFF
--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -168,20 +168,23 @@ jobs:
     - name: Copy OSA
       run: |
         pushd docs || exit 1
-        cp ../gloo/docs/content/static/content/osa_included.md assets/conrefs/pages/gateway/reference/osa_included_${{ steps.version-variables.outputs.minor }}.md
-        cp ../gloo/docs/content/static/content/osa_provided.md assets/conrefs/pages/gateway/reference/osa_provided_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/static/content/osa_included.md assets/gateway-docs/pages/reference/osa_included_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/static/content/osa_provided.md assets/gateway-docs/pages/reference/osa_provided_${{ steps.version-variables.outputs.minor }}.md
         popd || exit 1
     - name: Copy Helm
       run: |
         pushd docs || exit 1
         # OSS
-        cp ../gloo/docs/content/reference/values.txt assets/conrefs/pages/reference/helm/values_${{ steps.version-variables.outputs.minor }}.txt
+        cp ../gloo/docs/content/reference/values.txt assets/gateway-docs/pages/reference/helm/values_${{ steps.version-variables.outputs.minor }}.txt
         # Enterprise
-        cp ../gloo/docs/content/static/content/glooe-values.docgen assets/conrefs/pages/reference/helm/glooe-values_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/static/content/glooe-values.docgen assets/gateway-docs/pages/reference/helm/glooe-values_${{ steps.version-variables.outputs.minor }}.md
     - name: Copy CLI
       run: |
         pushd docs || exit 1
+        mkdir -p content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli
         cp ../gloo/docs/content/reference/cli/glooctl_check.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_check.md
+        cp ../gloo/docs/content/reference/cli/glooctl_debug.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_debug.md
+        cp ../gloo/docs/content/reference/cli/glooctl_debug_yaml.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_debug_yaml.md
         cp ../gloo/docs/content/reference/cli/glooctl_install_gateway.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_install_gateway.md
         cp ../gloo/docs/content/reference/cli/glooctl_install_gateway_enterprise.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_install_gateway_enterprise.md
         cp ../gloo/docs/content/reference/cli/glooctl_uninstall.md content/en/gateway/${{ steps.version-variables.outputs.directory }}/reference/cli/glooctl_uninstall.md
@@ -190,10 +193,10 @@ jobs:
     - name: Copy API
       run: |
         pushd docs || exit 1
-        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/direct_responses.md assets/conrefs/pages/gateway/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
-        sed -i '1,2d' assets/conrefs/pages/gateway/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
-        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/gateway_parameters.md assets/conrefs/pages/gateway/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
-        sed -i '1,2d' assets/conrefs/pages/gateway/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/direct_responses.md assets/gateway-docs/pages/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
+        sed -i '1,2d' assets/gateway-docs/pages/reference/direct_responses_${{ steps.version-variables.outputs.minor }}.md
+        cp ../gloo/docs/content/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/gateway_parameters.md assets/gateway-docs/pages/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
+        sed -i '1,2d' assets/gateway-docs/pages/reference/gateway_parameters_${{ steps.version-variables.outputs.minor }}.md
         popd || exit 1
     - name: Push and create PR
       uses: peter-evans/create-pull-request@v7

--- a/changelog/v1.18.41/fix-push-docs-helm-path.yaml
+++ b/changelog/v1.18.41/fix-push-docs-helm-path.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: NON_USER_FACING
+  resolvesIssue: false
+  description: >-
+    Fix push-docs workflow Copy Helm step on the v1.21.x branch by updating
+    destination paths from assets/conrefs/pages/ to assets/gateway-docs/pages/,
+    matching the docs repo directory structure after the migration in #11307.
+    skipCI-kube-tests:true


### PR DESCRIPTION
Update destination paths in the push-docs workflow from assets/conrefs/pages/ to assets/gateway-docs/pages/ to align with the docs repository structure changes from #11307. Also adds missing CLI documentation files (glooctl_debug, glooctl_debug_yaml) and ensures the CLI directory is created before copying files.