### PR TITLE
[v1.20.x] backport: validate upstreams at admission in k8s gateway api mode

### DIFF
--- a/changelog/v1.20.22/fix-kubegateway-upstream-admission-validation.yaml
+++ b/changelog/v1.20.22/fix-kubegateway-upstream-admission-validation.yaml
@@ -1,0 +1,8 @@
+changelog:
+- type: FIX
+  issueLink: https://github.com/solo-io/solo-projects/issues/8980
+  resolvesIssue: false
+  description: >-
+    Validate Upstreams at admission when using the Kubernetes Gateway API, so invalid configuration
+    such as a corrupt grpcJsonTranscoder protoDescriptorBin is caught instead of causing Envoy to NACK
+    at runtime.

--- a/projects/gateway/pkg/validation/validator.go
+++ b/projects/gateway/pkg/validation/validator.go
@@ -122,6 +122,7 @@ type validator struct {
 	extensionValidator                    syncerValidation.Validator
 	allowWarnings                         bool
 	disableValidationAgainstPreviousState bool
+	kubeGatewayEnabled                    bool
 }
 
 type validationOptions struct {
@@ -144,6 +145,7 @@ type ValidatorConfig struct {
 	ExtensionValidator                    syncerValidation.Validator
 	AllowWarnings                         bool
 	DisableValidationAgainstPreviousState bool
+	KubeGatewayEnabled                    bool
 }
 
 func NewValidator(cfg ValidatorConfig) *validator {
@@ -153,6 +155,7 @@ func NewValidator(cfg ValidatorConfig) *validator {
 		translator:                            cfg.Translator,
 		allowWarnings:                         cfg.AllowWarnings,
 		disableValidationAgainstPreviousState: cfg.DisableValidationAgainstPreviousState,
+		kubeGatewayEnabled:                    cfg.KubeGatewayEnabled,
 	}
 }
 
@@ -286,9 +289,46 @@ func (v *validator) validateProxiesAndExtensions(ctx context.Context, snapshot *
 		err          error
 	)
 
-	validatingK8sGateway := isK8sGatewayProxy(opts.Resource)
+	// dummyProxies marks the proxies built via a K8s Gateway dummy-proxy path, so the per-proxy loop below
+	// uses the simple error extractors for them rather than the full Edge error aggregation.
+	dummyProxies := map[*gloov1.Proxy]bool{}
+
+	validatingK8sGateway := isK8sGatewayProxy(opts.Resource, v.kubeGatewayEnabled)
 	if validatingK8sGateway {
-		proxies, errs = k8sgwvalidation.TranslateK8sGatewayProxies(ctx, snapshot, opts.Resource)
+		if upstream, ok := opts.Resource.(*gloov1.Upstream); ok {
+			// Validate the Upstream against the real Edge proxies too, so Edge usages are still checked in
+			// hybrid installs (for example a VirtualService still routing to it, or deleting an Upstream that
+			// is still in use). A pure K8s Gateway install has no Edge gateways, so this produces nothing.
+			edgeProxies, edgeErr := v.translateGlooEdgeProxies(ctx, snapshot, opts.collectAllErrors)
+			if edgeErr != nil {
+				errs = multierror.Append(errs, edgeErr)
+			}
+			proxies = append(proxies, edgeProxies...)
+
+			// Route a dummy proxy at the real Upstream so its own config is fully translated and validated,
+			// including by fullEnvoyValidation. Skip this on delete, since a deleted Upstream has nothing to
+			// validate and routing to it would only produce a warning.
+			if !opts.Delete {
+				upstreamProxies, upstreamErr := k8sgwvalidation.TranslateK8sGatewayProxiesForUpstream(ctx, snapshot, upstream)
+				if upstreamErr != nil {
+					errs = multierror.Append(errs, upstreamErr)
+				}
+				for _, p := range upstreamProxies {
+					dummyProxies[p] = true
+				}
+				proxies = append(proxies, upstreamProxies...)
+			}
+		} else {
+			// RouteOption and VirtualHostOption are validated only via the dummy proxy they are attached to.
+			policyProxies, policyErr := k8sgwvalidation.TranslateK8sGatewayProxies(ctx, snapshot, opts.Resource)
+			if policyErr != nil {
+				errs = multierror.Append(errs, policyErr)
+			}
+			for _, p := range policyProxies {
+				dummyProxies[p] = true
+			}
+			proxies = append(proxies, policyProxies...)
+		}
 	} else {
 		proxies, errs = v.translateGlooEdgeProxies(ctx, snapshot, opts.collectAllErrors)
 	}
@@ -321,13 +361,24 @@ func (v *validator) validateProxiesAndExtensions(ctx context.Context, snapshot *
 			continue
 		}
 
-		// if we are validating K8s Gateway Policy resources, we only want the errors resulting from
-		// the RouteOption/VirtualHostOption, so let's grab that here and skip the more sophisticated
-		// error aggregation below. Note that we do not care about allowWarnings, as they are not
-		// used in this case, as we do not do a full translation and use a 'dummy' proxy
-		if validatingK8sGateway {
+		// Dummy proxies (built for K8s Gateway resource validation) only carry the errors for the resource
+		// being admitted, so use the simple extractors and skip the fuller aggregation below. We do not
+		// apply allowWarnings here, as these are dummy proxies rather than a full translation. Real Edge
+		// proxies fall through to the full aggregation, which preserves the existing Edge-usage validation.
+		//
+		// A RouteOption or VirtualHostOption is attached to the dummy proxy, so its errors are reported
+		// against the proxy. fullEnvoyValidation errors are also reported against the proxy, so the proxy
+		// check covers the Upstream case too. An Upstream is the dummy proxy's route destination, and its
+		// ProcessUpstream errors are reported against the Upstream (and demoted to warnings by the
+		// sanitizers), so we read those from the pre-sanitization reports by the Upstream's ref.
+		if dummyProxies[proxy] {
 			if err = k8sgwvalidation.GetSimpleErrorFromGlooValidation(glooReports, proxy); err != nil {
 				errs = multierror.Append(errs, err)
+			}
+			if upstream, ok := opts.Resource.(*gloov1.Upstream); ok {
+				if err = k8sgwvalidation.GetSimpleErrorFromGlooValidationForUpstream(glooReports, upstream); err != nil {
+					errs = multierror.Append(errs, err)
+				}
 			}
 			continue
 		}
@@ -415,13 +466,23 @@ func (v *validator) translateGlooEdgeProxies(
 	return proxies, errs
 }
 
-// isK8sGatewayProxy returns true if we are evaluating a Policy resource in the context of K8s Gateway API support.
-// Currently the only signal needed to make this decision is if the resource being evaluated is a RouteOption
-// or a VirthalHostOption, as we only directly evaluate them in the validator to support K8s Gateway API mode.
-func isK8sGatewayProxy(res resources.Resource) bool {
+// isK8sGatewayProxy returns true if the given resource needs to be validated using the dummy K8s Gateway
+// API proxy.
+//
+// RouteOption and VirtualHostOption are validated only via the dummy proxy. We only directly evaluate them
+// in the validator to support K8s Gateway API mode.
+//
+// Upstreams need the dummy proxy when K8s Gateway API is enabled: an Upstream routed to only via an
+// HTTPRoute is never part of a translated Edge proxy, so its config (and fullEnvoyValidation) would
+// otherwise never run at admission. The dummy proxy is used in addition to the Edge proxies, not instead of
+// them, so Edge usages are still validated in hybrid installs. The gate keeps behavior unchanged when K8s
+// Gateway API is disabled.
+func isK8sGatewayProxy(res resources.Resource, kubeGatewayEnabled bool) bool {
 	switch res.(type) {
 	case *sologatewayv1.RouteOption, *sologatewayv1.VirtualHostOption:
 		return true
+	case *gloov1.Upstream:
+		return kubeGatewayEnabled
 	default:
 		return false
 	}

--- a/projects/gateway/pkg/validation/validator_test.go
+++ b/projects/gateway/pkg/validation/validator_test.go
@@ -127,6 +127,37 @@ var _ = Describe("Validator", func() {
 				Expect(warnings).To(BeEmpty())
 				Expect(errors).NotTo(HaveOccurred())
 			})
+			It("validates an upstream through the dummy proxy on create when k8s gateway is enabled", func() {
+				v.kubeGatewayEnabled = true
+				var validatedProxyNames []string
+				v.glooValidator = func(ctx context.Context, proxy *gloov1.Proxy, resource resources.Resource, shouldDelete bool) ([]*gloovalidation.GlooValidationReport, error) {
+					validatedProxyNames = append(validatedProxyNames, proxy.GetMetadata().GetName())
+					return ValidateAccept(ctx, proxy, resource, shouldDelete)
+				}
+
+				err := v.Sync(context.TODO(), samples.SimpleGlooSnapshot(ns))
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = v.ValidateModifiedGvk(context.TODO(), gloov1.UpstreamGVK, samples.SimpleUpstream(), false)
+				Expect(err).NotTo(HaveOccurred())
+				// the dummy proxy routes to the real upstream so its config is translated and validated
+				Expect(validatedProxyNames).To(ContainElement("zzz-fake-proxy-for-validation"))
+			})
+			It("rejects deletion of an in-use upstream through the edge proxies when k8s gateway is enabled", func() {
+				// On delete, a kube-gateway Upstream is validated through the real edge proxies, not the dummy
+				// proxy, so an edge-path warning (as an in-use route produces) is promoted to a rejection under
+				// strict validation (allowWarnings is false via the BeforeEach). If the delete wrongly took the
+				// dummy path, its simple extractor ignores warnings and the delete would be accepted, so
+				// asserting rejection here also verifies the dispatch skips the dummy proxy on delete.
+				v.kubeGatewayEnabled = true
+				v.glooValidator = ValidateWarn
+
+				err := v.Sync(context.TODO(), samples.SimpleGlooSnapshot(ns))
+				Expect(err).NotTo(HaveOccurred())
+
+				err = v.ValidateDeletedGvk(context.TODO(), gloov1.UpstreamGVK, samples.SimpleUpstream(), false)
+				Expect(err).To(HaveOccurred())
+			})
 			It("rejects an upstream when validation fails", func() {
 				v.glooValidator = ValidateFail
 				us := samples.SimpleUpstream()

--- a/projects/gateway2/validation/validator.go
+++ b/projects/gateway2/validation/validator.go
@@ -26,20 +26,53 @@ func TranslateK8sGatewayProxies(ctx context.Context, snap *gloosnapshot.ApiSnaps
 	}
 	snap.UpsertToResourceList(us)
 
-	routes := []*gloov1.Route{{
+	proxy, route, vhost := buildValidationProxy(us.GetMetadata().Ref())
+
+	// add the policy object we are validating to the correct location
+	switch policy := res.(type) {
+	case *sologatewayv1.RouteOption:
+		route.Options = policy.GetOptions()
+	case *sologatewayv1.VirtualHostOption:
+		vhost.Options = policy.GetOptions()
+	}
+
+	return []*gloov1.Proxy{proxy}, nil
+}
+
+// TranslateK8sGatewayProxiesForUpstream builds the same "dummy" gloov1.Proxy as TranslateK8sGatewayProxies,
+// but routes to the given `upstream` instead of the fake one. This is how an Upstream is validated in K8s
+// Gateway API mode, where the Upstream is otherwise never translated because HTTPRoutes are not in the ApiSnapshot.
+// The real Upstream must be the route destination because the plugin chain (for example the grpcjson plugin's
+// ProcessUpstream) only runs for Upstreams referenced by a route in the proxy. ValidateGloo adds the Upstream to
+// the snapshot before translation, so the reference resolves.
+func TranslateK8sGatewayProxiesForUpstream(ctx context.Context, snap *gloosnapshot.ApiSnapshot, upstream *gloov1.Upstream) ([]*gloov1.Proxy, error) {
+	proxy, _, _ := buildValidationProxy(upstream.GetMetadata().Ref())
+	return []*gloov1.Proxy{proxy}, nil
+}
+
+// buildValidationProxy builds the "dummy" gloov1.Proxy shared by the K8s Gateway API validation paths: a single
+// catch-all virtual host routing to `usRef`. It returns the route and virtual host so callers can attach a policy.
+func buildValidationProxy(usRef *core.ResourceRef) (*gloov1.Proxy, *gloov1.Route, *gloov1.VirtualHost) {
+	route := &gloov1.Route{
 		Name: "route",
 		Action: &gloov1.Route_RouteAction{
 			RouteAction: &gloov1.RouteAction{
 				Destination: &gloov1.RouteAction_Single{
 					Single: &gloov1.Destination{
 						DestinationType: &gloov1.Destination_Upstream{
-							Upstream: us.GetMetadata().Ref(),
+							Upstream: usRef,
 						},
 					},
 				},
 			},
 		},
-	}}
+	}
+
+	vhost := &gloov1.VirtualHost{
+		Name:    "vhost",
+		Domains: []string{"*"},
+		Routes:  []*gloov1.Route{route},
+	}
 
 	aggregateListener := &gloov1.Listener{
 		Name:        "aggregate-listener",
@@ -49,11 +82,7 @@ func TranslateK8sGatewayProxies(ctx context.Context, snap *gloosnapshot.ApiSnaps
 			AggregateListener: &gloov1.AggregateListener{
 				HttpResources: &gloov1.AggregateListener_HttpResources{
 					VirtualHosts: map[string]*gloov1.VirtualHost{
-						"vhost": {
-							Name:    "vhost",
-							Domains: []string{"*"},
-							Routes:  routes,
-						},
+						"vhost": vhost,
 					},
 				},
 				HttpFilterChains: []*gloov1.AggregateListener_HttpFilterChain{{
@@ -74,15 +103,7 @@ func TranslateK8sGatewayProxies(ctx context.Context, snap *gloosnapshot.ApiSnaps
 		},
 	}
 
-	// add the policy object we are validating to the correct location
-	switch policy := res.(type) {
-	case *sologatewayv1.RouteOption:
-		routes[0].Options = policy.GetOptions()
-	case *sologatewayv1.VirtualHostOption:
-		aggregateListener.GetAggregateListener().GetHttpResources().GetVirtualHosts()["vhost"].Options = policy.GetOptions()
-	}
-
-	return []*gloov1.Proxy{proxy}, nil
+	return proxy, route, vhost
 }
 
 // GetSimpleErrorFromGlooValidation will get the Errors for the provided `proxy` that exist in the provided `reports`
@@ -101,4 +122,24 @@ func GetSimpleErrorFromGlooValidation(
 	}
 
 	return errs
+}
+
+// GetSimpleErrorFromGlooValidationForUpstream returns the errors reported against the given `upstream` in the
+// provided `reports`. Unlike route and virtual host errors, ProcessUpstream errors such as an invalid grpcjson
+// protoDescriptorBin are attributed to the Upstream resource rather than the proxy, so they are looked up by the
+// Upstream's kind and ref. The pre-sanitization reports are read because the xDS sanitizers demote Upstream
+// errors to warnings before the final reports are produced. The first error found is returned if multiple
+// reports exist.
+func GetSimpleErrorFromGlooValidationForUpstream(
+	reports []*gloovalidation.GlooValidationReport,
+	upstream *gloov1.Upstream,
+) error {
+	for _, report := range reports {
+		_, usResReport := report.PreSanitizationReports.Find(resources.Kind(upstream), upstream.GetMetadata().Ref())
+		if usResReport.Errors != nil {
+			return usResReport.Errors
+		}
+	}
+
+	return nil
 }

--- a/projects/gateway2/validation/validator_test.go
+++ b/projects/gateway2/validation/validator_test.go
@@ -11,12 +11,16 @@ import (
 
 	. "github.com/onsi/gomega"
 
+	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gateway2/validation"
 	"github.com/solo-io/gloo/projects/gateway2/wellknown"
 	envoybuffer "github.com/solo-io/gloo/projects/gloo/pkg/api/external/envoy/extensions/filters/http/buffer/v3"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/faultinjection"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/grpc_json"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/static"
 	"github.com/solo-io/gloo/projects/gloo/pkg/bootstrap"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/registry"
@@ -136,6 +140,39 @@ var _ = Describe("Kube Gateway API Policy Validation Helper", func() {
 		Expect(proxyResourceReport.Errors).NotTo(HaveOccurred())
 	})
 
+	It("validates and rejects an Upstream with an invalid grpcJsonTranscoder protoDescriptorBin", func() {
+		gv := gloovalidation.NewValidator(vc)
+
+		us := grpcUpstreamWithBadDescriptor()
+		params := plugins.Params{
+			Ctx:      ctx,
+			Snapshot: samples.SimpleGlooSnapshot("gloo-system"),
+		}
+		proxies, _ := validation.TranslateK8sGatewayProxiesForUpstream(ctx, params.Snapshot, us)
+		gv.Sync(ctx, params.Snapshot)
+		rpt, err := gv.ValidateGloo(ctx, proxies[0], us, false)
+		Expect(err).NotTo(HaveOccurred())
+		err = validation.GetSimpleErrorFromGlooValidationForUpstream(rpt, us)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("protoDescriptorBin is not a valid FileDescriptorSet"))
+	})
+
+	It("validates and accepts an Upstream with a valid grpcJsonTranscoder", func() {
+		gv := gloovalidation.NewValidator(vc)
+
+		us := grpcUpstreamWithGoodDescriptor()
+		params := plugins.Params{
+			Ctx:      ctx,
+			Snapshot: samples.SimpleGlooSnapshot("gloo-system"),
+		}
+		proxies, _ := validation.TranslateK8sGatewayProxiesForUpstream(ctx, params.Snapshot, us)
+		gv.Sync(ctx, params.Snapshot)
+		rpt, err := gv.ValidateGloo(ctx, proxies[0], us, false)
+		Expect(err).NotTo(HaveOccurred())
+		err = validation.GetSimpleErrorFromGlooValidationForUpstream(rpt, us)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 	It("validates and a rejects a bad VirtualHostOption", func() {
 		gv := gloovalidation.NewValidator(vc)
 
@@ -176,6 +213,45 @@ var _ = Describe("Kube Gateway API Policy Validation Helper", func() {
 		Expect(proxyResourceReport.Errors).NotTo(HaveOccurred())
 	})
 })
+
+func grpcUpstreamWithBadDescriptor() *v1.Upstream {
+	return &v1.Upstream{
+		Metadata: &core.Metadata{
+			Name:      "grpc-us",
+			Namespace: "gloo-system",
+		},
+		UpstreamType: &v1.Upstream_Static{
+			Static: &static.UpstreamSpec{
+				Hosts: []*static.Host{
+					{Addr: "solo.io", Port: 80},
+				},
+				ServiceSpec: &options.ServiceSpec{
+					PluginType: &options.ServiceSpec_GrpcJsonTranscoder{
+						GrpcJsonTranscoder: &grpc_json.GrpcJsonTranscoder{
+							DescriptorSet: &grpc_json.GrpcJsonTranscoder_ProtoDescriptorBin{
+								ProtoDescriptorBin: []byte("this is not a valid proto descriptor"),
+							},
+							Services: []string{"main.Bookstore"},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func grpcUpstreamWithGoodDescriptor() *v1.Upstream {
+	validDescBytes, err := proto.Marshal(&descriptor.FileDescriptorSet{
+		File: []*descriptor.FileDescriptorProto{
+			{Name: proto.String("test.proto")},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+	us := grpcUpstreamWithBadDescriptor()
+	us.GetStatic().GetServiceSpec().GetGrpcJsonTranscoder().DescriptorSet =
+		&grpc_json.GrpcJsonTranscoder_ProtoDescriptorBin{ProtoDescriptorBin: validDescBytes}
+	return us
+}
 
 func vHostOptWithBadConfig() *sologatewayv1.VirtualHostOption {
 	return &sologatewayv1.VirtualHostOption{

--- a/projects/gloo/pkg/syncer/setup/setup_syncer.go
+++ b/projects/gloo/pkg/syncer/setup/setup_syncer.go
@@ -885,6 +885,7 @@ func RunGlooWithExtensions(opts bootstrap.Opts, extensions Extensions) error {
 		GlooValidator:                         validator.ValidateGloo,
 		ExtensionValidator:                    extensionValidator,
 		DisableValidationAgainstPreviousState: disableValidationAgainstPreviousState,
+		KubeGatewayEnabled:                    opts.GlooGateway.EnableK8sGatewayController,
 	}
 	if gwOpts.Validation != nil {
 		valOpts := gwOpts.Validation

--- a/projects/gloo/pkg/validation/validator.go
+++ b/projects/gloo/pkg/validation/validator.go
@@ -47,6 +47,11 @@ type GlooValidationReport struct {
 	Proxy           *gloov1.Proxy
 	ProxyReport     *validation.ProxyReport
 	ResourceReports reporter.ResourceReports
+	// PreSanitizationReports holds the reports for any resources that errored before the xDS sanitizers run.
+	// The UpstreamRemovingSanitizer demotes Upstream errors to warnings, so callers that need to see the
+	// original error for a resource (for example when validating an Upstream at admission) read it here.
+	// Only errored resources are present, so a resource that validated cleanly will not be found.
+	PreSanitizationReports reporter.ResourceReports
 }
 
 func (gv glooValidator) Validate(ctx context.Context, proxy *gloov1.Proxy, snapshot *gloosnapshot.ApiSnapshot, shouldDelete bool) []*GlooValidationReport {
@@ -81,14 +86,27 @@ func (gv glooValidator) Validate(ctx context.Context, proxy *gloov1.Proxy, snaps
 	for _, proxy := range proxiesToValidate {
 		xdsSnapshot, resourceReports, proxyReport := gv.translator.Translate(params, proxy)
 
+		// Capture the reports before sanitizing, as the sanitizers rewrite Upstream errors into warnings.
+		// Only errored resources are kept, so we avoid copying the full reports map on every validation.
+		var preSanitizationReports reporter.ResourceReports
+		for res, report := range resourceReports {
+			if report.Errors != nil {
+				if preSanitizationReports == nil {
+					preSanitizationReports = reporter.ResourceReports{}
+				}
+				preSanitizationReports[res] = report
+			}
+		}
+
 		// Sanitize routes before sending report to gateway
 		gv.xdsSanitizer.SanitizeSnapshot(ctx, snapshot, xdsSnapshot, resourceReports)
 		routeErrorToWarnings(resourceReports, proxyReport)
 
 		validationReports = append(validationReports, &GlooValidationReport{
-			Proxy:           proxy,
-			ProxyReport:     proxyReport,
-			ResourceReports: resourceReports,
+			Proxy:                  proxy,
+			ProxyReport:            proxyReport,
+			ResourceReports:        resourceReports,
+			PreSanitizationReports: preSanitizationReports,
 		})
 	}
 

--- a/test/kubernetes/e2e/features/upstreams/inputs/upstream-grpcjson-webhook-reject.yaml
+++ b/test/kubernetes/e2e/features/upstreams/inputs/upstream-grpcjson-webhook-reject.yaml
@@ -1,0 +1,16 @@
+apiVersion: gloo.solo.io/v1
+kind: Upstream
+metadata:
+  name: invalid-grpcjson-upstream
+  namespace: default
+spec:
+  static:
+    hosts:
+      - addr: "grpc-server.example.com"
+        port: 9090
+    serviceSpec:
+      grpcJsonTranscoder:
+        # aW52YWxpZA== is base64("invalid"), which is not a valid proto FileDescriptorSet
+        protoDescriptorBin: "aW52YWxpZA=="
+        services:
+          - "example.Service"

--- a/test/kubernetes/e2e/features/upstreams/suite.go
+++ b/test/kubernetes/e2e/features/upstreams/suite.go
@@ -70,3 +70,18 @@ func (s *testingSuite) TestConfigureBackingDestinationsWithUpstream() {
 		defaults.GlooReporter,
 	)
 }
+
+// TestRejectsGrpcJsonUpstreamWithInvalidProtoDescriptor verifies that in Kubernetes Gateway API mode an
+// Upstream with an invalid grpcJsonTranscoder protoDescriptorBin is rejected by the validating webhook.
+// No HTTPRoute references the Upstream, so previously it was never translated at admission and the invalid
+// descriptor was only caught by Envoy at runtime.
+func (s *testingSuite) TestRejectsGrpcJsonUpstreamWithInvalidProtoDescriptor() {
+	s.T().Cleanup(func() {
+		err := s.testInstallation.Actions.Kubectl().DeleteFileSafe(s.ctx, invalidGrpcJsonUpstreamManifest)
+		s.NoError(err, "can delete manifest")
+	})
+
+	output, err := s.testInstallation.Actions.Kubectl().ApplyFileWithOutput(s.ctx, invalidGrpcJsonUpstreamManifest)
+	s.testInstallation.Assertions.ExpectObjectAdmitted(invalidGrpcJsonUpstreamManifest, err, output,
+		"protoDescriptorBin is not a valid FileDescriptorSet")
+}

--- a/test/kubernetes/e2e/features/upstreams/types.go
+++ b/test/kubernetes/e2e/features/upstreams/types.go
@@ -19,6 +19,10 @@ var (
 	routeWithUpstreamManifest = filepath.Join(util.MustGetThisDir(), "inputs/route-with-upstream.yaml")
 	upstreamManifest          = filepath.Join(util.MustGetThisDir(), "inputs/upstream-for-route.yaml")
 
+	// invalidGrpcJsonUpstreamManifest is an Upstream with an invalid grpcJsonTranscoder protoDescriptorBin.
+	// The filename contains "webhook-reject", so ExpectObjectAdmitted asserts it is rejected at admission.
+	invalidGrpcJsonUpstreamManifest = filepath.Join(util.MustGetThisDir(), "inputs/upstream-grpcjson-webhook-reject.yaml")
+
 	// Proxy resource to be translated
 	glooProxyObjectMeta = metav1.ObjectMeta{
 		Name:      "gloo-proxy-gw",


### PR DESCRIPTION
# Description

Backporting https://github.com/solo-io/gloo/pull/11322 to `v1.20x`.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works