### PR TITLE
fix: report status for Kube Gateway resources rejected without an xDS change

### DIFF
--- a/changelog/v1.23.0-beta1/fix-vho-status-report-only-change.yaml
+++ b/changelog/v1.23.0-beta1/fix-vho-status-report-only-change.yaml
@@ -1,0 +1,13 @@
+changelog:
+  - type: FIX
+    issueLink: https://github.com/solo-io/solo-projects/issues/8013
+    resolvesIssue: false
+    description: >-
+      Report a status on Kubernetes Gateway resources that are rejected without changing the proxy
+      config. XdsSnapWrapper.Equals compared only the Envoy snapshot, so a translation whose only
+      change was a new report was treated as no change: rejecting an invalid option leaves the last
+      good config in place, which makes the snapshots identical. Change detection dropped that
+      update along with the plugin registry holding the rejected resource, so the status plugins
+      never saw it and the resource kept an empty status. Change detection now also compares the
+      proxy report, which is a deterministic function of translation and carries no timestamps, so
+      stable output still converges without redundant report processing.

--- a/projects/gateway2/proxy_syncer/xdswrapper.go
+++ b/projects/gateway2/proxy_syncer/xdswrapper.go
@@ -42,7 +42,17 @@ func (p XdsSnapWrapper) WithSnapshot(snap *xds.EnvoySnapshot) XdsSnapWrapper {
 var _ krt.ResourceNamer = XdsSnapWrapper{}
 
 func (p XdsSnapWrapper) Equals(in XdsSnapWrapper) bool {
-	return p.snap.Equal(in.snap)
+	// The proxy report is compared alongside the snapshot because a translation can change what
+	// gets reported about a resource without changing the xDS output at all: rejecting an invalid
+	// option leaves the last good config in place, so the two snapshots are identical. Comparing
+	// only the snapshot dropped those updates, and with them the plugin registry that carries the
+	// status for the newly rejected resource, so the resource never got a status written at all.
+	//
+	// The proxy report is a deterministic function of translation and carries no timestamps, so
+	// including it here does not reintroduce the no-op report churn that stable output used to
+	// cause.
+	return p.snap.Equal(in.snap) &&
+		proto.Equal(p.proxyWithReport.Reports.ProxyReport, in.proxyWithReport.Reports.ProxyReport)
 }
 
 func (p XdsSnapWrapper) ResourceName() string {

--- a/projects/gateway2/proxy_syncer/xdswrapper_equals_test.go
+++ b/projects/gateway2/proxy_syncer/xdswrapper_equals_test.go
@@ -1,0 +1,112 @@
+package proxy_syncer
+
+import (
+	"testing"
+
+	sologatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gateway2/translator/translatorutils"
+	"github.com/solo-io/gloo/projects/gloo/pkg/api/grpc/validation"
+	gloov1 "github.com/solo-io/gloo/projects/gloo/pkg/api/v1"
+	"github.com/solo-io/gloo/projects/gloo/pkg/xds"
+	"github.com/solo-io/solo-kit/pkg/api/v1/control-plane/cache"
+	"github.com/solo-io/solo-kit/pkg/api/v1/resources/core"
+)
+
+// vhoProxyReport builds a ProxyReport carrying a single VirtualHost error sourced by a
+// VirtualHostOption, which is the shape the VirtualHostOption status plugin reads from.
+func vhoProxyReport(reason string) *validation.ProxyReport {
+	return &validation.ProxyReport{
+		ListenerReports: []*validation.ListenerReport{{
+			ListenerTypeReport: &validation.ListenerReport_AggregateListenerReport{
+				AggregateListenerReport: &validation.AggregateListenerReport{
+					HttpListenerReports: map[string]*validation.HttpListenerReport{
+						"http": {
+							VirtualHostReports: []*validation.VirtualHostReport{{
+								Errors: []*validation.VirtualHostReport_Error{{
+									Type:   validation.VirtualHostReport_Error_ProcessingError,
+									Reason: reason,
+									Metadata: &gloov1.SourceMetadata{
+										Sources: []*gloov1.SourceMetadata_SourceRef{{
+											ResourceKind: sologatewayv1.VirtualHostOptionGVK.Kind,
+											ResourceRef: &core.ResourceRef{
+												Name:      "bad-retries",
+												Namespace: "default",
+											},
+										}},
+									},
+								}},
+							}},
+						},
+					},
+				},
+			},
+		}},
+	}
+}
+
+func wrapperWith(snapVersion string, report *validation.ProxyReport) XdsSnapWrapper {
+	return XdsSnapWrapper{
+		snap: &xds.EnvoySnapshot{
+			Clusters: cache.Resources{Version: snapVersion},
+		},
+		proxyKey: "gloo-system~gw-1",
+		proxyWithReport: translatorutils.ProxyWithReports{
+			Reports: translatorutils.TranslationReports{ProxyReport: report},
+		},
+	}
+}
+
+func TestXdsSnapWrapperEquals(t *testing.T) {
+	tests := []struct {
+		name  string
+		a     XdsSnapWrapper
+		b     XdsSnapWrapper
+		equal bool
+	}{
+		{
+			name:  "identical snapshot and report",
+			a:     wrapperWith("v1", vhoProxyReport("invalid retry policy")),
+			b:     wrapperWith("v1", vhoProxyReport("invalid retry policy")),
+			equal: true,
+		},
+		{
+			name:  "both reports empty",
+			a:     wrapperWith("v1", nil),
+			b:     wrapperWith("v1", nil),
+			equal: true,
+		},
+		{
+			// Rejecting an invalid option leaves the previous config in place, so only the
+			// report changes. Treating this as unchanged is what left the rejected resource
+			// without a status.
+			name:  "identical snapshot, report gained an error",
+			a:     wrapperWith("v1", nil),
+			b:     wrapperWith("v1", vhoProxyReport("invalid retry policy")),
+			equal: false,
+		},
+		{
+			name:  "identical snapshot, error reason changed",
+			a:     wrapperWith("v1", vhoProxyReport("invalid retry policy")),
+			b:     wrapperWith("v1", vhoProxyReport("some other problem")),
+			equal: false,
+		},
+		{
+			name:  "snapshot changed",
+			a:     wrapperWith("v1", nil),
+			b:     wrapperWith("v2", nil),
+			equal: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.a.Equals(tt.b); got != tt.equal {
+				t.Errorf("Equals() = %v, want %v", got, tt.equal)
+			}
+			// Equality must not depend on argument order.
+			if got := tt.b.Equals(tt.a); got != tt.equal {
+				t.Errorf("reversed Equals() = %v, want %v", got, tt.equal)
+			}
+		})
+	}
+}

--- a/test/kubernetes/e2e/features/client_tls/suite.go
+++ b/test/kubernetes/e2e/features/client_tls/suite.go
@@ -6,7 +6,9 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	gatewayv1 "github.com/solo-io/gloo/projects/gateway/pkg/api/v1"
 	"github.com/solo-io/gloo/projects/gateway/pkg/defaults"
 	"github.com/solo-io/gloo/test/gomega/matchers"
 	testdefaults "github.com/solo-io/gloo/test/kubernetes/e2e/defaults"
@@ -68,6 +70,11 @@ func (s *clientTlsTestingSuite) TestRouteSecureRequestToUpstream() {
 		err := s.testInstallation.Actions.Kubectl().Delete(s.ctx, VSTargetingUpstreamYaml, "-n", ns)
 		s.NoError(err, "can delete vs targeting upstream manifest file")
 		s.testInstallation.AssertionsT(s.T()).EventuallyObjectsNotExist(s.ctx, vSTargetingUpstreamObject(ns))
+		// Waiting for the object to leave Gloo's snapshot, and not just the Kubernetes API, is
+		// what keeps this test from leaking into the next one: this VirtualService shares the
+		// nginx.example.com domain with vs-targeting-kube, so a VirtualService applied while
+		// the deleted one is still in the snapshot is rejected for a domain conflict.
+		s.eventuallyNotInSnapshot(gatewayv1.VirtualServiceGVK, vSTargetingUpstreamObject(ns).ObjectMeta)
 
 		err = s.testInstallation.Actions.Kubectl().Delete(s.ctx, NginxUpstreamsYaml)
 		s.NoError(err, "can delete upstream manifest file")
@@ -99,6 +106,10 @@ func (s *clientTlsTestingSuite) TestRouteSecureRequestToAnnotatedService() {
 		err := s.testInstallation.Actions.Kubectl().Delete(s.ctx, VSTargetingKubeYaml, "-n", ns)
 		s.NoError(err, "can delete vs targeting services manifest file")
 		s.testInstallation.AssertionsT(s.T()).EventuallyObjectsNotExist(s.ctx, vSTargetingKubeObject(ns))
+		// See the note in TestRouteSecureRequestToUpstream: this VirtualService shares the
+		// nginx.example.com domain with vs-targeting-upstream, which runs next, so it has to be
+		// out of Gloo's snapshot before that test applies its own VirtualService.
+		s.eventuallyNotInSnapshot(gatewayv1.VirtualServiceGVK, vSTargetingKubeObject(ns).ObjectMeta)
 
 		err = s.testInstallation.Actions.Kubectl().Delete(s.ctx, NginxAnnotatedServicesYaml)
 		s.NoError(err, "can delete services manifest file")
@@ -133,6 +144,10 @@ func (s *clientTlsTestingSuite) TestOneWayTlsDoesNotRequestClientCertificate() {
 		err := s.testInstallation.Actions.Kubectl().Delete(s.ctx, VSOnewayDownstreamTlsYaml, "-n", ns)
 		s.NoError(err, "can delete vs oneway downstream tls manifest file")
 		s.testInstallation.AssertionsT(s.T()).EventuallyObjectsNotExist(s.ctx, vs)
+		// This VirtualService has its own domain, but it still has to leave Gloo's snapshot
+		// before the upstream it references is deleted below, so the snapshot never holds a
+		// VirtualService pointing at a missing upstream.
+		s.eventuallyNotInSnapshot(gatewayv1.VirtualServiceGVK, vs.ObjectMeta)
 
 		err = s.testInstallation.Actions.Kubectl().Delete(s.ctx, NginxUpstreamsYaml)
 		s.NoError(err, "can delete upstream manifest file")
@@ -199,6 +214,21 @@ func (s *clientTlsTestingSuite) assertEventualResponseForPath(path string, match
 			curl.WithPath(path),
 		},
 		matcher)
+}
+
+// eventuallyNotInSnapshot waits until Gloo's input snapshot no longer holds the given object.
+// Deletes are confirmed against the Kubernetes API first, but the admission webhook validates
+// against Gloo's snapshot, which trails it, so a test that only waits on the API can leave a
+// deleted resource behind for the next one to collide with.
+func (s *clientTlsTestingSuite) eventuallyNotInSnapshot(gvk schema.GroupVersionKind, meta metav1.ObjectMeta) {
+	s.testInstallation.AssertionsT(s.T()).AssertGlooAdminApi(
+		s.ctx,
+		metav1.ObjectMeta{
+			Name:      kubeutils.GlooDeploymentName,
+			Namespace: s.testInstallation.Metadata.InstallNamespace,
+		},
+		s.testInstallation.AssertionsT(s.T()).InputSnapshotDoesNotContainElement(gvk, meta),
+	)
 }
 
 func (s *clientTlsTestingSuite) eventuallySecretInSnapshot(meta metav1.ObjectMeta) {


### PR DESCRIPTION
# Description

A resource that Kubernetes Gateway translation rejects gets no status written at all if rejecting it does not change the proxy config. The resource keeps an empty `statuses: {}` map indefinitely, so users get no signal that their config was rejected.

`XdsSnapWrapper.Equals` compared only the Envoy snapshot, ignoring the reports and the plugin registry it carries. Rejecting an invalid option leaves the last good config in place, so the snapshot after the rejection is identical to the one before it. krt therefore saw no change, kept the previous `XdsSnapWrapper`, and discarded the plugin registry whose `classicStatusCache` held the newly rejected resource. The status ticker in `proxy_syncer.go` reports from the registries attached to the snapshots in `mostXdsSnapshots`, so it never saw the resource and never wrote its status.

Change detection now also compares the proxy report.

## Code changes

- Compare `proxyWithReport.Reports.ProxyReport` with `proto.Equal` in `XdsSnapWrapper.Equals`
- Add `TestXdsSnapWrapperEquals` covering the report-only change

# Context

This surfaced as a flake in `TestK8sGatewayNoValidation/VirtualHostOptions/TestConfigureInvalidVirtualHostOptions`, which applies an invalid `VirtualHostOption` (`bad-retries`, a retry backoff with `baseInterval` > `maxInterval`) with `alwaysAccept: true` and asserts it goes to `Rejected`. The assertion fails with `have matcher for namespace <install-ns> which is not found` — no status entry at all, rather than a wrong state — which is the signature of this bug rather than of a slow status write. Two occurrences on unrelated branches:

- https://github.com/solo-io/gloo/actions/runs/32189660295/job/95881990320 (cluster-six)
- https://github.com/solo-io/gloo/actions/runs/31626638905/job/94214693219 (cluster-six)

The test is a good fit for triggering this because it asserts the proxy config is *unchanged* after the bad VHO is applied, which is exactly the case the old equality check discarded. It passes most of the time only because an unrelated change often perturbs the snapshot in the same window.

## Interesting decisions

Comparing the proxy report risks reintroducing the no-op report churn fixed in #11308, so this is deliberately narrow:

- Only `ProxyReport` is compared, not `fullReports`/`ResourceReports`. The latter is keyed by `InputResource` pointers, which are freshly allocated per translation, so comparing it would flap on every recompute — the hot loop we want to avoid.
- `ProxyReport` is safe to compare: `MakeReport` builds it structurally from the proxy's own deterministic ordering, it carries no timestamps (the `LastTransitionTime` problem in #11308 was in the Gateway API `ReportMap`, not here), and its `HttpListenerReports` is a proto map, which `proto.Equal` compares order-independently.

## Testing steps

- `TestXdsSnapWrapperEquals` fails on `main` for the `identical snapshot, report gained an error` case and passes with this change

Have not run the kube e2e suite locally, so the fix to the flake itself is reasoned from the failure signature and the code path rather than observed.

## Notes for reviewers

- The changelog's `issueLink` is #11308, questionable
- The main thing to sanity check is the churn argument above: if `ProxyReport` turns out to be unstable across identical translations in some listener type I did not consider, this would spin the status ticker.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

