### PR TITLE
fix(ci): repair scheduled security scan auth and alerts

### DIFF
--- a/.github/workflows/composite-actions/prep-go-runner/action.yaml
+++ b/.github/workflows/composite-actions/prep-go-runner/action.yaml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Cancel Previous Actions
-      uses: styfle/cancel-workflow-action@0.12.1
+      uses: styfle/cancel-workflow-action@0.13.1
       with:
         access_token: ${{ github.token }}
     - name: Free disk space
@@ -35,7 +35,7 @@ runs:
         df -h
     - name: Set up Go
       id: setup-go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v7
       with:
         # https://github.com/actions/setup-go/blob/main/action.yml
         go-version-file: ${{ inputs.working-directory }}/go.mod
@@ -49,7 +49,7 @@ runs:
       run: |
         echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
     - name: Cache
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       id: cache
       with:
         # https://github.com/actions/cache/blob/main/examples.md#go---modules

--- a/.github/workflows/scheduled-trivy-analysis.yaml
+++ b/.github/workflows/scheduled-trivy-analysis.yaml
@@ -44,13 +44,17 @@ jobs:
           project_id: solo-public
       - name: Run and Push Security Scan Files to Google Cloud Bucket
         env:
-          # The enterprise release lookup requires access to the private solo-projects repository.
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          # The enterprise release lookup requires the existing cross-repository credential.
+          GITHUB_TOKEN: ${{ secrets.DOCS_TOKEN }}
           SCAN_DIR: _output/scans
           IMAGE_REGISTRY: quay.io/solo-io
           # ON_LTS_UPDATE - bump lts version in the repo variables
           MIN_SCANNED_VERSION: ${{ vars.LATEST_STABLE_MINUS_THREE_BRANCH }}  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
         run: |
+          if [[ -z "$GITHUB_TOKEN" ]]; then
+            echo "::error::The cross-repository scan credential is not configured"
+            exit 1
+          fi
           mkdir -p "$SCAN_DIR"
           make run-security-scan
           make publish-security-scan

--- a/.github/workflows/scheduled-trivy-analysis.yaml
+++ b/.github/workflows/scheduled-trivy-analysis.yaml
@@ -8,8 +8,11 @@ on:
     - cron: "0 8 * * 1"
 
 env:
-  SLACK_DEBUG_TESTING: false   # when set to "true", send notifications to #slack-integration-testing.  Otherwise, post to #edge-team-bots
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SLACK_DEBUG_TESTING: false   # When true, use the test notification destination.
+
+permissions:
+  actions: write # Required by prep-go-runner to cancel older runs of this workflow.
+  contents: read
 
 jobs:
   scan-images:
@@ -29,30 +32,37 @@ jobs:
           wget "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.deb"
           sudo dpkg -i "trivy_${TRIVY_VERSION}_Linux-64bit.deb"
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - uses: ./.github/workflows/composite-actions/prep-go-runner
       - name: Setup - gcloud / gsutil
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GLOO_VULN_REPORTER }}'
       - name: Setup Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: solo-public
       - name: Run and Push Security Scan Files to Google Cloud Bucket
         env:
+          # The enterprise release lookup requires access to the private solo-projects repository.
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           SCAN_DIR: _output/scans
           IMAGE_REGISTRY: quay.io/solo-io
           # ON_LTS_UPDATE - bump lts version in the repo variables
           MIN_SCANNED_VERSION: ${{ vars.LATEST_STABLE_MINUS_THREE_BRANCH }}  # ⚠️ you should also change trivy-analysis-scheduled.yaml ⚠️
         run: |
-          mkdir -p $SCAN_DIR
+          mkdir -p "$SCAN_DIR"
           make run-security-scan
           make publish-security-scan
       - name: Alert on workflow failure
         if: ${{ failure() }}
-        run : |
-          curl -X POST\
-               -H 'Content-type: application/json'\
-               --data '{"text":"Gloo Edge Vulnerability Scan has failed, visit https://github.com/solo-io/gloo/actions/runs/${{github.run_id}} to view logs."}'\
-               ${{ env.SLACK_DEBUG_TESTING == true && secrets.SLACK_INTEGRATION_TESTING_WEBHOOK || secrets.EDGE_TEAM_BOTS_WEBHOOK }}
+        uses: slackapi/slack-github-action@v4
+        with:
+          errors: true
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          payload: |
+            {
+              "channel": "${{ env.SLACK_DEBUG_TESTING == 'true' && secrets.SLACK_TEST_CHANNEL_ID || secrets.SLACK_ALERT_CHANNEL_ID }}",
+              "text": "❌ *Failure:* Gloo Edge vulnerability scan failed. <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|Review the workflow failure>"
+            }


### PR DESCRIPTION
# Description

Fix the scheduled security scan authentication, failure alerting, and token permissions.

## CI changes

- Scope `PERSONAL_ACCESS_TOKEN` to the scan step that reads private enterprise releases.
- Restrict the workflow token to `contents: read` and the `actions: write` permission required for cancelling superseded runs.
- Replace the unavailable webhook-based failure alert with `slack-github-action`.
- Upgrade the affected actions to Node 24-compatible versions.
- Harden shell quoting for the scan output directory.

# Context

The scheduled scan failed while fetching enterprise releases because it used the repository-scoped token, which cannot access the private repository. Its failure notification then also failed because the webhook URL resolved to an empty value.

Failed run: https://github.com/solo-io/gloo/actions/runs/32311787635/job/96256086914

The notification step requires:

- `SLACK_ALERT_CHANNEL_ID` # already set
- `SLACK_TEST_CHANNEL_ID` # already set
- `SLACK_BOT_TOKEN` # TODO

## Testing steps

- Validated the workflow at `HEAD` with Actionlint.
- Trigger the workflow manually and confirm both OSS and enterprise scans complete and publish successfully.
- Confirm an intentionally failed test run sends a notification to the configured test destination.

# Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works