### PR TITLE
docs(ci): drop unpublished SEE ALSO links from generated glooctl reference

### DIFF
--- a/.github/workflows/push-docs.yaml
+++ b/.github/workflows/push-docs.yaml
@@ -392,10 +392,50 @@ jobs:
           cp "$GEN/static/content/glooe-values.docgen"  "$DOCS/assets/gateway-docs/pages/reference/helm/glooe-values_${MINOR}.md"
 
           mkdir -p "$DOCS/content/en/gateway/${DIRECTORY}/reference/cli"
-          for c in glooctl_check glooctl_debug glooctl_debug_yaml glooctl_install_gateway \
-                   glooctl_install_gateway_enterprise glooctl_uninstall glooctl_upgrade; do
+          CLI_CMDS="glooctl_check glooctl_debug glooctl_debug_yaml glooctl_install_gateway
+                    glooctl_install_gateway_enterprise glooctl_uninstall glooctl_upgrade"
+          for c in $CLI_CMDS; do
             cp "$GEN/reference/cli/${c}.md" "$DOCS/content/en/gateway/${DIRECTORY}/reference/cli/${c}.md"
           done
+
+          # Cobra emits a "SEE ALSO" section linking the parent command and every
+          # sibling subcommand. Only the commands listed above are published, so
+          # those bullets point at pages that do not exist and break the docs link
+          # check on every gateway version at once (13 errors as of 2026-08-31 —
+          # ../glooctl, ../glooctl_install, ../glooctl_debug_logs). Drop the
+          # bullets that reference an unpublished command, and drop the SEE ALSO
+          # heading if nothing is left under it. Filtering here rather than in the
+          # docs repo because these files are regenerated on every run.
+          python3 - "$DOCS/content/en/gateway/${DIRECTORY}/reference/cli" $CLI_CMDS <<'PYEOF'
+          import os, re, sys
+          cli_dir, published = sys.argv[1], set(sys.argv[2:])
+          bullet = re.compile(r'^\* \[[^\]]*\]\(\.\./([A-Za-z0-9_.-]+)\)')
+          for name in sorted(os.listdir(cli_dir)):
+              if not name.endswith('.md'):
+                  continue
+              path = os.path.join(cli_dir, name)
+              kept, dropped = [], 0
+              for line in open(path).read().splitlines():
+                  m = bullet.match(line)
+                  if m and m.group(1) not in published:
+                      dropped += 1
+                      continue
+                  kept.append(line)
+              if not dropped:
+                  continue
+              # Remove a SEE ALSO heading that no longer has any bullets under it.
+              out = []
+              for i, line in enumerate(kept):
+                  if line.strip().upper() == '### SEE ALSO':
+                      rest = kept[i + 1:]
+                      if not any(r.startswith('* [') for r in rest[:5]):
+                          continue
+                  out.append(line)
+              while out and not out[-1].strip():
+                  out.pop()
+              open(path, 'w').write('\n'.join(out) + '\n')
+              print(f'  {name}: dropped {dropped} unpublished SEE ALSO link(s)')
+          PYEOF
 
           cp "$GEN/reference/api/github.com/solo-io/gloo/projects/gateway2/api/v1alpha1/direct_responses.md" \
              "$DOCS/assets/gateway-docs/pages/reference/direct_responses_${MINOR}.md"

--- a/changelog/v1.23.0-beta1/push-docs-see-also-links.yaml
+++ b/changelog/v1.23.0-beta1/push-docs-see-also-links.yaml
@@ -1,0 +1,11 @@
+changelog:
+  - type: NON_USER_FACING
+    resolvesIssue: false
+    description: >-
+      Filter unpublished commands out of the SEE ALSO section of the generated glooctl
+      reference pages before push-docs copies them into solo-io/docs. Cobra links the parent
+      command and every sibling subcommand, but only seven glooctl commands are published, so
+      the remaining bullets pointed at pages that do not exist and broke the docs link check
+      on every gateway version tree at once. Drops the bullets that reference an unpublished
+      command, and the SEE ALSO heading when nothing is left under it.
+      skipCI-kube-tests:true

--- a/changelog/v1.23.0-beta1/push-docs-see-also-links.yaml
+++ b/changelog/v1.23.0-beta1/push-docs-see-also-links.yaml
@@ -5,7 +5,7 @@ changelog:
       Filter unpublished commands out of the SEE ALSO section of the generated glooctl
       reference pages before push-docs copies them into solo-io/docs. Cobra links the parent
       command and every sibling subcommand, but only seven glooctl commands are published, so
-      the remaining bullets pointed at pages that do not exist and broke the docs link check
-      on every gateway version tree at once. Drops the bullets that reference an unpublished
-      command, and the SEE ALSO heading when nothing is left under it.
+      the rest pointed at pages that do not exist and broke the docs link check on every
+      gateway version tree at once.
+
       skipCI-kube-tests:true


### PR DESCRIPTION
# Description

`push-docs` copies a subset of the cobra-generated `glooctl` reference pages into the docs repo. Cobra writes a `### SEE ALSO` section into every page linking the parent command and all sibling subcommands, but only seven commands are published. The bullets pointing at the unpublished ones resolve to pages that do not exist, so they break the docs link check on every gateway version tree at once.

This filters those bullets out during the copy step, and drops the `SEE ALSO` heading when nothing is left under it.

## CI changes

- Added a post-copy filter to the `glooctl` reference step in `.github/workflows/push-docs.yaml`
- The published command list is now held in a `CLI_CMDS` variable so the copy loop and the filter cannot drift apart

## Docs changes

- Generated `glooctl_*.md` pages in `solo-io/docs` will no longer contain links to unpublished commands

# Context

The link checker reported 13 errors traceable to this, as of 2026-08-31: `../glooctl`, `../glooctl_install`, and `../glooctl_debug_logs`, repeated across the `1.18.x` through `1.23.x` trees.

## Interesting decisions

**Filtering here rather than in the docs repo.** These files are regenerated by this workflow on every run, including a daily cron with `lines: all`. A fix applied to the generated pages in `solo-io/docs` is reverted within a day. The generator is the only place the fix survives.

**Dropping the bullets rather than publishing the missing pages.** Publishing `glooctl`, `glooctl_install`, and `glooctl_debug_logs` would also resolve the errors, but it expands the published CLI surface, which is a docs decision rather than a link-check one. Happy to go that route instead if the omission is unintentional.

**Filtering by the published list rather than by a fixed pattern.** Any bullet whose target is not in `CLI_CMDS` is dropped, so adding or removing a published command needs no change to the filter.

## Testing steps

Ran the filter against the generated `glooctl` pages currently checked into `solo-io/docs`:

- Of the seven published pages, five contain a bullet pointing at an unpublished command and are rewritten; `glooctl_debug_yaml.md` and `glooctl_install_gateway_enterprise.md` link only to published commands and are left byte-identical. That is 30 pages across the six gateway version trees.
- The four bullets that point at published commands are retained.
- Output is byte-identical to the equivalent fix applied by hand, across all seven files.
- Re-running the filter over its own output is a no-op.

The hand-applied fixes have been reverted from the docs branch so this workflow becomes the single source of the change.

## Notes for reviewers

The filter is inlined as a heredoc Python block to match the surrounding steps in this file. If you would rather it live in `docs/cli/` as a script, say so and I will move it.

Changelog: `changelog/v1.23.0-beta1/push-docs-see-also-links.yaml`, `NON_USER_FACING` with `skipCI-kube-tests:true`, matching the three existing push-docs entries in that directory.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- No automated test: this workflow has no existing test harness. Verified by running the filter against the current generated output, as described above. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
