### PR TITLE
feat: host rewrite literal for shadow hosts

### DIFF
--- a/changelog/v1.22.0-beta11/host-rewrite-literal-shadowing.yaml
+++ b/changelog/v1.22.0-beta11/host-rewrite-literal-shadowing.yaml
@@ -1,0 +1,7 @@
+changelog:
+  - type: NEW_FEATURE
+    issueLink: https://github.com/solo-io/solo-projects/issues/9092
+    resolvesIssue: false
+    description: >-
+      Add support for hostRewriteLiteral in the shadowing plugin, allowing users to replace the Host
+      header of mirrored requests with a specific value.

--- a/docs/content/guides/traffic_management/request_processing/shadowing/_index.md
+++ b/docs/content/guides/traffic_management/request_processing/shadowing/_index.md
@@ -21,6 +21,8 @@ To enable traffic shadowing in Gloo Gateway, we need to add a route option to th
 
 * `upstream` : Indicates the upstream to which to send the shadowed traffic.
 * `percentage` : Percent of traffic to shadow (must be an integer between 0 and 100).
+* `disableShadowHostSuffixAppend` : If `true`, the shadowed `Host` header keeps its original value instead of having `-shadow` appended.
+* `hostRewriteLiteral` : Replaces the shadowed `Host` header with this value. Setting it implies `disableShadowHostSuffixAppend`.
 
 In the example below, all traffic going to `petstore` is also forwarded to `petstore-v2`.
 {{< highlight yaml "hl_lines=19-23" >}}
