### PR TITLE
helm: Fix issues with sds container readiness probe

### DIFF
--- a/changelog/v1.23.0-beta1/fix-sds-readiness-probe.yaml
+++ b/changelog/v1.23.0-beta1/fix-sds-readiness-probe.yaml
@@ -1,0 +1,9 @@
+changelog:
+  - type: HELM
+    resolvesIssue: false
+    description: >-
+      Fix the SDS container's readinessProbe so it falls back to the default probe only when
+      `global.glooMtls.sds.readinessProbe` is unset, instead of always requiring a value from
+      values-template.yaml. This lets users fully disable the probe by explicitly setting it to
+      null/empty, and lets a partial override apply on top of an explicit probe without silently
+      losing the default when none is provided.

--- a/changelog/v1.23.0-beta1/fix-sds-readiness-probe.yaml
+++ b/changelog/v1.23.0-beta1/fix-sds-readiness-probe.yaml
@@ -1,6 +1,7 @@
 changelog:
   - type: HELM
-    resolvesIssue: false
+    issueLink: https://github.com/solo-io/gloo/issues/11389
+    resolvesIssue: true
     description: >-
       Fix the SDS container's readinessProbe so it falls back to the default probe only when
       `global.glooMtls.sds.readinessProbe` is unset, instead of always requiring a value from

--- a/docs/content/reference/values.txt
+++ b/docs/content/reference/values.txt
@@ -1739,17 +1739,17 @@
 |global.glooMtls.sds.readinessProbe.httpGet.scheme|string|||
 |global.glooMtls.sds.readinessProbe.httpGet.httpHeaders[].name|string|||
 |global.glooMtls.sds.readinessProbe.httpGet.httpHeaders[].value|string|||
-|global.glooMtls.sds.readinessProbe.tcpSocket.port|int64|0||
-|global.glooMtls.sds.readinessProbe.tcpSocket.port|int32|8234||
+|global.glooMtls.sds.readinessProbe.tcpSocket.port|int64|||
+|global.glooMtls.sds.readinessProbe.tcpSocket.port|int32|||
 |global.glooMtls.sds.readinessProbe.tcpSocket.port|string|||
 |global.glooMtls.sds.readinessProbe.tcpSocket.host|string|||
 |global.glooMtls.sds.readinessProbe.grpc.port|int32|||
 |global.glooMtls.sds.readinessProbe.grpc.service|string|||
-|global.glooMtls.sds.readinessProbe.initialDelaySeconds|int32|3||
-|global.glooMtls.sds.readinessProbe.timeoutSeconds|int32|0||
-|global.glooMtls.sds.readinessProbe.periodSeconds|int32|10||
-|global.glooMtls.sds.readinessProbe.successThreshold|int32|0||
-|global.glooMtls.sds.readinessProbe.failureThreshold|int32|3||
+|global.glooMtls.sds.readinessProbe.initialDelaySeconds|int32|||
+|global.glooMtls.sds.readinessProbe.timeoutSeconds|int32|||
+|global.glooMtls.sds.readinessProbe.periodSeconds|int32|||
+|global.glooMtls.sds.readinessProbe.successThreshold|int32|||
+|global.glooMtls.sds.readinessProbe.failureThreshold|int32|||
 |global.glooMtls.sds.readinessProbe.terminationGracePeriodSeconds|int64|||
 |global.glooMtls.envoy.image.tag|string|<release_version, ex: 1.2.3>|The image tag for the container.|
 |global.glooMtls.envoy.image.repository|string|gloo-envoy-wrapper|The image repository (name) for the container.|

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,6 @@ require (
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
-	github.com/golang/mock v1.7.0-rc.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/mccutchen/go-httpbin/v2 v2.15.0
@@ -133,6 +132,7 @@ require (
 	github.com/go-openapi/swag/typeutils v0.25.4 // indirect
 	github.com/go-openapi/swag/yamlutils v0.25.4 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
+	github.com/golang/mock v1.7.0-rc.1 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect

--- a/go.mod
+++ b/go.mod
@@ -92,7 +92,7 @@ require (
 	github.com/envoyproxy/go-control-plane/ratelimit v0.1.0
 	github.com/go-logr/zapr v1.3.0
 	github.com/golang-jwt/jwt/v4 v4.5.2
-	github.com/golang/mock v1.7.0-rc.1 // indirect
+	github.com/golang/mock v1.7.0-rc.1
 	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/mccutchen/go-httpbin/v2 v2.15.0

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -357,9 +357,15 @@ spec:
         - name: http-monitoring
           containerPort: 9091
         {{- end }}
-{{- with $global.glooMtls.sds.readinessProbe }}
         readinessProbe:
-{{ toYaml . | indent 10}}
+{{- if $global.glooMtls.sds.readinessProbe }}
+{{ toYaml $global.glooMtls.sds.readinessProbe | indent 10}}
+{{- else }}
+          tcpSocket:
+            port: 8234
+          initialDelaySeconds: 3
+          periodSeconds: 10
+          failureThreshold: 3
 {{- end }} {{/*  $global.glooMtls.sds.readinessProbe */}}
 {{- end }} {{- /* or $global.glooMtls.enabled (or $.Values.istioSDS.enabled $global.istioIntegration.enabled) */}}
 {{- if or $global.istioSDS.enabled $global.istioIntegration.enabled }}

--- a/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
+++ b/install/helm/gloo/templates/7-gateway-proxy-deployment.yaml
@@ -357,10 +357,13 @@ spec:
         - name: http-monitoring
           containerPort: 9091
         {{- end }}
-        readinessProbe:
+{{- if hasKey $global.glooMtls.sds "readinessProbe" }}
 {{- if $global.glooMtls.sds.readinessProbe }}
+        readinessProbe:
 {{ toYaml $global.glooMtls.sds.readinessProbe | indent 10}}
+{{- end }}
 {{- else }}
+        readinessProbe:
           tcpSocket:
             port: 8234
           initialDelaySeconds: 3

--- a/install/helm/gloo/values-template.yaml
+++ b/install/helm/gloo/values-template.yaml
@@ -304,12 +304,6 @@ global:
       image:
         repository: sds
       logLevel: info
-      readinessProbe:
-        tcpSocket:
-          port: 8234
-        initialDelaySeconds: 3
-        periodSeconds: 10
-        failureThreshold: 3
     istioProxy:
       image:
         repository: proxyv2


### PR DESCRIPTION
# Description

Fix the SDS container's readinessProbe so it falls back to the default probe only when `global.glooMtls.sds.readinessProbe` is unset