### PR TITLE
trivy scan with the default GITHUB_TOKEN instead of the PAT

### DIFF
--- a/.github/workflows/scheduled-trivy-analysis.yaml
+++ b/.github/workflows/scheduled-trivy-analysis.yaml
@@ -9,7 +9,7 @@ on:
 
 env:
   SLACK_DEBUG_TESTING: false   # when set to "true", send notifications to #slack-integration-testing.  Otherwise, post to #edge-team-bots
-  GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   scan-images:


### PR DESCRIPTION
# Description

The token is only used to get a higher rate limit against what could be an unauthenticated request. 
<!--
A concise explanation of the change. You may include:
- **Motivation:** why this change is needed
- **What changed:** key implementation details
- **Related issues:** e.g., `Fixes #123`
-->

# Change Type
/kind fix

<!--
Select one or more of the following by including the corresponding slash-command.

If you pick more than one, the release note is filed under whichever appears first here (manual reordering does not have any effect):
```
/kind breaking_change
/kind feature
/kind fix
/kind deprecation
/kind documentation
/kind cleanup
/kind install
/kind bump
(the following kinds are not included in release notes)
/kind design
/kind flake
/kind test
```
-->

# Changelog

<!--
Provide the exact line to appear in the release notes for this PR.

A PR gets one release note, filed under the highest-precedence /kind above.
If this change needs no release note, write "NONE" in the block below.
-->

```release-note
NONE
```

# Additional Notes

<!--
Any extra context or edge cases for reviewers.
-->
