### PR TITLE
[v1.22.x] fix: keep discovered Upstream selector in sync with its Service (#11348)

### DIFF
--- a/changelog/v1.22.0/fix-discovered-upstream-selector-sync.yaml
+++ b/changelog/v1.22.0/fix-discovered-upstream-selector-sync.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/9078
+    resolvesIssue: false
+    description: >-
+      POTENTIALLY BREAKING CHANGE: Keep a discovered Upstream's kube.selector in sync with its Kubernetes Service. It was
+      previously set once at discovery and preserved on every resync, so changing a Service's
+      spec.selector left EDS filtering endpoints against stale pod labels, which could leave
+      the Upstream with no endpoints and break blue/green deployments. Note that discovery now
+      owns kube.selector on discovered Upstreams, so if you have manually edited
+      that field on one, your edit will be silently reverted on the next resync. To set a
+      custom selector, use the Service's gloo.solo.io/upstream_config annotation (along with
+      gloo.solo.io/upstream_config.deep_merge: "true") or manage your own Upstream instead.

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert.go
@@ -113,8 +113,8 @@ func UpdateUpstream(original, desired *v1.Upstream) (didChange bool, err error) 
 	}
 	// copy service spec, we don't want to overwrite that
 	desiredSpec.Kube.ServiceSpec = originalSpec.Kube.GetServiceSpec()
-	// copy labels; user may have written them over. cannot be auto-discovered
-	desiredSpec.Kube.Selector = originalSpec.Kube.GetSelector()
+
+	// Keep the selector produced during Service conversion instead of preserving a stale value.
 
 	utils.UpdateUpstream(original, desired)
 

--- a/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_convert_test.go
@@ -148,6 +148,46 @@ var _ = Describe("UdsConvert", func() {
 				Expect(up.GetUseHttp2().GetValue()).To(BeFalse())
 			})
 
+			It("should keep an annotation-provided selector over the Service selector and a manual edit", func() {
+				svc := &corev1.Service{
+					Spec: corev1.ServiceSpec{
+						Selector: map[string]string{"app": "echo", "version": "blue"},
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test",
+						Namespace: "test-ns",
+						Annotations: map[string]string{
+							serviceconverter.DeepMergeAnnotationPrefix: "true",
+							serviceconverter.GlooAnnotationPrefix: `{
+								"kube": {
+									"selector": {
+										"app": "echo",
+										"version": "green"
+									}
+								}
+							}`,
+						},
+					},
+				}
+
+				port := corev1.ServicePort{Port: 123}
+				desired := uc.CreateUpstream(context.TODO(), svc, port)
+
+				// Simulate a user editing the discovered Upstream. Cloning desired ensures the
+				// selector is the only difference, so didChange is tied to that field.
+				original := desired.Clone().(*v1.Upstream)
+				original.GetKube().Selector = map[string]string{"app": "echo", "version": "red"}
+
+				updated, err := UpdateUpstream(original, desired)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updated).To(BeTrue())
+
+				Expect(desired.GetKube().GetSelector()).To(Equal(map[string]string{"app": "echo", "version": "green"}))
+				Expect(desired.GetKube().GetServiceName()).To(Equal("test"))
+				Expect(desired.GetKube().GetServiceNamespace()).To(Equal("test-ns"))
+				Expect(desired.GetKube().GetServicePort()).To(Equal(uint32(123)))
+			})
+
 			Describe("Should create upstream with SSL Config when annotations exist", testSetSslConfig)
 
 			expectAnnotationsToProduceUpstreamConfig := func(annotations map[string]string, expectedCfg *v1.Upstream) {

--- a/projects/gloo/pkg/plugins/kubernetes/uds_test.go
+++ b/projects/gloo/pkg/plugins/kubernetes/uds_test.go
@@ -2,6 +2,7 @@ package kubernetes_test
 
 import (
 	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
 	gloov1kube "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options/kubernetes"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/ssl"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
@@ -58,6 +59,99 @@ var _ = Describe("Uds", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(updated).To(BeTrue())
 		Expect(desired.SslConfig).To(BeIdenticalTo(desiredSslConfig))
+	})
+
+	It("should update the selector when the service selector changes", func() {
+		desired := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+					Selector:    map[string]string{"app": "echo", "version": "green"},
+				},
+			},
+		}
+		original := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+					Selector:    map[string]string{"app": "echo", "version": "blue"},
+				},
+			},
+		}
+		updated, err := UpdateUpstream(original, desired)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeTrue())
+		Expect(desired.GetKube().GetSelector()).To(Equal(map[string]string{"app": "echo", "version": "green"}))
+	})
+
+	It("should not report a change when the selector is unchanged", func() {
+		selector := map[string]string{"app": "echo", "version": "blue"}
+		desired := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+					Selector:    selector,
+				},
+			},
+		}
+		original := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+					Selector:    selector,
+				},
+			},
+		}
+		updated, err := UpdateUpstream(original, desired)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeFalse())
+		Expect(desired.GetKube().GetSelector()).To(Equal(selector))
+	})
+
+	It("should clear the selector when the service no longer has one", func() {
+		desired := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+				},
+			},
+		}
+		original := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+					Selector:    map[string]string{"app": "echo", "version": "blue"},
+				},
+			},
+		}
+		updated, err := UpdateUpstream(original, desired)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeTrue())
+		Expect(desired.GetKube().GetSelector()).To(BeEmpty())
+	})
+
+	It("should preserve the service spec when updating upstreams", func() {
+		desired := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+				},
+			},
+		}
+		original := &gloov1.Upstream{
+			UpstreamType: &gloov1.Upstream_Kube{
+				Kube: &gloov1kube.UpstreamSpec{
+					ServiceName: "test",
+					ServiceSpec: &options.ServiceSpec{
+						PluginType: &options.ServiceSpec_GrpcJsonTranscoder{},
+					},
+				},
+			},
+		}
+		updated, err := UpdateUpstream(original, desired)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated).To(BeFalse())
+		Expect(desired.GetKube().GetServiceSpec()).NotTo(BeNil())
 	})
 
 })