@@ -54,3 +56,10 @@ spec:
 When your new service gets a copy of a live-traffic message (ie, the copy), how can your service know that this is indeed a copy? This could be valuable information in how your service deals with the message, especially if this is a stateful service. For example, if you can detect this is a shadowed message, you can rollback any stateful transactions that may be associated with the processing of the message. 
 
 With Gloo Gateway, since it's based on Envoy, the `Host` or `Authority` header includes a `-shadow` postfix to it. For example, if we're sending traffic to `foo.bar.com` the `Host` value will then be `foo.bar.com-shadow`. From there, the service can detect this and response accordingly. See this blog [on advanced traffic shadowing patterns](https://blog.christianposta.com/microservices/advanced-traffic-shadowing-patterns-for-microservices-with-istio-service-mesh/) for more.
+
+Some shadow destinations reject the modified header, for example when they enforce strict host-based routing. Two options change this behavior:
+
+* Set `disableShadowHostSuffixAppend: true` to leave the original `Host` value untouched.
+* Set `hostRewriteLiteral` to send a specific `Host` value instead. The whole header is replaced, so include a port if the shadow destination needs one, and note that the port from the original host is not carried over. This option implies `disableShadowHostSuffixAppend`, so setting both is redundant. Requires Envoy 1.36 or newer.
+
+If your service relies on the `-shadow` suffix to detect shadowed traffic, changing either option means it needs another way to tell the copy apart.

--- a/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto.sk.md
+++ b/docs/content/reference/api/github.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto.sk.md
@@ -36,6 +36,7 @@ See here for additional information on Envoy's shadowing capabilities: https://w
 "upstream": .core.solo.io.ResourceRef
 "percentage": float
 "disableShadowHostSuffixAppend": bool
+"hostRewriteLiteral": string
 
 ```
 
@@ -44,6 +45,7 @@ See here for additional information on Envoy's shadowing capabilities: https://w
 | `upstream` | [.core.solo.io.ResourceRef](../../../../../../../../solo-kit/api/v1/ref.proto.sk/#resourceref) | The upstream to which the shadowed traffic should be sent. |
 | `percentage` | `float` | This should be a value between 0.0 and 100.0, with up to 6 significant digits. |
 | `disableShadowHostSuffixAppend` | `bool` | If true, the host/authority header of the shadow request will not have `-shadow` appended. Useful when the shadow destination has strict host-based routing rules that would reject the modified header. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-disable-shadow-host-suffix-append. |
+| `hostRewriteLiteral` | `string` | If set, the host/authority header of the shadow request is replaced with this value. The whole value is replaced, so include a port if the shadow destination needs one. Implies disable_shadow_host_suffix_append. Requires Envoy 1.36 or newer. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-host-rewrite-literal. |
 
 
 

--- a/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_RouteOption.yaml
@@ -1943,6 +1943,8 @@ spec:
                     properties:
                       disableShadowHostSuffixAppend:
                         type: boolean
+                      hostRewriteLiteral:
+                        type: string
                       percentage:
                         type: number
                       upstream:

--- a/install/helm/gloo/crds/gateway.solo.io_v1_RouteTable.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_RouteTable.yaml
@@ -2046,6 +2046,8 @@ spec:
                           properties:
                             disableShadowHostSuffixAppend:
                               type: boolean
+                            hostRewriteLiteral:
+                              type: string
                             percentage:
                               type: number
                             upstream:

--- a/install/helm/gloo/crds/gateway.solo.io_v1_VirtualService.yaml
+++ b/install/helm/gloo/crds/gateway.solo.io_v1_VirtualService.yaml
@@ -5302,6 +5302,8 @@ spec:
                               properties:
                                 disableShadowHostSuffixAppend:
                                   type: boolean
+                                hostRewriteLiteral:
+                                  type: string
                                 percentage:
                                   type: number
                                 upstream:

--- a/projects/gloo/api/v1/options/shadowing/shadowing.proto
+++ b/projects/gloo/api/v1/options/shadowing/shadowing.proto
@@ -26,4 +26,10 @@ message RouteShadowing {
     // Useful when the shadow destination has strict host-based routing rules that would reject the modified header.
     // See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-disable-shadow-host-suffix-append
     bool disable_shadow_host_suffix_append = 3;
+
+    // If set, the host/authority header of the shadow request is replaced with this value.
+    // The whole value is replaced, so include a port if the shadow destination needs one.
+    // Implies disable_shadow_host_suffix_append. Requires Envoy 1.36 or newer.
+    // See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-host-rewrite-literal
+    string host_rewrite_literal = 4;
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.clone.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.clone.go
@@ -45,5 +45,7 @@ func (m *RouteShadowing) Clone() proto.Message {
 
 	target.DisableShadowHostSuffixAppend = m.GetDisableShadowHostSuffixAppend()
 
+	target.HostRewriteLiteral = m.GetHostRewriteLiteral()
+
 	return target
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.equal.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.equal.go
@@ -64,5 +64,9 @@ func (m *RouteShadowing) Equal(that interface{}) bool {
 		return false
 	}
 
+	if strings.Compare(m.GetHostRewriteLiteral(), target.GetHostRewriteLiteral()) != 0 {
+		return false
+	}
+
 	return true
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.go
@@ -39,8 +39,13 @@ type RouteShadowing struct {
 	// Useful when the shadow destination has strict host-based routing rules that would reject the modified header.
 	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-disable-shadow-host-suffix-append
 	DisableShadowHostSuffixAppend bool `protobuf:"varint,3,opt,name=disable_shadow_host_suffix_append,json=disableShadowHostSuffixAppend,proto3" json:"disable_shadow_host_suffix_append,omitempty"`
-	unknownFields                 protoimpl.UnknownFields
-	sizeCache                     protoimpl.SizeCache
+	// If set, the host/authority header of the shadow request is replaced with this value.
+	// The whole value is replaced, so include a port if the shadow destination needs one.
+	// Implies disable_shadow_host_suffix_append. Requires Envoy 1.36 or newer.
+	// See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-requestmirrorpolicy-host-rewrite-literal
+	HostRewriteLiteral string `protobuf:"bytes,4,opt,name=host_rewrite_literal,json=hostRewriteLiteral,proto3" json:"host_rewrite_literal,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *RouteShadowing) Reset() {
@@ -94,17 +99,25 @@ func (x *RouteShadowing) GetDisableShadowHostSuffixAppend() bool {
 	return false
 }
 
+func (x *RouteShadowing) GetHostRewriteLiteral() string {
+	if x != nil {
+		return x.HostRewriteLiteral
+	}
+	return ""
+}
+
 var File_github_com_solo_io_gloo_projects_gloo_api_v1_options_shadowing_shadowing_proto protoreflect.FileDescriptor
 
 const file_github_com_solo_io_gloo_projects_gloo_api_v1_options_shadowing_shadowing_proto_rawDesc = "" +
 	"\n" +
-	"Ngithub.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto\x12\x1eshadowing.options.gloo.solo.io\x1a,github.com/solo-io/solo-kit/api/v1/ref.proto\x1a\x12extproto/ext.proto\"\xb1\x01\n" +
+	"Ngithub.com/solo-io/gloo/projects/gloo/api/v1/options/shadowing/shadowing.proto\x12\x1eshadowing.options.gloo.solo.io\x1a,github.com/solo-io/solo-kit/api/v1/ref.proto\x1a\x12extproto/ext.proto\"\xe3\x01\n" +
 	"\x0eRouteShadowing\x125\n" +
 	"\bupstream\x18\x01 \x01(\v2\x19.core.solo.io.ResourceRefR\bupstream\x12\x1e\n" +
 	"\n" +
 	"percentage\x18\x02 \x01(\x02R\n" +
 	"percentage\x12H\n" +
-	"!disable_shadow_host_suffix_append\x18\x03 \x01(\bR\x1ddisableShadowHostSuffixAppendBP\xb8\xf5\x04\x01\xc0\xf5\x04\x01\xd0\xf5\x04\x01ZBgithub.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/shadowingb\x06proto3"
+	"!disable_shadow_host_suffix_append\x18\x03 \x01(\bR\x1ddisableShadowHostSuffixAppend\x120\n" +
+	"\x14host_rewrite_literal\x18\x04 \x01(\tR\x12hostRewriteLiteralBP\xb8\xf5\x04\x01\xc0\xf5\x04\x01\xd0\xf5\x04\x01ZBgithub.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/shadowingb\x06proto3"
 
 var (
 	file_github_com_solo_io_gloo_projects_gloo_api_v1_options_shadowing_shadowing_proto_rawDescOnce sync.Once

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.hash.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.hash.go
@@ -72,5 +72,9 @@ func (m *RouteShadowing) Hash(hasher hash.Hash64) (uint64, error) {
 		return 0, err
 	}
 
+	if _, err = hasher.Write([]byte(m.GetHostRewriteLiteral())); err != nil {
+		return 0, err
+	}
+
 	return hasher.Sum64(), nil
 }

--- a/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.uniquehash.go
+++ b/projects/gloo/pkg/api/v1/options/shadowing/shadowing.pb.uniquehash.go
@@ -79,5 +79,12 @@ func (m *RouteShadowing) HashUnique(hasher hash.Hash64) (uint64, error) {
 		return 0, err
 	}
 
+	if _, err = hasher.Write([]byte("HostRewriteLiteral")); err != nil {
+		return 0, err
+	}
+	if _, err = hasher.Write([]byte(m.GetHostRewriteLiteral())); err != nil {
+		return 0, err
+	}
+
 	return hasher.Sum64(), nil
 }

--- a/projects/gloo/pkg/plugins/shadowing/plugin.go
+++ b/projects/gloo/pkg/plugins/shadowing/plugin.go
@@ -75,6 +75,7 @@ func applyShadowSpec(out *envoy_config_route_v3.RouteAction, spec *shadowing.Rou
 			Cluster:                       translator.UpstreamToClusterName(spec.GetUpstream()),
 			RuntimeFraction:               getFractionalPercent(spec.GetPercentage()),
 			DisableShadowHostSuffixAppend: spec.GetDisableShadowHostSuffixAppend(),
+			HostRewriteLiteral:            spec.GetHostRewriteLiteral(),
 		},
 	}
 	return nil

--- a/projects/gloo/pkg/plugins/shadowing/plugin_test.go
+++ b/projects/gloo/pkg/plugins/shadowing/plugin_test.go
@@ -131,6 +131,76 @@ var _ = Describe("Plugin", func() {
 		Expect(out.GetRoute().GetRequestMirrorPolicies()[0].GetDisableShadowHostSuffixAppend()).To(BeTrue())
 	})
 
+	It("should set HostRewriteLiteral when specified", func() {
+		p := NewPlugin()
+
+		upRef := &core.ResourceRef{
+			Name:      "some-upstream",
+			Namespace: "default",
+		}
+		in := &v1.Route{
+			Options: &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:           upRef,
+					Percentage:         100,
+					HostRewriteLiteral: "shadow-svc.internal:8080",
+				},
+			},
+		}
+		out := &envoy_config_route_v3.Route{}
+		err := p.ProcessRoute(plugins.RouteParams{}, in, out)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out.GetRoute().GetRequestMirrorPolicies()[0].GetHostRewriteLiteral()).To(Equal("shadow-svc.internal:8080"))
+	})
+
+	It("should not set HostRewriteLiteral by default", func() {
+		p := NewPlugin()
+
+		upRef := &core.ResourceRef{
+			Name:      "some-upstream",
+			Namespace: "default",
+		}
+		in := &v1.Route{
+			Options: &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:   upRef,
+					Percentage: 100,
+				},
+			},
+		}
+		out := &envoy_config_route_v3.Route{}
+		err := p.ProcessRoute(plugins.RouteParams{}, in, out)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out.GetRoute().GetRequestMirrorPolicies()[0].GetHostRewriteLiteral()).To(BeEmpty())
+	})
+
+	// Envoy implicitly disables the -shadow suffix when host_rewrite_literal is set, so we pass both
+	// through as configured rather than reconciling them here.
+	It("should pass through both HostRewriteLiteral and DisableShadowHostSuffixAppend", func() {
+		p := NewPlugin()
+
+		upRef := &core.ResourceRef{
+			Name:      "some-upstream",
+			Namespace: "default",
+		}
+		in := &v1.Route{
+			Options: &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:                      upRef,
+					Percentage:                    100,
+					DisableShadowHostSuffixAppend: false,
+					HostRewriteLiteral:            "shadow-svc.internal",
+				},
+			},
+		}
+		out := &envoy_config_route_v3.Route{}
+		err := p.ProcessRoute(plugins.RouteParams{}, in, out)
+		Expect(err).NotTo(HaveOccurred())
+		mirrorPolicy := out.GetRoute().GetRequestMirrorPolicies()[0]
+		Expect(mirrorPolicy.GetHostRewriteLiteral()).To(Equal("shadow-svc.internal"))
+		Expect(mirrorPolicy.GetDisableShadowHostSuffixAppend()).To(BeFalse())
+	})
+
 	It("should error when given invalid specs", func() {
 		p := NewPlugin()
 

--- a/projects/gloo/pkg/translator/translator_test.go
+++ b/projects/gloo/pkg/translator/translator_test.go
@@ -4093,6 +4093,37 @@ var _ = Describe("Translator", func() {
 			Expect(mirrorPolicies).To(HaveLen(1))
 			Expect(mirrorPolicies[0].GetDisableShadowHostSuffixAppend()).To(BeFalse())
 		})
+
+		It("should translate shadowing with HostRewriteLiteral", func() {
+			routes[0].Options = &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:           upstream.Metadata.Ref(),
+					Percentage:         100,
+					HostRewriteLiteral: "shadow-svc.internal:8080",
+				},
+			}
+
+			translate()
+
+			mirrorPolicies := routeConfiguration.VirtualHosts[0].Routes[0].GetRoute().GetRequestMirrorPolicies()
+			Expect(mirrorPolicies).To(HaveLen(1))
+			Expect(mirrorPolicies[0].GetHostRewriteLiteral()).To(Equal("shadow-svc.internal:8080"))
+		})
+
+		It("should translate shadowing without HostRewriteLiteral by default", func() {
+			routes[0].Options = &v1.RouteOptions{
+				Shadowing: &shadowing.RouteShadowing{
+					Upstream:   upstream.Metadata.Ref(),
+					Percentage: 100,
+				},
+			}
+
+			translate()
+
+			mirrorPolicies := routeConfiguration.VirtualHosts[0].Routes[0].GetRoute().GetRequestMirrorPolicies()
+			Expect(mirrorPolicies).To(HaveLen(1))
+			Expect(mirrorPolicies[0].GetHostRewriteLiteral()).To(BeEmpty())
+		})
 	})
 
 	Context("Protocol Upgrades - CONNECT", func() {


### PR DESCRIPTION
# Description

Adds `hostRewriteLiteral` to `RouteShadowing` proto so that mirrored requests can carry a specific user-defined `Host`/`:authority` value for shadow backends that enforces host-based routing.

## API changes

* Added `hostRewriteLiteral` field to `RouteShadowing` proto

## Code changes

Passed new `hostRewriteLiteral` field through to Envoy's `RequestMirrorPolicy.host_rewrite_literal` in shadowing plugin.

## Docs changes

Added docs for `hostRewriteLiteral`, and also went back and added docs for `disableShadowHostSuffixAppend`, which the earlier PR #11252 never added. Also corrected the claim that the `-shadow` suffix was unconditional.

## Interesting decisions

Applies per route, not per VHost, so that different routes can target different shadow hosts.

Envoy added this field in 1.36, so backports are limited to release branches that ship Envoy 1.36 or newer.

## Testing

Added plugin, translator, and other unit tests.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works