--- a/test/kubernetes/e2e/features/discovery_watchlabels/discovery_watchlabels_suite.go
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/discovery_watchlabels_suite.go
@@ -2,17 +2,28 @@ package discovery_watchlabels
 
 import (
 	"context"
+	"net/http"
+	"time"
 
 	"github.com/onsi/gomega"
 
+	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	glooMatchers "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/core/matchers"
 	v1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1/kube/apis/gloo.solo.io/v1"
 	"github.com/solo-io/gloo/projects/gloo/pkg/api/v1/options"
 	"github.com/solo-io/gloo/projects/gloo/pkg/plugins/kubernetes"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/solo-io/gloo/pkg/utils/kubeutils"
+	"github.com/solo-io/gloo/pkg/utils/requestutils/curl"
+	"github.com/solo-io/gloo/test/gomega/matchers"
 	"github.com/solo-io/gloo/test/kubernetes/e2e"
+	testdefaults "github.com/solo-io/gloo/test/kubernetes/e2e/defaults"
 	"github.com/solo-io/solo-kit/pkg/api/v1/clients"
 	"github.com/solo-io/solo-kit/pkg/api/v1/resources"
+	gloocore "github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -156,4 +167,110 @@ func (s *discoveryWatchlabelsSuite) TestDiscoverySpecPreserved() {
 		us, err := s.testInstallation.ResourceClients.UpstreamClient().Read(us.GetMetadata().GetNamespace(), us.GetMetadata().GetName(), clients.ReadOpts{Ctx: s.ctx})
 		return us.GetKube().GetServiceSpec(), err
 	}).Should(gomega.Not(gomega.BeNil()))
+}
+
+// TestDiscoveredSelectorTracksService verifies that changing a Service selector
+// updates the discovered Upstream and its Envoy endpoints.
+func (s *discoveryWatchlabelsSuite) TestDiscoveredSelectorTracksService() {
+	installNs := s.testInstallation.Metadata.InstallNamespace
+	usName := kubernetes.UpstreamName(installNs, "echo-svc", 8000)
+
+	s.T().Cleanup(func() {
+		err := s.testInstallation.ResourceClients.VirtualServiceClient().Delete(installNs, "echo-vs",
+			clients.DeleteOpts{Ctx: s.ctx, IgnoreNotExist: true})
+		s.Assertions.NoError(err, "can delete virtual service")
+
+		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, serviceBlueGreenManifest, "-n", installNs)
+		s.Assertions.NoError(err, "can delete blue/green service")
+
+		err = s.testInstallation.Actions.Kubectl().DeleteFile(s.ctx, testdefaults.CurlPodManifest)
+		s.Assertions.NoError(err, "can delete curl pod")
+	})
+
+	err := s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, testdefaults.CurlPodManifest)
+	s.Assert().NoError(err, "can apply curl pod")
+
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, serviceBlueGreenManifest, "-n", installNs)
+	s.Assert().NoError(err, "can apply blue/green service")
+
+	s.testInstallation.Assertions.EventuallyResourceExists(
+		func() (resources.Resource, error) {
+			return s.testInstallation.ResourceClients.UpstreamClient().Read(installNs, usName, clients.ReadOpts{Ctx: s.ctx})
+		},
+	)
+
+	// Route directly to the discovered Upstream. A kube destination would use an
+	// in-memory Upstream instead.
+	_, err = s.testInstallation.ResourceClients.VirtualServiceClient().Write(&gatewayv1.VirtualService{
+		Metadata: &gloocore.Metadata{
+			Name:      "echo-vs",
+			Namespace: installNs,
+		},
+		VirtualHost: &gatewayv1.VirtualHost{
+			Domains: []string{"echo.example.com"},
+			Routes: []*gatewayv1.Route{{
+				Matchers: []*glooMatchers.Matcher{{
+					PathSpecifier: &glooMatchers.Matcher_Prefix{Prefix: "/"},
+				}},
+				Action: &gatewayv1.Route_RouteAction{
+					RouteAction: &gloov1.RouteAction{
+						Destination: &gloov1.RouteAction_Single{
+							Single: &gloov1.Destination{
+								DestinationType: &gloov1.Destination_Upstream{
+									Upstream: &gloocore.ResourceRef{
+										Name:      usName,
+										Namespace: installNs,
+									},
+								},
+							},
+						},
+					},
+				},
+			}},
+		},
+	}, clients.WriteOpts{Ctx: s.ctx, OverwriteExisting: true})
+	s.Assert().NoError(err, "can write virtual service")
+
+	curlOpts := []curl.Option{
+		curl.WithHost(kubeutils.ServiceFQDN(metav1.ObjectMeta{
+			Name:      defaults.GatewayProxyName,
+			Namespace: installNs,
+		})),
+		curl.WithHostHeader("echo.example.com"),
+		curl.WithPort(80),
+	}
+
+	s.testInstallation.Assertions.AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		curlOpts,
+		&matchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Body:       gomega.ContainSubstring("BLUE"),
+		},
+		time.Minute,
+	)
+
+	err = s.testInstallation.Actions.Kubectl().ApplyFile(s.ctx, serviceBlueGreenFlippedManifest, "-n", installNs)
+	s.Assert().NoError(err, "can flip service selector to green")
+
+	s.testInstallation.Assertions.Gomega.Eventually(func() (map[string]string, error) {
+		upstream, err := s.testInstallation.ResourceClients.UpstreamClient().Read(installNs, usName, clients.ReadOpts{Ctx: s.ctx})
+		return upstream.GetKube().GetSelector(), err
+	}, time.Minute, time.Second).Should(gomega.Equal(map[string]string{
+		"app":     "echo",
+		"version": "green",
+	}))
+
+	// Verify Envoy receives the EDS update after the selector changes.
+	s.testInstallation.Assertions.AssertEventualCurlResponse(
+		s.ctx,
+		testdefaults.CurlPodExecOpt,
+		curlOpts,
+		&matchers.HttpResponse{
+			StatusCode: http.StatusOK,
+			Body:       gomega.ContainSubstring("GREEN"),
+		},
+		time.Minute,
+	)
 }

--- a/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-blue-green-flipped.yaml
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-blue-green-flipped.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    watchedKey: watchedValue
+  name: echo-svc
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 80
+  selector:
+    app: echo
+    version: green

--- a/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-blue-green.yaml
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/testdata/service-blue-green.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-blue
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+      version: blue
+  template:
+    metadata:
+      labels:
+        app: echo
+        version: blue
+    spec:
+      containers:
+        - name: whoami
+          image: traefik/whoami:v1.10.2
+          args: ["--name=BLUE"]
+          ports:
+            - containerPort: 80
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: echo-green
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: echo
+      version: green
+  template:
+    metadata:
+      labels:
+        app: echo
+        version: green
+    spec:
+      containers:
+        - name: whoami
+          image: traefik/whoami:v1.10.2
+          args: ["--name=GREEN"]
+          ports:
+            - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    watchedKey: watchedValue
+  name: echo-svc
+spec:
+  ports:
+    - name: http
+      port: 8000
+      targetPort: 80
+  selector:
+    app: echo
+    version: blue

--- a/test/kubernetes/e2e/features/discovery_watchlabels/types.go
+++ b/test/kubernetes/e2e/features/discovery_watchlabels/types.go
@@ -11,4 +11,6 @@ var (
 	serviceWithModifiedLabelsManifest   = filepath.Join(util.MustGetThisDir(), "testdata/service-with-modified-labels.yaml")
 	serviceWithoutLabelsManifest        = filepath.Join(util.MustGetThisDir(), "testdata/service-without-labels.yaml")
 	serviceWithNoMatchingLabelsManifest = filepath.Join(util.MustGetThisDir(), "testdata/service-with-no-matching-labels.yaml")
+	serviceBlueGreenManifest            = filepath.Join(util.MustGetThisDir(), "testdata/service-blue-green.yaml")
+	serviceBlueGreenFlippedManifest     = filepath.Join(util.MustGetThisDir(), "testdata/service-blue-green-flipped.yaml")
 )

--- a/test/kubernetes/e2e/tests/discovery_watchlabels_test.go
+++ b/test/kubernetes/e2e/tests/discovery_watchlabels_test.go
@@ -24,7 +24,7 @@ func TestDiscoveryWatchlabels(t *testing.T) {
 		t,
 		&gloogateway.Context{
 			InstallNamespace:          installNs,
-			ProfileValuesManifestFile: e2e.KubernetesGatewayProfilePath,
+			ProfileValuesManifestFile: e2e.EdgeGatewayProfilePath,
 			ValuesManifestFile:        filepath.Join(util.MustGetThisDir(), "manifests", "discovery-watchlabels-test-helm.yaml"),
 		},
 	)


### PR DESCRIPTION
# Description

Backport of #11348 to `v1.22.x`.

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works